### PR TITLE
Adding Trigger and Crossing Inv Mass Histograms to KFPQA

### DIFF
--- a/offline/QA/KFParticle/QAKFParticle.cc
+++ b/offline/QA/KFParticle/QAKFParticle.cc
@@ -8,6 +8,9 @@
 //#include <g4eval/SvtxClusterEval.h>
 //#include <g4eval/SvtxEvalStack.h>  // for SvtxEvalStack
 
+#include <calotrigger/TriggerRunInfo.h>
+#include <ffarawobjects/Gl1Packet.h>
+
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
@@ -113,6 +116,26 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
   h2 = new TH2F(TString(get_histo_prefix()) + "InvMass_KFP_pT",  //
                 ";pT [GeV]; mass [GeV/c^{2}] ", 100, pt_min, pt_max, 100, m_min_mass, m_max_mass);
   hm->registerHisto(h2);
+  
+  h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_crossing0",  //
+               ";mass [GeV/c^{2}];Entries", 100, m_min_mass, m_max_mass);
+  hm->registerHisto(h);
+  
+  h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_non_crossing0",  //
+               ";mass [GeV/c^{2}];Entries", 100, m_min_mass, m_max_mass);
+  hm->registerHisto(h);
+  
+  h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_ZDC_Coincidence",  //
+               ";mass [GeV/c^{2}];Entries", 100, m_min_mass, m_max_mass);
+  hm->registerHisto(h);
+  
+  h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_MBD_NandS_geq_1_vtx_l_30_cm",  //
+               ";mass [GeV/c^{2}];Entries", 100, m_min_mass, m_max_mass);
+  hm->registerHisto(h);
+  
+  h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm",  //
+               ";mass [GeV/c^{2}];Entries", 100, m_min_mass, m_max_mass);
+  hm->registerHisto(h);
 
   h_mass_KFP = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP"));
   assert(h_mass_KFP);
@@ -125,6 +148,21 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
 
   h_mass_KFP_pt = dynamic_cast<TH2F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_pT"));
   assert(h_mass_KFP_pt);
+
+  h_mass_KFP_crossing0 = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_crossing0"));
+  assert(h_mass_KFP_crossing0);
+
+  h_mass_KFP_non_crossing0 = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_non_crossing0"));
+  assert(h_mass_KFP_non_crossing0);
+
+  h_mass_KFP_ZDC_Coincidence = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_ZDC_Coincidence"));
+  assert(h_mass_KFP_ZDC_Coincidence);
+
+  h_mass_KFP_MBD_NandS_geq_1_vtx_l_30_cm = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_MBD_NandS_geq_1_vtx_l_30_cm"));
+  assert(h_mass_KFP_MBD_NandS_geq_1_vtx_l_30_cm);
+
+  h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm"));
+  assert(h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -139,6 +177,10 @@ int QAKFParticle::process_event(PHCompositeNode *topNode)
   // load relevant nodes from NodeTree
   load_nodes(topNode);
 
+  if (counter == 0)
+  {
+    initializeTriggerInfo(topNode);
+  }
   // histogram manager
 
   /*
@@ -203,6 +245,8 @@ int QAKFParticle::process_event(PHCompositeNode *topNode)
   }
   */
 
+  triggeranalyzer->decodeTriggers(topNode);
+  
   for (auto &iter : *m_kfpContainer)
   {
     if (iter.second->GetPDG() == m_mother_id)
@@ -216,8 +260,50 @@ int QAKFParticle::process_event(PHCompositeNode *topNode)
 
       h_mass_KFP_pt->Fill(iter.second->GetPt(), iter.second->GetMass());
       // h_DecayTime->Fill(part->GetLifeTime());
+     
+      const std::vector<int> track_ids = iter.second->DaughterIds(); 
+      SvtxTrack *kfpTrack = nullptr;
+      for (auto &iter2 : *m_trackMap)
+      {
+        if (iter2.first == (unsigned int) track_ids[0])
+        {
+          kfpTrack = iter2.second;
+          break;
+        }
+      }
+     
+      if (kfpTrack)
+      { 
+        if (kfpTrack->get_crossing() == 0)
+        {
+          h_mass_KFP_crossing0->Fill(iter.second->GetMass());
+        }
+        else
+        {
+          h_mass_KFP_non_crossing0->Fill(iter.second->GetMass());
+        }
+      }
+
+      for (int i = 0; i < nTriggerBits; ++i)
+      {
+        if (m_ZDC_Coincidence_bit == i && triggeranalyzer->didTriggerFire(i) == 1)
+        {
+          h_mass_KFP_ZDC_Coincidence->Fill(iter.second->GetMass());
+        }
+        else if (m_MBD_NandS_geq_1_vtx_l_30_cm_bit == i && triggeranalyzer->didTriggerFire(i) == 1)
+        {
+          h_mass_KFP_MBD_NandS_geq_1_vtx_l_30_cm->Fill(iter.second->GetMass());
+        }
+        else if (m_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm_bit == i && triggeranalyzer->didTriggerFire(i) == 1)
+        {
+          h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm->Fill(iter.second->GetMass());
+        }
+      }
     }
   }
+
+  ++counter;
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -320,4 +406,78 @@ int QAKFParticle::load_nodes(PHCompositeNode *topNode)
 std::string QAKFParticle::get_histo_prefix()
 {
   return std::string("h_") + Name() + std::string("_") + m_trackMapName + std::string("_");
+}
+
+void QAKFParticle::initializeTriggerInfo(PHCompositeNode* topNode)
+{
+  triggeranalyzer = new TriggerAnalyzer();
+
+  //Check whether we actually have the right information
+  auto gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
+  if (!gl1packet)
+  {
+    //std::cout << "No GL1RAWHIT" << std::endl;
+    gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+    if (!gl1packet)
+    {
+      //std::cout << "No GL1Packet" << std::endl;
+      return;
+    }
+  }
+
+  auto triggerruninfo = findNode::getClass<TriggerRunInfo>(topNode, "TriggerRunInfo");
+  if (!triggerruninfo)
+  {
+    //std::cout << "No triggerRunInfo" << std::endl;
+    return;
+  }
+
+  size_t pos;
+  std::string undrscr = "_";
+  std::string nothing = "";
+  std::map<std::string, std::string> forbiddenStrings;
+  forbiddenStrings[" "] = undrscr;
+  forbiddenStrings[","] = nothing;
+  forbiddenStrings["/"] = undrscr;
+  forbiddenStrings["&"] = "and";
+  forbiddenStrings["="] = "eq";
+  forbiddenStrings["<"] = "l";
+  forbiddenStrings[">"] = "g";
+  forbiddenStrings["+"] = "plus";
+  forbiddenStrings["-"] = "minus";
+  forbiddenStrings["*"] = "star";
+
+  triggeranalyzer->decodeTriggers(topNode);
+
+  for (int i = 0; i < nTriggerBits; ++i)
+  {
+    //std::cout << "in loop" << std::endl;
+    std::string triggerName = triggeranalyzer->getTriggerName(i);
+
+    if (triggerName.find("unknown") != std::string::npos)
+    {
+      continue;
+    }
+
+    for (auto const& [badString, goodString] : forbiddenStrings)
+    {
+      while ((pos = triggerName.find(badString)) != std::string::npos)
+      {
+        triggerName.replace(pos, 1, goodString);
+      }
+    }
+ 
+    if (triggerName == "ZDC_Coincidence") 
+    {
+      m_ZDC_Coincidence_bit = i;
+    }    
+    else if (triggerName == "MBD_NandS_geq_1_vtx_l_30_cm")
+    {
+      m_MBD_NandS_geq_1_vtx_l_30_cm_bit = i;
+    }
+    else if (triggerName == "Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm")
+    {
+      m_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm_bit = i;
+    }
+  }
 }

--- a/offline/QA/KFParticle/QAKFParticle.h
+++ b/offline/QA/KFParticle/QAKFParticle.h
@@ -6,6 +6,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <g4eval/SvtxEvalStack.h>
+#include <calotrigger/TriggerAnalyzer.h>
 
 #include <TH1.h>
 #include <TH2.h>
@@ -53,9 +54,22 @@ class QAKFParticle : public SubsysReco
   TH2F *h_mass_KFP_eta = nullptr;
   TH2F *h_mass_KFP_phi = nullptr;
   TH2F *h_mass_KFP_pt = nullptr;
+  TH1F *h_mass_KFP_crossing0 = nullptr;
+  TH1F *h_mass_KFP_non_crossing0 = nullptr;
+  TH1F *h_mass_KFP_ZDC_Coincidence = nullptr;
+  TH1F *h_mass_KFP_MBD_NandS_geq_1_vtx_l_30_cm = nullptr;
+  TH1F *h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm = nullptr;  
+
+  TriggerAnalyzer *triggeranalyzer{nullptr};
+
+  int m_ZDC_Coincidence_bit = INT_MAX;
+  int m_MBD_NandS_geq_1_vtx_l_30_cm_bit = INT_MAX;
+  int m_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm_bit = INT_MAX; 
 
  private:
   int load_nodes(PHCompositeNode *);
+
+  void initializeTriggerInfo(PHCompositeNode *);
 
   // SvtxTrack *getTrack(unsigned int track_id, SvtxTrackMap *trackmap);
   // PHG4Particle *getTruthTrack(SvtxTrack *thisTrack);
@@ -70,6 +84,9 @@ class QAKFParticle : public SubsysReco
   KFParticle_Container *m_kfpContainer = nullptr;
   std::map<std::string, std::pair<int, float>> particleMasses;
   std::string m_trackMapName = "SvtxTrackMap";
+
+  static const int nTriggerBits = 64;
+  int counter = 0;
 };
 
 #endif  // QAKFPARTICLE_H


### PR DESCRIPTION
Adds mass histograms for crossing = 0, crossing != 0, and 3 different trigger conditions to be able to view how each of those affect a given decay. Should work for any KFP reconstruction (e.g. K_S0, D0, etc.) so long as the KFParticle_Container and SvtxTrackMap are saved to the node tree. Ability to select different trigger conditions than these 3 coming soon

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

