### PR TITLE
Fix rollover

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -190,16 +190,16 @@ int SingleTriggeredInput::FillEventVector()
       }
       else
       {
-	m_bclkdiffarray[i] = m_bclkarray[i + 1] - m_bclkarray[i];
+        m_bclkdiffarray[i] = m_bclkarray[i + 1] - m_bclkarray[i];
       }
-// this is just a safeguard addressing the previous wrong handling of the rollover
-// I leave it here just in case this happens again
+      // this is just a safeguard addressing the previous wrong handling of the rollover
+      // I leave it here just in case this happens again
       if (m_bclkdiffarray[i] != (m_bclkdiffarray[i] & 0xFFFFFFFF))
       {
         std::cout << Name() << " This should not happen: Found upper 32bits set: 0x" << std::hex << m_bclkdiffarray[i]
-		  << " for event # " << std::dec << evt->getEvtSequence() << std::endl;
+                  << " for event # " << std::dec << evt->getEvtSequence() << std::endl;
         std::cout << std::hex << "current clk: 0x" << myClock << " corrected: 0x" << m_bclkarray[i + 1]
-		  << ", previous clock : 0x" << m_bclkarray[i] << std::dec << std::endl;
+                  << ", previous clock : 0x" << m_bclkarray[i] << std::dec << std::endl;
         m_bclkdiffarray[i] &= 0xFFFFFFFF;
       }
     }
@@ -639,12 +639,12 @@ int SingleTriggeredInput::checkfirstsebevent()
 {
   // copy arrays into vectors for easier searching
   std::deque<uint64_t> gl1clkvector;
-  for (auto iter = Gl1Input()->clkdiffbegin(); iter != Gl1Input()->clkdiffend(); ++iter)
+  for (const auto *iter = Gl1Input()->clkdiffbegin(); iter != Gl1Input()->clkdiffend(); ++iter)
   {
     gl1clkvector.push_back(*iter);
   }
   std::deque<uint64_t> myclkvector;
-  for (auto iter = clkdiffbegin(); iter != clkdiffend(); ++iter)
+  for (const auto *iter = clkdiffbegin(); iter != clkdiffend(); ++iter)
   {
     myclkvector.push_back(*iter);
   }

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -186,12 +186,17 @@ int SingleTriggeredInput::FillEventVector()
     {
       if (m_bclkarray[i + 1] < m_bclkarray[i])
       {
-        m_bclkarray[i + 1] += 0x100000000;
+        m_bclkdiffarray[i] = m_bclkarray[i + 1] + 0x100000000 - m_bclkarray[i];
       }
-      m_bclkdiffarray[i] = m_bclkarray[i + 1] - m_bclkarray[i];
+      else
+      {
+	m_bclkdiffarray[i] = m_bclkarray[i + 1] - m_bclkarray[i];
+      }
+// this is just a safeguard addressing the previous wrong handling of the rollover
+// I leave it here just in case this happens again
       if (m_bclkdiffarray[i] != (m_bclkdiffarray[i] & 0xFFFFFFFF))
       {
-        std::cout << Name() << " Found upper 32bits set: 0x" << std::hex << m_bclkdiffarray[i]
+        std::cout << Name() << " This should not happen: Found upper 32bits set: 0x" << std::hex << m_bclkdiffarray[i]
 		  << " for event # " << std::dec << evt->getEvtSequence() << std::endl;
         std::cout << std::hex << "current clk: 0x" << myClock << " corrected: 0x" << m_bclkarray[i + 1]
 		  << ", previous clock : 0x" << m_bclkarray[i] << std::dec << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Found and fixed the reason for the upper 32 bit set in the clock diff. The effect was already handled before, so this won't result in more events from the event combining. But one less warning in the log. I left the warning for this case in (the clock diff exceeding 32 bits) - if it still shows up we have another problem

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

