### PR TITLE
Fix eventcombiner 1

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllTriggeredInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllTriggeredInputManager.cc
@@ -62,6 +62,26 @@ Fun4AllTriggeredInputManager::~Fun4AllTriggeredInputManager()
 int Fun4AllTriggeredInputManager::run(const int /*nevents*/)
 {
   m_Gl1TriggeredInput->FillPool(1);
+  for (auto *iter : m_TriggeredInputVector)
+  {
+    //    std::cout << "prdf input: " << iter->Name() << std::endl;
+    iter->FillPool(1);
+    if (iter->AllDone())
+    {
+      return -1;
+    }
+  }
+  m_Gl1TriggeredInput->ReadEvent();
+  for (auto *iter : m_TriggeredInputVector)
+  {
+    //    std::cout << "prdf input: " << iter->Name() << std::endl;
+    iter->ReadEvent();
+    if (iter->AllDone())
+    {
+      return -1;
+    }
+  }
+
   if (m_RunNumber == 0)
   {
     m_RunNumber = m_Gl1TriggeredInput->RunNumber();
@@ -73,15 +93,6 @@ int Fun4AllTriggeredInputManager::run(const int /*nevents*/)
   }
   EventNumber(m_Gl1TriggeredInput->EventNumber());
   MySyncManager()->CurrentEvent(EventNumber());
-  for (auto *iter : m_TriggeredInputVector)
-  {
-    //    std::cout << "prdf input: " << iter->Name() << std::endl;
-    iter->FillPool(1);
-    if (iter->AllDone())
-    {
-      return -1;
-    }
-  }
   //    std::cout << "saving event on dst" << std::endl;
   return 0;
 }

--- a/offline/framework/fun4allraw/Fun4AllTriggeredInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllTriggeredInputManager.cc
@@ -61,11 +61,11 @@ Fun4AllTriggeredInputManager::~Fun4AllTriggeredInputManager()
 
 int Fun4AllTriggeredInputManager::run(const int /*nevents*/)
 {
-  m_Gl1TriggeredInput->FillPool(1);
+  m_Gl1TriggeredInput->FillPool();
   for (auto *iter : m_TriggeredInputVector)
   {
     //    std::cout << "prdf input: " << iter->Name() << std::endl;
-    iter->FillPool(1);
+    iter->FillPool();
     if (iter->AllDone())
     {
       return -1;

--- a/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
@@ -97,8 +97,8 @@ uint64_t SingleGl1TriggeredInput::GetClock(Event *evt)
   if (!packet)
   {
     std::cout << Name()
-	      <<" no packet 14001 for event, possible corrupt data event before EOR"
-	      << std::endl;
+              << " no packet 14001 for event, possible corrupt data event before EOR"
+              << std::endl;
     std::cout << Name() << ": ";
     evt->identify();
     return std::numeric_limits<uint64_t>::max();

--- a/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
@@ -35,7 +35,7 @@ SingleGl1TriggeredInput::SingleGl1TriggeredInput(const std::string &name)
 {
 }
 
-void SingleGl1TriggeredInput::FillPool(const unsigned int keep)
+void SingleGl1TriggeredInput::FillPool()
 {
   if (AllDone())  // no more files and all events read
   {
@@ -44,10 +44,6 @@ void SingleGl1TriggeredInput::FillPool(const unsigned int keep)
   if (!FilesDone())
   {
     FillEventVector();
-  }
-  if (keep > 100000000)
-  {
-    std::cout << "huh?" << std::endl;
   }
   return;
 }

--- a/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
@@ -5,6 +5,8 @@
 
 #include <ffarawobjects/Gl1Packetv2.h>
 
+#include <fun4all/Fun4AllReturnCodes.h>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode
 #include <phool/PHNode.h>          // for PHNode
@@ -47,65 +49,7 @@ void SingleGl1TriggeredInput::FillPool(const unsigned int keep)
   {
     std::cout << "huh?" << std::endl;
   }
-  if (m_EventDeque.empty())
-  {
-    std::cout << Name() << ":all events done" << std::endl;
-    AllDone(1);
-    return;
-  }
-  Event *evt = m_EventDeque.front();
-  m_EventDeque.pop_front();
-  RunNumber(evt->getRunNumber());
-  int EventSequence = evt->getEvtSequence();
-  EventNumber(evt->getEvtSequence());
-  //  evt->identify();
-  Packet *packet = evt->getPacket(14001);
-  if (packet)
-  {
-    Gl1Packet *gl1packet = findNode::getClass<Gl1Packet>(topNode(), 14001);
-    int packetnumber = packet->iValue(0);
-    uint64_t gtm_bco = packet->lValue(0, "BCO");
-    //    std::cout << "saving bco 0x" << std::hex << gtm_bco << std::dec << std::endl;
-    gl1packet->setBCO(packet->lValue(0, "BCO"));
-    gl1packet->setHitFormat(packet->getHitFormat());
-    gl1packet->setIdentifier(packet->getIdentifier());
-    gl1packet->setEvtSequence(EventSequence);
-    gl1packet->setPacketNumber(packetnumber);
-
-    gl1packet->setBunchNumber(packet->lValue(0, "BunchNumber"));
-    gl1packet->setTriggerInput(packet->lValue(0, "TriggerInput"));
-    gl1packet->setLiveVector(packet->lValue(0, "LiveVector"));
-    gl1packet->setScaledVector(packet->lValue(0, "ScaledVector"));
-    gl1packet->setGTMBusyVector(packet->lValue(0, "GTMBusyVector"));
-    for (int i = 0; i < 64; i++)
-    {
-      for (int j = 0; j < 3; j++)
-      {
-        gl1packet->setScaler(i, j, packet->lValue(i, j));
-      }
-    }
-    for (int i = 0; i < 12; i++)
-    {
-      gl1packet->setGl1pScaler(i, 0, packet->lValue(i, "GL1PRAW"));
-      gl1packet->setGl1pScaler(i, 1, packet->lValue(i, "GL1PLIVE"));
-      gl1packet->setGl1pScaler(i, 2, packet->lValue(i, "GL1PSCALED"));
-    }
-    if (Verbosity() > 2)
-    {
-      std::cout << PHWHERE << " Packet: " << packet->getIdentifier()
-                << " evtno: " << EventSequence
-                << ", bco: 0x" << std::hex << gtm_bco << std::dec
-                << ", bunch no: " << packet->lValue(0, "BunchNumber")
-                << std::endl;
-      std::cout << PHWHERE << " RB Packet: " << gl1packet->getIdentifier()
-                << " evtno: " << gl1packet->getEvtSequence()
-                << ", bco: 0x" << std::hex << gl1packet->getBCO() << std::dec
-                << ", bunch no: " << +gl1packet->getBunchNumber()
-                << std::endl;
-    }
-    delete packet;
-  }
-  delete evt;
+  return;
 }
 
 void SingleGl1TriggeredInput::Print(const std::string &what) const
@@ -166,4 +110,68 @@ uint64_t SingleGl1TriggeredInput::GetClock(Event *evt)
   uint64_t clock = packet->lValue(0, "BCO");
   delete packet;
   return clock;
+}
+
+int SingleGl1TriggeredInput::ReadEvent()
+{
+  if (m_EventDeque.empty())
+  {
+    std::cout << Name() << ":all events done" << std::endl;
+    AllDone(1);
+    return -1;
+  }
+  Event *evt = m_EventDeque.front();
+  m_EventDeque.pop_front();
+  RunNumber(evt->getRunNumber());
+  int EventSequence = evt->getEvtSequence();
+  EventNumber(evt->getEvtSequence());
+  //  evt->identify();
+  Packet *packet = evt->getPacket(14001);
+  if (packet)
+  {
+    Gl1Packet *gl1packet = findNode::getClass<Gl1Packet>(topNode(), 14001);
+    int packetnumber = packet->iValue(0);
+    uint64_t gtm_bco = packet->lValue(0, "BCO");
+    //    std::cout << "saving bco 0x" << std::hex << gtm_bco << std::dec << std::endl;
+    gl1packet->setBCO(packet->lValue(0, "BCO"));
+    gl1packet->setHitFormat(packet->getHitFormat());
+    gl1packet->setIdentifier(packet->getIdentifier());
+    gl1packet->setEvtSequence(EventSequence);
+    gl1packet->setPacketNumber(packetnumber);
+
+    gl1packet->setBunchNumber(packet->lValue(0, "BunchNumber"));
+    gl1packet->setTriggerInput(packet->lValue(0, "TriggerInput"));
+    gl1packet->setLiveVector(packet->lValue(0, "LiveVector"));
+    gl1packet->setScaledVector(packet->lValue(0, "ScaledVector"));
+    gl1packet->setGTMBusyVector(packet->lValue(0, "GTMBusyVector"));
+    for (int i = 0; i < 64; i++)
+    {
+      for (int j = 0; j < 3; j++)
+      {
+        gl1packet->setScaler(i, j, packet->lValue(i, j));
+      }
+    }
+    for (int i = 0; i < 12; i++)
+    {
+      gl1packet->setGl1pScaler(i, 0, packet->lValue(i, "GL1PRAW"));
+      gl1packet->setGl1pScaler(i, 1, packet->lValue(i, "GL1PLIVE"));
+      gl1packet->setGl1pScaler(i, 2, packet->lValue(i, "GL1PSCALED"));
+    }
+    if (Verbosity() > 2)
+    {
+      std::cout << PHWHERE << " Packet: " << packet->getIdentifier()
+                << " evtno: " << EventSequence
+                << ", bco: 0x" << std::hex << gtm_bco << std::dec
+                << ", bunch no: " << packet->lValue(0, "BunchNumber")
+                << std::endl;
+      std::cout << PHWHERE << " RB Packet: " << gl1packet->getIdentifier()
+                << " evtno: " << gl1packet->getEvtSequence()
+                << ", bco: 0x" << std::hex << gl1packet->getBCO() << std::dec
+                << ", bunch no: " << +gl1packet->getBunchNumber()
+                << std::endl;
+    }
+    delete packet;
+  }
+  delete evt;
+  return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/framework/fun4allraw/SingleGl1TriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleGl1TriggeredInput.h
@@ -24,6 +24,7 @@ class SingleGl1TriggeredInput : public SingleTriggeredInput
   void Print(const std::string &what = "ALL") const override;
   void CreateDSTNodes(Event *evt) override;
   uint64_t GetClock(Event *evt) override;
+  int ReadEvent() override;
 
  private:
 };

--- a/offline/framework/fun4allraw/SingleGl1TriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleGl1TriggeredInput.h
@@ -18,7 +18,7 @@ class SingleGl1TriggeredInput : public SingleTriggeredInput
  public:
   explicit SingleGl1TriggeredInput(const std::string &name);
   ~SingleGl1TriggeredInput() override = default;
-  void FillPool(const unsigned int) override;
+  void FillPool() override;
   // void CleanupUsedPackets(const int eventno);
   // void ClearCurrentEvent();
   void Print(const std::string &what = "ALL") const override;

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -144,7 +144,7 @@ int SingleTriggeredInput::FillEventVector()
       delete evt;
       continue;
     }
-// this is for tests
+    // this is for tests
     if (m_ProblemEvent >= 0)
     {
       if (m_ProblemEvent == 0)
@@ -168,8 +168,8 @@ int SingleTriggeredInput::FillEventVector()
     uint64_t myClock = GetClock(evt);
     if (Verbosity() > 0)
     {
-    std::cout << Name() << " evt# " << evt->getEvtSequence() << " clock: 0x" << std::hex
-	      << myClock << std::dec << std::endl;
+      std::cout << Name() << " evt# " << evt->getEvtSequence() << " clock: 0x" << std::hex
+                << myClock << std::dec << std::endl;
     }
     if (myClock == std::numeric_limits<uint64_t>::max())
     {
@@ -186,7 +186,7 @@ int SingleTriggeredInput::FillEventVector()
     {
       if (m_bclkarray[i + 1] < m_bclkarray[i])
       {
-	m_bclkarray[i + 1] += 0x100000000;
+        m_bclkarray[i + 1] += 0x100000000;
       }
       m_bclkdiffarray[i] = m_bclkarray[i + 1] - m_bclkarray[i];
     }
@@ -209,7 +209,7 @@ int SingleTriggeredInput::FillEventVector()
   // {
   //   std::cout << "0x" << std::hex << iter << std::dec << std::endl;
   // }
-    return m_EventDeque.size();
+  return m_EventDeque.size();
 }
 
 uint64_t SingleTriggeredInput::GetClock(Event *evt)
@@ -266,8 +266,8 @@ void SingleTriggeredInput::FillPool()
       bool isequal = std::equal(begin(), end(), Gl1Input()->begin());
       if (!isequal)
       {
-	std::cout << Name() << " and GL1 clock diffs differ, here is the dump:" << std::endl;
-	dumpdeque(); // dump the clock diffs so we can see in the log
+        std::cout << Name() << " and GL1 clock diffs differ, here is the dump:" << std::endl;
+        dumpdeque();  // dump the clock diffs so we can see in the log
         const auto *iter1 = begin();
         const auto *iter2 = Gl1Input()->begin();
         if (*(++iter1) != *(++iter2))
@@ -284,18 +284,18 @@ void SingleTriggeredInput::FillPool()
             std::cout << "subsequent events are good, first event is off reset packets from first event" << std::endl;
             m_DitchPackets = true;
           }
-	  else
-	  {
-	    std::cout << "check subsequent events failed, this is not the problem" << std::endl;
-	    if (checkfirstsebevent() == 0)
-	    {
-	      std::cout << Name() << " started with bad event" << std::endl;
-	    }
-	    else
-	    {
-	      std::cout << Name() << " first event in seb is not the problem either" << std::endl;
-	    }
-	  }
+          else
+          {
+            std::cout << "check subsequent events failed, this is not the problem" << std::endl;
+            if (checkfirstsebevent() == 0)
+            {
+              std::cout << Name() << " started with bad event" << std::endl;
+            }
+            else
+            {
+              std::cout << Name() << " first event in seb is not the problem either" << std::endl;
+            }
+          }
         }
         else
         {
@@ -308,13 +308,13 @@ void SingleTriggeredInput::FillPool()
           while (iter1 != end())
           {
             //           std::cout  << "bclk1: 0x" << *iter3 << ", gl1bclk: 0x" << *iter4 << std::dec << std::endl;
-// this catches the condition where there is no gl1 packet (14001)
-	    // the GL1 data sometimes has a corrupt last data event
-	    if (*iter1 != std::numeric_limits<uint64_t>::max())
-	    {
-	      std::cout << Name() << ": ";
-	      m_EventDeque[position]->identify();
-	    }
+            // this catches the condition where there is no gl1 packet (14001)
+            // the GL1 data sometimes has a corrupt last data event
+            if (*iter1 != std::numeric_limits<uint64_t>::max())
+            {
+              std::cout << Name() << ": ";
+              m_EventDeque[position]->identify();
+            }
             if (*iter1 != *iter2)
             {
               if (*iter1 == std::numeric_limits<uint64_t>::max())
@@ -514,7 +514,7 @@ void SingleTriggeredInput::dumpdeque()
   while (iter1 != end())
   {
     std::cout << Name() << " clk: 0x" << std::hex << *iter1
-	      << " Gl1 clk: 0x" << *iter2 << std::dec << std::endl;
+              << " Gl1 clk: 0x" << *iter2 << std::dec << std::endl;
     iter1++;
     iter2++;
   }
@@ -624,13 +624,13 @@ int SingleTriggeredInput::ReadEvent()
 
 int SingleTriggeredInput::checkfirstsebevent()
 {
-// copy arrays into vectors for easier searching
+  // copy arrays into vectors for easier searching
   std::deque<uint64_t> gl1clkvector;
   for (auto iter = Gl1Input()->begin(); iter != Gl1Input()->end(); ++iter)
   {
     gl1clkvector.push_back(*iter);
   }
-   std::deque<uint64_t> myclkvector;
+  std::deque<uint64_t> myclkvector;
   for (auto iter = begin(); iter != end(); ++iter)
   {
     myclkvector.push_back(*iter);
@@ -639,28 +639,28 @@ int SingleTriggeredInput::checkfirstsebevent()
   // the tricky part is that if there is a mismatch in clock diffs it is caused by
   // the previous channel, so we have to subtract the last one where the clock diff matched
   int badindex = -1;
-  while(*(myclkvector.begin()) == *(gl1clkvector.begin()))
+  while (*(myclkvector.begin()) == *(gl1clkvector.begin()))
   {
     badindex++;
-//    std::cout << "removing " << std::hex << *(myclkvector.begin()) << std::dec << std::endl;
+    //    std::cout << "removing " << std::hex << *(myclkvector.begin()) << std::dec << std::endl;
     myclkvector.pop_front();
     gl1clkvector.pop_front();
   }
-  while(!myclkvector.empty())
+  while (!myclkvector.empty())
   {
-    auto it = std::search(gl1clkvector.begin(), gl1clkvector.end(),myclkvector.begin(), myclkvector.end());
+    auto it = std::search(gl1clkvector.begin(), gl1clkvector.end(), myclkvector.begin(), myclkvector.end());
     if (it == gl1clkvector.end())
     {
       if (Verbosity() > 0)
       {
-      std::cout << "found no match comparing seb and Gl1 clock diffs" << std::endl;
+        std::cout << "found no match comparing seb and Gl1 clock diffs" << std::endl;
       }
-      }
+    }
     else
     {
       if (Verbosity() > 0)
       {
-      std::cout << "found matching sequence" << std::endl;
+        std::cout << "found matching sequence" << std::endl;
       }
       break;
     }
@@ -672,46 +672,46 @@ int SingleTriggeredInput::checkfirstsebevent()
     EventAlignmentProblem(1);
   }
   // reshuffle clock refs
-  for (unsigned int i = badindex; i < pooldepth-1; i++)
+  for (unsigned int i = badindex; i < pooldepth - 1; i++)
   {
-    m_bclkarray[i] = m_bclkarray[i+1];
-    m_bclkdiffarray[i] = m_bclkdiffarray[i+1];
+    m_bclkarray[i] = m_bclkarray[i + 1];
+    m_bclkdiffarray[i] = m_bclkdiffarray[i + 1];
   }
   m_bclkarray[pooldepth] = std::numeric_limits<uint64_t>::max();
-//    std::cout << Name() << " deleting event " << m_EventDeque[badindex]->getEvtSequence() << std::endl;
-delete m_EventDeque[badindex];
-m_EventDeque.erase(m_EventDeque.begin() + badindex);
-// read next event to fill our arrays up to pooldepth
-    Event *evt = GetEventIterator()->getNextEvent();
-    while (!evt)
+  //    std::cout << Name() << " deleting event " << m_EventDeque[badindex]->getEvtSequence() << std::endl;
+  delete m_EventDeque[badindex];
+  m_EventDeque.erase(m_EventDeque.begin() + badindex);
+  // read next event to fill our arrays up to pooldepth
+  Event *evt = GetEventIterator()->getNextEvent();
+  while (!evt)
+  {
+    fileclose();
+    if (!OpenNextFile())
     {
-      fileclose();
-      if (!OpenNextFile())
+      FilesDone(1);
+      if (Verbosity() > 0)
       {
-        FilesDone(1);
-        if (Verbosity() > 0)
-        {
-          std::cout << "no more events to read, deque depth: " << m_EventDeque.size() << std::endl;
-        }
-        return -1;
+        std::cout << "no more events to read, deque depth: " << m_EventDeque.size() << std::endl;
       }
-      evt = GetEventIterator()->getNextEvent();
+      return -1;
     }
-    m_EventsThisFile++;
-    if (evt->getEvtType() != DATAEVENT)
-    {
-      std::cout << Name() << " things will crash and burn: non data event: " << evt->getEvtSequence() << std::endl;
-      delete evt;
-    }
-    uint64_t myClock = GetClock(evt);
-    m_bclkarray[pooldepth] = myClock; //GetClock(evt);
-      if (m_bclkarray[pooldepth] < m_bclkarray[pooldepth -1])
-      {
-	m_bclkarray[pooldepth] += 0x100000000;
-      }
-        m_bclkdiffarray[pooldepth-1] = m_bclkarray[pooldepth] - m_bclkarray[pooldepth-1];
-    m_Event++;
-    m_EventDeque.push_back(evt);
+    evt = GetEventIterator()->getNextEvent();
+  }
+  m_EventsThisFile++;
+  if (evt->getEvtType() != DATAEVENT)
+  {
+    std::cout << Name() << " things will crash and burn: non data event: " << evt->getEvtSequence() << std::endl;
+    delete evt;
+  }
+  uint64_t myClock = GetClock(evt);
+  m_bclkarray[pooldepth] = myClock;  // GetClock(evt);
+  if (m_bclkarray[pooldepth] < m_bclkarray[pooldepth - 1])
+  {
+    m_bclkarray[pooldepth] += 0x100000000;
+  }
+  m_bclkdiffarray[pooldepth - 1] = m_bclkarray[pooldepth] - m_bclkarray[pooldepth - 1];
+  m_Event++;
+  m_EventDeque.push_back(evt);
 
-return 0;
+  return 0;
 }

--- a/offline/framework/fun4allraw/SingleTriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.h
@@ -26,7 +26,7 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   explicit SingleTriggeredInput(const std::string &name);
   ~SingleTriggeredInput() override;
   virtual Eventiterator *GetEventIterator() { return m_EventIterator; }
-  virtual void FillPool(const unsigned int = 1);
+  virtual void FillPool();
   virtual void RunNumber(const int runno) { m_RunNumber = runno; }
   virtual int RunNumber() const { return m_RunNumber; }
   virtual void EventNumber(const int i) { m_EventNumber = i; }

--- a/offline/framework/fun4allraw/SingleTriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.h
@@ -22,7 +22,7 @@ class PHCompositeNode;
 class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
 {
  public:
-  static constexpr size_t pooldepth{10}; // number of events which are read in in one go
+  static constexpr size_t pooldepth{10};  // number of events which are read in in one go
   explicit SingleTriggeredInput(const std::string &name);
   ~SingleTriggeredInput() override;
   virtual Eventiterator *GetEventIterator() { return m_EventIterator; }
@@ -31,7 +31,7 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   virtual int RunNumber() const { return m_RunNumber; }
   virtual void EventNumber(const int i) { m_EventNumber = i; }
   virtual int EventNumber() const { return m_EventNumber; }
-  virtual int EventsInThisFile() const {return m_EventsThisFile;}
+  virtual int EventsInThisFile() const { return m_EventsThisFile; }
   virtual int fileopen(const std::string &filename) override;
   virtual int fileclose() override;
   virtual int AllDone() const { return m_AllDone; }
@@ -51,15 +51,15 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   virtual std::array<uint64_t, pooldepth>::const_iterator begin() { return m_bclkdiffarray.begin(); }
   virtual std::array<uint64_t, pooldepth>::const_iterator end() { return m_bclkdiffarray.end(); }
   virtual std::array<uint64_t, pooldepth>::const_iterator beginclock() { return m_bclkarray.begin(); }
-  virtual void KeepPackets() {m_KeepPacketsFlag = true;}
-  virtual bool KeepMyPackets() const {return m_KeepPacketsFlag;}
+  virtual void KeepPackets() { m_KeepPacketsFlag = true; }
+  virtual bool KeepMyPackets() const { return m_KeepPacketsFlag; }
   void topNode(PHCompositeNode *topNode) { m_topNode = topNode; }
   PHCompositeNode *topNode() { return m_topNode; }
   virtual void FakeProblemEvent(const int ievent) { m_ProblemEvent = ievent; }
   virtual int FemEventNrClockCheck(OfflinePacket *calopkt);
   void dumpdeque();
   int checkfirstsebevent();
-  
+
  protected:
   PHCompositeNode *m_topNode{nullptr};
   // lined up like this:

--- a/offline/framework/fun4allraw/SingleTriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.h
@@ -44,7 +44,7 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   // these ones are used directly by the derived classes, maybe later
   // move to cleaner accessors
   virtual int FillEventVector();
-
+  virtual int ReadEvent();
   virtual SingleTriggeredInput *Gl1Input() { return m_Gl1Input; }
   virtual void Gl1Input(SingleTriggeredInput *input) { m_Gl1Input = input; }
   virtual uint64_t GetClock(Event *evt);
@@ -57,6 +57,7 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   PHCompositeNode *topNode() { return m_topNode; }
   virtual void FakeProblemEvent(const int ievent) { m_ProblemEvent = ievent; }
   virtual int FemEventNrClockCheck(OfflinePacket *calopkt);
+  void dumpdeque();
   
  protected:
   PHCompositeNode *m_topNode{nullptr};

--- a/offline/framework/fun4allraw/SingleTriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.h
@@ -58,6 +58,7 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   virtual void FakeProblemEvent(const int ievent) { m_ProblemEvent = ievent; }
   virtual int FemEventNrClockCheck(OfflinePacket *calopkt);
   void dumpdeque();
+  int checkfirstsebevent();
   
  protected:
   PHCompositeNode *m_topNode{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
For a lot of the late cosmic runs all sebs start with a bad event (clock is way off, I doubt it is a skipped event in the gl1). This patch handles this case (it basically drops this event). The implementation needs refinement but this should get us going

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

