### PR TITLE
Bug Fix: CaloCDB Filter-Datasets Delimiter

### DIFF
--- a/calibrations/calorimeter/calo_cdb/filter-datasets.cc
+++ b/calibrations/calorimeter/calo_cdb/filter-datasets.cc
@@ -89,11 +89,11 @@ void FilterDatasets::analyze(const std::string &input, const std::string &output
       std::stringstream ss;
       if (cdbName == "CEMC_BadTowerMap")
       {
-        ss << "EMCalHotMap_" << dataset << "-" << run << "cdb.root";
+        ss << "EMCalHotMap_" << dataset << "_" << run << "cdb.root";
       }
       else
       {
-        ss << cdbName << "_" << dataset << "-" << run << ".root";
+        ss << cdbName << "_" << dataset << "_" << run << ".root";
       }
 
       std::string suffix = ss.str();


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Bug fix:
- Delimiter between dataset and run should be "_", not "-" to be consistent with the output from the genStatus.cc module.
- Now the same runs aren't flagged again if they already have a latest CDB map.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

