### PR TITLE
fix: use scaled instead of live trigger vector

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -253,7 +253,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     if (gl1PacketInfo)
     {
       m_gl1BunchCrossing = gl1PacketInfo->getBunchNumber();
-      uint64_t triggervec = gl1PacketInfo->getTriggerVector();
+      uint64_t triggervec = gl1PacketInfo->getScaledVector();
       m_bco = gl1PacketInfo->getBCO();
       auto lbshift = m_bco << 24U;
       m_bcotr = lbshift >> 24U;


### PR DESCRIPTION
This PR fixes a bug that used the live trigger vector instead of the scaled trigger vector in the filling of the fired trigger bits of the tracking diagnostic workflow

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

