### PR TITLE
make onnx return vector compatible with template fit return

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -138,20 +138,19 @@ int CaloTowerBuilder::InitRun(PHCompositeNode *topNode)
     {
       WaveformProcessing->set_processing_type(CaloWaveformProcessing::TEMPLATE);  // default the EPD to fast processing
     }
-      
+
     m_calibName = "SEPD_CHANNELMAP2";
     m_fieldname = "epd_channel_map2";
-        
+
     calibdir = CDBInterface::instance()->getUrl(m_calibName);
 
     if (calibdir.empty())
     {
-        std::cout << PHWHERE << "No sEPD mapping file for domain " << m_calibName << " found" << std::endl;
-         exit(1);
+      std::cout << PHWHERE << "No sEPD mapping file for domain " << m_calibName << " found" << std::endl;
+      exit(1);
     }
-        
-    cdbttree_sepd_map = new CDBTTree(calibdir);
 
+    cdbttree_sepd_map = new CDBTTree(calibdir);
   }
   else if (m_dettype == CaloTowerDefs::ZDC)
   {
@@ -363,8 +362,11 @@ int CaloTowerBuilder::process_data(PHCompositeNode *topNode, std::vector<std::ve
       }
 
       int nch_padded = nchannels;
-      if (m_dettype == CaloTowerDefs::CEMC) nch_padded += n_pad_skip_mask;
-      if ( nch_padded  < m_nchannels)
+      if (m_dettype == CaloTowerDefs::CEMC)
+      {
+        nch_padded += n_pad_skip_mask;
+      }
+      if (nch_padded < m_nchannels)
       {
         for (int channel = 0; channel < m_nchannels - nch_padded; channel++)
         {
@@ -462,31 +464,26 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
   for (int i = 0; i < n_channels; i++)
   {
     int idx = i;
-    //Align sEPD ADC channels to TowerInfoContainer
+    // Align sEPD ADC channels to TowerInfoContainer
     if (m_dettype == CaloTowerDefs::SEPD)
     {
-        idx = cdbttree_sepd_map->GetIntValue(i, m_fieldname);
+      idx = cdbttree_sepd_map->GetIntValue(i, m_fieldname);
     }
     TowerInfo *towerinfo = m_CaloInfoContainer->get_tower_at_channel(i);
     towerinfo->set_time(processed_waveforms.at(idx).at(1));
     towerinfo->set_energy(processed_waveforms.at(idx).at(0));
     towerinfo->set_time_float(processed_waveforms.at(idx).at(1));
     towerinfo->set_pedestal(processed_waveforms.at(idx).at(2));
-    bool SZS{true};
-    
-    if (_processingtype != CaloWaveformProcessing::ONNX)
-     {
-       towerinfo->set_chi2(processed_waveforms.at(idx).at(3));
-       SZS = isSZS(processed_waveforms.at(idx).at(1), processed_waveforms.at(idx).at(3));
-       if (processed_waveforms.at(idx).at(4) == 0)
-       {
-     	towerinfo->set_isRecovered(false);
-       }
-       else
-       {
-     	towerinfo->set_isRecovered(true);
-       }
-     }
+    towerinfo->set_chi2(processed_waveforms.at(idx).at(3));
+    bool SZS = isSZS(processed_waveforms.at(idx).at(1), processed_waveforms.at(idx).at(3));
+    if (processed_waveforms.at(idx).at(4) == 0)
+    {
+      towerinfo->set_isRecovered(false);
+    }
+    else
+    {
+      towerinfo->set_isRecovered(true);
+    }
     int n_samples = waveforms.at(idx).size();
     if (n_samples == m_nzerosuppsamples || SZS)
     {

--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -30,7 +30,6 @@ class CaloTowerBuilder : public SubsysReco
   void CreateNodeTree(PHCompositeNode *topNode);
 
   int process_data(PHCompositeNode *topNode, std::vector<std::vector<float>> &waveforms);
-  
 
   void set_detector_type(CaloTowerDefs::DetectorSystem dettype)
   {
@@ -82,7 +81,7 @@ class CaloTowerBuilder : public SubsysReco
   {
     m_UseOfflinePacketFlag = f;
   }
-  void set_timeFitLim(float low,float high)
+  void set_timeFitLim(float low, float high)
   {
     m_setTimeLim = true;
     m_timeLim_low = low;
@@ -107,9 +106,9 @@ class CaloTowerBuilder : public SubsysReco
     m_zs_fieldname = fieldname;
     return;
   }
-  
-  CaloWaveformProcessing *get_WaveformProcessing() {return WaveformProcessing;}
-  
+
+  CaloWaveformProcessing *get_WaveformProcessing() { return WaveformProcessing; }
+
  private:
   int process_sim();
   bool skipChannel(int ich, int pid);
@@ -151,7 +150,6 @@ class CaloTowerBuilder : public SubsysReco
   std::string m_directURL;
   std::string m_zsURL;
   std::string m_zs_fieldname{"zs_threshold"};
-
 };
 
 #endif  // CALOTOWERBUILDER_H

--- a/offline/packages/CaloReco/CaloWaveformProcessing.cc
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.cc
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cstdlib>  // for getenv
 #include <iostream>
+#include <limits>
 #include <memory>  // for allocator_traits<>::value_type
 #include <string>
 
@@ -32,7 +33,7 @@ void CaloWaveformProcessing::initialize_processing()
     url_template = CDBInterface::instance()->getUrl(m_template_name, calibrations_repo_template);
     m_Fitter = new CaloWaveformFitting();
     m_Fitter->initialize_processing(url_template);
-    if(m_processingtype == CaloWaveformProcessing::TEMPLATE_NOSAT)
+    if (m_processingtype == CaloWaveformProcessing::TEMPLATE_NOSAT)
     {
       m_Fitter->set_handleSaturation(false);
     }
@@ -53,8 +54,8 @@ void CaloWaveformProcessing::initialize_processing()
   }
   else if (m_processingtype == CaloWaveformProcessing::ONNX)
   {
-    //std::string calibrations_repo_model = m_model_name;
-    //url_onnx = CDBInterface::instance()->getUrl("CEMC_ONNX", m_model_name);
+    // std::string calibrations_repo_model = m_model_name;
+    // url_onnx = CDBInterface::instance()->getUrl("CEMC_ONNX", m_model_name);
     onnxmodule = onnxSession(m_model_name);
   }
   else if (m_processingtype == CaloWaveformProcessing::NYQUIST)
@@ -100,21 +101,29 @@ std::vector<std::vector<float>> CaloWaveformProcessing::calo_processing_ONNX(con
   for (unsigned int m = 0; m < nchnls; m++)
   {
     const std::vector<float> &v = chnlvector.at(m);
-    unsigned int nsamples = v.size() - 1;
-    std::vector<float> vtmp;
-    vtmp.reserve(nsamples);
-    for (unsigned int k = 0; k < v.size(); k++)
+    unsigned int nsamples = v.size();
+    if (nsamples == 12)
     {
-      vtmp.push_back((float) (v.at(k)));
+      // downstream onnx does not have a static input vector API,
+      // so we need to make a copy
+      std::vector<float> vtmp(v);
+      std::vector<float> val = onnxInference(onnxmodule, vtmp, 1, 12, 3);
+      unsigned int nvals = val.size();
+      for (unsigned int i = 0; i < nvals; i++)
+      {
+        val.at(i) = val.at(i) * m_Onnx_factor[i] + m_Onnx_offset[i];
+      }
+      val.push_back(2000);
+      val.push_back(0);
+      fit_values.push_back(val);
+      val.clear();
     }
-    std::vector<float> val = onnxInference(onnxmodule, vtmp, 1, 12, 3);
-    unsigned int nvals = val.size();
-    for (unsigned int i = 0; i < nvals; i++)
+    else
     {
-      val.at(i) = val.at(i) * m_Onnx_factor[i] + m_Onnx_offset[i];
+      float v_diff = v[1] - v[0];
+      std::vector<float> val{v_diff, std::numeric_limits<float>::quiet_NaN(), v[1], std::numeric_limits<float>::quiet_NaN(), 0};
+      fit_values.push_back(val);
     }
-    fit_values.push_back(val);
-    val.clear();
   }
   return fit_values;
 }

--- a/offline/packages/CaloReco/CaloWaveformProcessing.h
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.h
@@ -80,30 +80,30 @@ class CaloWaveformProcessing : public SubsysReco
 
   void initialize_processing();
 
-  void set_onnx_factor(const int i, const double val) {m_Onnx_factor.at(i) = val;}
-  void set_onnx_offset(const int i, const double val) {m_Onnx_offset.at(i) = val;}
+  void set_onnx_factor(const int i, const double val) { m_Onnx_factor.at(i) = val; }
+  void set_onnx_offset(const int i, const double val) { m_Onnx_offset.at(i) = val; }
 
  private:
   CaloWaveformFitting *m_Fitter = nullptr;
 
-  CaloWaveformProcessing::process m_processingtype {CaloWaveformProcessing::TEMPLATE};
-  int _nthreads {1};
-  int _nsoftwarezerosuppression {40};
-  bool _bdosoftwarezerosuppression {false};
-  bool _dobitfliprecovery {false};
+  CaloWaveformProcessing::process m_processingtype{CaloWaveformProcessing::TEMPLATE};
+  int _nthreads{1};
+  int _nsoftwarezerosuppression{40};
+  bool _bdosoftwarezerosuppression{false};
+  bool _dobitfliprecovery{false};
 
   std::string m_template_input_file;
   std::string url_template;
-  std::string m_template_name {"NONE"};
+  std::string m_template_name{"NONE"};
 
   bool m_setTimeLim{false};
   float m_timeLim_low{-3.0};
   float m_timeLim_high{4.0};
 
   std::string url_onnx;
-  std::string m_model_name {"CEMC_ONNX"};
-  std::array<double,3> m_Onnx_factor{std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
-  std::array<double,3> m_Onnx_offset {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+  std::string m_model_name{"CEMC_ONNX"};
+  std::array<double, 3> m_Onnx_factor{std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+  std::array<double, 3> m_Onnx_offset{std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The returned vector from the onnx was not compatible with the vector from the template fit (3dim instead of 5dim). This PR patches the onnx return so it can be used without special treatment by the calo tower builder, it's values are fine for processing via Calo_Calib

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

