### PR TITLE
check for offline packets

### DIFF
--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -447,12 +447,12 @@ int MbdEvent::SetRawData(std::array< CaloPacket *,2> &dstp, MbdPmtContainer *bbc
     {
       _nsamples = dstp[ipkt]->iValue(0, "SAMPLES");
       {
-        static int counter = 0;
-        if ( counter<1 )
+        static bool printcount{true};
+        if ( printcount && Verbosity() > 0)
         {
           std::cout << "NSAMPLES = " << _nsamples << std::endl;
+	  printcount = false;
         }
-        counter++;
       }
 
       m_xmitclocks[ipkt] = static_cast<UShort_t>(dstp[ipkt]->iValue(0, "CLOCK"));

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -83,6 +83,18 @@ int MbdReco::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;  // missing an essential object in BBC/MBD
   }
 
+  if (m_mbdpacket[0] && m_mbdpacket[1] &&
+      (m_mbdpacket[0]->getIdentifier() != 1001 || m_mbdpacket[1]->getIdentifier() != 1002))
+  {
+    static int counter = 0;
+    if (counter < 100)
+    {
+      std::cout << PHWHERE << "packet 1001 and/or packet 1002 missing, bailing out" << std::endl;
+      counter++;
+    }
+    return Fun4AllReturnCodes::EVENT_OK; // no mbd packets here
+  }
+
   // Process raw waveforms from real data
   if ( m_mbdevent!=nullptr || m_mbdraw!=nullptr || m_mbdpacket[0]==nullptr || m_mbdpacket[1]==nullptr)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The new offline packets are nodes, so they will always exist, even if they are empty. This PR adds a check that packets 1001,1002 actually have content before proceeding. That should take care of the multi GB logs for the early run2pp runs where we have yet another problem with the gl1 (though it does not fix the gl1 issue)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

