### PR TITLE
calo embedding, new option to embed the waveform

### DIFF
--- a/offline/packages/CaloEmbedding/caloTowerEmbed.h
+++ b/offline/packages/CaloEmbedding/caloTowerEmbed.h
@@ -55,22 +55,38 @@ class caloTowerEmbed : public SubsysReco
     m_removeBadTowers = a;
     return;
   }
+  void set_nsamples(int _nsamples)
+  {
+    m_nsamples = _nsamples;
+    return;
+  }
+  void set_embedwaveform(bool embed = true)
+  {
+    m_embedwaveform = embed;
+    return;
+  }
 
  private:
   TowerInfoContainer *_data_towers{nullptr};
   TowerInfoContainer *_sim_towers{nullptr};
+  TowerInfoContainer *m_PedestalContainer{nullptr};
 
   RawTowerGeomContainer *tower_geom{nullptr};
 
   bool m_useRetower{false};
   bool m_removeBadTowers{false};
+  bool m_embedwaveform{false};
 
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
 
   std::string m_detector;
   std::string m_inputNodePrefix{"TOWERINFO_CALIB_"};
+  std::string m_waveformNodePrefix{"WAVEFORM_"};
 
   int m_eventNumber{-1};
+  int m_nsamples{31};
+  int m_datasamples{12};
+  float m_pedestal_scale{1.};
 };
 
 #endif  // CALOTOWEREMBED_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

We take in the TowerInfov3 object and superpose the data waveform with the simulated waveform from calowaveformsim. When data tower is ZSed we embed the pedestal noise and add the ZS post - pre to the waveform sample 6.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

