### PR TITLE
Fix - CaloTowerStatus Sim

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -90,6 +90,11 @@ class CaloTowerStatus : public SubsysReco
     m_doAbortNoHotMap = status;
     return;
   }
+  void set_isSim(bool isSim = true)
+  {
+    m_isSim = isSim;
+    return;
+  }
 
  private:
   TowerInfoContainer *m_raw_towers{nullptr};
@@ -121,6 +126,7 @@ class CaloTowerStatus : public SubsysReco
   bool use_directURL_time{false};
   bool use_directURL_hotMap{false};
   bool use_directURL_chi2{false};
+  bool m_isSim{false};
 
   float badChi2_treshold_const = {1e4};
   float badChi2_treshold_quadratic = {1./100};


### PR DESCRIPTION
This PR fixes a breakage that occurs when cdb attempts to access the `sigma` field for a simulation run.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
- Added a flag `isSim` that uses the z_score information only if run is from data (not sim). 
- For the simulation runs, the default approach of checking the `hotMap_val` is used. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
Related PR in macros: https://github.com/sPHENIX-Collaboration/macros/pull/1161