### PR TITLE
tag events in  jetbackground where flow was not applied in UE subtraction

### DIFF
--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -544,9 +544,14 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   }
   // first, calculate flow: Psi2 & v2, if enabled
 
+  //_Psi2 is left as 0
+  //since _v2 is derived from _Psi2, initializing _Psi2 to NAN will set _v2 = NAN
+  //_is_flow_failure tags events where _Psi2 & _v2 are set to 0 because there are no strips for flow
+  //and when sEPD _Psi2 has no determined _Psi2 because the event is outside +/- z = 60cm
   _Psi2 = 0;
   _v2 = 0;
   _nStrips = 0;
+  _is_flow_failure = false;
 
   if (_do_flow == 0)
   {
@@ -750,6 +755,10 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
               auto _EPDNS = epmap->get(EventplaneinfoMap::sEPDNS);
               _Psi2 = _EPDNS->get_shifted_psi(2);
           }
+          else
+          {
+            _is_flow_failure = true;
+          }
       }
 
       // determine v2 from calo regardless of origin of Psi2
@@ -768,6 +777,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       _Psi2 = 0;
       _v2 = 0;
       _nStrips = 0;
+      _is_flow_failure = true;
       if (Verbosity() > 0)
       {
         std::cout << "DetermineTowerBackground::process_event: no full strips available for flow modulation, setting v2 and Psi = 0" << std::endl;
@@ -959,6 +969,8 @@ void DetermineTowerBackground::FillNode(PHCompositeNode *topNode)
     towerbackground->set_nStripsUsedForFlow(_nStrips);
 
     towerbackground->set_nTowersUsedForBkg(_nTowers);
+
+    towerbackground->set_flow_failure_flag(_is_flow_failure);
   }
 
   return;

--- a/offline/packages/jetbackground/DetermineTowerBackground.h
+++ b/offline/packages/jetbackground/DetermineTowerBackground.h
@@ -90,6 +90,7 @@ class DetermineTowerBackground : public SubsysReco
   Jet::PROPERTY _index_SeedItr{};
 
   bool m_use_towerinfo{false};
+  bool _is_flow_failure{false};
 
   std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
   std::string EMTowerName;

--- a/offline/packages/jetbackground/TowerBackground.h
+++ b/offline/packages/jetbackground/TowerBackground.h
@@ -18,12 +18,14 @@ class TowerBackground : public PHObject
   virtual void set_Psi2(float) {}
   virtual void set_nStripsUsedForFlow(int) {}
   virtual void set_nTowersUsedForBkg(int) {}
+  virtual void set_flow_failure_flag(bool) {}
 
   virtual std::vector<float> get_UE(int /*layer*/) { return std::vector<float>(); };
   virtual float get_v2() { return 0; }
   virtual float get_Psi2() { return 0; }
   virtual int get_nStripsUsedForFlow() { return 0; }
   virtual int get_nTowersUsedForBkg() { return 0; }
+  virtual bool get_flow_failure_flag() { return false; }
 
  protected:
   TowerBackground() {}

--- a/offline/packages/jetbackground/TowerBackgroundv1.h
+++ b/offline/packages/jetbackground/TowerBackgroundv1.h
@@ -21,11 +21,13 @@ class TowerBackgroundv1 : public TowerBackground
   void set_Psi2(float Psi2) override { _Psi2 = Psi2; }
   void set_nStripsUsedForFlow(int nStrips) override { _nStrips = nStrips; }
   void set_nTowersUsedForBkg(int nTowers) override { _nTowers = nTowers; }
+  void set_flow_failure_flag(bool flag) override { _flow_failure_flag = flag; }
 
   std::vector<float> get_UE(int layer) override { return _UE[layer]; }
   float get_v2() override { return _v2; }
   float get_Psi2() override { return _Psi2; }
   int get_nStripsUsedForFlow() override { return _nStrips; }
+  bool get_flow_failure_flag() override { return _flow_failure_flag; }  
 
   // our own - not from parent class
   virtual int get_nTowersUsedForFlow() { return _nTowers; }
@@ -36,6 +38,7 @@ class TowerBackgroundv1 : public TowerBackground
   float _Psi2{0};
   int _nStrips{0};
   int _nTowers{0};
+  bool _flow_failure_flag = false;
 
   ClassDefOverride(TowerBackgroundv1, 1);
 };


### PR DESCRIPTION
PR adds a flag to jet background to tag events where flow is not determined because there are no calorimeter strips for v2 determination or when there is no provide psi_2 during the flow modulated jet background subtraction.

Can be used downstream as:

TowerBackground *towerbackground;
towerbackground = findNode::getClass<TowerBackground>(topNode, "TowerInfoBackground_Sub2");
if(towerbackground->get_flow_failure_flag())
{
  these events have no strips for flow, or no provided psi_2
}
