### PR TITLE
More phfield optimization

### DIFF
--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -26,6 +26,8 @@
 PHField3DCartesian::PHField3DCartesian(const std::string &fname, const float magfield_rescale, const float innerradius, const float outerradius, const float size_z)
   : filename(fname)
 {
+  std::cout << "PHField3DCartesian::PHField3DCartesian" << std::endl;
+
   for (int i = 0; i < 2; i++)
   {
     for (int j = 0; j < 2; j++)
@@ -116,6 +118,7 @@ PHField3DCartesian::PHField3DCartesian(const std::string &fname, const float mag
 
 PHField3DCartesian::~PHField3DCartesian()
 {
+  std::cout << "PHField3DCartesian::~PHField3DCartesian" << std::endl;
   if (Verbosity() > 0)
   {
     std::cout << "PHField3DCartesian: cache hits: " << cache_hits

--- a/offline/packages/PHField/PHFieldConfig.h
+++ b/offline/packages/PHField/PHFieldConfig.h
@@ -74,8 +74,13 @@ class PHFieldConfig : public PHObject
 
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
   virtual double get_field_mag_z() const { return std::numeric_limits<double>::signaling_NaN(); }
+
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
   virtual void set_field_mag_z(double /*fieldMagZ*/) { return; }
+
+  //! equal to operator, to base class
+  virtual bool operator == (const PHFieldConfig& ) const
+  { return false; }
 
  protected:
   //! pure virtual interface class. not for direct use

--- a/offline/packages/PHField/PHFieldConfigv1.cc
+++ b/offline/packages/PHField/PHFieldConfigv1.cc
@@ -45,3 +45,13 @@ int PHFieldConfigv1::isValid() const
 {
   return filename_.length();
 }
+
+//_______________________________________________________________________
+bool PHFieldConfigv1::operator == (const PHFieldConfig& other ) const
+{
+  return 
+    get_field_config() == other.get_field_config() &&
+    get_filename() == other.get_filename() &&
+    get_magfield_rescale() == other.get_magfield_rescale();
+}
+    

--- a/offline/packages/PHField/PHFieldConfigv1.h
+++ b/offline/packages/PHField/PHFieldConfigv1.h
@@ -81,7 +81,7 @@ class PHFieldConfigv1 : public PHFieldConfig
   }
 
   //! equal to operator, to base class
-  bool operator == (const PHFieldConfig& ) const;
+  bool operator == (const PHFieldConfig& ) const override;
 
  protected:
   FieldConfigTypes field_config_;

--- a/offline/packages/PHField/PHFieldConfigv1.h
+++ b/offline/packages/PHField/PHFieldConfigv1.h
@@ -80,6 +80,9 @@ class PHFieldConfigv1 : public PHFieldConfig
     magfield_rescale_ = magfieldRescale;
   }
 
+  //! equal to operator, to base class
+  bool operator == (const PHFieldConfig& ) const;
+
  protected:
   FieldConfigTypes field_config_;
   std::string filename_;

--- a/offline/packages/PHField/PHFieldConfigv2.cc
+++ b/offline/packages/PHField/PHFieldConfigv2.cc
@@ -44,3 +44,13 @@ void PHFieldConfigv2::identify(std::ostream& os) const
   }
   os << std::endl;
 }
+
+
+bool PHFieldConfigv2::operator == (const PHFieldConfig& other ) const
+{
+  return
+    get_field_config() == other.get_field_config() &&
+    get_field_mag_x() == other.get_field_mag_x() &&
+    get_field_mag_y() == other.get_field_mag_y() &&
+    get_field_mag_z() == other.get_field_mag_z();
+}

--- a/offline/packages/PHField/PHFieldConfigv2.h
+++ b/offline/packages/PHField/PHFieldConfigv2.h
@@ -93,7 +93,7 @@ class PHFieldConfigv2 : public PHFieldConfig
   }
 
   //! equal to operator, to base class
-  bool operator == (const PHFieldConfig& ) const;
+  bool operator == (const PHFieldConfig& ) const override;
 
  protected:
   double field_mag_x_;

--- a/offline/packages/PHField/PHFieldConfigv2.h
+++ b/offline/packages/PHField/PHFieldConfigv2.h
@@ -92,6 +92,9 @@ class PHFieldConfigv2 : public PHFieldConfig
     field_mag_z_ = fieldMagZ;
   }
 
+  //! equal to operator, to base class
+  bool operator == (const PHFieldConfig& ) const;
+
  protected:
   double field_mag_x_;
   double field_mag_y_;

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -129,17 +129,12 @@ class PHCASeeding : public PHTrackSeeding
     }
   }
 
-  void set_field_dir(const double rescale)
-  {
-    std::cout << "PHCASeeding::set_field_dir rescale: " << rescale << std::endl;
-    _fieldDir = 1;
-    if (rescale > 0)
-      _fieldDir = -1;
-  }
+  // obsolete
+  void set_field_dir(const double) {}
+  void magFieldFile(const std::string&) {}
+  void useConstBField(bool) {}
+  void constBField(float) {}
 
-  void magFieldFile(const std::string& fname) { m_magField = fname; }
-  void useConstBField(bool opt) { _use_const_field = opt; }
-  void constBField(float b) { _const_field = b; }
   void useFixedClusterError(bool opt) { _use_fixed_clus_err = opt; }
   void setFixedClusterError(int i, double val) { _fixed_clus_err.at(i) = val; }
   void set_pp_mode(bool mode) { _pp_mode = mode; }
@@ -250,16 +245,11 @@ class PHCASeeding : public PHTrackSeeding
   /* float _cosTheta_limit; */
   double _rz_outlier_threshold = 0.1;
   double _xy_outlier_threshold = 0.1;
-  double _fieldDir = -1;
-  bool _use_const_field = false;
   bool _split_seeds = true;
   bool _reject_zsize1 = false;
-  float _const_field = 1.4;
   bool _use_fixed_clus_err = false;
   bool _pp_mode = false;
   std::array<double, 3> _fixed_clus_err = {.1, .1, .1};
-
-  std::string m_magField;
 
   /// acts geometry
   ActsGeometry* m_tGeometry{nullptr};

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -13,12 +13,12 @@
 /* #define _PHCASEEDING_CHAIN_FORKS_ */
 /* #define _PHCASEEDING_TIMER_OUT_ */
 
-#include "ALICEKF.h"
 #include "PHTrackSeeding.h"  // for PHTrackSeeding
 
 #include <tpc/TpcGlobalPositionWrapper.h>
 
 #include <trackbase/TrkrDefs.h>  // for cluskey
+#include <trackbase_historic/TrackSeed_v2.h>
 
 #include <phool/PHTimer.h>  // for PHTimer
 
@@ -266,8 +266,6 @@ class PHCASeeding : public PHTrackSeeding
 
   /// global position wrapper
   TpcGlobalPositionWrapper m_globalPositionWrapper;
-
-  std::unique_ptr<ALICEKF> fitter;
 
   std::unique_ptr<PHTimer> t_seed;
   std::unique_ptr<PHTimer> t_fill;

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -128,11 +128,10 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
    * Otherwise the configuration passed as argument is stored on the node tree.
    */
   const auto node_fcfg = PHFieldUtility::GetFieldConfigNode(&fcfg, topNode);
-
   if( fcfg == *node_fcfg )
   {
     // both configurations are identical, use field map from node tree
-    std::cout << "PHSimpleKFProp::InitRun - using field map found from node tree" << std::endl;
+    std::cout << "PHSimpleKFProp::InitRun - using node tree field map" << std::endl;
     _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
   } else {
     // both configurations differ. Use our own field map

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -133,11 +133,12 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
     // both configurations are identical, use field map from node tree
     std::cout << "PHSimpleKFProp::InitRun - using node tree field map" << std::endl;
     _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
+    m_own_fieldmap = false;
   } else {
     // both configurations differ. Use our own field map
     std::cout << "PHSimpleKFProp::InitRun - using own field map" << std::endl;
     _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
-
+    m_own_fieldmap = true;
   }
 
   // alice kalman filter

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -74,9 +74,16 @@ using keylist = std::vector<TrkrDefs::cluskey>;
 
 PHSimpleKFProp::PHSimpleKFProp(const std::string& name)
   : SubsysReco(name)
+{}
+
+//______________________________________________________
+PHSimpleKFProp::~PHSimpleKFProp()
 {
+  if( m_own_fieldmap )
+  { delete _field_map; }
 }
 
+//______________________________________________________
 int PHSimpleKFProp::End(PHCompositeNode* /*unused*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
@@ -91,22 +98,18 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
   }
 
   PHFieldConfigv1 fcfg;
-
   fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
+
   if (std::filesystem::path(m_magField).extension() != ".root")
-  {
-    m_magField = CDBInterface::instance()->getUrl(m_magField);
-  }
+  { m_magField = CDBInterface::instance()->getUrl(m_magField); }
+
   if (!_use_const_field)
   {
     if (!std::filesystem::exists(m_magField))
     {
       if (m_magField.empty())
-      {
-        m_magField = "empty string";
-      }
-      std::cout << PHWHERE << "Fieldmap " << m_magField
-                << " does not exist" << std::endl;
+      { m_magField = "empty string"; }
+      std::cout << PHWHERE << "Fieldmap " << m_magField << " does not exist" << std::endl;
       gSystem->Exit(1);
     }
 
@@ -117,11 +120,29 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
     fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::kFieldUniform);
     fcfg.set_magfield_rescale(_const_field);
   }
-  //  fcfg.set_rescale(1);
-  _field_map = std::unique_ptr<PHField>(PHFieldUtility::BuildFieldMap(&fcfg));
 
-  fitter = std::make_unique<ALICEKF>(topNode, _cluster_map, _field_map.get(), _fieldDir,
-                                     _min_clusters_per_track, _max_sin_phi, Verbosity());
+  // compare field config from that on node tree
+  /*
+   * if the magnetic field is already on the node tree PHFieldUtility::GetFieldConfigNode returns the existing configuration.
+   * One must then check wheter the two configurations are identical, to decide whether one must use the field from node tree or create our own.
+   * Otherwise the configuration passed as argument is stored on the node tree.
+   */
+  const auto node_fcfg = PHFieldUtility::GetFieldConfigNode(&fcfg, topNode);
+
+  if( fcfg == *node_fcfg )
+  {
+    // both configurations are identical, use field map from node tree
+    std::cout << "PHSimpleKFProp::InitRun - using field map found from node tree" << std::endl;
+    _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
+  } else {
+    // both configurations differ. Use our own field map
+    std::cout << "PHSimpleKFProp::InitRun - using own field map" << std::endl;
+    _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
+
+  }
+
+  // alice kalman filter
+  fitter = std::make_unique<ALICEKF>(topNode, _cluster_map, _field_map, _fieldDir, _min_clusters_per_track, _max_sin_phi, Verbosity());
   fitter->setNeonFraction(Ne_frac);
   fitter->setArgonFraction(Ar_frac);
   fitter->setCF4Fraction(CF4_frac);

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -44,7 +44,7 @@ class PHSimpleKFProp : public SubsysReco
 {
  public:
   PHSimpleKFProp(const std::string& name = "PHSimpleKFProp");
-  ~PHSimpleKFProp() override = default;
+  ~PHSimpleKFProp() override;
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
@@ -119,7 +119,8 @@ class PHSimpleKFProp : public SubsysReco
 
   TrackSeedContainer* _track_map = nullptr;
 
-  std::unique_ptr<PHField> _field_map = nullptr;
+  PHField* _field_map = nullptr;
+  bool m_own_fieldmap = false;
 
   /// acts geometry
   ActsGeometry* m_tgeometry = nullptr;

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -119,6 +119,7 @@ class PHSimpleKFProp : public SubsysReco
 
   TrackSeedContainer* _track_map = nullptr;
 
+  //! magnetic field map
   PHField* _field_map = nullptr;
   bool m_own_fieldmap = false;
 

--- a/offline/packages/trackreco/PrelimDistortionCorrection.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.cc
@@ -8,6 +8,8 @@
 
 #include "ALICEKF.h"
 
+#include <ffamodules/CDBInterface.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <g4detectors/PHG4TpcCylinderGeom.h>
@@ -72,12 +74,8 @@ int PrelimDistortionCorrection::InitRun(PHCompositeNode* topNode)
   PHFieldConfigv1 fcfg;
   fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
 
-  char *calibrationsroot = getenv("CALIBRATIONROOT");
-  assert(calibrationsroot);
-
-  auto magField = std::string(calibrationsroot) +
-    std::string("/Field/Map/sphenix3dtrackingmapxyz.root");
-
+  // load magnetic field map from CDB
+  auto magField = CDBInterface::instance()->getUrl("FIELDMAP_TRACKING");
   fcfg.set_filename(magField);
 
   // compare field config from that on node tree

--- a/offline/packages/trackreco/PrelimDistortionCorrection.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.cc
@@ -92,10 +92,12 @@ int PrelimDistortionCorrection::InitRun(PHCompositeNode* topNode)
     // both configurations are identical, use field map from node tree
     std::cout << "PrelimDistortionCorrection::InitRun - using field map found from node tree" << std::endl;
     _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
+    m_own_fieldmap = false;
   } else {
     // both configurations differ. Use our own field map
     std::cout << "PrelimDistortionCorrection::InitRun - using own field map" << std::endl;
     _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
+    m_own_fieldmap = true;
   }
 
   fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map, _fieldDir,

--- a/offline/packages/trackreco/PrelimDistortionCorrection.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.h
@@ -39,7 +39,7 @@ class PrelimDistortionCorrection : public SubsysReco
 {
  public:
   PrelimDistortionCorrection(const std::string &name = "PrelimDistortionCorrection");
-  ~PrelimDistortionCorrection() override = default;
+  ~PrelimDistortionCorrection() override;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -96,7 +96,9 @@ class PrelimDistortionCorrection : public SubsysReco
 
   TrackSeedContainer *_track_map = nullptr;
 
-  std::unique_ptr<PHField> _field_map = nullptr;
+  //! magnetic field map
+  PHField* _field_map = nullptr;
+  bool m_own_fieldmap = false;
 
   /// acts geometry
   ActsGeometry *_tgeometry = nullptr;

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
@@ -92,10 +92,12 @@ int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
     // both configurations are identical, use field map from node tree
     std::cout << "PrelimDistortionCorrectionAuAu::InitRun - using field map found from node tree" << std::endl;
     _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
+    m_own_fieldmap = false;
   } else {
     // both configurations differ. Use our own field map
     std::cout << "PrelimDistortionCorrectionAuAu::InitRun - using own field map" << std::endl;
     _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
+    m_own_fieldmap = true;
   }
 
   fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map, _fieldDir,

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
@@ -49,6 +49,13 @@ PrelimDistortionCorrectionAuAu::PrelimDistortionCorrectionAuAu(const std::string
   : SubsysReco(name)
 {}
 
+//______________________________________________________
+PrelimDistortionCorrectionAuAu::~PrelimDistortionCorrectionAuAu()
+{
+  if( m_own_fieldmap )
+  { delete _field_map; }
+}
+
 //___________________________________________________________________________________________
 int PrelimDistortionCorrectionAuAu::End(PHCompositeNode* /*unused*/)
 {
@@ -68,15 +75,30 @@ int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
   char *calibrationsroot = getenv("CALIBRATIONROOT");
   assert(calibrationsroot);
 
-  auto magField = std::string(calibrationsroot) +
-    std::string("/Field/Map/sphenix3dtrackingmapxyz.root");
+  auto magField = std::string(calibrationsroot) + std::string("/Field/Map/sphenix3dtrackingmapxyz.root");
 
   fcfg.set_filename(magField);
 
-  //  fcfg.set_rescale(1);
-  _field_map = std::unique_ptr<PHField>(PHFieldUtility::BuildFieldMap(&fcfg));
 
-  fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map.get(), _fieldDir,
+  // compare field config from that on node tree
+  /*
+   * if the magnetic field is already on the node tree PHFieldUtility::GetFieldConfigNode returns the existing configuration.
+   * One must then check wheter the two configurations are identical, to decide whether one must use the field from node tree or create our own.
+   * Otherwise the configuration passed as argument is stored on the node tree.
+   */
+  const auto node_fcfg = PHFieldUtility::GetFieldConfigNode(&fcfg, topNode);
+  if( fcfg == *node_fcfg )
+  {
+    // both configurations are identical, use field map from node tree
+    std::cout << "PrelimDistortionCorrectionAuAu::InitRun - using field map found from node tree" << std::endl;
+    _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
+  } else {
+    // both configurations differ. Use our own field map
+    std::cout << "PrelimDistortionCorrectionAuAu::InitRun - using own field map" << std::endl;
+    _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
+  }
+
+  fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map, _fieldDir,
 				     _min_clusters_per_track,_max_sin_phi,Verbosity());
   fitter->setNeonFraction(Ne_frac);
   fitter->setArgonFraction(Ar_frac);
@@ -319,7 +341,7 @@ void PrelimDistortionCorrectionAuAu::publishSeeds(std::vector<TrackSeed_v2>& see
       {
 	continue;   // ALICEKalmanFilter can drop clusters. Seeds require at least 3 clusters for circle fit
       }
-    
+
     /// The ALICEKF gives a better charge determination at high pT
     int q = seed.get_charge();
     TrackSeedHelper::circleFitByTaubin(&seed,positions, 7, 55);

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
@@ -8,6 +8,8 @@
 
 #include "ALICEKF.h"
 
+#include <ffamodules/CDBInterface.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <g4detectors/PHG4TpcCylinderGeom.h>
@@ -72,13 +74,9 @@ int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
   PHFieldConfigv1 fcfg;
   fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
 
-  char *calibrationsroot = getenv("CALIBRATIONROOT");
-  assert(calibrationsroot);
-
-  auto magField = std::string(calibrationsroot) + std::string("/Field/Map/sphenix3dtrackingmapxyz.root");
-
+  // load magnetic field map from CDB
+  auto magField = CDBInterface::instance()->getUrl("FIELDMAP_TRACKING");
   fcfg.set_filename(magField);
-
 
   // compare field config from that on node tree
   /*

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
@@ -39,7 +39,7 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
 {
  public:
   PrelimDistortionCorrectionAuAu(const std::string &name = "PrelimDistortionCorrectionAuAu");
-  ~PrelimDistortionCorrectionAuAu() override = default;
+  ~PrelimDistortionCorrectionAuAu() override;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -96,7 +96,9 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
 
   TrackSeedContainer *_track_map = nullptr;
 
-  std::unique_ptr<PHField> _field_map = nullptr;
+  //! magnetic field map
+  PHField* _field_map = nullptr;
+  bool m_own_fieldmap = false;
 
   /// acts geometry
   ActsGeometry *_tgeometry = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This pull request is a first step towards having only one field map loaded at the seeding stage (right now we have 2, even 3 for a short time).
1/ in PHCASeeder, the loaded field map (as well as the ALICEKF fitter) are actually not used, and deleted immediately after being created. All of this is now removed. 
2/ in PHSimpleKFProp, and PrelimDistortionCorrection, the modules now try to load the field map stored on the node tree first, provided that it is found and that the field map configuration matches what is requested. 
if no field map is found, the module will create one and store it, together with the configuration, on the node tree.
if the field map is found but the configuration differ, the module will use an internal map instead. 

Unfortunately, PHSimpleKFProp and PrelimDistortionCorrection use different field configurations for now, so that there are still two maps created: the latter uses the field map stored in the CALIBRATION_ROOT directory, hard coded; while the former gets it from the CDB, as specified in the macro. 

This will be fixed in an upcoming PR, once this one goes through. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

