### PR TITLE
sEPD template fit as default

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -133,9 +133,10 @@ int CaloTowerBuilder::InitRun(PHCompositeNode *topNode)
     m_packet_low = 9001;
     m_packet_high = 9006;
     m_nchannels = 128;
+    WaveformProcessing->set_template_name("SEPD_TEMPLATE");
     if (_processingtype == CaloWaveformProcessing::NONE)
     {
-      WaveformProcessing->set_processing_type(CaloWaveformProcessing::FAST);  // default the EPD to fast processing
+      WaveformProcessing->set_processing_type(CaloWaveformProcessing::TEMPLATE);  // default the EPD to fast processing
     }
       
     m_calibName = "SEPD_CHANNELMAP2";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add the SEPD template CDB payload name. this doesn't change the default production yet(a change to the [Calo_Fitting.C](https://github.com/sPHENIX-Collaboration/macros/blob/master/common/Calo_Fitting.C) would be needed for changing the production). 


## TODOs (if applicable)

change the default method for SEPD fitting to be template.


## Links to other PRs in macros and calibration repositories (if applicable)

