### PR TITLE
Added tower time histograms of cosmic muons

### DIFF
--- a/calibrations/calorimeter/calo_tower_slope/HCalCosmics.cc
+++ b/calibrations/calorimeter/calo_tower_slope/HCalCosmics.cc
@@ -40,6 +40,10 @@ int HCalCosmics::Init(PHCompositeNode * /*topNode*/)
     {
       std::string channel_histname = "h_channel_" + std::to_string(ieta) + "_" + std::to_string(iphi);
       h_channel_hist[ieta][iphi] = new TH1F(channel_histname.c_str(), "", 500, 0, 500 * bin_width);
+      
+      std::string time_histname = "h_towertime_" + std::to_string(ieta) + "_" + std::to_string(iphi);
+      h_towertime_hist[ieta][iphi] = new TH1F(time_histname.c_str(), "", 100, -10, 10);
+   
     }
   }
   h_waveformchi2 = new TH2F("h_waveformchi2", "", 1000, 0, 500 * bin_width, 1000, 0, 1000000);
@@ -90,6 +94,7 @@ int HCalCosmics::process_towers(PHCompositeNode *topNode)
     int iphi = towers->getTowerPhiBin(towerkey);
     m_peak[ieta][iphi] = energy;
     m_chi2[ieta][iphi] = chi2;
+    m_time[ieta][iphi] = time;
     h_waveformchi2->Fill(m_peak[ieta][iphi], m_chi2[ieta][iphi]);
     if (tower->get_isBadChi2())
     {
@@ -130,6 +135,7 @@ int HCalCosmics::process_towers(PHCompositeNode *topNode)
         continue;  // right veto cut
       }
       h_channel_hist[ieta][iphi]->Fill(m_peak[ieta][iphi]);
+      h_towertime_hist[ieta][iphi]->Fill(m_time[ieta][iphi]);
       h_mip->Fill(m_peak[ieta][iphi]);
     }
   }
@@ -148,6 +154,16 @@ int HCalCosmics::End(PHCompositeNode * /*topNode*/)
       delete iphi;
     }
   }
+
+  for (auto &ieta : h_towertime_hist)
+  {
+    for (auto &iphi : ieta)
+    {
+      iphi->Write();
+      delete iphi;
+    }
+  }
+  	
   h_mip->Write();
   h_waveformchi2->Write();
   h_waveformchi2_aftercut->Write();

--- a/calibrations/calorimeter/calo_tower_slope/HCalCosmics.h
+++ b/calibrations/calorimeter/calo_tower_slope/HCalCosmics.h
@@ -49,6 +49,7 @@ class HCalCosmics : public SubsysReco
   TH1 *h_channel_hist[n_etabin][n_phibin]{{nullptr}};
   TH2 *h_waveformchi2{nullptr};
   TH2 *h_waveformchi2_aftercut{nullptr};
+  TH1 *h_towertime_hist[n_etabin][n_phibin]{{nullptr}}; // distribution of tower time of muons
   TH2 *h_time_energy{nullptr};
   TH1 *h_mip{nullptr};
   TH1 *h_event{nullptr};
@@ -63,6 +64,7 @@ class HCalCosmics : public SubsysReco
 
   float m_peak[n_etabin][n_phibin]{};
   float m_chi2[n_etabin][n_phibin]{};
+  float m_time[n_etabin][n_phibin]{};
 
   //  bool debug {false};
 


### PR DESCRIPTION
Added histograms of peak time distributions per tower for cosmic muons [name of the histogram: h_towertime_hist] that pass the topological selection cuts. These histograms are included as part of the cosmic production outputs and are useful for time-based calibration. 

