### PR TITLE
Removed extraneous print statements

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -1243,28 +1243,23 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
       residual_z[daughter_id].push_back(global.z() - tstate->get_z());
 
       uint8_t id = TrkrDefs::getTrkrId(stateckey);
-      std::cout << "The ID is " << unsigned(id) << std::endl;
 
       switch (id)
       {
       case TrkrDefs::mvtxId:
         ++detector_nStates_MVTX[daughter_id];
-        // std::cout <<"MVTX is good" << std::endl;
         break;
       case TrkrDefs::inttId:
         ++detector_nStates_INTT[daughter_id];
-        // std::cout <<"INTT is good" << std::endl;
         break;
       case TrkrDefs::tpcId:
         ++detector_nStates_TPC[daughter_id];
-        // std::cout <<"TPC is good" << std::endl;
         break;
       case TrkrDefs::micromegasId:
         ++detector_nStates_TPOT[daughter_id];
-        // std::cout <<"TPOT is good" << std::endl;
         break;
       default:
-        //  std::cout << "Cluster key doesnt match a tracking system, this shouldn't happen" << std::endl;
+        std::cout << "Cluster key doesnt match a tracking system, this shouldn't happen" << std::endl;
         break;
       }
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
@pinkenburg @jdosbo there was an extra print statement left in some KFP code that Alex found this morning. I've removed it. This is a minimal change so feel free to merge if we want to keep Jenkins available for people. I tested it compiled with gcc but not clang
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

