### PR TITLE
Two changes in the TPC Event Builder

### DIFF
--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -215,22 +215,23 @@ class TpcTimeFrameBuilder
       TRIG_EARLY_LARGE_DATA_T = 0b111,
     };
 
-    /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
-    // Standard scheduler /home/phnxrc/operations/TPC/schedulers/standard_beam.scheduler
-    // 0        100    0    0
-    // 1          0    0    0     0:0x01 # FEE SAMPA BX Counter Sync
-    // 2          0    0    0     0:0x40 # DAM    Clear GTM Last Level-1
-    // 3          0    0    0     0:0x80 # DAM    Clear GTM Level-1 and Endat Counters
-    // 4          0    0    0
-    // 5        256    0    0
-    // 6          0    1    5     0:0x02 #FEE    SAMPA E-Link Heartbeat
+    // Command   | OLD Mode-Bit | New Mode-Number | Function
+    // ======================================================
+    // NOP       |     0b000    |             0x0 | No Operation
+    // BX_SYNC   |     0b001    |             0x1 | SAMPA Beam-crossing sync
+    // H_BEAT    |     0b010    |             0x2 | Generates Heartbeat frame
+    // TRIG      |     0b100    |             0x3 | Trigger data when FEM user bit is 0b01, otherwise the level 1 accept is used when FEM user bit is 0b00
+    // CLK_SYNC  |     N/A      |             0x4 | Reset and align 40 MHz and 20 MHz clocks to SAMPA
+    // SAMPA_RST |     N/A      |             0x5 | Hard reset SAMPA
+    // DC_START  |     N/A      |             0x6 | Start digital current reading
+    // DC_STOP   |     N/A      |             0x7 | Stop and send digital current packet
     enum ModeBitType
     {
-      BX_COUNTER_SYNC_T = 0,
-      ELINK_HEARTBEAT_T = 1,
-      SAMPA_EVENT_TRIGGER_T = 2,
-      CLEAR_LV1_LAST_T = 6,
-      CLEAR_LV1_ENDAT_T = 7
+      BX_COUNTER_SYNC_T = 0x1,
+      ELINK_HEARTBEAT_T = 0x2
+      // SAMPA_EVENT_TRIGGER_T = 2,
+      // CLEAR_LV1_LAST_T = 6,
+      // CLEAR_LV1_ENDAT_T = 7
     };
 
     // get the difference between two BCO WITHOUT rollover corrections


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Two changes in the TPC Event Builder: 

1. Reinterpret GTM mode bits to mode numbers as used in v46+ firmware. Previous and new definition are documented in the header file. Nonetheless, it is expected to be back compatible with how we run in the past. But it is needed change so new digital current mode numbers are not misinterpreted as heartbeats

2. Make the code more robust to junk data arriving BEFORE the start of run sequence in GTM, e.g. due to lingering data in the DMA buffer 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Output digital current data during event building

## Links to other PRs in macros and calibration repositories (if applicable)

