### PR TITLE
mask upper 32 bits off from clockdiff if set and print values for deb…

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.h
@@ -48,8 +48,8 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   virtual SingleTriggeredInput *Gl1Input() { return m_Gl1Input; }
   virtual void Gl1Input(SingleTriggeredInput *input) { m_Gl1Input = input; }
   virtual uint64_t GetClock(Event *evt);
-  virtual std::array<uint64_t, pooldepth>::const_iterator begin() { return m_bclkdiffarray.begin(); }
-  virtual std::array<uint64_t, pooldepth>::const_iterator end() { return m_bclkdiffarray.end(); }
+  virtual std::array<uint64_t, pooldepth>::const_iterator clkdiffbegin() { return m_bclkdiffarray.begin(); }
+  virtual std::array<uint64_t, pooldepth>::const_iterator clkdiffend() { return m_bclkdiffarray.end(); }
   virtual std::array<uint64_t, pooldepth>::const_iterator beginclock() { return m_bclkarray.begin(); }
   virtual void KeepPackets() { m_KeepPacketsFlag = true; }
   virtual bool KeepMyPackets() const { return m_KeepPacketsFlag; }


### PR DESCRIPTION
…ugging

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
I can't reproduce this problem with a subset of the events. This patch just masks the upper 32 bits of the clock diff if they are set and prints the values (and the event number). This should in principle correct the dropping out of sebs under these condition but the printout should give me enough info to figure out what's wrong without waiting for 10 hours

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

