### PR TITLE
Removed dependency on DST_CALOFITTING files in KFParticle_truthAndDetTools.cc

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -513,15 +513,15 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       // return Fun4AllReturnCodes::ABORTEVENT;
     }
   }
-  if (!EMCalGeo)
-  {
-    EMCalGeo = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
-    if (!EMCalGeo)
-    {
-      std::cout << __FILE__ << "::" << __func__ << " : FATAL ERROR, cannot find cluster container " << "TOWERGEOM_CEMC" << std::endl;
-      // return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  }
+  // if (!EMCalGeo)
+  // {
+  //   EMCalGeo = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
+  //   if (!EMCalGeo)
+  //   {
+  //     std::cout << __FILE__ << "::" << __func__ << " : FATAL ERROR, cannot find cluster container " << "TOWERGEOM_CEMC" << std::endl;
+  //     // return Fun4AllReturnCodes::ABORTEVENT;
+  //   }
+  // }
   // if(!_towersEM)
   // {
   //   _towersEM = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
@@ -590,7 +590,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   double caloRadiusEMCal;
   // double caloRadiusIHCal;
   // double caloRadiusOHCal;
-  // caloRadiusEMCal = EMCalGeo->get_radius();
+  // caloRadiusEMCal = EMCalGeo->get_radius(); //This requires DST_CALOFITTING 
   caloRadiusEMCal = 100.70;  // cm
   // caloRadiusOHCal = OHCalGeo->get_radius();
   // caloRadiusIHCal = IHCalGeo->get_radius();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
KFParticle_truthAndDetTools.cc doesn't use any of the nodes stored in DST_CALOFITTING, so I commented out the lines which read in TOWERGEOM_CEMC. Eventually this might be added back in so that the function `EMCalGeo->get_radius()` can be used, but it has been commented out for many months now, so in the short to mid term, I think it's ok to leave it like this. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Bug fix. I commented out a few lines of code in KFParticle_truthAndDetTools.cc. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

