### PR TITLE
Module to refit track seeds in AuAu data

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -72,6 +72,12 @@ namespace
   std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track)
   {
     std::vector<TrkrDefs::cluskey> out;
+
+    if(!track)
+      {
+	return out;
+      }
+    
     for (const auto& seed : {track->get_silicon_seed(), track->get_tpc_seed()})
     {
       if (seed)
@@ -509,6 +515,7 @@ void TrackResiduals::fillVertexTree(PHCompositeNode* topNode)
       m_vy = vertex->get_y();
       m_vz = vertex->get_z();
       m_ntracks = vertex->size_tracks();
+
       for (auto it = vertex->begin_tracks(); it != vertex->end_tracks(); ++it)
       {
         auto id = *it;

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -76,6 +76,7 @@ pkginclude_HEADERS = \
   PHTruthSiliconAssociation.h \
   PHTruthVertexing.h \
   PrelimDistortionCorrection.h \
+  PrelimDistortionCorrectionAuAu.h \
   SecondaryVertexFinder.h \
   SvtxTrackStateRemoval.h \
   TrackingIterationCounter.h \
@@ -158,6 +159,7 @@ libtrack_reco_la_SOURCES = \
   PHTruthVertexing.cc \
   PHTruthSiliconAssociation.cc \
   PrelimDistortionCorrection.cc \
+  PrelimDistortionCorrectionAuAu.cc \
   SecondaryVertexFinder.cc \
   SvtxTrackStateRemoval.cc \
   TrackingIterationCounter.cc \

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -214,6 +214,9 @@ int PHActsTrkFitter::process_event(PHCompositeNode* topNode)
     }
   }
 
+  // in case the track map already exist in the file, we want to replace it
+  m_trackMap->Reset(); 
+     
   loopTracks(logLevel);
 
   eventTimer.stop();
@@ -407,7 +410,8 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	// non pp mode, we want only crossing zero, veto others
 	if(siseed && silicon_crossing != 0)
 	  {
-	    continue;
+	    crossing = 0;
+	    //continue;
 	  }
 	crossing_estimate = crossing;
       }

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -186,6 +186,9 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
   // _track_map_silicon contains the silicon seed track stubs
   // _svtx_seed_map contains the combined silicon and tpc track seeds
 
+    // in case these objects are in the input file, we clear the nodes and replace them
+  _svtx_seed_map->Reset(); 
+  
   if (Verbosity() > 0)
   {
     cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << endl;
@@ -288,6 +291,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
     for (const auto &seed : *_svtx_seed_map)
     {
       seed->identify();
+      std::cout << std::endl;
     }
 
     cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;
@@ -392,7 +396,7 @@ int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
   _cluster_crossing_map = findNode::getClass<TrkrClusterCrossingAssoc>(topNode, "TRKR_CLUSTERCROSSINGASSOC");
   if (!_cluster_crossing_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << endl;
+    //cerr << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << endl;
     // return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -711,14 +715,15 @@ void PHSiliconTpcTrackMatching::checkZMatches(
       tpc_q = _tracklet_tpc->get_charge();
       si_z = TrackSeedHelper::get_z(si_track);
     }
-    bool is_posQ = (tpc_q>0.);
-    float z_mismatch = tpc_z - si_z;
 
     // get TPC side from one of the TPC clusters
     std::vector<TrkrDefs::cluskey> temp_clusters = getTrackletClusterList(tpc_track);
     if(temp_clusters.size() == 0) { continue; }
     unsigned int this_side = TpcDefs::getSide(temp_clusters[0]);
 
+    bool is_posQ = (tpc_q>0.);
+
+    float z_mismatch = tpc_z - si_z;
     float tpc_z_corrected = _clusterCrossingCorrection.correctZ(tpc_z, this_side, crossing);
     float z_mismatch_corrected = tpc_z_corrected - si_z;
 

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -76,10 +76,9 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode * /*topNode*/)
 
   _active_dcacut = _base_dcacut;
 
-  if (_vertex_track_map.size() > 0)
-  {
-    _svtx_vertex_map->clear();
-  }
+  // in case these objects are in the input file, we clear the nodes and replace them
+    _svtx_vertex_map->Reset();
+    _track_vertex_crossing_map->Reset();
 
   // Write to a new map on the node tree that contains (crossing, trackid) pairs for all tracks
   // Later, will add to it a map  containing (crossing, vertexid)

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
@@ -1,0 +1,353 @@
+/*!
+ *  \File PrelimDistortionCorrectionAuAu.cc
+ *  \brief	Refits AuAu TPC seeds with distortion corrections and current calibrations
+ *  \author Tony Frawley
+ */
+
+#include "PrelimDistortionCorrectionAuAu.h"
+
+#include "ALICEKF.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
+
+#include <phfield/PHField.h>
+#include <phfield/PHFieldUtility.h>
+#include <phfield/PHFieldConfig.h>
+#include <phfield/PHFieldConfigv1.h>
+
+#include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>                       // for PHWHERE
+
+// tpc distortion correction
+#include <tpc/TpcDistortionCorrectionContainer.h>
+
+#include <trackbase/TrackFitUtils.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/ActsGeometry.h>
+
+#include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/TrackSeedContainer.h>
+#include <trackbase_historic/TrackSeed_v2.h>
+#include <trackbase_historic/TrackSeedHelper.h>
+
+#include <Geant4/G4SystemOfUnits.hh>
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <iostream>                            // for operator<<, basic_ostream
+#include <vector>
+
+//___________________________________________________________________________________________
+PrelimDistortionCorrectionAuAu::PrelimDistortionCorrectionAuAu(const std::string& name)
+  : SubsysReco(name)
+{}
+
+//___________________________________________________________________________________________
+int PrelimDistortionCorrectionAuAu::End(PHCompositeNode* /*unused*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//___________________________________________________________________________________________
+int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
+{
+
+  int ret = get_nodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret; }
+
+  PHFieldConfigv1 fcfg;
+  fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
+
+  char *calibrationsroot = getenv("CALIBRATIONROOT");
+  assert(calibrationsroot);
+
+  auto magField = std::string(calibrationsroot) +
+    std::string("/Field/Map/sphenix3dtrackingmapxyz.root");
+
+  fcfg.set_filename(magField);
+
+  //  fcfg.set_rescale(1);
+  _field_map = std::unique_ptr<PHField>(PHFieldUtility::BuildFieldMap(&fcfg));
+
+  fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map.get(), _fieldDir,
+				     _min_clusters_per_track,_max_sin_phi,Verbosity());
+  fitter->setNeonFraction(Ne_frac);
+  fitter->setArgonFraction(Ar_frac);
+  fitter->setCF4Fraction(CF4_frac);
+  fitter->setNitrogenFraction(N2_frac);
+  fitter->setIsobutaneFraction(isobutane_frac);
+  fitter->useConstBField(_use_const_field);
+  fitter->setConstBField(_const_field);
+  fitter->useFixedClusterError(_use_fixed_clus_err);
+  fitter->setFixedClusterError(0,_fixed_clus_err.at(0));
+  fitter->setFixedClusterError(1,_fixed_clus_err.at(1));
+  fitter->setFixedClusterError(2,_fixed_clus_err.at(2));
+  //  _field_map = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
+  // m_Cache = magField->makeCache(m_tGeometry->magFieldContext);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________________________
+int PrelimDistortionCorrectionAuAu::get_nodes(PHCompositeNode* topNode)
+{
+  //---------------------------------
+  // Get Objects off of the Node Tree
+  //---------------------------------
+
+  _tgeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if(!_tgeometry)
+    {
+      std::cout << "No Acts tracking geometry, exiting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  // tpc distortion correction
+  // input tpc distortion correction module edge
+  m_dcc_module_edge = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerModuleEdge");
+  if (m_dcc_module_edge)
+  {
+    std::cout << "PrelimDistortionCorrectionAuAu::get_nodes - found TPC distortion correction container module edge" << std::endl;
+  }
+
+  // input tpc distortion correction static
+  m_dcc_static = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerStatic");
+  if (m_dcc_static)
+  {
+    std::cout << "PrelimDistortionCorrectionAuAu::get_nodes - found TPC distortion correction container static" << std::endl;
+  }
+
+  // input tpc distortion correction average
+  m_dcc_average = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerAverage");
+  if (m_dcc_average)
+  {
+    std::cout << "PrelimDistortionCorrectionAuAu::get_nodes - found TPC distortion correction container average" << std::endl;
+  }
+
+
+  if(_use_truth_clusters) {
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
+  } else {
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+}
+
+  if (!_cluster_map)
+  {
+    std::cerr << PHWHERE << "PrelimDistortionCorrectionAuAu::get_nodes - ERROR: Can't find node TRKR_CLUSTER" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _track_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+  if (!_track_map)
+  {
+    std::cerr << PHWHERE << "PrelimDistortionCorrectionAuAu::get_nodes - ERROR: Can't find TrackSeedContainer " << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  PHG4TpcCylinderGeomContainer *geom_container =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom_container)
+  {
+    std::cerr << PHWHERE << "PrelimDistortionCorrectionAuAu::get_nodes - ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  for(int i=7;i<=54;i++)
+  {
+    radii.push_back(geom_container->GetLayerCellGeom(i)->get_radius());
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//________________________________________________________________________________________________________________
+int PrelimDistortionCorrectionAuAu::process_event(PHCompositeNode* /*topNode*/)
+{
+  if(_pp_mode)
+  {
+    std::cout << "PrelimDistortionCorrectionAuAu called but in pp_mode, do nothing!" << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  PHTimer timer("PrelimDistortionCorrectionAuAuTimer");
+  timer.stop();
+  timer.restart();
+
+  if(Verbosity()>0)
+  {
+    std::cout << "starting PrelimDistortionCorrectionAuAu process_event" << std::endl;
+  }
+
+  // These accumulate trackseeds as we loop over tracks, keylist is a vector of vectors of seed cluskeys
+  // The seeds are all given to the fitter at once
+  std::vector<std::vector<TrkrDefs::cluskey>> keylist_A;
+  PositionMap correctedOffsetTrackClusPositions;   //  this is an std::map<TrkrDefs::cluskey, Acts::Vector3>
+
+  for(unsigned int track_it = 0; track_it != _track_map->size(); ++track_it )
+  {
+    if(Verbosity()>0) { std::cout << "TPC seed " << track_it << std::endl; }
+    // if not a TPC track, ignore
+    TrackSeed* track = _track_map->get(track_it);
+    if(!track)
+      {
+	continue;
+      }
+
+    if(Verbosity() > 0)
+      {
+	std::cout << "Input seed pars for " << track_it
+		  << " q " << track->get_charge()
+		  << " qOverR " << fabs(track->get_qOverR()) * track->get_charge()
+		  << " X0 " << TrackSeedHelper::get_x(track)
+		  << " Y0 " << TrackSeedHelper::get_y(track)
+		  << " Z0 " << TrackSeedHelper::get_z(track)
+		  << " eta " << track->get_eta()
+		  << " phi " << track->get_phi()
+		  << std::endl;
+      }
+
+    const bool is_tpc = std::any_of(
+      track->begin_cluster_keys(),
+      track->end_cluster_keys(),
+      []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId; } );
+
+    if(is_tpc)
+    {
+      // We want to move all clusters in this seed to point to Z0 = 0
+      //float Z0 = track->get_Z0();
+      float Z0 = 0;
+      float offset_Z = 0.0 - Z0;
+
+      if(Verbosity() > 0)
+	{
+	  std::cout << "  processing seed with offset_Z " << offset_Z
+		    << " eta " << track->get_eta()
+        << " x " << TrackSeedHelper::get_x(track)
+        << " y " << TrackSeedHelper::get_y(track)
+        << " z " << TrackSeedHelper::get_z(track)
+		    << std::endl;
+	}
+
+      // We want to make  distortion corrections to all clusters in this seed after offsetting the z values
+      std::vector<TrkrDefs::cluskey> dumvec;
+      for(TrackSeed::ConstClusterKeyIter iter = track->begin_cluster_keys();
+	  iter != track->end_cluster_keys();
+	  ++iter)
+	{
+	  TrkrDefs::cluskey cluskey = *iter;
+	  TrkrCluster *cluster = _cluster_map->findCluster(cluskey);
+
+    // get global position
+    const Acts::Vector3 pos = _tgeometry->getGlobalPosition(cluskey, cluster);
+
+    // apply z offset
+    Acts::Vector3 offsetpos(pos.x(), pos.y(), pos.z() + offset_Z);
+
+    // apply distortion corrections
+    if (m_dcc_module_edge)
+    {
+      offsetpos = m_distortionCorrection.get_corrected_position(offsetpos, m_dcc_module_edge);
+    }
+
+    if (m_dcc_static)
+    {
+      offsetpos = m_distortionCorrection.get_corrected_position(offsetpos, m_dcc_static);
+    }
+
+    if (m_dcc_average)
+    {
+      offsetpos = m_distortionCorrection.get_corrected_position(offsetpos, m_dcc_average);
+    }
+
+	  // now move the distortion corrected cluster back by offset_Z, to preserve the z measurement info
+    const Acts::Vector3 corrpos(offsetpos(0), offsetpos(1), offsetpos(2) - offset_Z);
+	  correctedOffsetTrackClusPositions.emplace(cluskey,corrpos);
+	  dumvec.push_back(cluskey);
+
+	  if(Verbosity() > 0)
+	    {
+	      std::cout << " cluskey " << cluskey << " input pos " << pos(0) << "  " << pos(1) << "  " << pos(2)
+			<< "   corr. pos " << corrpos(0) << "  " << corrpos(1) << "  " << corrpos(2) << std::endl
+			<< "distortion correction " <<  corrpos(0) - pos(0) << "  " << corrpos(1) - pos(1) << "  " << corrpos(2) - pos(2)
+			<< std::endl;
+
+	    }
+	}
+
+      /// Can't circle fit a seed with less than 3 clusters, skip it
+      if(dumvec.size() < 3)
+	{ continue; }
+      keylist_A.push_back(dumvec);
+
+      if(Verbosity() > 0)
+	{
+	  std::cout << "Added  input seed " << track_it << "  becomes output seed " << keylist_A.size() - 1 << std::endl;
+	}
+
+    } // end if TPC seed
+
+  }  // end loop over tracks
+
+  // reset the seed map for the TPC
+  _track_map->Reset();
+
+  // refit the corrected clusters
+  std::vector<float> trackChi2;
+  auto seeds = fitter->ALICEKalmanFilter(keylist_A, true, correctedOffsetTrackClusPositions, trackChi2);
+
+  // update the seed parameters on the node tree
+  // This calls circle fit and line fit (setting x, y, z, phi, eta) and sets qOverR explicitly using q from KF
+  publishSeeds(seeds.first, correctedOffsetTrackClusPositions);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________________________________________
+void PrelimDistortionCorrectionAuAu::publishSeeds(std::vector<TrackSeed_v2>& seeds, PositionMap& positions)
+{
+  int seed_index = 0;
+  for(auto& seed: seeds )
+  {
+    if(seed.size_cluster_keys() < 3)
+      {
+	continue;   // ALICEKalmanFilter can drop clusters. Seeds require at least 3 clusters for circle fit
+      }
+    
+    /// The ALICEKF gives a better charge determination at high pT
+    int q = seed.get_charge();
+    TrackSeedHelper::circleFitByTaubin(&seed,positions, 7, 55);
+    TrackSeedHelper::lineFit(&seed,positions, 7, 55);
+
+    seed.set_qOverR(fabs(seed.get_qOverR()) * q);
+    seed.set_phi(TrackSeedHelper::get_phi(&seed,positions));
+    _track_map->insert(&seed);
+
+    if(Verbosity() > 0)
+      {
+	std::cout << "Publishing seed " << seed_index
+		  << " q " << q
+		  << " qOverR " << fabs(seed.get_qOverR()) * q
+		  << " x " << TrackSeedHelper::get_x(&seed)
+		  << " y " << TrackSeedHelper::get_y(&seed)
+		  << " z " << TrackSeedHelper::get_z(&seed)
+		  << " pT " << seed.get_pt()
+		  << " eta " << seed.get_eta()
+		  << " phi " << seed.get_phi()
+		  << std::endl;
+      }
+    if(Verbosity() > 5)
+      {
+	TrackSeed* readseed = _track_map->get(seed_index);
+	readseed->identify();
+      }
+
+    seed_index++;
+  }
+}

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
@@ -1,0 +1,127 @@
+/*!
+ *  \file PrelimDistortionCorrectionAuAu.h
+ *  \brief	   Refits AuAu TPC seeds with distortion corrections and current calibrations
+ *  \author Tony Frawley
+ */
+
+#ifndef TRACKRECO_PRELIMDISTORTIONCORRECTIONAUAU_H
+#define TRACKRECO_PRELIMDISTORTIONCORRECTIONAUAU_H
+
+#include "ALICEKF.h"
+#include "nanoflann.hpp"
+
+// PHENIX includes
+#include <fun4all/SubsysReco.h>
+#include <tpc/TpcDistortionCorrection.h>
+#include <trackbase/TrkrDefs.h>
+#include <Acts/MagneticField/MagneticFieldProvider.hpp>
+
+#include <Eigen/Core>
+
+// STL includes
+#include <memory>
+#include <string>
+#include <vector>
+
+class ActsGeometry;
+class PHCompositeNode;
+class PHField;
+class TpcDistortionCorrectionContainer;
+class TrkrClusterContainer;
+class TrkrClusterIterationMapv1;
+class SvtxTrackMap;
+class TrackSeedContainer;
+class TrackSeed_v2;
+
+using PositionMap = std::map<TrkrDefs::cluskey, Acts::Vector3>;
+
+class PrelimDistortionCorrectionAuAu : public SubsysReco
+{
+ public:
+  PrelimDistortionCorrectionAuAu(const std::string &name = "PrelimDistortionCorrectionAuAu");
+  ~PrelimDistortionCorrectionAuAu() override = default;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+  void set_field_dir(const double rescale)
+  {
+    _fieldDir = 1;
+    if(rescale > 0)
+      { _fieldDir = -1; }
+  }
+  void set_max_window(double s){_max_dist = s;}
+  void useConstBField(bool opt){_use_const_field = opt;}
+  void setConstBField(float b) { _const_field = b; }
+  void useFixedClusterError(bool opt){_use_fixed_clus_err = opt;}
+  void setFixedClusterError(int i, double val){_fixed_clus_err.at(i) = val;}
+  void use_truth_clusters(bool truth) { _use_truth_clusters = truth; }
+  void set_pp_mode(bool mode) {_pp_mode = mode;}
+
+  void setNeonFraction(double frac) { Ne_frac = frac; };
+  void setArgonFraction(double frac) { Ar_frac = frac; };
+  void setCF4Fraction(double frac) { CF4_frac = frac; };
+  void setNitrogenFraction(double frac) { N2_frac = frac; };
+  void setIsobutaneFraction(double frac) { isobutane_frac = frac; };
+
+ private:
+
+  //! put refitted seeds on map
+  void publishSeeds(std::vector<TrackSeed_v2>& seeds, PositionMap &positions);
+
+  /// tpc distortion correction utility class
+  TpcDistortionCorrection m_distortionCorrection;
+
+  bool _use_truth_clusters = false;
+
+  /// fetch node pointers
+  int get_nodes(PHCompositeNode *topNode);
+  std::vector<double> radii;
+  std::vector<double> _vertex_x;
+  std::vector<double> _vertex_y;
+  std::vector<double> _vertex_z;
+  std::vector<double> _vertex_xerr;
+  std::vector<double> _vertex_yerr;
+  std::vector<double> _vertex_zerr;
+  std::vector<double> _vertex_ids;
+  //double _Bz = 1.4*_Bzconst;
+  double _max_dist = .05;
+  size_t _min_clusters_per_track = 3;
+  double _fieldDir = -1;
+  double _max_sin_phi = 1.;
+  bool _pp_mode = false;
+
+  TrkrClusterContainer *_cluster_map = nullptr;
+
+  TrackSeedContainer *_track_map = nullptr;
+
+  std::unique_ptr<PHField> _field_map = nullptr;
+
+  /// acts geometry
+  ActsGeometry *_tgeometry = nullptr;
+
+  //!@name distortion correction containers
+  //@{
+  /** used in input to correct CM clusters before calculating residuals */
+  TpcDistortionCorrectionContainer *m_dcc_module_edge{nullptr};
+  TpcDistortionCorrectionContainer *m_dcc_static{nullptr};
+  TpcDistortionCorrectionContainer *m_dcc_average{nullptr};
+  //@}
+
+  std::unique_ptr<ALICEKF> fitter;
+
+  bool _use_const_field = false;
+  float _const_field = 1.4;
+  bool _use_fixed_clus_err = false;
+  std::array<double,3> _fixed_clus_err = {.1,.1,.1};
+
+  double Ne_frac = 0.00;
+  double Ar_frac = 0.75;
+  double CF4_frac = 0.20;
+  double N2_frac = 0.00;
+  double isobutane_frac = 0.05;
+
+};
+
+#endif


### PR DESCRIPTION

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adds a module to refit TPC seeds, to be used to apply new calibrations after seeding but before seed matching and fitting. 
Had to modify seed matcher, Acts fitter and vertex finder to handle cases where their output nodes are already filled, since Joe's files contained everything through vertices.

This plot shows a comparison of the seed-matching Δz before and after the refit. This is for run 66641, produced by Joe with rough calibrations, and refitted with the new module using the current CDB drift velocity and time zero calibrations. 

![refit_dz](https://github.com/user-attachments/assets/d3b485ee-919a-4119-84a5-502fd536fa94)

To use, add the module before seed matching:

#include <trackreco/PrelimDistortionCorrectionAuAu.h>

 // recalibrate, distortion correct and refit the TPC seeds 
 auto seedsrefit = new PrelimDistortionCorrectionAuAu();
 seedsrefit->Verbosity(0);
 se->registerSubsystem(seedsrefit);


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

