### PR TITLE
add warning when required calorimeter nodes are missing

### DIFF
--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -238,6 +238,11 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
       {
         std::cout << "RetowerCEMC::CreateNode : creating " << EMRetowerName << " node " << std::endl;
       }
+      if (!hcal_towers)
+      {
+        std::cout << PHWHERE << " Could not find input HCAL tower node: " << IHTowerName << std::endl;
+        exit(1);
+      }
       TowerInfoContainer *emcal_retower = dynamic_cast<TowerInfoContainer *>(hcal_towers->CloneMe());
       PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_retower, EMRetowerName, "PHObject");
       emcalNode->addNode(emcalTowerNode);


### PR DESCRIPTION
The JetReco module currently crashes without a clear warning when input calorimeter nodes (e.g., from calo DSTs) are unavailable. This issue tends to arise when working with global-only DSTs—particularly in simulation—where the calo DSTs may not be included initially. It’s easy to overlook this when migrating to jet reconstruction. Adding an explicit check with a warning message helps clarify the source of the crash.