### PR TITLE
Waveformsim: refactor the MC calibration, update time de-calibration

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -43,27 +43,34 @@ public:
   void set_detector_type(CaloTowerDefs::DetectorSystem dettype) { m_dettype = dettype; }
   void set_detector(const std::string &detector) { m_detector = detector; }
 
-  // Calibration settings (data)
-  void set_fieldname(const std::string &fieldname) { m_fieldname = fieldname; m_overrideCalibName = false; }
+  // Calibration settings (data energy)
+  void set_fieldname(const std::string &fieldname) { m_fieldname = fieldname; m_overrideFieldName = true; }
   void set_calibName(const std::string &calibName) { m_calibName = calibName; m_overrideCalibName = true; }
   void set_directURL_calib(const std::string &url) { m_giveDirectURL = true; m_directURL = url; }
+  void set_overrideCalibName(bool overrideCalib) { m_overrideCalibName = overrideCalib; }
+  void set_overrideFieldName(bool overrideField) { m_overrideFieldName = overrideField; }
 
-  // Calibration settings (MC)
-  void set_MC_fieldname(const std::string &MC_fieldname) { m_MC_fieldname = MC_fieldname; }
-  void set_MC_calibName(const std::string &MC_calibName) { m_MC_calibName = MC_calibName; }
+  // Calibration settings (MC energy)
+  void set_MC_fieldname(const std::string &MC_fieldname) { m_MC_fieldname = MC_fieldname; m_overrideMCFieldName = true; }
+  void set_MC_calibName(const std::string &MC_calibName) { m_MC_calibName = MC_calibName; m_overrideMCCalibName = true; }
   void set_directURL_MCcalib(const std::string &url) { m_giveDirectURL_MC = true; m_directURL_MC = url; }
+  void set_overrideMCFieldName(bool overrideField) { m_overrideMCFieldName = overrideField; }
+  void set_overrideMCCalibName(bool overrideCalib) { m_overrideMCCalibName = overrideCalib; }
 
   // Time calibration (data)
-  void set_overrideFieldName(bool overrideFieldName) { m_overrideFieldName = overrideFieldName; }
-  void set_fieldname_time(const std::string &fieldname_time) { m_fieldname_time = fieldname_time; }
-  void set_calibName_time(const std::string &calibName_time) { m_calibName_time = calibName_time; }
+  void set_fieldname_time(const std::string &fieldname_time) { m_fieldname_time = fieldname_time; m_overrideTimeFieldName = true; }
+  void set_calibName_time(const std::string &calibName_time) { m_calibName_time = calibName_time; m_overrideTimeCalibName = true; }
   void set_directURL_timecalib(const std::string &url) { m_giveDirectURL_time = true; m_directURL_time = url; }
   void set_dotimecalib(bool dotimecalib) { m_dotimecalib = dotimecalib; }
+  void set_overrideTimeFieldName(bool overrideField) { m_overrideTimeFieldName = overrideField; }
+  void set_overrideTimeCalibName(bool overrideCalib) { m_overrideTimeCalibName = overrideCalib; }
 
   // Time calibration (MC)
-  void set_MC_fieldname_time(const std::string &MC_fieldname_time) { m_MC_fieldname_time = MC_fieldname_time; }
-  void set_MC_calibName_time(const std::string &MC_calibName_time) { m_MC_calibName_time = MC_calibName_time; }
+  void set_MC_fieldname_time(const std::string &MC_fieldname_time) { m_MC_fieldname_time = MC_fieldname_time; m_overrideMCTimeFieldName = true; }
+  void set_MC_calibName_time(const std::string &MC_calibName_time) { m_MC_calibName_time = MC_calibName_time; m_overrideMCTimeCalibName = true; }
   void set_directURL_MCtimecalib(const std::string &url) { m_giveDirectURL_MC_time = true; m_directURL_MC_time = url; }
+  void set_overrideMCTimeFieldName(bool overrideField) { m_overrideMCTimeFieldName = overrideField; }
+  void set_overrideMCTimeCalibName(bool overrideCalib) { m_overrideMCTimeCalibName = overrideCalib; }
 
   // Waveform template & sampling
   void set_templatefile(const std::string &templatefile) { m_templatefile = templatefile; }
@@ -94,29 +101,38 @@ private:
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::CEMC};
   std::string m_detector{"CEMC"};
 
+  // Data energy calibration
   std::string m_fieldname{"Femc_datadriven_qm1_correction"};
   std::string m_calibName{"cemc_pi0_twrSlope_v1"};
   bool        m_overrideCalibName{false};
+  bool        m_overrideFieldName{false};
   bool        m_giveDirectURL{false};
   std::string m_directURL{""};
-
+  // MC energy calibration
   std::string m_MC_fieldname{"Femc_datadriven_qm1_correction"};
   std::string m_MC_calibName{"cemc_pi0_twrSlope_v1"};
+  bool        m_overrideMCFieldName{false};
+  bool        m_overrideMCCalibName{false};
   bool        m_giveDirectURL_MC{false};
   std::string m_directURL_MC{""};
 
-  bool        m_overrideFieldName{false};
+  // Data time calibration
   std::string m_fieldname_time{"time"};
   std::string m_calibName_time{"CEMC_meanTime"};
-  bool        m_dotimecalib{true};
+  bool        m_overrideTimeFieldName{false};
+  bool        m_overrideTimeCalibName{false};
+  bool        m_dotimecalib{false};
   bool        m_giveDirectURL_time{false};
   std::string m_directURL_time{""};
-
+  // MC time calibration
   std::string m_MC_fieldname_time{"time"};
   std::string m_MC_calibName_time{"CEMC_meanTime"};
+  bool        m_overrideMCTimeFieldName{false};
+  bool        m_overrideMCTimeCalibName{false};
   bool        m_giveDirectURL_MC_time{false};
   std::string m_directURL_MC_time{""};
 
+  // Waveform settings
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
   int         m_nsamples{31};
   int         m_pedestalsamples{31};
@@ -124,6 +140,11 @@ private:
   int         m_nchannels{24576};
   float       m_sampling_fraction{1.0f};
 
+  //containers
+  TowerInfoContainer *m_CaloWaveformContainer{nullptr};
+  TowerInfoContainer *m_PedestalContainer{nullptr};
+
+  // Shaping & noise
   int   m_fixpedestal{1500};
   int   m_gaussian_noise{3};
   float m_deltaT{100.};
@@ -146,6 +167,8 @@ private:
   CDBTTree *cdbttree_time{nullptr}, *cdbttree_MC_time{nullptr};
   TProfile *h_template{nullptr};
   LightCollectionModel light_collection_model;
+
+  NoiseType m_noiseType{NOISE_TREE};
 
   void CreateNodeTree(PHCompositeNode *topNode);
   void maphitetaphi(PHG4Hit *g4hit,

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -149,6 +149,12 @@ class CaloWaveformSim : public SubsysReco
     m_directURL_time = url;
   }
 
+  void set_directURL_MCtimecalib(const std::string &url)
+  {
+    m_giveDirectURL_MC_time = true;
+    m_directURL_MC_time = url;
+  }
+
   void set_dotimecalib(bool dotimecalib)
   {
     m_dotimecalib = dotimecalib;
@@ -161,15 +167,25 @@ class CaloWaveformSim : public SubsysReco
   std::string m_detector{"CEMC"};
   std::string m_fieldname{"Femc_datadriven_qm1_correction"};
   std::string m_calibName{"cemc_pi0_twrSlope_v1"};
+  std::string m_MC_fieldname{"Femc_datadriven_qm1_correction"};
+  std::string m_MC_calibName{"cemc_pi0_twrSlope_v1"};
   std::string m_fieldname_time{"time"};
   std::string m_calibName_time{"CEMC_meanTime"};
+  std::string m_MC_fieldname_time{"time"};
+  std::string m_MC_calibName_time{"CEMC_meanTime"};
   std::string m_directURL_time{""};
+   std::string m_directURL_MC_time{""};
   bool m_dotimecalib{true};
+  bool m_giveDirectURL{false};
+  bool m_giveDirectURL_MC{false};
   bool m_giveDirectURL_time{false};
+  bool m_giveDirectURL_MC_time{false};
   bool m_overrideCalibName{false};
   bool m_overrideFieldName{false};
   CDBTTree *cdbttree{nullptr};
-  CDBTTree *cdbttree_time = nullptr;
+  CDBTTree *cdbttree_MC{nullptr};
+  CDBTTree *cdbttree_time{nullptr};
+  CDBTTree *cdbttree_MC_time{nullptr};
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
   TProfile *h_template{nullptr};
   TowerInfoContainer *m_CaloWaveformContainer{nullptr};

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -1,11 +1,11 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-/*!
+/*!  
  * \file CaloWaveformSim.h
  * \brief create waveform from hits, could also use for event overlay
  * \author Shuhang Li <sli7@bnl.gov>
  * \version $Revision:   $
- * \date $Date: $
+ * \date    $Date: $
  */
 #ifndef CALOWAVEFORMSIM_H
 #define CALOWAVEFORMSIM_H
@@ -13,12 +13,9 @@
 #include <calobase/TowerInfoDefs.h>
 #include <caloreco/CaloTowerDefs.h>
 #include <fun4all/SubsysReco.h>
-
 #include <g4detectors/LightCollectionModel.h>
-
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
-
 #include <string>
 #include <vector>
 
@@ -34,191 +31,128 @@ class TowerInfoContainer;
 
 class CaloWaveformSim : public SubsysReco
 {
- public:
+public:
   CaloWaveformSim(const std::string &name = "CaloWaveformSim");
-
   ~CaloWaveformSim() override;
 
-  enum NoiseType
-  {
-    NOISE_NONE = 0,
-    NOISE_GAUSSIAN = 1,
-    NOISE_TREE = 2
-  };
-
   int InitRun(PHCompositeNode *topNode) override;
-
-  /** Called for each event.
-      This is where you do the real work.
-   */
   int process_event(PHCompositeNode *topNode) override;
-
-  /// Called at the end of all processing.
   int End(PHCompositeNode *topNode) override;
 
-  void set_detector_type(CaloTowerDefs::DetectorSystem dettype)
-  {
-    m_dettype = dettype;
-    return;
-  }
-  void set_detector(const std::string &detector)
-  {
-    m_detector = detector;
-    return;
-  }
-  void set_fieldname(const std::string &fieldname)
-  {
-    m_fieldname = fieldname;
-    return;
-  }
-  void set_calibName(const std::string &calibName)
-  {
-    m_calibName = calibName;
-    m_overrideCalibName = true;
-    return;
-  }
-  void set_overrideCalibName(bool overrideCalibName)
-  {
-    m_overrideCalibName = overrideCalibName;
-    return;
-  }
-  void set_overrideFieldName(bool overrideFieldName)
-  {
-    m_overrideFieldName = overrideFieldName;
-    return;
-  }
-  void set_templatefile(const std::string &templatefile)
-  {
-    m_templatefile = templatefile;
-    return;
-  }
-  void set_nsamples(int _nsamples)
-  {
-    m_nsamples = _nsamples;
-    return;
-  }
-  void set_pedestalsamples(int _pedestalsamples)
-  {
-    m_pedestalsamples = _pedestalsamples;
-    return;
-  }
-  void set_noise_type(NoiseType noiseType)
-  {
-    m_noiseType = noiseType;
-    return;
-  }
-  void set_fixpedestal(int _fixpedestal)
-  {
-    m_fixpedestal = _fixpedestal;
-    return;
-  }
-  void set_gaussian_noise(int _gaussian_noise)
-  {
-    m_gaussian_noise = _gaussian_noise;
-    return;
-  }
-  void set_deltaT(float _deltaT)
-  {
-    m_deltaT = _deltaT;
-    return;
-  }
-  void set_timewidth(float _timewidth)
-  {
-    m_timeshiftwidth = _timewidth;
-    return;
-  }
-  void set_peakpos(float _peakpos)
-  {
-    m_peakpos = _peakpos;
-    return;
-  }
-  void set_highgain(bool _highgain = true)
-  {
-    m_highgain = _highgain;
-    return;
-  }
-  void set_pedestal_scale(float _pedestal_scale)
-  {
-    m_pedestal_scale = _pedestal_scale;
-    return;
-  }
+  // Detector configuration
+  void set_detector_type(CaloTowerDefs::DetectorSystem dettype) { m_dettype = dettype; }
+  void set_detector(const std::string &detector) { m_detector = detector; }
 
-  void set_directURL_timecalib(const std::string &url)
-  {
-    m_giveDirectURL_time = true;
-    m_directURL_time = url;
-  }
+  // Calibration settings (data)
+  void set_fieldname(const std::string &fieldname) { m_fieldname = fieldname; m_overrideCalibName = false; }
+  void set_calibName(const std::string &calibName) { m_calibName = calibName; m_overrideCalibName = true; }
+  void set_directURL_calib(const std::string &url) { m_giveDirectURL = true; m_directURL = url; }
 
-  void set_directURL_MCtimecalib(const std::string &url)
-  {
-    m_giveDirectURL_MC_time = true;
-    m_directURL_MC_time = url;
-  }
+  // Calibration settings (MC)
+  void set_MC_fieldname(const std::string &MC_fieldname) { m_MC_fieldname = MC_fieldname; }
+  void set_MC_calibName(const std::string &MC_calibName) { m_MC_calibName = MC_calibName; }
+  void set_directURL_MCcalib(const std::string &url) { m_giveDirectURL_MC = true; m_directURL_MC = url; }
 
-  void set_dotimecalib(bool dotimecalib)
-  {
-    m_dotimecalib = dotimecalib;
-  }
-  // for CEMC light yield correction
+  // Time calibration (data)
+  void set_overrideFieldName(bool overrideFieldName) { m_overrideFieldName = overrideFieldName; }
+  void set_fieldname_time(const std::string &fieldname_time) { m_fieldname_time = fieldname_time; }
+  void set_calibName_time(const std::string &calibName_time) { m_calibName_time = calibName_time; }
+  void set_directURL_timecalib(const std::string &url) { m_giveDirectURL_time = true; m_directURL_time = url; }
+  void set_dotimecalib(bool dotimecalib) { m_dotimecalib = dotimecalib; }
+
+  // Time calibration (MC)
+  void set_MC_fieldname_time(const std::string &MC_fieldname_time) { m_MC_fieldname_time = MC_fieldname_time; }
+  void set_MC_calibName_time(const std::string &MC_calibName_time) { m_MC_calibName_time = MC_calibName_time; }
+  void set_directURL_MCtimecalib(const std::string &url) { m_giveDirectURL_MC_time = true; m_directURL_MC_time = url; }
+
+  // Waveform template & sampling
+  void set_templatefile(const std::string &templatefile) { m_templatefile = templatefile; }
+  void set_nsamples(int nsamples) { m_nsamples = nsamples; }
+  void set_pedestalsamples(int pedestalsamples) { m_pedestalsamples = pedestalsamples; }
+  void set_sampletime(float sampletime) { m_sampletime = sampletime; }
+  void set_nchannels(int nchannels) { m_nchannels = nchannels; }
+  void set_sampling_fraction(float fraction) { m_sampling_fraction = fraction; }
+
+  // Signal shaping parameters
+  void set_deltaT(float deltaT) { m_deltaT = deltaT; }
+  void set_timewidth(float timewidth) { m_timeshiftwidth = timewidth; }
+  void set_peakpos(float peakpos) { m_peakpos = peakpos; }
+  void set_highgain(bool highgain = true) { m_highgain = highgain; }
+  void set_gain(int gain) { m_gain = gain; }
+  void set_pedestal_scale(float scale) { m_pedestal_scale = scale; }
+
+  // Noise configuration
+  enum NoiseType { NOISE_NONE = 0, NOISE_GAUSSIAN = 1, NOISE_TREE = 2 };
+  void set_noise_type(NoiseType noiseType) { m_noiseType = noiseType; }
+  void set_fixpedestal(int fixpedestal) { m_fixpedestal = fixpedestal; }
+  void set_gaussian_noise(int gaussian_noise) { m_gaussian_noise = gaussian_noise; }
+
+  // Light collection model access
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
- private:
+private:
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::CEMC};
   std::string m_detector{"CEMC"};
+
   std::string m_fieldname{"Femc_datadriven_qm1_correction"};
   std::string m_calibName{"cemc_pi0_twrSlope_v1"};
+  bool        m_overrideCalibName{false};
+  bool        m_giveDirectURL{false};
+  std::string m_directURL{""};
+
   std::string m_MC_fieldname{"Femc_datadriven_qm1_correction"};
   std::string m_MC_calibName{"cemc_pi0_twrSlope_v1"};
+  bool        m_giveDirectURL_MC{false};
+  std::string m_directURL_MC{""};
+
+  bool        m_overrideFieldName{false};
   std::string m_fieldname_time{"time"};
   std::string m_calibName_time{"CEMC_meanTime"};
+  bool        m_dotimecalib{true};
+  bool        m_giveDirectURL_time{false};
+  std::string m_directURL_time{""};
+
   std::string m_MC_fieldname_time{"time"};
   std::string m_MC_calibName_time{"CEMC_meanTime"};
-  std::string m_directURL_time{""};
-   std::string m_directURL_MC_time{""};
-  bool m_dotimecalib{true};
-  bool m_giveDirectURL{false};
-  bool m_giveDirectURL_MC{false};
-  bool m_giveDirectURL_time{false};
-  bool m_giveDirectURL_MC_time{false};
-  bool m_overrideCalibName{false};
-  bool m_overrideFieldName{false};
-  CDBTTree *cdbttree{nullptr};
-  CDBTTree *cdbttree_MC{nullptr};
-  CDBTTree *cdbttree_time{nullptr};
-  CDBTTree *cdbttree_MC_time{nullptr};
-  std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
-  TProfile *h_template{nullptr};
-  TowerInfoContainer *m_CaloWaveformContainer{nullptr};
-  TowerInfoContainer *m_PedestalContainer{nullptr};
+  bool        m_giveDirectURL_MC_time{false};
+  std::string m_directURL_MC_time{""};
 
-  std::vector<std::vector<float>> m_waveforms = {{}};
-  int m_runNumber{0};
-  int m_nsamples{31};
-  int m_nchannels{24576};
-  int m_pedestalsamples{31};
-  float m_sampletime{50. / 3.};
-  int m_fixpedestal{1500};
-  int m_gaussian_noise{3};
+  std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
+  int         m_nsamples{31};
+  int         m_pedestalsamples{31};
+  float       m_sampletime{50. / 3.};
+  int         m_nchannels{24576};
+  float       m_sampling_fraction{1.0f};
+
+  int   m_fixpedestal{1500};
+  int   m_gaussian_noise{3};
   float m_deltaT{100.};
   float m_timeshiftwidth{0.};
-  bool m_highgain{false};
-  int m_gain{1};
+  bool  m_highgain{false};
+  int   m_gain{1};
   float m_peakpos{6.};
   float m_pedestal_scale{1.};
+
   gsl_rng *m_RandomGenerator{nullptr};
-
   PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};
-  const PHG4CylinderGeom_Spacalv3 *layergeom{nullptr};
-  float m_sampling_fraction = {1.0};
-  void maphitetaphi(PHG4Hit *g4hit, unsigned short &etabin, unsigned short &phibin, float &correction);
-  unsigned int (*encode_tower)(const unsigned int etabin, const unsigned int phibin){TowerInfoDefs::encode_emcal};
-  unsigned int (*decode_tower)(const unsigned int tower_key){TowerInfoDefs::decode_emcal};
-  double template_function(double *x, double *par);
-  void CreateNodeTree(PHCompositeNode *topNode);
+  const PHG4CylinderGeom_Spacalv3  *layergeom{nullptr};
+  std::vector<std::vector<float>> m_waveforms;
+  int m_runNumber{0};
 
+  unsigned int (*encode_tower)(unsigned int, unsigned int){TowerInfoDefs::encode_emcal};
+  unsigned int (*decode_tower)(unsigned int){TowerInfoDefs::decode_emcal};
+
+  CDBTTree *cdbttree{nullptr}, *cdbttree_MC{nullptr};
+  CDBTTree *cdbttree_time{nullptr}, *cdbttree_MC_time{nullptr};
+  TProfile *h_template{nullptr};
   LightCollectionModel light_collection_model;
 
-  NoiseType m_noiseType{NOISE_TREE};
+  void CreateNodeTree(PHCompositeNode *topNode);
+  void maphitetaphi(PHG4Hit *g4hit,
+                    unsigned short &etabin,
+                    unsigned short &phibin,
+                    float &correction);
+  double template_function(double *x, double *par);
 };
 
 #endif  // CALOWAVEFORMSIM_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

1.  This PR refactor the MC calibration that used to applied in the process calo_calib stage to the waveform simulation step.
2. Waveform sim with the time decalibration option now reads the MC_meantime and the the G4Hit_time = 0 puts the peak at Data_meantime - MC_meantime.


## TODOs (if applicable)




## Links to other PRs in macros and calibration repositories (if applicable)

