### PR TITLE
Phfield optimization

### DIFF
--- a/offline/packages/PHField/PHField.h
+++ b/offline/packages/PHField/PHField.h
@@ -10,9 +10,11 @@ class PHField
   //! constructor
   explicit PHField(const int verb = 0)
     : m_Verbosity(verb)
-  {
-  }
-  virtual ~PHField() {}
+  {}
+
+  //! destructor
+  virtual ~PHField() = default;
+
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
@@ -21,11 +23,23 @@ class PHField
       const double Point[4],
       double *Bfield) const = 0;
 
+  //! un-cached version of field accessor.
+  /* used for multi-threading. By default, the same as GetFieldValue */
+  virtual void GetFieldValue_nocache(
+      const double Point[4],
+      double *Bfield) const
+  { return GetFieldValue( Point, Bfield ); }
+
+  //! verbosity
   void Verbosity(const int i) { m_Verbosity = i; }
+
+  //! verbosity
   int Verbosity() const { return m_Verbosity; }
 
  protected:
-  int m_Verbosity;
+
+  //! verbosity
+  int m_Verbosity = 0;
 };
 
 #endif

--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -283,6 +283,62 @@ void PHField2D::GetFieldValue(const double point[4], double *Bfield) const
   return;
 }
 
+void PHField2D::GetFieldValue_nocache(const double point[4], double *Bfield) const
+{
+  if (Verbosity() > 2)
+  {
+    std::cout << "\nPHField2D::GetFieldValue" << std::endl;
+  }
+  double x = point[0];
+  double y = point[1];
+  double z = point[2];
+  double r = sqrt(x * x + y * y);
+  double phi;
+  phi = atan2(y, x);
+  if (phi < 0)
+  {
+    phi += 2 * M_PI;  // normalize phi to be over the range [0,2*pi]
+  }
+
+  // Check that the point is within the defined z region (check r in a second)
+  if ((z >= minz_) && (z <= maxz_))
+  {
+    double BFieldCyl[3];
+    double cylpoint[4] = {z, r, phi, 0};
+
+    // take <z,r,phi> location and return a vector of <Bz, Br, Bphi>
+    GetFieldCyl_nocache(cylpoint, BFieldCyl);
+
+    // X direction of B-field ( Bx = Br*cos(phi) - Bphi*sin(phi)
+    Bfield[0] = cos(phi) * BFieldCyl[1] - sin(phi) * BFieldCyl[2];  // unit vector transformations
+
+    // Y direction of B-field ( By = Br*sin(phi) + Bphi*cos(phi)
+    Bfield[1] = sin(phi) * BFieldCyl[1] + cos(phi) * BFieldCyl[2];
+
+    // Z direction of B-field
+    Bfield[2] = BFieldCyl[0];
+  }
+  else  // x,y,z is outside of z range of the field map
+  {
+    Bfield[0] = 0.0;
+    Bfield[1] = 0.0;
+    Bfield[2] = 0.0;
+    if (Verbosity() > 2)
+    {
+      std::cout << "!!!!!!!!!! Field point not in defined region (outside of z bounds)" << std::endl;
+    }
+  }
+
+  if (Verbosity() > 2)
+  {
+    std::cout << "END PHField2D::GetFieldValue\n"
+              << "  --->  {Bx, By, Bz} : "
+              << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
+  }
+
+  return;
+}
+
 void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
 {
   float z = CylPoint[0];
@@ -309,10 +365,6 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
   // since GEANT4 looks up the field ~95% of the time in the same voxel
   // between subsequent calls, we can save on the expense of the upper_bound
   // lookup (~10-15% of central event run time) with some caching between calls
-
-  // mutex lock to prevent data race when accessing the cache from multiple threads
-  std::lock_guard<std::mutex> guard(m_cache_mutex);
-
   unsigned int r_index0 = r_index0_cache;
   unsigned int r_index1 = r_index1_cache;
 
@@ -366,6 +418,114 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
     // update cache
     z_index0_cache = z_index0;
     z_index1_cache = z_index1;
+  }
+
+  double Br000 = BFieldR_[z_index0][r_index0];
+  double Br010 = BFieldR_[z_index0][r_index1];
+  double Br100 = BFieldR_[z_index1][r_index0];
+  double Br110 = BFieldR_[z_index1][r_index1];
+
+  double Bz000 = BFieldZ_[z_index0][r_index0];
+  double Bz100 = BFieldZ_[z_index1][r_index0];
+  double Bz010 = BFieldZ_[z_index0][r_index1];
+  double Bz110 = BFieldZ_[z_index1][r_index1];
+
+  double zweight = z - z_map_[z_index0];
+  double zspacing = z_map_[z_index1] - z_map_[z_index0];
+  zweight /= zspacing;
+
+  double rweight = r - r_map_[r_index0];
+  double rspacing = r_map_[r_index1] - r_map_[r_index0];
+  rweight /= rspacing;
+
+  // Z direction of B-field
+  BfieldCyl[0] =
+      (1 - zweight) * ((1 - rweight) * Bz000 +
+                       rweight * Bz010) +
+      zweight * ((1 - rweight) * Bz100 +
+                 rweight * Bz110);
+
+  // R direction of B-field
+  BfieldCyl[1] =
+      (1 - zweight) * ((1 - rweight) * Br000 +
+                       rweight * Br010) +
+      zweight * ((1 - rweight) * Br100 +
+                 rweight * Br110);
+
+  // PHI Direction of B-field
+  BfieldCyl[2] = 0;
+
+  if (Verbosity() > 2)
+  {
+    std::cout << "End GFCyl Call: <bz,br,bphi> : {"
+              << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
+              << std::endl;
+  }
+
+  return;
+}
+
+
+void PHField2D::GetFieldCyl_nocache(const double CylPoint[4], double *BfieldCyl) const
+{
+  float z = CylPoint[0];
+  float r = CylPoint[1];
+
+  BfieldCyl[0] = 0.0;
+  BfieldCyl[1] = 0.0;
+  BfieldCyl[2] = 0.0;
+
+  if (Verbosity() > 2)
+  {
+    std::cout << "GetFieldCyl@ <z,r>: {" << z << "," << r << "}" << std::endl;
+  }
+
+  if (z < z_map_[0] || z > z_map_[z_map_.size() - 1])
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
+    }
+    return;
+  }
+
+  // since GEANT4 looks up the field ~95% of the time in the same voxel
+  // between subsequent calls, we can save on the expense of the upper_bound
+  // lookup (~10-15% of central event run time) with some caching between calls
+
+  // if miss cached r values, search through the lookup table
+  std::vector<float>::const_iterator riter = upper_bound(r_map_.begin(), r_map_.end(), r);
+  const unsigned int r_index0 = distance(r_map_.begin(), riter) - 1;
+  if (r_index0 >= r_map_.size())
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
+    }
+    return;
+  }
+
+  const unsigned int r_index1 = r_index0 + 1;
+  if (r_index1 >= r_map_.size())
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
+    }
+    return;
+  }
+
+  // if miss cached z values, search through the lookup table
+  std::vector<float>::const_iterator ziter = upper_bound(z_map_.begin(), z_map_.end(), z);
+  const unsigned int z_index0 = distance(z_map_.begin(), ziter) - 1;
+  const unsigned int z_index1 = z_index0 + 1;
+  if (z_index1 >= z_map_.size())
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << "!!!! Point not in defined region (z too large in specific r-plane)" << std::endl;
+    }
+    return;
   }
 
   double Br000 = BFieldR_[z_index0][r_index0];

--- a/offline/packages/PHField/PHField2D.h
+++ b/offline/packages/PHField/PHField2D.h
@@ -5,7 +5,6 @@
 #include "PHField.h"
 
 #include <map>
-#include <mutex>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -16,16 +15,21 @@ class PHField2D : public PHField
 
  public:
   PHField2D(const std::string &filename, const int verb = 0, const float magfield_rescale = 1.0);
-  ~PHField2D() override {}
+
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
   void GetFieldValue(const double Point[4], double *Bfield) const override;
 
+  //! access field value
+  void GetFieldValue_nocache(const double Point[4], double *Bfield) const override;
+
   void GetFieldCyl(const double CylPoint[4], double *Bfield) const;
 
- protected:
+  void GetFieldCyl_nocache(const double CylPoint[4], double *Bfield) const;
+
+  protected:
   // < i, j, k > , this allows i and i+1 to be neighbors ( <i,j,k>=<z,r,phi> )
   std::vector<std::vector<float> > BFieldZ_;
   std::vector<std::vector<float> > BFieldR_;
@@ -47,9 +51,6 @@ class PHField2D : public PHField
   // I want them to be data members so we can run 2 fieldmaps in parallel
   // and still have caching. Putting those as static variables into
   // the implementation will prevent this
-
-  // needed to prevent data race when accessing cache
-  mutable std::mutex m_cache_mutex;
 
   mutable unsigned int r_index0_cache;
   mutable unsigned int r_index1_cache;

--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -34,7 +34,6 @@ PHField3DCartesian::PHField3DCartesian(const std::string &fname, const float mag
       {
         for (int l = 0; l < 3; l++)
         {
-          xyz[i][j][k][l] = NAN;
           bf[i][j][k][l] = NAN;
         }
       }
@@ -128,17 +127,13 @@ PHField3DCartesian::~PHField3DCartesian()
 void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) const
 {
 
-  /*
-   * note: this is not thread safe, but used only for diagnostic
-   * so ignore for now
-   */
   static double xsav = -1000000.;
   static double ysav = -1000000.;
   static double zsav = -1000000.;
 
-  double x = point[0];
-  double y = point[1];
-  double z = point[2];
+  const double& x = point[0];
+  const double& y = point[1];
+  const double& z = point[2];
 
   Bfield[0] = 0.0;
   Bfield[1] = 0.0;
@@ -167,11 +162,11 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
     }
     return;
   }
-  
+
   xsav = x;
   ysav = y;
   zsav = z;
-  
+
   if (point[0] < xmin || point[0] > xmax ||
       point[1] < ymin || point[1] > ymax ||
       point[2] < zmin || point[2] > zmax)
@@ -232,9 +227,6 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
     zkey[1] = *it;
   }
 
-  // mutex lock to prevent data race when accessing the cache from multiple threads
-  std::lock_guard<std::mutex> guard(m_cache_mutex);
-
   if (xkey_save != xkey[0] ||
       ykey_save != ykey[0] ||
       zkey_save != zkey[0])
@@ -262,20 +254,21 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
                       << ", z: " << zkey[k] / cm << std::endl;
             return;
           }
-          xyz[i][j][k][0] = std::get<0>(magval->first);
-          xyz[i][j][k][1] = std::get<1>(magval->first);
-          xyz[i][j][k][2] = std::get<2>(magval->first);
           bf[i][j][k][0] = std::get<0>(magval->second);
           bf[i][j][k][1] = std::get<1>(magval->second);
           bf[i][j][k][2] = std::get<2>(magval->second);
           if (Verbosity() > 0)
           {
-            std::cout << "read x/y/z: " << xyz[i][j][k][0] / cm << "/"
-                      << xyz[i][j][k][1] / cm << "/"
-                      << xyz[i][j][k][2] / cm << " bx/by/bz: "
-                      << bf[i][j][k][0] / tesla << "/"
-                      << bf[i][j][k][1] / tesla << "/"
-                      << bf[i][j][k][2] / tesla << std::endl;
+            const double x_loc = std::get<0>(magval->first);
+            const double y_loc = std::get<1>(magval->first);
+            const double z_loc = std::get<2>(magval->first);
+
+            std::cout << "read x/y/z: " << x_loc / cm << "/"
+              << y_loc / cm << "/"
+              << z_loc / cm << " bx/by/bz: "
+              << bf[i][j][k][0] / tesla << "/"
+              << bf[i][j][k][1] / tesla << "/"
+              << bf[i][j][k][2] / tesla << std::endl;
           }
         }
       }
@@ -323,6 +316,163 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
                 bf[0][1][1][i] * fractionx * (1. - fractiony) * (1. - fractionz) +
                 bf[1][1][0][i] * (1. - fractionx) * (1. - fractiony) * fractionz +
                 bf[1][1][1][i] * (1. - fractionx) * (1. - fractiony) * (1. - fractionz);
+  }
+
+  return;
+}
+
+//_____________________________________________________________
+void PHField3DCartesian::GetFieldValue_nocache(const double point[4], double *Bfield) const
+{
+
+  const double& x = point[0];
+  const double& y = point[1];
+  const double& z = point[2];
+
+  Bfield[0] = 0.0;
+  Bfield[1] = 0.0;
+  Bfield[2] = 0.0;
+  if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z))
+  { return; }
+
+  if (point[0] < xmin || point[0] > xmax ||
+      point[1] < ymin || point[1] > ymax ||
+      point[2] < zmin || point[2] > zmax)
+  { return; }
+
+  double xkey[2];
+  std::set<float>::const_iterator it = xvals.lower_bound(x);
+  xkey[0] = *it;
+  if (it == xvals.begin())
+  {
+    xkey[1] = *it;
+    if (x < xkey[0])
+    {
+      std::cout << PHWHERE << ": This should not happen! x too small - outside range: " << x / cm << std::endl;
+      return;
+    }
+  }
+  else
+  {
+    --it;
+    xkey[1] = *it;
+  }
+
+  double ykey[2];
+  it = yvals.lower_bound(y);
+  ykey[0] = *it;
+  if (it == yvals.begin())
+  {
+    ykey[1] = *it;
+    if (y < ykey[0])
+    {
+      std::cout << PHWHERE << ": This should not happen! y too small - outside range: " << y / cm << std::endl;
+      return;
+    }
+  }
+  else
+  {
+    --it;
+    ykey[1] = *it;
+  }
+  double zkey[2];
+  it = zvals.lower_bound(z);
+  zkey[0] = *it;
+  if (it == zvals.begin())
+  {
+    zkey[1] = *it;
+    if (z < zkey[0])
+    {
+      std::cout << PHWHERE << ": This should not happen! z too small - outside range: " << z / cm << std::endl;
+      return;
+    }
+  }
+  else
+  {
+    --it;
+    zkey[1] = *it;
+  }
+
+  // local xyz and field
+  double bf_loc[2][2][2][3]{};
+
+  std::map<std::tuple<float, float, float>, std::tuple<float, float, float> >::const_iterator magval;
+  trio key;
+  for (int i = 0; i < 2; i++)
+  {
+    for (int j = 0; j < 2; j++)
+    {
+      for (int k = 0; k < 2; k++)
+      {
+        key = std::make_tuple(xkey[i], ykey[j], zkey[k]);
+        magval = fieldmap.find(key);
+        if (magval == fieldmap.end())
+        {
+          std::cout << PHWHERE << " could not locate key in " << filename
+            << " value: x: " << xkey[i] / cm
+            << ", y: " << ykey[j] / cm
+            << ", z: " << zkey[k] / cm << std::endl;
+          return;
+        }
+
+        bf_loc[i][j][k][0] = std::get<0>(magval->second);
+        bf_loc[i][j][k][1] = std::get<1>(magval->second);
+        bf_loc[i][j][k][2] = std::get<2>(magval->second);
+        if (Verbosity() > 0)
+        {
+
+          const double x_loc = std::get<0>(magval->first);
+          const double y_loc = std::get<1>(magval->first);
+          const double z_loc = std::get<2>(magval->first);
+
+          std::cout << "read x/y/z: " << x_loc / cm << "/"
+            << y_loc / cm << "/"
+            << z_loc / cm << " bx/by/bz: "
+            << bf_loc[i][j][k][0] / tesla << "/"
+            << bf_loc[i][j][k][1] / tesla << "/"
+            << bf_loc[i][j][k][2] / tesla << std::endl;
+        }
+      }
+    }
+  }
+
+  // how far are we away from the reference point
+  double xinblock = point[0] - xkey[1];
+  double yinblock = point[1] - ykey[1];
+  double zinblock = point[2] - zkey[1];
+  // normalize distance to step size
+  double fractionx = xinblock / xstepsize;
+  double fractiony = yinblock / ystepsize;
+  double fractionz = zinblock / zstepsize;
+  if (Verbosity() > 0)
+  {
+    std::cout << "x/y/z stepsize: " << xstepsize / cm << "/" << ystepsize / cm << "/" << zstepsize / cm << std::endl;
+    std::cout << "x/y/z inblock: " << xinblock / cm << "/" << yinblock / cm << "/" << zinblock / cm << std::endl;
+    std::cout << "x/y/z fraction: " << fractionx << "/" << fractiony << "/" << fractionz << std::endl;
+  }
+
+  // linear extrapolation in cube:
+
+  // Vxyz =
+  // V000 * x * y * z +
+  // V100 * (1 - x) * y * z +
+  // V010 * x * (1 - y) * z +
+  // V001 * x y * (1 - z) +
+  // V101 * (1 - x) * y * (1 - z) +
+  // V011 * x * (1 - y) * (1 - z) +
+  // V110 * (1 - x) * (1 - y) * z +
+  // V111 * (1 - x) * (1 - y) * (1 - z)
+
+  for (int i = 0; i < 3; i++)
+  {
+    Bfield[i] = bf_loc[0][0][0][i] * fractionx * fractiony * fractionz +
+                bf_loc[1][0][0][i] * (1. - fractionx) * fractiony * fractionz +
+                bf_loc[0][1][0][i] * fractionx * (1. - fractiony) * fractionz +
+                bf_loc[0][0][1][i] * fractionx * fractiony * (1. - fractionz) +
+                bf_loc[1][0][1][i] * (1. - fractionx) * fractiony * (1. - fractionz) +
+                bf_loc[0][1][1][i] * fractionx * (1. - fractiony) * (1. - fractionz) +
+                bf_loc[1][1][0][i] * (1. - fractionx) * (1. - fractiony) * fractionz +
+                bf_loc[1][1][1][i] * (1. - fractionx) * (1. - fractiony) * (1. - fractionz);
   }
 
   return;

--- a/offline/packages/PHField/PHField3DCartesian.h
+++ b/offline/packages/PHField/PHField3DCartesian.h
@@ -5,7 +5,6 @@
 
 #include <cmath>
 #include <map>
-#include <mutex>
 #include <set>
 #include <string>
 #include <tuple>
@@ -13,7 +12,11 @@
 class PHField3DCartesian : public PHField
 {
  public:
+
+  //! constructor
   explicit PHField3DCartesian(const std::string &fname, const float magfield_rescale = 1.0, const float innerradius = 0, const float outerradius = 1.e10, const float size_z = 1.e10);
+
+  //! destructor
   ~PHField3DCartesian() override;
 
   //! access field value
@@ -22,7 +25,9 @@ class PHField3DCartesian : public PHField
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
   void GetFieldValue(const double Point[4], double *Bfield) const override;
 
- private:
+  void GetFieldValue_nocache(const double Point[4], double *Bfield) const override;
+
+  private:
   std::string filename;
   double xmin = 1000000;
   double xmax = -1000000;
@@ -34,12 +39,8 @@ class PHField3DCartesian : public PHField
   double ystepsize = NAN;
   double zstepsize = NAN;
 
-  // needed to prevent data race when accessing cache
-  mutable std::mutex m_cache_mutex;
-
   // these are updated in a const method
   // to cache previous values
-  mutable double xyz[2][2][2][3]{};
   mutable double bf[2][2][2][3]{};
   mutable double xkey_save = NAN;
   mutable double ykey_save = NAN;

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -151,7 +151,15 @@ double PHSimpleKFProp::get_Bz(double x, double y, double z) const
   }
   double p[4] = {x * cm, y * cm, z * cm, 0. * cm};
   double bfield[3];
-  _field_map->GetFieldValue(p, bfield);
+
+  // check thread number. Use uncached field accessor for all but thread 0.
+  if( omp_get_thread_num() == 0 )
+  {
+    _field_map->GetFieldValue(p, bfield);
+  } else {
+    _field_map->GetFieldValue_nocache(p, bfield);
+  }
+
   /*  Acts::Vector3 loc(0,0,0);
   int mfex = (magField != nullptr);
   int tgex = (m_tGeometry != nullptr);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR removes the use of a mutex of relevant PHField classes, needed for thread safety, due to significant overhead when the number of threads is large.

Instead add a GetFieldValue_nocache() method, that is thread safe (reentrant), and is the one to be used in multithreaded enviroment. 

In PHSimpleKFProp and ALICEKF, the cached version of GetFieldValue is used for thread number 0; and the uncached version is used for any other thread >0. In any case the cache was always missed in such cases.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

