### PR TITLE
add forgotten flow methods, remove get_nTowersUsedForFlow()

### DIFF
--- a/offline/packages/jetbackground/TowerBackground.h
+++ b/offline/packages/jetbackground/TowerBackground.h
@@ -20,12 +20,12 @@ class TowerBackground : public PHObject
   virtual void set_nTowersUsedForBkg(int) {}
   virtual void set_flow_failure_flag(bool) {}
 
-  virtual std::vector<float> get_UE(int /*layer*/) { return std::vector<float>(); };
-  virtual float get_v2() { return 0; }
-  virtual float get_Psi2() { return 0; }
-  virtual int get_nStripsUsedForFlow() { return 0; }
-  virtual int get_nTowersUsedForBkg() { return 0; }
-  virtual bool get_flow_failure_flag() { return false; }
+  virtual std::vector<float> get_UE(int /*layer*/) const { return std::vector<float>(); };
+  virtual float get_v2() const { return 0; }
+  virtual float get_Psi2() const { return 0; }
+  virtual int get_nStripsUsedForFlow() const { return 0; }
+  virtual int get_nTowersUsedForBkg() const { return 0; }
+  virtual bool get_flow_failure_flag() const { return false; }
 
  protected:
   TowerBackground() {}

--- a/offline/packages/jetbackground/TowerBackgroundv1.h
+++ b/offline/packages/jetbackground/TowerBackgroundv1.h
@@ -21,14 +21,13 @@ class TowerBackgroundv1 : public TowerBackground
   void set_Psi2(float Psi2) override { _Psi2 = Psi2; }
   void set_nStripsUsedForFlow(int nStrips) override { _nStrips = nStrips; }
   void set_nTowersUsedForBkg(int nTowers) override { _nTowers = nTowers; }
+  void set_flow_failure_flag(bool b) override {_flow_failure_flag = b;}
 
-  std::vector<float> get_UE(int layer) override { return _UE[layer]; }
-  float get_v2() override { return _v2; }
-  float get_Psi2() override { return _Psi2; }
-  int get_nStripsUsedForFlow() override { return _nStrips; }
-
-  // our own - not from parent class
-  virtual int get_nTowersUsedForFlow() { return _nTowers; }
+  std::vector<float> get_UE(int layer) const override { return _UE[layer]; }
+  float get_v2() const override { return _v2; }
+  float get_Psi2() const override { return _Psi2; }
+  int get_nStripsUsedForFlow() const override { return _nStrips; }
+  bool get_flow_failure_flag() const override { return _flow_failure_flag; }
 
  private:
   std::vector<std::vector<float> > _UE;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds some forgotten methods to TowerBackgroundv1

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

