### PR TITLE
Processing TPC digital current data in offline event builder

### DIFF
--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -292,6 +292,10 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
 
         m_TpcTimeFrameBuilderMap[packet_id] = new TpcTimeFrameBuilder(packet_id);
         m_TpcTimeFrameBuilderMap[packet_id]->setVerbosity(Verbosity());
+        if (m_digitalCurrentDebugTTreeName.size())
+        {
+          m_TpcTimeFrameBuilderMap[packet_id]->SaveDigitalCurrentDebugTTree(m_digitalCurrentDebugTTreeName);
+        }
       }
 
       if (Verbosity() > 1)

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
@@ -39,6 +39,11 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
 
   void AddPacketID(const int packetID) { m_SelectedPacketIDs.insert(packetID); }
 
+  void setDigitalCurrentDebugTTreeName(const std::string &name)
+  {
+    m_digitalCurrentDebugTTreeName = name;
+  }
+
  private:
   const int NTPCPACKETS = 3;
 
@@ -73,6 +78,7 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
     bool stopped = false;
   };
 
+  std::string m_digitalCurrentDebugTTreeName;
 };
 
 #endif

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -1096,21 +1096,37 @@ void TpcTimeFrameBuilder::process_fee_data_digital_current(const unsigned int & 
 
 void TpcTimeFrameBuilder::SaveDigitalCurrentDebugTTree(const std::string &name)
 {
+  if (m_verbosity >= 1)
+  {
+    cout << __PRETTY_FUNCTION__ << "\t- : Saving digital current debug TTree to " << name << endl;
+  }
+
   m_digitalCurrentDebugTTree = new TpcTimeFrameBuilder::DigitalCurrentDebugTTree(name); 
 }
 
 TpcTimeFrameBuilder::DigitalCurrentDebugTTree::DigitalCurrentDebugTTree(const std::string &name)
+: m_name(name) 
 {  
   // open TFile
-  PHTFileServer::get().open(name, "RECREATE");
+  PHTFileServer::get().open(m_name, "RECREATE");
 
   m_tDigitalCurrent = new TTree("T_DigitalCurrent", "DigitalCurrent Debug TTree");
+  assert(m_tDigitalCurrent);
+  
+  m_tDigitalCurrent->Branch("dc", &m_payload, 
+    "fee/s:channel/s:sampa_address/s:bx_timestamp/i:pkt_length/s:current[8]/i:nsamples[8]/i:data_crc/s:calc_crc/s");
+}
 
-  m_tDigitalCurrent->Branch("payload", &m_payload);
+TpcTimeFrameBuilder::DigitalCurrentDebugTTree::~DigitalCurrentDebugTTree()
+{  
+  // open TFile
+  PHTFileServer::get().write(m_name);
 }
 
 void TpcTimeFrameBuilder::DigitalCurrentDebugTTree::fill(const TpcTimeFrameBuilder::digital_current_payload &payload)
 {
+  assert(m_tDigitalCurrent);
+
   m_payload = payload;
   m_tDigitalCurrent->Fill();
 }

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -1114,7 +1114,7 @@ TpcTimeFrameBuilder::DigitalCurrentDebugTTree::DigitalCurrentDebugTTree(const st
   assert(m_tDigitalCurrent);
   
   m_tDigitalCurrent->Branch("dc", &m_payload, 
-    "fee/s:channel/s:sampa_address/s:bx_timestamp/i:pkt_length/s:current[8]/i:nsamples[8]/i:data_crc/s:calc_crc/s");
+    "fee/s:pkt_length/s:channel/s:sampa_address/s:bx_timestamp/i:current[8]/i:nsamples[8]/i:data_crc/s:calc_crc/s");
 }
 
 TpcTimeFrameBuilder::DigitalCurrentDebugTTree::~DigitalCurrentDebugTTree()

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -1110,6 +1110,8 @@ TpcTimeFrameBuilder::DigitalCurrentDebugTTree::DigitalCurrentDebugTTree(const st
   // open TFile
   PHTFileServer::get().open(m_name, "RECREATE");
 
+  // cppcheck-suppress noCopyConstructor
+  // cppcheck-suppress noOperatorEq
   m_tDigitalCurrent = new TTree("T_DigitalCurrent", "DigitalCurrent Debug TTree");
   assert(m_tDigitalCurrent);
   

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -117,17 +117,19 @@ class TpcTimeFrameBuilder
 
   struct digital_current_payload
   {
+    static const int MAX_CHANNELS = 8;
+
     uint16_t fee {std::numeric_limits<uint16_t>::max()};
     uint16_t pkt_length {std::numeric_limits<uint16_t>::max()};
     uint16_t channel {std::numeric_limits<uint16_t>::max()};
     // uint16_t sampa_max_channel {std::numeric_limits<uint16_t>::max()};
     uint16_t sampa_address {std::numeric_limits<uint16_t>::max()};
     uint32_t bx_timestamp {0};
-    uint32_t current[8] {0};
-    uint32_t nsamples[8] {0};
-    uint16_t checksum {std::numeric_limits<uint16_t>::max()};
-    uint16_t type {std::numeric_limits<uint16_t>::max()};
-    bool     valid {false};
+    uint32_t current[MAX_CHANNELS] {0};
+    uint32_t nsamples[MAX_CHANNELS] {0};
+    uint16_t data_crc {std::numeric_limits<uint16_t>::max()};
+    uint16_t calc_crc = {std::numeric_limits<uint16_t>::max()};
+    // uint16_t type {std::numeric_limits<uint16_t>::max()};
   };
 
   // -------------------------

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -46,6 +46,7 @@ class TpcTimeFrameBuilder
 
   static const uint16_t FEE_PACKET_MAGIC_KEY_1 = 0xfe;
   static const uint16_t FEE_PACKET_MAGIC_KEY_2 = 0xed;
+  static const uint16_t FEE_PACKET_MAGIC_KEY_3_DC = 0xdcdc; // Digital Current word[3]
 
   static const uint16_t FEE_MAGIC_KEY = 0xba00;
   static const uint16_t GTM_MAGIC_KEY = 0xbb00;
@@ -76,6 +77,8 @@ class TpcTimeFrameBuilder
 
   int decode_gtm_data(const dma_word &gtm_word);
   int process_fee_data(unsigned int fee_id);
+  void process_fee_data_waveform(const unsigned int & fee_id, std::deque<uint16_t>& data_buffer);
+  void process_fee_data_digital_current(const unsigned int & fee_id, std::deque<uint16_t>& data_buffer);
 
   struct gtm_payload
   {
@@ -110,6 +113,21 @@ class TpcTimeFrameBuilder
     uint16_t calc_parity = 0;
 
     std::vector<std::pair<uint16_t, std::vector<uint16_t>>> waveforms;
+  };
+
+  struct digital_current_payload
+  {
+    uint16_t fee {std::numeric_limits<uint16_t>::max()};
+    uint16_t pkt_length {std::numeric_limits<uint16_t>::max()};
+    uint16_t channel {std::numeric_limits<uint16_t>::max()};
+    // uint16_t sampa_max_channel {std::numeric_limits<uint16_t>::max()};
+    uint16_t sampa_address {std::numeric_limits<uint16_t>::max()};
+    uint32_t bx_timestamp {0};
+    uint32_t current[8] {0};
+    uint32_t nsamples[8] {0};
+    uint16_t checksum {std::numeric_limits<uint16_t>::max()};
+    uint16_t type {std::numeric_limits<uint16_t>::max()};
+    bool     valid {false};
   };
 
   // -------------------------

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -140,6 +140,7 @@ class TpcTimeFrameBuilder
   {
    public:
     explicit DigitalCurrentDebugTTree(const std::string &name);
+    virtual ~DigitalCurrentDebugTTree();
 
     void fill(const digital_current_payload &payload);
 
@@ -149,7 +150,7 @@ class TpcTimeFrameBuilder
     std::string m_name;
     TTree *m_tDigitalCurrent = nullptr;
   };
-  DigitalCurrentDebugTTree * m_digitalCurrentDebugTTree;
+  DigitalCurrentDebugTTree * m_digitalCurrentDebugTTree = nullptr;
 
   // -------------------------
   // GTM Matcher

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -21,6 +21,7 @@ class TpcRawHit;
 class PHTimer;
 class TH1;
 class TH2;
+class TTree;
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 class TpcTimeFrameBuilder
@@ -39,6 +40,9 @@ class TpcTimeFrameBuilder
   {
     m_fastBCOSkip = fastBCOSkip;
   }
+
+  // enable saving of digital current debug TTree with file name `name`
+  void SaveDigitalCurrentDebugTTree(const std::string &name);
 
  protected:
   // Length for the 256-bit wide Round Robin Multiplexer for the data stream
@@ -131,6 +135,21 @@ class TpcTimeFrameBuilder
     uint16_t calc_crc = {std::numeric_limits<uint16_t>::max()};
     // uint16_t type {std::numeric_limits<uint16_t>::max()};
   };
+
+  class DigitalCurrentDebugTTree
+  {
+   public:
+    explicit DigitalCurrentDebugTTree(const std::string &name);
+
+    void fill(const digital_current_payload &payload);
+
+   private:
+    digital_current_payload m_payload;
+
+    std::string m_name;
+    TTree *m_tDigitalCurrent = nullptr;
+  };
+  DigitalCurrentDebugTTree * m_digitalCurrentDebugTTree;
 
   // -------------------------
   // GTM Matcher


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Decoding the digital current data in offline TPC event builder, which prints DC packets like the following when Verbosity is enabled, and add decoding statistics to the event builder QA histograms. 

```
void TpcTimeFrameBuilder::process_fee_data_digital_current(const unsigned int&, std::deque<short unsigned int>&)	- : received digital current packet 	- from FEE 8
	- pkt_length = 39
	- sampa_address = 3
	- channel = 103
	- bx_timestamp = 0x1b9cb
	- current:	[0] = 4804	[1] = 5380	[2] = 4612	[3] = 4534	[4] = 12389	[5] = 5585	[6] = 4824	[7] = 3944
	- nsamples:	[0] = 32	[1] = 44	[2] = 42	[3] = 40	[4] = 74	[5] = 44	[6] = 37	[7] = 31
	- data_crc = 0x3266
	- calc_crc = 0x3266
```
<img width="791" height="995" alt="image" src="https://github.com/user-attachments/assets/0225d766-543e-4403-b0ae-bf384250b54d" />

### Example macro to enable the digital current debug tree output

Single call to `SingleTpcTimeFrameInput::setDigitalCurrentDebugTTreeName( )` as in https://github.com/blackcathj/macros/blob/761311ce1639b9a16c7c69658fce7fb5478d1efb/StreamingProduction/Fun4All_TPC_SingleStream_Combiner.C#L102C1-L107C30

```c++

      SingleTpcTimeFrameInput *tpc_sngl = new SingleTpcTimeFrameInput("SingleTpcTimeFrameInput_" + to_string(i));
      tpc_sngl->setHitContainerName("TPCRAWHIT_" + ebdc);
      tpc_sngl->AddListFile(iter);
      tpc_sngl->setDigitalCurrentDebugTTreeName(iter + "_DigitalCurrentDebugTTree.root");
      tpc_sngl->Verbosity(1);
      
 ```
 

### Example tree output

One 8-channel digital current reading per TTree Entry as in example: 

```
root data/tpc-00069260-05_1.list_DigitalCurrentDebugTTree.root
root [0] 
Attaching file data/tpc-00069260-05_1.list_DigitalCurrentDebugTTree.root as _file0...
(TFile *) 0x2a00c70
root [1] T_DigitalCurrent->Show(0)
======> EVENT:0
 fee             = 6
 pkt_length      = 39
 channel         = 7
 sampa_address   = 0
 bx_timestamp    = 113099
 current         = 3947, 
                  6917, 4824, 15717, 3909, 5543, 5238, 10169
 nsamples        = 29, 
                  51, 37, 104, 31, 35, 36, 68
 data_crc        = 61123
 calc_crc        = 61123
 ```

<img width="1088" height="984" alt="image" src="https://github.com/user-attachments/assets/1509c7d9-b579-4dad-a55a-50ca38cb6b82" />


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/online_distribution/pull/199
