### PR TITLE
Removed special handling of tile 0 (SCO) when calculating acceptance for the phi layer

### DIFF
--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -330,10 +330,7 @@ CylinderGeomMicromegas::range_t CylinderGeomMicromegas::get_theta_range(uint til
       const auto strip_count = get_strip_count(tileid, geometry);
       const auto strip_length = get_strip_length(tileid, geometry);
       const auto mid_strip_center_local = get_local_coordinates(tileid, geometry, strip_count/2);
-      // need to add special care for tile 0, whose half detector is disconnected
-      const auto mid_strip_begin = tileid == 0 ?
-        get_world_from_local_coords(tileid, geometry, mid_strip_center_local):
-        get_world_from_local_coords(tileid, geometry, mid_strip_center_local + TVector2(0,-strip_length/2));
+      const auto mid_strip_begin = get_world_from_local_coords(tileid, geometry, mid_strip_center_local + TVector2(0,-strip_length/2));
       const auto mid_strip_end = get_world_from_local_coords( tileid, geometry, mid_strip_center_local + TVector2(0,strip_length/2));
       return {
         std::atan2(mid_strip_begin.z(), get_r(mid_strip_begin.x(), mid_strip_begin.y())),


### PR DESCRIPTION
title says it all. 
@xyu3 What we discussed

Indded only the z layer has the first half disconnected.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

