### PR TITLE
fixed nan error in first iteration of UE sub

### DIFF
--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -923,7 +923,19 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       float dphi = phibounds.second - phibounds.first;
       float total_area = total_tower * deta * dphi;
 
-      _UE[layer].at(eta) = total_E / total_tower;
+      if ( total_towers > 0 )
+      {
+        _UE[layer].at(eta) = total_E / total_tower; // calculate the UE density
+      } 
+      else 
+      {
+        if (Verbosity() > 0)
+        {
+          std::cout << "DetermineTowerBackground::process_event: WARNING, no towers in layer " << layer << " / eta " << eta << ", setting UE density to 0" << std::endl;
+        }
+      
+        _UE[layer].at(eta) = 0; // no towers, no UE
+      }
 
       if (Verbosity() > 3)
       {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Added a check on ntowers to prevent setting the UE to nan in central events .

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

