### PR TITLE
Update TPC Event Builder to process 100% streaming run

### DIFF
--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -204,10 +204,10 @@ bool TpcTimeFrameBuilder::isMoreDataRequired(const uint64_t& gtm_bco) const
 {
   for (const BcoMatchingInformation& bcoMatchingInformation : m_bcoMatchingInformation_vec)
   {
-    if (not bcoMatchingInformation.is_verified())
-    {
-      continue;
-    }
+    // if (not bcoMatchingInformation.is_verified())
+    // {
+    //   continue;
+    // }
 
     if (bcoMatchingInformation.isMoreDataRequired(gtm_bco))
     {
@@ -1171,9 +1171,9 @@ int TpcTimeFrameBuilder::decode_gtm_data(const TpcTimeFrameBuilder::dma_word& gt
   payload.modebits = gtm[22];
   payload.userbits = gtm[23];
 
-  if (m_verbosity > 2)
+  if (m_verbosity >= 2)
   {
-    cout << "\t- GTM data : "
+    cout << __PRETTY_FUNCTION__ << "\t- GTM data : "
          << "\t- pkt_type = " << payload.pkt_type << endl
          << "\t- is_lvl1 = " << payload.is_lvl1 << endl
          << "\t- is_endat = " << payload.is_endat << endl
@@ -1419,11 +1419,19 @@ bool TpcTimeFrameBuilder::BcoMatchingInformation::isMoreDataRequired(const uint6
 {
   const uint64_t bco_correction = get_gtm_rollover_correction(gtm_bco);
 
+  if (m_verbosity>=2)
+  {
+    std::cout << "TpcTimeFrameBuilder[" << m_name << "]::BcoMatchingInformation::isMoreDataRequired entry"
+              << " at gtm_bco = 0x" << hex << gtm_bco << dec
+              << " bco_correction = 0x" << hex << bco_correction << dec
+              << std::endl;
+  }
+
   if (m_bco_reference)
   {
     if (m_bco_reference.value().first > bco_correction + m_max_fee_sync_time)
     {
-      if (m_verbosity > 2)
+      if (m_verbosity >= 2)
       {
         std::cout << "TpcTimeFrameBuilder[" << m_name << "]::BcoMatchingInformation::isMoreDataRequired"
                   << " at gtm_bco = 0x" << hex << gtm_bco << dec
@@ -1441,7 +1449,7 @@ bool TpcTimeFrameBuilder::BcoMatchingInformation::isMoreDataRequired(const uint6
   {
     if (m_bco_reference_candidate_list.back().first > bco_correction + m_max_fee_sync_time)
     {
-      if (m_verbosity > 2)
+      if (m_verbosity >= 2)
       {
         std::cout << "TpcTimeFrameBuilder[" << m_name << "]::BcoMatchingInformation::isMoreDataRequired"
                   << "at gtm_bco = 0x" << hex << gtm_bco << dec

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -1963,14 +1963,16 @@ std::optional<uint64_t> TpcTimeFrameBuilder::BcoMatchingInformation::find_gtm_bc
 
         const int fee_bco_diff = (iter2 != m_gtm_bco_trig_list.end()) ? get_bco_diff(get_predicted_fee_bco(*iter2).value(), fee_bco) : -1;
 
-        std::cout << "TpcTimeFrameBuilder[" << m_name << "]::BcoMatchingInformation::find_gtm_bco - match failed!"
-                  << std::hex
-                  << "\t- fee_bco: 0x" << fee_bco
-                  << std::dec
-                  << "\t- gtm_bco: 0x" << *iter2
-                  << "\t- difference: " << fee_bco_diff
-                  << std::endl;
-
+        if (m_verbosity >=2)
+        {
+          std::cout << "TpcTimeFrameBuilder[" << m_name << "]::BcoMatchingInformation::find_gtm_bco - match failed!"
+                    << std::hex
+                    << "\t- fee_bco: 0x" << fee_bco
+                    << std::dec
+                    << "\t- gtm_bco: 0x" << *iter2
+                    << "\t- difference: " << fee_bco_diff
+                    << std::endl;
+        }
       }  //       if ((new_orphan and verbosity()) or (verbosity()>3))
 
       if (verbosity() > 3)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

100% streaming run [69413](https://chat.sdcc.bnl.gov/sphenix/pl/57r6fxxh37fk9g5jnnajobd6te), [69414](https://chat.sdcc.bnl.gov/sphenix/pl/y4hayh6e3jyt5nsw6eoorhwtzc) as in https://chat.sdcc.bnl.gov/sphenix/pl/i6hffsqq73813xq7dbd8fg6e7w has new features that require updates to the event builder: 

* Tolerate significant more data (e.g. streaming data) before the GL1 start run and the start of clock sync 
* Don't print complains about FEE waveform not matched with GL1 trigger, as many waveforms in such run are streaming data and not corresponding to trigger. 

## Testing

Event building QA showing matched GTM events are back in the 100 events test for segment `tpc-00069413-02_0`

<img width="588" height="968" alt="image" src="https://github.com/user-attachments/assets/e6e02f77-3517-4786-9096-e303d64b70a1" />



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Test and more fixes

## Links to other PRs in macros and calibration repositories (if applicable)

- https://github.com/sPHENIX-Collaboration/coresoftware/pull/3762
- https://github.com/sPHENIX-Collaboration/coresoftware/pull/3757