### PR TITLE
Add code to: check runnumber and update m_species flag in CaloValid, set verbosity for CaloValid.

### DIFF
--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -17,15 +17,16 @@
 #include <qautils/QAHistManagerDef.h>
 
 #include <ffaobjects/EventHeader.h>
+#include <ffaobjects/RunHeader.h>  // for runnumber
 
 #include <ffarawobjects/Gl1Packet.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 
+#include <phool/RunnumberRange.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
-
 
 #include <TH1.h>
 #include <TH2.h>
@@ -73,6 +74,32 @@ int CaloValid::Init(PHCompositeNode* /*unused*/)
   if (m_debug)
   {
     std::cout << "In CaloValid::Init" << std::endl;
+  }
+
+  int runnumber = RunHeader::get_RunNumber();
+
+  if (runnumber >= RunnumberRange::RUN2PP_FIRST && runnumber <= RunnumberRange::RUN2PP_LAST)
+  {
+    m_species = "pp";
+    if (Verbosity > 0)
+      std::cout << "This run is in Run-2 p+p.\n";
+  }
+  else if (runnumber >= RunnumberRange::RUN2AUAU_FIRST && runnumber <= RunnumberRange::RUN2AUAU_LAST)
+  {
+    m_species = "AuAu";
+    if (Verbosity > 0)
+      std::cout << "This run is in Run-2 Au+Au.\n";
+  }
+  else if (runnumber >= RunnumberRange::RUN3AUAU_FIRST && runnumber <= RunnumberRange::RUN3AUAU_LAST)
+  {
+    m_species = "AuAu";
+    if (Verbosity > 0)
+      std::cout << "This run is in Run-3 Au+Au.\n";
+  }
+  else
+  {
+    if (Verbosity > 0)
+      std::cout << "Run number is out of known range. Using pp as default. \n";
   }
 
   createHistos();
@@ -123,11 +150,11 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
   float totalihcal = 0.;
   float totalohcal = 0.;
   float totalmbd = 0.;
-    
+
   float emcaldownscale, ihcaldownscale, ohcaldownscale, mbddownscale;
   float adc_threshold;
   float emcal_hit_threshold, ohcal_hit_threshold, ihcal_hit_threshold;
-    
+
   if (m_species == "AuAu")
   {
     emcaldownscale = 1350000. / 800.;
@@ -180,7 +207,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
   {
     if (m_debug)
     {
-    std::cout << "[ERROR] No TriggerAnalyzer pointer!\n";
+      std::cout << "[ERROR] No TriggerAnalyzer pointer!\n";
     }
   }
 
@@ -191,10 +218,10 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
   {
     if (trigAna->didTriggerFire(bit))
     {
-    scaledActiveBits.push_back(bit);
+      scaledActiveBits.push_back(bit);
     }
   }
-    
+
   bool scaledBits[64] = {false};
   long long int raw[64] = {0};
   long long int live[64] = {0};
@@ -206,7 +233,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
     if (!gl1PacketInfo)
     {
       std::cout << PHWHERE << "GlobalQA::process_event: GL1Packet node is missing"
-		<< std::endl;
+                << std::endl;
     }
   }
   uint64_t triggervec = 0;
@@ -228,7 +255,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
       }
       triggervec = (triggervec >> 1U) & 0xffffffffU;
     }
-    //triggervec = gl1PacketInfo->getScaledVector(); commented out to get rid of never used warning using clang -tidy
+    // triggervec = gl1PacketInfo->getScaledVector(); commented out to get rid of never used warning using clang -tidy
   }
 
   //---------------------------calibrated towers-------------------------------//
@@ -634,23 +661,22 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         unsigned int lt_eta = recoCluster->get_lead_tower().first;
         unsigned int lt_phi = recoCluster->get_lead_tower().second;
 
-        int IB_num = (lt_eta / 8)*32 + (lt_phi / 8);
+        int IB_num = (lt_eta / 8) * 32 + (lt_phi / 8);
 
         for (int bit : scaledActiveBits)
         {
-          if (std::find(triggerIndices.begin(), triggerIndices.end(), bit)
-              == triggerIndices.end())
+          if (std::find(triggerIndices.begin(), triggerIndices.end(), bit) == triggerIndices.end())
           {
             continue;
           }
           h_pi0_trigIB_mass->Fill(
-            static_cast<double>(bit),
-            static_cast<double>(IB_num),
-            static_cast<double>(pi0Mass));
+              static_cast<double>(bit),
+              static_cast<double>(IB_num),
+              static_cast<double>(pi0Mass));
         }
         h_InvMass->Fill(pi0Mass);
       }
-    } // end cluster loop
+    }  // end cluster loop
   }
 
   //----------------- Trigger / alignment ----------------------------//
@@ -809,7 +835,7 @@ TH2* CaloValid::LogYHist2D(const std::string& name, const std::string& title, in
   Double_t logymin = std::log10(ymin);
   Double_t logymax = std::log10(ymax);
   Double_t binwidth = (logymax - logymin) / ybins_in;
-  Double_t *ybins = new Double_t[ybins_in + 2]; //allocate 1 extra bin to fix "malloc()L memory corruption crash
+  Double_t* ybins = new Double_t[ybins_in + 2];  // allocate 1 extra bin to fix "malloc()L memory corruption crash
 
   for (Int_t i = 0; i <= ybins_in + 1; i++)
   {
@@ -817,7 +843,7 @@ TH2* CaloValid::LogYHist2D(const std::string& name, const std::string& title, in
   }
 
   TH2F* h = new TH2F(name.c_str(), title.c_str(), xbins_in, xmin, xmax, ybins_in, ybins);
-  delete [] ybins;
+  delete[] ybins;
   return h;
 }
 std::string CaloValid::getHistoPrefix() const { return std::string("h_") + Name() + std::string("_"); }
@@ -1109,15 +1135,15 @@ void CaloValid::createHistos()
     }
   }
   h_pi0_trigIB_mass = new TH3F(
-    "h_pi0_trigIB_mass",
-    ";Trigger Bit; iIB (eta*32 + phi); #pi^{0} Mass (GeV/c^{2})",
-    64, -0.5, 63.5,    // triggers
-    384, -0.5, 383.5,  // IB index
-    120, 0.0, 1.2      // mass range
+      "h_pi0_trigIB_mass",
+      ";Trigger Bit; iIB (eta*32 + phi); #pi^{0} Mass (GeV/c^{2})",
+      64, -0.5, 63.5,    // triggers
+      384, -0.5, 383.5,  // IB index
+      120, 0.0, 1.2      // mass range
   );
   h_pi0_trigIB_mass->SetDirectory(nullptr);
   hm->registerHisto(h_pi0_trigIB_mass);
-    
+
   // Trigger QA
   // h_triggerVec = new TH1F("h_CaloValid_triggerVec", "", 64, 0, 64); commented out due to memory allocation issue w/ redef from line 1009
   pr_ldClus_trig =
@@ -1154,4 +1180,3 @@ void CaloValid::createHistos()
   hm->registerHisto(h_triggerVec);
   hm->registerHisto(pr_ldClus_trig);
 }
-

--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -81,24 +81,24 @@ int CaloValid::Init(PHCompositeNode* /*unused*/)
   if (runnumber >= RunnumberRange::RUN2PP_FIRST && runnumber <= RunnumberRange::RUN2PP_LAST)
   {
     m_species = "pp";
-    if (Verbosity > 0)
+    if (m_Verbosity > 0)
       std::cout << "This run is in Run-2 p+p.\n";
   }
   else if (runnumber >= RunnumberRange::RUN2AUAU_FIRST && runnumber <= RunnumberRange::RUN2AUAU_LAST)
   {
     m_species = "AuAu";
-    if (Verbosity > 0)
+    if (m_Verbosity > 0)
       std::cout << "This run is in Run-2 Au+Au.\n";
   }
   else if (runnumber >= RunnumberRange::RUN3AUAU_FIRST && runnumber <= RunnumberRange::RUN3AUAU_LAST)
   {
     m_species = "AuAu";
-    if (Verbosity > 0)
+    if (m_Verbosity > 0)
       std::cout << "This run is in Run-3 Au+Au.\n";
   }
   else
   {
-    if (Verbosity > 0)
+    if (m_Verbosity > 0)
       std::cout << "Run number is out of known range. Using pp as default. \n";
   }
 

--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -76,38 +76,52 @@ int CaloValid::Init(PHCompositeNode* /*unused*/)
     std::cout << "In CaloValid::Init" << std::endl;
   }
 
-  int runnumber = RunHeader::get_RunNumber();
-
-  if (runnumber >= RunnumberRange::RUN2PP_FIRST && runnumber <= RunnumberRange::RUN2PP_LAST)
-  {
-    m_species = "pp";
-    if (m_Verbosity > 0)
-      std::cout << "This run is in Run-2 p+p.\n";
-  }
-  else if (runnumber >= RunnumberRange::RUN2AUAU_FIRST && runnumber <= RunnumberRange::RUN2AUAU_LAST)
-  {
-    m_species = "AuAu";
-    if (m_Verbosity > 0)
-      std::cout << "This run is in Run-2 Au+Au.\n";
-  }
-  else if (runnumber >= RunnumberRange::RUN3AUAU_FIRST && runnumber <= RunnumberRange::RUN3AUAU_LAST)
-  {
-    m_species = "AuAu";
-    if (m_Verbosity > 0)
-      std::cout << "This run is in Run-3 Au+Au.\n";
-  }
-  else
-  {
-    if (m_Verbosity > 0)
-      std::cout << "Run number is out of known range. Using pp as default. \n";
-  }
-
   createHistos();
   trigAna = new TriggerAnalyzer();
   if (m_debug)
   {
     std::cout << "Leaving CaloValid::Init" << std::endl;
   }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CaloValid::InitRun(PHCompositeNode *topNode)
+{
+  RunHeader *runhdr = findNode::getClass<RunHeader>(topNode, "RunHeader");
+
+  if (runhdr)
+  {
+    int runnumber = runhdr->get_RunNumber();
+
+    if (runnumber >= RunnumberRange::RUN2PP_FIRST && runnumber <= RunnumberRange::RUN2PP_LAST)
+    {
+      m_species = "pp";
+      if (m_Verbosity > 0)
+        std::cout << "This run is from Run-2 p+p.\n";
+    }
+    else if (runnumber >= RunnumberRange::RUN2AUAU_FIRST && runnumber <= RunnumberRange::RUN2AUAU_LAST)
+    {
+      m_species = "AuAu";
+      if (m_Verbosity > 0)
+        std::cout << "This run is from Run-2 Au+Au.\n";
+    }
+    else if (runnumber >= RunnumberRange::RUN3AUAU_FIRST && runnumber <= RunnumberRange::RUN3AUAU_LAST)
+    {
+      m_species = "AuAu";
+      if (m_Verbosity > 0)
+        std::cout << "This run is from Run-3 Au+Au.\n";
+    }
+    else
+    {
+      if (m_Verbosity > 0)
+        std::cout << "Run number is out of range. Check RunnumberRange.h .Using pp as default. \n";
+    }
+  }
+  else if (m_Verbosity > 0)
+  {
+    std::cout << "No RunHeader node found. Using pp as default species.\n";
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -85,9 +85,9 @@ int CaloValid::Init(PHCompositeNode* /*unused*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int CaloValid::InitRun(PHCompositeNode *topNode)
+int CaloValid::InitRun(PHCompositeNode* topNode)
 {
-  RunHeader *runhdr = findNode::getClass<RunHeader>(topNode, "RunHeader");
+  RunHeader* runhdr = findNode::getClass<RunHeader>(topNode, "RunHeader");
 
   if (runhdr)
   {
@@ -121,7 +121,7 @@ int CaloValid::InitRun(PHCompositeNode *topNode)
   {
     std::cout << "No RunHeader node found. Using pp as default species.\n";
   }
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -27,8 +27,8 @@ class CaloValid : public SubsysReco
 
   //! full initialization
   int Init(PHCompositeNode*) override;
-  
-  int InitRun(PHCompositeNode *) override;
+
+  int InitRun(PHCompositeNode*) override;
 
   //! event processing method
   int process_event(PHCompositeNode*) override;
@@ -44,7 +44,7 @@ class CaloValid : public SubsysReco
   void set_timing_cut_width(const int& t) { _range = t; }
 
   void set_debug(bool debug) { m_debug = debug; }
-  void SetSpecies(const std::string &species) { m_species = species; }
+  void SetSpecies(const std::string& species) { m_species = species; }
   TH2* LogYHist2D(const std::string& name, const std::string& title, int, double, double, int, double, double);
   void Verbosity(const int i) { m_Verbosity = i; }
 
@@ -55,9 +55,9 @@ class CaloValid : public SubsysReco
   std::string m_species = "pp";
 
   TriggerAnalyzer* trigAna{nullptr};
-  TH3* h_pi0_trigIB_mass {nullptr};
-  std::vector<int> triggerIndices {10, 28, 29, 30, 31}; //MBD NS>=1, Photon Triggers
-    
+  TH3* h_pi0_trigIB_mass{nullptr};
+  std::vector<int> triggerIndices{10, 28, 29, 30, 31};  // MBD NS>=1, Photon Triggers
+
   TH1* h_cemc_channel_pedestal[128 * 192]{nullptr};
   TH1* h_ihcal_channel_pedestal[32 * 48]{nullptr};
   TH1* h_ohcal_channel_pedestal[32 * 48]{nullptr};
@@ -125,14 +125,14 @@ class CaloValid : public SubsysReco
   TProfile2D* h_ihcal_etaphi_time_raw{nullptr};
 
   // Trigger histos
-  TH1 *h_triggerVec{nullptr};
-  TH2 *h_edist[64] = {nullptr};
-  TH1 *h_ldClus_trig[64] = {nullptr};
-  TProfile *pr_evtNum_ldClus_trig[64] = {nullptr};
-  TProfile *pr_rejection[64] = {nullptr};
-  TProfile *pr_livetime[64] = {nullptr};
-  TProfile *pr_ldClus_trig{nullptr};
-  std::vector<int> trigOfInterest = {3,10,11,21,22,23,25,26,27};
+  TH1* h_triggerVec{nullptr};
+  TH2* h_edist[64] = {nullptr};
+  TH1* h_ldClus_trig[64] = {nullptr};
+  TProfile* pr_evtNum_ldClus_trig[64] = {nullptr};
+  TProfile* pr_rejection[64] = {nullptr};
+  TProfile* pr_livetime[64] = {nullptr};
+  TProfile* pr_ldClus_trig{nullptr};
+  std::vector<int> trigOfInterest = {3, 10, 11, 21, 22, 23, 25, 26, 27};
 
   int _eventcounter{0};
   int _range{1};
@@ -145,4 +145,3 @@ class CaloValid : public SubsysReco
 };
 
 #endif
-

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -27,6 +27,8 @@ class CaloValid : public SubsysReco
 
   //! full initialization
   int Init(PHCompositeNode*) override;
+  
+  int InitRun(PHCompositeNode *) override;
 
   //! event processing method
   int process_event(PHCompositeNode*) override;

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -44,6 +44,7 @@ class CaloValid : public SubsysReco
   void set_debug(bool debug) { m_debug = debug; }
   void SetSpecies(const std::string &species) { m_species = species; }
   TH2* LogYHist2D(const std::string& name, const std::string& title, int, double, double, int, double, double);
+  void Verbosity(const int i) { m_Verbosity = i; }
 
  private:
   void createHistos();
@@ -133,6 +134,7 @@ class CaloValid : public SubsysReco
 
   int _eventcounter{0};
   int _range{1};
+  int m_Verbosity{0};
 
   bool m_debug{false};
 


### PR DESCRIPTION
Add code to: check runnumber and update m_species flag in CaloValid, set verbosity for CaloValid.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add code that gets the runnumber during CaloValid::InitRun.
The runnumber is compared to run ranges defined in RunnumberRange.h 
This sets the m_species (pp, AuAu) flag so the correct charge scaledowns are applied for correlation QA plots.

Additionally added verbosity method to CaloValid.h
Currently the only couts it applies to are ones that announce the species, lack of a RunHeader node, or if the runnumber is outside of the range defined in RunnumberRange.h.
These are shown if verbosity>0 

## TODOs (if applicable)

## Links to other PRs in macros and calibration repositories (if applicable)

