### PR TITLE
Phfield mutex

### DIFF
--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -310,6 +310,9 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
   // between subsequent calls, we can save on the expense of the upper_bound
   // lookup (~10-15% of central event run time) with some caching between calls
 
+  // mutex lock to prevent data race when accessing the cache from multiple threads
+  std::lock_guard<std::mutex> guard(m_cache_mutex);
+
   unsigned int r_index0 = r_index0_cache;
   unsigned int r_index1 = r_index1_cache;
 

--- a/offline/packages/PHField/PHField2D.h
+++ b/offline/packages/PHField/PHField2D.h
@@ -5,6 +5,7 @@
 #include "PHField.h"
 
 #include <map>
+#include <mutex>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -46,6 +47,10 @@ class PHField2D : public PHField
   // I want them to be data members so we can run 2 fieldmaps in parallel
   // and still have caching. Putting those as static variables into
   // the implementation will prevent this
+
+  // needed to prevent data race when accessing cache
+  mutable std::mutex m_cache_mutex;
+
   mutable unsigned int r_index0_cache;
   mutable unsigned int r_index1_cache;
   mutable unsigned int z_index0_cache;

--- a/offline/packages/PHField/PHField3DCartesian.h
+++ b/offline/packages/PHField/PHField3DCartesian.h
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <map>
+#include <mutex>
 #include <set>
 #include <string>
 #include <tuple>
@@ -32,6 +33,10 @@ class PHField3DCartesian : public PHField
   double xstepsize = NAN;
   double ystepsize = NAN;
   double zstepsize = NAN;
+
+  // needed to prevent data race when accessing cache
+  mutable std::mutex m_cache_mutex;
+
   // these are updated in a const method
   // to cache previous values
   mutable double xyz[2][2][2][3]{};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR adds a std::mutex lock to PHField3DCartesian::GetFieldValue() and PHField2D::GetFieldValue(), to prevent data race when accessing the internal (mutable) cache from multiple thread. 

This is part of an ongoing effort initiated by @KvapilJ (Jakub) to parallelize the time consuming parts of PHSimpleKFProp
(to be discussed separately with @pinkenburg and others)

Since the current code uses PHField only inside one single thread, this should be transparent to all. 
I have tested it on a local paralellized version of the reconstruction loop.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

