### PR TITLE
Support IDTPCFEEV6 with TPC digital current firmware

### DIFF
--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -422,13 +422,13 @@ int TpcTimeFrameBuilder::ProcessPacket(Packet* packet)
 
   if (m_hitFormat <0 )
   {
-    if (packet->getHitFormat() != IDTPCFEEV4 and packet->getHitFormat() != IDTPCFEEV5 )
+    if (packet->getHitFormat() != IDTPCFEEV4 and packet->getHitFormat() != IDTPCFEEV5 and packet->getHitFormat() != IDTPCFEEV6 )
     {
       cout << __PRETTY_FUNCTION__ << "\t- Error : expect packet format " << IDTPCFEEV4 
-          << " or "<< IDTPCFEEV5
+          << " or "<< IDTPCFEEV5<< " or "<< IDTPCFEEV6
           << "\t- but received packet format " << packet->getHitFormat() << ":" << endl;
       packet->identify();
-      assert(packet->getHitFormat() == IDTPCFEEV4 or packet->getHitFormat() == IDTPCFEEV5);
+      assert(packet->getHitFormat() == IDTPCFEEV4 or packet->getHitFormat() == IDTPCFEEV5 or packet->getHitFormat() == IDTPCFEEV6);
       return 0;
     }
 
@@ -441,7 +441,7 @@ int TpcTimeFrameBuilder::ProcessPacket(Packet* packet)
       // Tested with Run24 data. Could be changable in future runs
       clock_multiplier = 4.262916255;
     }
-    else if (m_hitFormat == IDTPCFEEV5)
+    else if (m_hitFormat == IDTPCFEEV5 or packet->getHitFormat() == IDTPCFEEV6)
     {
       // version 46 FEE firmware 
       clock_multiplier = 30./8.;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Support TPC hit format `IDTPCFEEV6` in offline event building in preparation for the digital current firmware that is similar to the online decoder https://github.com/sPHENIX-Collaboration/online_distribution/pull/199 

@osbornjd 
Currently digital current data are not yet enabled. But this is needed to process cosmic run 67442+ starting 2025-06-13 23:04:00 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

* Decode and build digital current frames

## Links to other PRs in macros and calibration repositories (if applicable)

* https://github.com/sPHENIX-Collaboration/tpc_dam/commit/b4093b386825420c92dada8d8caa47fc712e2bd3 
* https://github.com/sPHENIX-Collaboration/online_distribution/pull/199