### PR TITLE
Update 2 for TPC Event Builder to process 100% streaming run

### DIFF
--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -550,7 +550,6 @@ int TpcTimeFrameBuilder::ProcessPacket(Packet* packet)
          << "\t- in packet " << m_packet_id << ". Data length: " << data_length
          << ", data padding: " << data_padding <<". Ignore this packet: "<< endl;
     packet->identify();
-    assert(l2 >= 0);
     return Fun4AllReturnCodes::DISCARDEVENT;
   }
   l2 -= data_padding;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

In the 100% streaming run test production, we found a piece of broken data before GL1 start in `TPC_ebdc17_1_physics-00069413-0000.evt` that the data length is shorter than padding length. This would crash `ddump` and trigger an assert check in TPC event builder. 

```
Packet  4171     6 -1 (sPHENIX Packet) 123 (IDTPCFEEV6)
int TpcTimeFrameBuilder::ProcessPacket(Packet*) - :  data_length = 2    - data_padding = 7
```

This PR ask event builder to skip such event than trigger an `assert`. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Test and more fixes

## Links to other PRs in macros and calibration repositories (if applicable)

- https://github.com/sPHENIX-Collaboration/coresoftware/pull/3764
- https://github.com/sPHENIX-Collaboration/coresoftware/pull/3762
- https://github.com/sPHENIX-Collaboration/coresoftware/pull/3757
