### PR TITLE
use clock diff in seb to check for gl1 problem in packet numbering

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.h
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.h
@@ -64,6 +64,8 @@ class SingleTriggeredInput : public Fun4AllBase, public InputFileHandler
   bool DoneFilling() const;
   void RunCheck();
   void ResetClockDiffCounters();
+  uint64_t get_clkdiff(const int index) const { return m_bclkdiffarray.at(index); }
+  uint64_t calccurrentclockdiff(const int index, Event *evt);
 
  protected:
   PHCompositeNode *m_topNode{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
In the early run2pp the gl1 packet numbering is off (seems to be incremented by 2 for each event) which throws off the detection of gl1 skips. This PR compares the clock diff between the seb and the gl1 to check if the event should be dropped on the seb side

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

