### PR TITLE
Added method for changing alignment state map node created by PHActsTrkFitter

### DIFF
--- a/offline/packages/trackreco/ActsAlignmentStates.cc
+++ b/offline/packages/trackreco/ActsAlignmentStates.cc
@@ -49,7 +49,7 @@ void ActsAlignmentStates::loadNodes( PHCompositeNode* topNode )
   m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
 
   // state map
-  m_alignmentStateMap = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
+  m_alignmentStateMap = findNode::getClass<SvtxAlignmentStateMap>(topNode, m_alignmentStateMapName);
 
 }
 

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -48,6 +48,10 @@ class ActsAlignmentStates
   void fieldMap(std::string& fieldmap)
   {m_fieldMap = fieldmap; }
 
+  //! alignment states map
+  void alignmentStateMap (std::string const& name)
+  {m_alignmentStateMapName = name;}
+
  private:
 
   std::pair<Acts::Vector3, Acts::Vector3> get_projectionXY(const Acts::Surface& surface, const Acts::Vector3& tangent);
@@ -62,6 +66,8 @@ class ActsAlignmentStates
 
   //! alignment state map
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
+  std::string m_alignmentStateMapName = "SvtxAlignmentStateMap";
+
 
   //! cluster map
   TrkrClusterContainer* m_clusterMap = nullptr;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1289,11 +1289,11 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
     svtxNode->addNode(node);
   }
 
-  m_alignmentStateMap = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
+  m_alignmentStateMap = findNode::getClass<SvtxAlignmentStateMap>(topNode, _svtx_alignment_state_map_name);
   if (!m_alignmentStateMap)
   {
     m_alignmentStateMap = new SvtxAlignmentStateMap_v1;
-    auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap, "SvtxAlignmentStateMap", "PHObject");
+    auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap, _svtx_alignment_state_map_name, "PHObject");
     svtxNode->addNode(node);
   }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -125,10 +125,16 @@ class PHActsTrkFitter : public SubsysReco
   {
     m_outlierFinder.outfileName(outfilename);
   }
+
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_track_map_name(const std::string& map_name) { _track_map_name = map_name; }
   void set_svtx_seed_map_name(const std::string& map_name) { _svtx_seed_map_name = map_name; }
   void set_trajctories_name(const std::string& map_name) {m_trajectories_name = map_name; }
+
+  void set_svtx_alignment_state_map_name(const std::string& map_name) { 
+      _svtx_alignment_state_map_name = map_name; 
+      m_alignStates.alignmentStateMap(map_name);
+  }
 
   /// Set flag for pp running
   void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
@@ -266,6 +272,7 @@ class PHActsTrkFitter : public SubsysReco
   int _n_iteration = 0;
   std::string _track_map_name = "SvtxTrackMap";
   std::string _svtx_seed_map_name = "SvtxTrackSeedContainer";
+  std::string _svtx_alignment_state_map_name =  "SvtxAlignmentStateMap";
 
   /// Default particle assumption to pion
   unsigned int m_pHypothesis = 211;


### PR DESCRIPTION
Added method for changing alignment state map node created by PHActsTrkFitter
(requires changes to ActsAlignmentStates, where the map is actually filled)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

