### PR TITLE
fix: check strobe in silicon seed merger

### DIFF
--- a/offline/packages/trackreco/PHSiliconSeedMerger.cc
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.cc
@@ -3,23 +3,23 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
 #include <phool/PHObject.h>
 #include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 
 #include <trackbase/TrkrDefs.h>
 
-#include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/TrackSeed.h>
-
+#include <trackbase_historic/TrackSeedContainer.h>
 
 #include <phool/PHCompositeNode.h>
 
 //____________________________________________________________________________..
-PHSiliconSeedMerger::PHSiliconSeedMerger(const std::string &name):
- SubsysReco(name)
-{}
+PHSiliconSeedMerger::PHSiliconSeedMerger(const std::string& name)
+  : SubsysReco(name)
+{
+}
 
 //____________________________________________________________________________..
 PHSiliconSeedMerger::~PHSiliconSeedMerger()
@@ -29,188 +29,198 @@ PHSiliconSeedMerger::~PHSiliconSeedMerger()
 //____________________________________________________________________________..
 int PHSiliconSeedMerger::Init(PHCompositeNode*)
 {
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int PHSiliconSeedMerger::InitRun(PHCompositeNode *topNode)
+int PHSiliconSeedMerger::InitRun(PHCompositeNode* topNode)
 {
   int ret = getNodes(topNode);
   return ret;
 }
 
 //____________________________________________________________________________..
-int PHSiliconSeedMerger::process_event(PHCompositeNode *)
+int PHSiliconSeedMerger::process_event(PHCompositeNode*)
 {
-
   std::multimap<unsigned int, std::set<TrkrDefs::cluskey>> matches;
   std::set<unsigned int> seedsToDelete;
 
-  if(Verbosity() > 0)
+  if (Verbosity() > 0)
+  {
+    std::cout << "Silicon seed track container has " << m_siliconTracks->size() << std::endl;
+  }
+
+  for (unsigned int track1ID = 0;
+       track1ID != m_siliconTracks->size();
+       ++track1ID)
+  {
+    TrackSeed* track1 = m_siliconTracks->get(track1ID);
+
+    if (seedsToDelete.find(track1ID) != seedsToDelete.end())
     {
-      std::cout << "Silicon seed track container has " << m_siliconTracks->size() << std::endl;
+      continue;
     }
-  
-  for(unsigned int track1ID = 0;
-      track1ID != m_siliconTracks->size(); 
-      ++track1ID)
+
+    std::set<TrkrDefs::cluskey> mvtx1Keys;
+    for (TrackSeed::ConstClusterKeyIter iter = track1->begin_cluster_keys();
+         iter != track1->end_cluster_keys();
+         ++iter)
     {
-      TrackSeed* track1 = m_siliconTracks->get(track1ID);
+      TrkrDefs::cluskey ckey = *iter;
+      auto trkrid = TrkrDefs::getTrkrId(ckey);
+      if (m_mvtxOnly && trkrid == TrkrDefs::TrkrId::inttId)
+      {
+        continue;
+      }
 
-      if(seedsToDelete.find(track1ID) != seedsToDelete.end())
-	{ continue; }
+      mvtx1Keys.insert(ckey);
+    }
 
-      std::set<TrkrDefs::cluskey> mvtx1Keys;
-      for (TrackSeed::ConstClusterKeyIter iter = track1->begin_cluster_keys();
-           iter != track1->end_cluster_keys();
+    /// We can speed up the code by only iterating over the track seeds
+    /// that are further in the map container from the current track,
+    /// since the comparison of e.g. track 1 with track 2 doesn't need
+    /// to be repeated with track 2 to track 1.
+    for (unsigned int track2ID = track1ID;
+         track2ID != m_siliconTracks->size();
+         ++track2ID)
+    {
+      if (track1ID == track2ID)
+      {
+        continue;
+      }
+
+      TrackSeed* track2 = m_siliconTracks->get(track2ID);
+      if (track2 == nullptr)
+      {
+        continue;
+      }
+      std::set<TrkrDefs::cluskey> mvtx2Keys;
+      for (TrackSeed::ConstClusterKeyIter iter = track2->begin_cluster_keys();
+           iter != track2->end_cluster_keys();
            ++iter)
-	{
-	  TrkrDefs::cluskey ckey = *iter;
-          auto trkrid = TrkrDefs::getTrkrId(ckey);
-		  if(m_mvtxOnly && trkrid == TrkrDefs::TrkrId::inttId)
-		  {
-                    continue;
-                  }
+      {
+        TrkrDefs::cluskey ckey = *iter;
+        auto trkrid = TrkrDefs::getTrkrId(ckey);
+        if (m_mvtxOnly && trkrid == TrkrDefs::TrkrId::inttId)
+        {
+          continue;
+        }
+        mvtx2Keys.insert(ckey);
+      }
 
-            mvtx1Keys.insert(ckey); 
-			}
-	
-   
-      /// We can speed up the code by only iterating over the track seeds
-      /// that are further in the map container from the current track,
-      /// since the comparison of e.g. track 1 with track 2 doesn't need
-      /// to be repeated with track 2 to track 1.
-      for(unsigned int track2ID = track1ID;
-	  track2ID != m_siliconTracks->size();
-	  ++track2ID) 
-	{
-	  if(track1ID == track2ID)
-	    { continue; }
+      std::vector<TrkrDefs::cluskey> intersection;
+      std::set_intersection(mvtx1Keys.begin(),
+                            mvtx1Keys.end(),
+                            mvtx2Keys.begin(),
+                            mvtx2Keys.end(),
+                            std::back_inserter(intersection));
 
-	  TrackSeed* track2 = m_siliconTracks->get(track2ID);
-	  if(track2 == nullptr)
-	    { continue; }
-	  std::set<TrkrDefs::cluskey> mvtx2Keys;
-	  for (TrackSeed::ConstClusterKeyIter iter = track2->begin_cluster_keys();
-	       iter != track2->end_cluster_keys();
-	       ++iter)
-	    {
-	      TrkrDefs::cluskey ckey = *iter;
-              auto trkrid = TrkrDefs::getTrkrId(ckey);
-              if (m_mvtxOnly && trkrid == TrkrDefs::TrkrId::inttId)
-              {
-                continue;
-              }
-         mvtx2Keys.insert(ckey); 
-	    }
+      /// If we have two clusters in common in the triplet, it is likely
+      /// from the same track
+      if (intersection.size() > m_clusterOverlap)
+      {
+        if (Verbosity() > 2)
+        {
+          std::cout << "Track " << track1ID << " keys " << std::endl;
+          for (auto& key : mvtx1Keys)
+          {
+            std::cout << "   ckey: " << key << std::endl;
+          }
+          std::cout << "Track " << track2ID << " keys " << std::endl;
+          for (auto& key : mvtx2Keys)
+          {
+            std::cout << "   ckey: " << key << std::endl;
+          }
+          std::cout << "Intersection keys " << std::endl;
+          for (auto& key : intersection)
+          {
+            std::cout << "   ckey: " << key << std::endl;
+          }
+        }
 
-	  std::vector<TrkrDefs::cluskey> intersection;
-	  std::set_intersection(mvtx1Keys.begin(),
-				mvtx1Keys.end(),
-				mvtx2Keys.begin(),
-				mvtx2Keys.end(),
-				std::back_inserter(intersection));
+        for (auto& key : mvtx2Keys)
+        {
+          mvtx1Keys.insert(key);
+        }
 
-	  /// If we have two clusters in common in the triplet, it is likely
-	  /// from the same track
-	  if(intersection.size() > m_clusterOverlap) 
-	    {
-	      if(Verbosity() > 2) 
-		{
-		  std::cout << "Track " << track1ID << " keys " << std::endl;
-		  for(auto& key : mvtx1Keys) 
-		    { std::cout << "   ckey: " << key << std::endl; }
-		  std::cout << "Track " << track2ID << " keys " << std::endl;
-		  for(auto& key : mvtx2Keys) 
-		    { std::cout << "   ckey: " << key << std::endl; }
-		  std::cout << "Intersection keys " << std::endl;
-		  for(auto& key : intersection)
-		    { std::cout << "   ckey: " << key << std::endl; }
-		}
+        if (Verbosity() > 2)
+        {
+          std::cout << "Match IDed" << std::endl;
+          for (auto& key : mvtx1Keys)
+          {
+            std::cout << "  total track keys " << key << std::endl;
+          }
+        }
 
-	      for(auto& key : mvtx2Keys)
-		{
-		  mvtx1Keys.insert(key); 
-		}
-	      
-	      if(Verbosity() > 2)
-		{ 
-		  std::cout << "Match IDed"<<std::endl; 
-		  for(auto& key : mvtx1Keys)
-		    { std::cout << "  total track keys " << key << std::endl; }
-		}
-
-	      matches.insert(std::make_pair(track1ID, mvtx1Keys)); 
-	      seedsToDelete.insert(track2ID);
-	      break;
-	    }
-	}
+        matches.insert(std::make_pair(track1ID, mvtx1Keys));
+        seedsToDelete.insert(track2ID);
+        break;
+      }
     }
+  }
 
-  for(const auto& [trackKey, mvtxKeys] : matches)
+  for (const auto& [trackKey, mvtxKeys] : matches)
+  {
+    auto track = m_siliconTracks->get(trackKey);
+    if (Verbosity() > 2)
     {
-      auto track = m_siliconTracks->get(trackKey);
-      if(Verbosity() > 2)
-	{ std::cout << "original track: " << std::endl; track->identify(); }
-
-      for(auto& key : mvtxKeys) 
-	{
-	  if(track->find_cluster_key(key) == track->end_cluster_keys())
-	    { 
-	      track->insert_cluster_key(key); 
-	      if(Verbosity() > 2) 
-		std::cout << "adding " << key << std::endl;
-	    }
-	}
-      
+      std::cout << "original track: " << std::endl;
+      track->identify();
     }
 
-  for(const auto& key : seedsToDelete) 
+    for (auto& key : mvtxKeys)
     {
-      if(Verbosity() > 2 )
-	{ std::cout << "Erasing track " << key << std::endl; }
-      m_siliconTracks->erase(key);
+      if (track->find_cluster_key(key) == track->end_cluster_keys())
+      {
+        track->insert_cluster_key(key);
+        if (Verbosity() > 2)
+          std::cout << "adding " << key << std::endl;
+      }
     }
+  }
 
-  if(Verbosity() > 2)
+  for (const auto& key : seedsToDelete)
+  {
+    if (Verbosity() > 2)
     {
-      for(const auto& seed : *m_siliconTracks)
-	{ 
-	  if (!seed) continue;
-	  seed->identify(); 
-	}
+      std::cout << "Erasing track " << key << std::endl;
     }
-	  
+    m_siliconTracks->erase(key);
+  }
+
+  if (Verbosity() > 2)
+  {
+    for (const auto& seed : *m_siliconTracks)
+    {
+      if (!seed) continue;
+      seed->identify();
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int PHSiliconSeedMerger::ResetEvent(PHCompositeNode *)
+int PHSiliconSeedMerger::ResetEvent(PHCompositeNode*)
 {
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
-
 
 //____________________________________________________________________________..
-int PHSiliconSeedMerger::End(PHCompositeNode *)
+int PHSiliconSeedMerger::End(PHCompositeNode*)
 {
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHSiliconSeedMerger::getNodes(PHCompositeNode *topNode)
+int PHSiliconSeedMerger::getNodes(PHCompositeNode* topNode)
 {
   m_siliconTracks = findNode::getClass<TrackSeedContainer>(topNode, m_trackMapName.c_str());
-  if(!m_siliconTracks)
-    {
-      std::cout << PHWHERE << "No silicon track container, can't merge seeds"
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  
-return Fun4AllReturnCodes::EVENT_OK;
-}
+  if (!m_siliconTracks)
+  {
+    std::cout << PHWHERE << "No silicon track container, can't merge seeds"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHSiliconSeedMerger.cc
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.cc
@@ -8,6 +8,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrDefs.h>
 
 #include <trackbase_historic/TrackSeed.h>
@@ -62,7 +63,8 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode*)
     }
 
     std::set<TrkrDefs::cluskey> mvtx1Keys;
-    for (TrackSeed::ConstClusterKeyIter iter = track1->begin_cluster_keys();
+    int track1Strobe = std::numeric_limits<int>::quiet_NaN();
+    for (auto iter = track1->begin_cluster_keys();
          iter != track1->end_cluster_keys();
          ++iter)
     {
@@ -72,7 +74,7 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode*)
       {
         continue;
       }
-
+      track1Strobe = MvtxDefs::getStrobeId(ckey);
       mvtx1Keys.insert(ckey);
     }
 
@@ -94,6 +96,8 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode*)
       {
         continue;
       }
+      int track2Strobe = std::numeric_limits<int>::quiet_NaN();
+
       std::set<TrkrDefs::cluskey> mvtx2Keys;
       for (TrackSeed::ConstClusterKeyIter iter = track2->begin_cluster_keys();
            iter != track2->end_cluster_keys();
@@ -106,6 +110,7 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode*)
           continue;
         }
         mvtx2Keys.insert(ckey);
+        track2Strobe = MvtxDefs::getStrobeId(ckey);
       }
 
       std::vector<TrkrDefs::cluskey> intersection;
@@ -117,7 +122,7 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode*)
 
       /// If we have two clusters in common in the triplet, it is likely
       /// from the same track
-      if (intersection.size() > m_clusterOverlap)
+      if (intersection.size() > m_clusterOverlap && track1Strobe == track2Strobe)
       {
         if (Verbosity() > 2)
         {

--- a/offline/packages/trackreco/PHSiliconSeedMerger.h
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.h
@@ -5,9 +5,9 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 class PHCompositeNode;
 class TrackSeedContainer;
@@ -15,7 +15,6 @@ class TrackSeedContainer;
 class PHSiliconSeedMerger : public SubsysReco
 {
  public:
-
   PHSiliconSeedMerger(const std::string &name = "PHSiliconSeedMerger");
 
   virtual ~PHSiliconSeedMerger();
@@ -26,18 +25,17 @@ class PHSiliconSeedMerger : public SubsysReco
   int ResetEvent(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
-  void trackMapName(const std::string& name) { m_trackMapName = name; }
+  void trackMapName(const std::string &name) { m_trackMapName = name; }
   void clusterOverlap(const unsigned int nclusters) { m_clusterOverlap = nclusters; }
   void searchIntt() { m_mvtxOnly = false; }
 
  private:
-
   int getNodes(PHCompositeNode *topNode);
 
-  TrackSeedContainer *m_siliconTracks {nullptr};
-  std::string m_trackMapName {"SiliconTrackSeedContainer"};
-  unsigned int m_clusterOverlap {1};
-  bool m_mvtxOnly {true};
+  TrackSeedContainer *m_siliconTracks{nullptr};
+  std::string m_trackMapName{"SiliconTrackSeedContainer"};
+  unsigned int m_clusterOverlap{1};
+  bool m_mvtxOnly{true};
 };
 
-#endif // PHSILICONSEEDMERGER_H
+#endif  // PHSILICONSEEDMERGER_H


### PR DESCRIPTION
This PR clang-formats the silicon seed merger and checks that the two seeds being merged have the same strobe ID. Interestingly over 100 events this does not change the number of seeds at all - but for completeness it should be there.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

