### PR TITLE
G4TPC - handle pedestal subtraction and zero suppression threshold in digitizer

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -43,6 +43,8 @@ class PHG4TpcDigitizer : public SubsysReco
 
   void SetTpcMinLayer(const int minlayer) { TpcMinLayer = minlayer; };
   void SetADCThreshold(const float thresh) { ADCThreshold = thresh; };
+  void SetZSThreshold(const float zsthresh) { ZSThreshold = zsthresh; };
+  void SetPedestal(const float ped) { Pedestal = ped; };
   void SetENC(const float enc) { TpcEnc = enc; };
   void set_drift_velocity(float vd) {_drift_velocity = vd;}
   void set_skip_noise_flag(const bool skip) {skip_noise = skip;}
@@ -59,11 +61,15 @@ class PHG4TpcDigitizer : public SubsysReco
   float ADCThreshold_mV = 0;
   float TpcEnc;
   float Pedestal;
+  float ZSThreshold;
   float ChargeToPeakVolts;
   float _drift_velocity = 8.0e-3;  // override from macro with simulation drift velocity
 
   float ADCSignalConversionGain;
   float ADCNoiseConversionGain;
+
+  unsigned int pedestal_adc;
+  unsigned int zsthreshold_adc;
 
   bool skip_noise = false;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -68,8 +68,8 @@ class PHG4TpcDigitizer : public SubsysReco
   float ADCSignalConversionGain;
   float ADCNoiseConversionGain;
 
-  unsigned int pedestal_adc;
-  unsigned int zsthreshold_adc;
+  unsigned int pedestal_adc = 0;
+  unsigned int zsthreshold_adc = 0;
 
   bool skip_noise = false;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
As a means to better replicate data, the pedestal subtraction in G4TPC is moved from the clusterizer to the digitizer and matched by default to the same value as the raw data unpacker. Additionally, a zero suppression threshold matching what is used in the unpacker is included as a default. Both parameters are settable from the Trkr_Clustering macro. 

For the simulations to be implemented appropriately, the clusterizer must call set_rawdata_reco(). A corresponding PR in macros https://github.com/sPHENIX-Collaboration/macros/pull/1110 handles this, as well as setting the 60 ADU pedestal and 20 ADU zero suppression threshold in G4_TrkrSimulation.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

