### PR TITLE
Seb clock skip fix

### DIFF
--- a/offline/framework/ffarawmodules/ClockDiffCheck.cc
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.cc
@@ -320,6 +320,10 @@ void ClockDiffCheck::FillCaloClockDiff(CaloPacketContainer *pktcont)
 void ClockDiffCheck::FillCaloClockDiffSngl(CaloPacket *calopkt)
 {
   unsigned int packetid = calopkt->getIdentifier();
+  if (packetid > 1000000)
+  {
+    return;
+  }
   if (m_PacketStuffMap.find(packetid) == m_PacketStuffMap.end())
   {
     std::string hname = "clkdiff" + std::to_string(packetid);
@@ -366,6 +370,10 @@ void ClockDiffCheck::FillCaloClockDiffSngl(CaloPacket *calopkt)
 void ClockDiffCheck::FillPacketDiff(OfflinePacket *pkt)
 {
   unsigned int packetid = pkt->getIdentifier();
+  if (packetid > 1000000)
+  {
+    return;
+  }
   uint64_t clk = (pkt->getBCO() & 0xFFFFFFFF);
   if (m_PacketStuffMap.find(packetid) == m_PacketStuffMap.end())
   {

--- a/offline/framework/ffarawobjects/OfflinePacket.h
+++ b/offline/framework/ffarawobjects/OfflinePacket.h
@@ -13,6 +13,7 @@ class OfflinePacket : public PHObject
   {
     PACKET_OK = 0,
     PACKET_DROPPED = 1,
+    PACKET_CORRUPT = 2,
     NOTSET = std::numeric_limits<uint64_t>::max()
   };
 

--- a/offline/framework/ffarawobjects/OfflinePacketv1.cc
+++ b/offline/framework/ffarawobjects/OfflinePacketv1.cc
@@ -21,6 +21,16 @@ void OfflinePacketv1::Reset()
 void OfflinePacketv1::identify(std::ostream &os) const
 {
   os << "Id: " << getIdentifier() << std::endl;
+  os << "Status: " << getStatus();
+  if (getStatus())
+  {
+    std::cout << " --> Bad";
+  }
+  else
+  {
+    std::cout << " --> Good";
+  }
+  std::cout << std::endl;
   os << "EvtSeq: " << getEvtSequence() << std::endl;
   os << "BCO: 0x" << std::hex << getBCO() << std::dec << std::endl;
   return;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This should prevent quite a few of these seb dropouts. The decoder cannot deal with corrupt events and hands back an invalid (random?) clock. One has to check the packet status after an ivalue call to check for corrupt packets. The drooping of those packets (marked with status OFFline_paket::PACKET_CORRUPT) works but the clock diff check chokes a bit and drops the same packet two events later. That needs to be looked at but this PR should remedy a lot of those dropped out seb's

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

