### PR TITLE
Reduced matrix inversion fixes

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -5,7 +5,7 @@
  */
 
 #include "TpcSpaceChargeMatrixInversion.h"
-#include "TpcSpaceChargeMatrixContainerv1.h"
+#include "TpcSpaceChargeMatrixContainerv2.h"
 #include "TpcSpaceChargeReconstructionHelper.h"
 
 #include <frog/FROG.h>
@@ -175,7 +175,7 @@ bool TpcSpaceChargeMatrixInversion::add(const TpcSpaceChargeMatrixContainer& sou
   // check internal container, create if necessary
   if (!m_matrix_container)
   {
-    m_matrix_container.reset(new TpcSpaceChargeMatrixContainerv1);
+    m_matrix_container.reset(new TpcSpaceChargeMatrixContainerv2);
 
     // get grid dimensions from source
     int phibins = 0;
@@ -293,7 +293,7 @@ void TpcSpaceChargeMatrixInversion::calculate_distortion_corrections(const Inver
           case InversionMode::ReducedInversion_z:
           {
             /* number of coordinates must match that of the matrix container */
-            static constexpr int ncoord = 3;
+            static constexpr int ncoord = 2;
             using matrix_t = Eigen::Matrix<float, ncoord, ncoord>;
             using column_t = Eigen::Matrix<float, ncoord, 1>;
 


### PR DESCRIPTION
This fixes the reduced (2x2) distortion matrix inversion, for more detailed comparisons to direct fits performed by Xudong and to full matrix inversion. 

- use TpcSpaceChargeMatrixContainerv2
- set n_coord = 2 for the reduced matrix inversions.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

