### PR TITLE
KFP track-calo matching bug fixes.

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -487,7 +487,9 @@ void KFParticle_truthAndDetTools::initializeCaloBranches(TTree *m_tree, int daug
 }
 
 /*
-The following function matches tracks to calo clusters. As of 5/28/2025, this only extends to the EMCal. HCal matching is in development.
+The following function matches tracks to calo clusters. As of 7/1/2025, this only extends to the EMCal. HCal matching is in development.
+
+To run EMCal matching, DST_CALO files must be read into the Fun4All server. 
 */
 void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
                                                  TTree * /*m_tree*/, const KFParticle &daughter, int daughter_id)
@@ -588,10 +590,11 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
 
   // Radii for track projections
   double caloRadiusEMCal;
+  caloRadiusEMCal = m_emcal_radius_user;  //Use function set_emcal_radius_user(float set_variable) to set this in your Fun4All macro
   // double caloRadiusIHCal;
   // double caloRadiusOHCal;
+  // caloRadiusEMCal = 100.70;
   // caloRadiusEMCal = EMCalGeo->get_radius(); //This requires DST_CALOFITTING 
-  caloRadiusEMCal = 100.70;  // cm
   // caloRadiusOHCal = OHCalGeo->get_radius();
   // caloRadiusIHCal = IHCalGeo->get_radius();
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -74,7 +74,7 @@ class KFParticle_truthAndDetTools
 
   void clearVectors();
 
-  float get_e3x3(RawCluster *cluster, RawTowerContainer *Towers, int layer);
+  float get_e3x3(RawCluster *cluster, RawTowerContainer *Towers, int layer); //Nonfunctional; for now, tree fills with NAN
   float get_e5x5(RawCluster *cluster, RawTowerContainer *Towers, int layer);
 
   float PiRange(float deltaPhi)
@@ -85,9 +85,7 @@ class KFParticle_truthAndDetTools
   }
 
   // Functions to set cuts
-  void set_ntpc_low_cut(int set_variable) { m_ntpc_low_cut = set_variable; }  // THIS DOESN'T DO ANYTHING!!!!
   void set_emcal_radius_user(float set_variable) { m_emcal_radius_user = set_variable; }
-  void set_track_pt_low_cut(float set_variable) { m_track_pt_low_cut = set_variable; }
   void set_emcal_e_low_cut(float set_variable) { m_emcal_e_low_cut = set_variable; }
   void set_dphi_cut_low(float set_variable) { m_dphi_cut_low = set_variable; }
   void set_dphi_cut_high(float set_variable) { m_dphi_cut_high = set_variable; }
@@ -132,8 +130,6 @@ class KFParticle_truthAndDetTools
   float m_ihcal_radius_user{117};
   float m_ohcal_radius_user{177.423};
 
-  int m_ntpc_low_cut{20};  // THIS DOESNT ACTUALLY DO ANYTHING THO
-  float m_track_pt_low_cut{0.5};
   float m_emcal_e_low_cut{0.2};
   float m_ihcal_e_low_cut{0.01};
   float m_ohcal_e_low_cut{0.01};


### PR DESCRIPTION
### Function to set projection radius for track-EMCal matching fixed. Code that doesn't do anything removed.

[comment]: <> (Please tell us something about this pull request)
I removed some variables and functions defined in KFParticle_truthAndDetTools.h that don't affect KFParticle_truthAndDetTools.cc. I also removed a hardcoded value in KFParticle_truthAndDetTools.cc, so that the user can now specify the radius they would like to project tracks to when running track-EMCal matching. I also added a few comments for clarity's sake.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Bug fix + gives the user more control when running track-calo matching in KFP. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

