### PR TITLE
updating truth jet reco for new sphenix primary particles

### DIFF
--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -58,7 +58,7 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
   //     (1) Loop on GetPrimaryParticleRange
   //     (2) Or add a loop on GetSecondaryParticleRange
   std::vector<Jet *> pseudojets;
-  PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
+  PHG4TruthInfoContainer::ConstRange range = truthinfo->GetSPHENIXPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
        iter != range.second;
        ++iter)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Updates the truth jet reconstruction to use GetSPHENIXPrimaryParticleRange() instead of GetPrimaryParticleRange(). This will no longer work on simulations produced before the new sPHENIX primary particle definition was implemented 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

