### PR TITLE
CaloTowerStatus - Set Tower Status Based on Z-Score

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -57,6 +57,11 @@ class CaloTowerStatus : public SubsysReco
     badChi2_treshold_max = threshold;
     return;
   }
+  void set_z_score_threshold(float threshold)
+  {
+    z_score_threshold = threshold;
+    return;
+  }
   void set_time_cut(float threshold)
   {
     time_cut = threshold;
@@ -106,6 +111,7 @@ class CaloTowerStatus : public SubsysReco
   std::string m_fieldname_chi2;
   std::string m_calibName_chi2;
   std::string m_fieldname_hotMap;
+  std::string m_fieldname_z_score;
   std::string m_calibName_hotMap;
   std::string m_inputNodePrefix{"TOWERS_"};
 
@@ -120,6 +126,8 @@ class CaloTowerStatus : public SubsysReco
   float badChi2_treshold_quadratic = {1./100};
   float badChi2_treshold_max = {1e8};
   float fraction_badChi2_threshold = {0.01};
+  float z_score_threshold = {5};
+  float z_score_threshold_default = {5};
   float time_cut = 2;  // number of samples from the mean time for the channel in the run
 };
 


### PR DESCRIPTION
Change hot / cold tower tagging based on the z-score value instead of the status value that's provided from the CDB TTree. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Feature: This PR adds functionality to determine the hot / cold tower status based on the z-score threshold. The default z-score is 5 and the user can adjust this as desired to determine hot / cold towers based on a different z-score threshold. 