### PR TITLE
Allow Si only refit of tracks with ACTS track fitting and vtx propaga…

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -554,11 +554,15 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
         {
           continue;
         }
-        //std::cout<<"m_materialSurfaces.size(): "<<m_materialSurfaces.size()<<std::endl; 
-        //uint64_t last_sens_vol = 0;
-        //uint64_t last_sens_lay = 0;
         for (const auto& surface_apr : m_materialSurfaces)
         {
+          if(m_forceSiOnlyFit)
+          {
+            if(surface_apr->geometryId().volume() >12)
+            {
+              continue;
+            }
+          }
           bool pop_flag = false;
           if(surface_apr->geometryId().approach() == 1)
           {
@@ -986,6 +990,13 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
 	  }
       }
     
+  if(m_forceSiOnlyFit)
+  {
+    if(m_tGeometry->maps().isMicromegasSurface(surf)||m_tGeometry->maps().isTpcSurface(surf))
+      {
+        continue;
+      }
+  }
     // update vectors
     siliconMMSls.push_back(sl);
     surfaces.push_back(surf);
@@ -1074,7 +1085,7 @@ void PHActsTrkFitter::updateSvtxTrack(std::vector<Acts::MultiTrajectoryTraits::I
     track->identify();
   }
 
-  if (!m_fitSiliconMMs)
+  if (!m_fitSiliconMMs && !m_forceSiOnlyFit)
   {
     track->clear_states();
   }
@@ -1260,12 +1271,12 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
     }
   }
 
-  m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsTrajectories");
+  m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, m_trajectories_name);
   if (!m_trajectories)
   {
     m_trajectories = new std::map<const unsigned int, Trajectory>;
     auto node =
-        new PHDataNode<std::map<const unsigned int, Trajectory>>(m_trajectories, "ActsTrajectories");
+        new PHDataNode<std::map<const unsigned int, Trajectory>>(m_trajectories, m_trajectories_name);
     svtxNode->addNode(node);
   }
 
@@ -1355,6 +1366,7 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
 
   // tpc global position wrapper
   m_globalPositionWrapper.loadNodes(topNode);
+  m_globalPositionWrapper.set_suppressCrossing(true);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -78,6 +78,12 @@ class PHActsTrkFitter : public SubsysReco
     m_fitSiliconMMs = fitSiliconMMs;
   }
 
+  /// with direct navigation, force a fit with only silicon hits
+  void forceSiOnlyFit(bool forceSiOnlyFit)
+  {
+    m_forceSiOnlyFit = forceSiOnlyFit;
+  }
+
   /// require micromegas in SiliconMM fits
   void setUseMicromegas(bool value)
   {
@@ -122,6 +128,7 @@ class PHActsTrkFitter : public SubsysReco
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_track_map_name(const std::string& map_name) { _track_map_name = map_name; }
   void set_svtx_seed_map_name(const std::string& map_name) { _svtx_seed_map_name = map_name; }
+  void set_trajctories_name(const std::string& map_name) {m_trajectories_name = map_name; }
 
   /// Set flag for pp running
   void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
@@ -200,6 +207,8 @@ class PHActsTrkFitter : public SubsysReco
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs = false;
 
+  bool m_forceSiOnlyFit = false;
+
   /// requires micromegas present when fitting silicon-MM surfaces
   bool m_useMicromegas = true;
 
@@ -239,6 +248,7 @@ class PHActsTrkFitter : public SubsysReco
 
   //! acts trajectories
   std::map<const unsigned int, Trajectory>* m_trajectories = nullptr;
+  std::string m_trajectories_name = "ActsTrajectories";
 
   //! tracks
 //  SvtxTrackMap* m_seedTracks = nullptr;

--- a/offline/packages/trackreco/PHActsVertexPropagator.cc
+++ b/offline/packages/trackreco/PHActsVertexPropagator.cc
@@ -150,6 +150,9 @@ void PHActsVertexPropagator::updateSvtxTrack(SvtxTrack* track,
               << ", " << track->get_y() << ", " << track->get_z() << " to "
               << position.transpose() / 10.
               << std::endl;
+    std::cout << "Updating momentum track parameters from " << track->get_px()
+              << ", " << track->get_py() << ", " << track->get_pz()
+              << " to " << params.momentum().transpose() << std::endl; 
   }
 
   track->set_x(position(0) / Acts::UnitConstants::cm);
@@ -230,7 +233,7 @@ int PHActsVertexPropagator::getNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsTrajectories");
+  m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, m_trajectories_name);
 
   if (!m_trajectories)
   {

--- a/offline/packages/trackreco/PHActsVertexPropagator.h
+++ b/offline/packages/trackreco/PHActsVertexPropagator.h
@@ -35,6 +35,7 @@ class PHActsVertexPropagator : public SubsysReco
   int End(PHCompositeNode *topNode) override;
 
   void setTrackMapName(std::string const& track_map_name) { m_trackMapName = track_map_name; }
+  void setTrajectoriesName(std::string const& trajectories_name) { m_trajectories_name = trajectories_name; }
   void fieldMap(std::string &fieldmap) { m_fieldMap = fieldmap; }
 
  private:
@@ -50,6 +51,7 @@ class PHActsVertexPropagator : public SubsysReco
   ActsGeometry *m_tGeometry = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
   std::string m_trackMapName = "SvtxTrackMap";
+  std::string m_trajectories_name = "ActsTrajectories";
   SvtxTrackMap *m_trackMap = nullptr;
   std::map<const unsigned int, Trajectory> *m_trajectories = nullptr;
   std::string m_fieldMap = "";


### PR DESCRIPTION
…tion

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> Adds ability to run two rounds of ACTS track fitting, to refit the Si only seeds after they are matched and fit to TPC seeds. This is useful for alignment and AuAu studies of TPC Si matching.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

