### PR TITLE
Detailed calorimeter geometry - minor fix

### DIFF
--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -139,6 +139,9 @@ class BEmcRec
   static void ZeroVector(float *, int);
   static void ZeroVector(EmcModule *, int);
 
+  void set_UseCorrectPosition(bool useCorrectPosition) { m_UseCorrectPosition = useCorrectPosition; }
+  void set_UseCorrectShowerDepth(bool useCorrectShowerDepth) { m_UseCorrectShowerDepth = useCorrectShowerDepth; }
+
  protected:
   // Geometry
   bool bCYL {true};  // Cylindrical?
@@ -165,6 +168,9 @@ class BEmcRec
   bool m_UseDetailedGeometry {false};
   // Use a more detailed calorimeter geometry
   // Only available for CEMC
+
+  bool m_UseCorrectPosition = true;
+  bool m_UseCorrectShowerDepth = true;
 
  private:
   std::string m_ThisName {"NOTSET"};

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -247,15 +247,19 @@ void BEmcRecCEMC::CorrectShowerDepth(int ix, int iy, float E, float xA, float yA
     logE = std::log(E);
   }
 
-  if (!m_UseDetailedGeometry)
+  float phi = 0;
+  // Rotate by phi (towers are tilted by a fixed angle in phi by ~9 deg?)
+  // Just tuned from sim data
+  if (m_UseDetailedGeometry)
   {
-    // Rotate by phi (towers are tilted by a fixed angle in phi by ~9 deg?)
-    // Just tuned from sim data
-    float phi = 0.002 - (0.001 * logE);
-    phi = 0;
-    xC = xA * std::cos(phi) - yA * std::sin(phi);
-    yC = xA * std::sin(phi) + yA * std::cos(phi);
+    phi = 0.0033 - 0.0010 * logE;
   }
+  else
+  {
+    phi = 0.0016 - 0.0010 * logE;
+  }
+  xC = xA * std::cos(phi) - yA * std::sin(phi);
+  yC = xA * std::sin(phi) + yA * std::cos(phi);
 
   // Correction in z
   float rA = std::sqrt((xA * xA) + (yA * yA));

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -237,9 +237,13 @@ float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float 
 
 void BEmcRecCEMC::CorrectShowerDepth(int ix, int iy, float E, float xA, float yA, float zA, float& xC, float& yC, float& zC)
 {
-  xC = xA;
-  yC = yA;
-  zC = zA;
+  if (!m_UseCorrectShowerDepth)
+  {
+    xC = xA;
+    yC = yA;
+    zC = zA;
+    return;
+  }
 
   float logE = log(0.1);
   if (E > 0.1)
@@ -375,8 +379,12 @@ void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
   int ix0;
   int iy0;
 
-  xc = x;
-  yc = y;
+  if (!m_UseCorrectPosition)
+  {
+    xc = x;
+    yc = y;
+    return;
+  }
 
   if (Energy < 0.01)
   {

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -86,6 +86,27 @@ void RawClusterBuilderTemplate::Detector(const std::string &d)
   bemc->SetProbNoiseParam(fProbNoiseParam);
 }
 
+void RawClusterBuilderTemplate::set_UseCorrectPosition(const bool useCorrectPosition)
+{
+  if (bemc == nullptr)
+  {
+    std::cerr << "Error in RawClusterBuilderTemplate::set_UseCorrectPosition()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    return;
+  }
+
+  bemc->set_UseCorrectPosition(useCorrectPosition);
+}
+
+void RawClusterBuilderTemplate::set_UseCorrectShowerDepth(const bool useCorrectShowerDepth) {
+  if (bemc == nullptr)
+  {
+    std::cerr << "Error in RawClusterBuilderTemplate::set_UseCorrectShowerDepth()(): detector is not defined; use RawClusterBuilderTemplate::Detector() to define it" << std::endl;
+    return;
+  }
+
+  bemc->set_UseCorrectShowerDepth(useCorrectShowerDepth);
+}
+
 void RawClusterBuilderTemplate::set_UseDetailedGeometry(const bool useDetailedGeometry)
 {
   if (bemc == nullptr)

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -52,6 +52,10 @@ class RawClusterBuilderTemplate : public SubsysReco
     m_UseAltZVertex = useAltZMode;
   }
 
+  void set_UseCorrectPosition(const bool useCorrectPosition);
+  
+  void set_UseCorrectShowerDepth(const bool useCorrectShowerDepth);
+
   void set_UseDetailedGeometry(const bool useDetailedGeometry);
 
   void setOutputClusterNodeName(const std::string& inpNodenm)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR fixes the correction of the shower depth bias in the phi dimension. It also adds the option to activate/deactivate the S-corrections (`CorrectPosition`) and the shower depth correction (`CorrectShowerDepth`) in the reconstruction software. This can be done by using the new methods `set_UseCorrectPosition(const bool)` and `set_UseCorrectShowerDepth(const bool)` in the class `RawClusterBuilderTemplate`. By default, both methods are activated, just as in the previous implementation.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

