### PR TITLE
set_UseDetailedGeometry() called after Detector() in RawClusterBuilde…

### DIFF
--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -68,10 +68,6 @@ void RawClusterBuilderTemplate::Detector(const std::string &d)
   if (detector == "CEMC")
   {
     bemc = new BEmcRecCEMC();
-    if (m_UseDetailedGeometry)
-    {
-      bemc->set_UseDetailedGeometry(true);
-    }
   }
   else
   {
@@ -90,8 +86,25 @@ void RawClusterBuilderTemplate::Detector(const std::string &d)
   bemc->SetProbNoiseParam(fProbNoiseParam);
 }
 
+void RawClusterBuilderTemplate::set_UseDetailedGeometry(const bool useDetailedGeometry)
+{
+  if (bemc == nullptr)
+  {
+    std::cerr << "Error in RawClusterBuilderTemplate::set_UseDetailedGeometry()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    return;
+  }
+
+  m_UseDetailedGeometry = useDetailedGeometry;
+  bemc->set_UseDetailedGeometry(m_UseDetailedGeometry);
+}
+
 void RawClusterBuilderTemplate::LoadProfile(const std::string &fname)
 {
+  if (bemc == nullptr)
+  {
+    std::cerr << "Error in RawClusterBuilderTemplate::LoadProfile()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    return;
+  }
   std::string url = CDBInterface::instance()->getUrl("EMCPROFILE", fname);
   bemc->LoadProfile(url);
 }
@@ -100,7 +113,7 @@ void RawClusterBuilderTemplate::SetCylindricalGeometry()
 {
   if (bemc == nullptr)
   {
-    std::cout << "Error in RawClusterBuilderTemplate::SetCylindricalGeometry()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    std::cerr << "Error in RawClusterBuilderTemplate::SetCylindricalGeometry()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
     return;
   }
 
@@ -111,7 +124,7 @@ void RawClusterBuilderTemplate::SetPlanarGeometry()
 {
   if (bemc == nullptr)
   {
-    std::cout << "Error in RawClusterBuilderTemplate::SetPlanarGeometry()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    std::cerr << "Error in RawClusterBuilderTemplate::SetPlanarGeometry()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
     return;
   }
 
@@ -122,8 +135,17 @@ int RawClusterBuilderTemplate::InitRun(PHCompositeNode *topNode)
 {
   if (bemc == nullptr)
   {
-    std::cout << "Error in RawClusterBuilderTemplate::InitRun(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    std::cerr << "Error in RawClusterBuilderTemplate::InitRun(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // Ensure that the detailed geometry is available if the user requests it.
+  // Otherwise, use the default geometry 
+  if (m_UseDetailedGeometry && detector != "CEMC")
+  {
+    m_UseDetailedGeometry = false;
+    bemc->set_UseDetailedGeometry(false);
+    std::cout << "Warning in RawClusterBuilderTemplate::InitRun()(): No alternative detailed geometry defined for detector " << detector << ". m_UseDetailedGeometry automatically set to false." << std::endl;
   }
 
   try

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -52,10 +52,7 @@ class RawClusterBuilderTemplate : public SubsysReco
     m_UseAltZVertex = useAltZMode;
   }
 
-  void set_UseDetailedGeometry(const bool useDetailedGeometry)
-  {
-    m_UseDetailedGeometry = useDetailedGeometry;
-  }
+  void set_UseDetailedGeometry(const bool useDetailedGeometry);
 
   void setOutputClusterNodeName(const std::string& inpNodenm)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Before this PR, the method `RawClusterBuilderTemplate::set_UseDetailedGeometry()` had to be called **before** `RawClusterBuilderTemplate::Detector()`. This was because `RawClusterBuilderTemplate::Detector()` constructs a `BEmcRec` object (called `bemc`) and immediately assigns it the private attribute `m_UseDetailedGeometry`, which is configured by `set_UseDetailedGeometry()`. Besides, `m_UseDetailedGeometry` is not only involved in the construction of `bemc` but also in other parts of the `RawClusterBuilderTemplate` code. 

As a result, calling the methods `RawClusterBuilderTemplate::Detector()` and `RawClusterBuilderTemplate::set_UseDetailedGeometry()` out of order could lead to an inconsistent state between the `BemcRec` and `RawClusterBuilderTemplate` classes, and silent misbehavior.

This ordering requirement also contradicted the general ordering design of initializing `bemc` first with `Detector()` then modifying its attributes, for instance with `setCylindricalGeometry()`, `setPlanarGeometry()` and `LoadProfile()`.

After this PR, the ordering requirement has been corrected: `set_UseDetailedGeometry()` must now be called **after** `Detector()`. If `set_UseDetailedGeometry()` is called before `Detector()`, an error is raised in cerr.

```
Error in RawClusterBuilderTemplate::set_UseDetailedGeometry()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it

```
 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

