### PR TITLE
Phsimplekfprop parallelization follow up

### DIFF
--- a/offline/packages/trackreco/PHGhostRejection.cc
+++ b/offline/packages/trackreco/PHGhostRejection.cc
@@ -104,9 +104,6 @@ void PHGhostRejection::find_ghosts(std::vector<float>& trackChi2)
   // Elimate low-interest track, and try to eliminate repeated tracks
   std::set<unsigned int> matches_set;
   std::multimap<unsigned int, unsigned int> matches;
-
-  // TODO: this can be parallelized
-  // there is no modification in here
   for (size_t trid1 = 0; trid1 < seeds.size(); ++trid1)
   {
     if (m_rejected[trid1]) { continue; }

--- a/offline/packages/trackreco/PHGhostRejection.cc
+++ b/offline/packages/trackreco/PHGhostRejection.cc
@@ -105,9 +105,9 @@ void PHGhostRejection::find_ghosts(std::vector<float>& trackChi2)
   std::set<unsigned int> matches_set;
   std::multimap<unsigned int, unsigned int> matches;
 
-  for (unsigned int trid1 = 0;
-       trid1 != seeds.size();
-       ++trid1)
+  // TODO: this can be parallelized
+  // there is no modification in here
+  for (size_t trid1 = 0; trid1 < seeds.size(); ++trid1)
   {
     if (m_rejected[trid1]) { continue; }
     const auto& track1 = seeds[trid1];
@@ -115,9 +115,9 @@ void PHGhostRejection::find_ghosts(std::vector<float>& trackChi2)
 
     const auto track1_pos = TrackSeedHelper::get_xyz(&track1);
     const float track1eta = track1.get_eta();
-    for (unsigned int trid2 = trid1; trid2 != seeds.size(); ++trid2)
+    for (size_t trid2 = trid1+1; trid2 < seeds.size(); ++trid2)
     {
-      if (m_rejected[trid2] ||  (trid1 == trid2))
+      if (m_rejected[trid2])
       {
         continue;
       }

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -261,7 +261,8 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
     }
   }
 
-  const auto globalPositions = PrepareKDTrees();
+  PHTimer timer("KFPropTimer");
+  timer.restart();
 
   // check number of seeds against maximum
   if(_max_seeds > 0 && _track_map->size() > _max_seeds)
@@ -271,10 +272,15 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
+  const auto globalPositions = PrepareKDTrees();
+  std::cout << "PHSimpleKFProp::process_event - PrepareKDTrees time: " << timer.elapsed() << " ms" << std::endl;
+
+
   // list of cluster chains
   std::vector<std::vector<TrkrDefs::cluskey>> new_chains;
   std::vector<TrackSeed_v2> unused_tracks;
 
+  timer.restart();
   #pragma omp parallel
   {
     if (Verbosity())
@@ -286,7 +292,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         << std::endl;
     }
 
-    PHTimer timer("KFPropTimer");
+    PHTimer timer_mp("KFPropTimer_parallel");
 
     std::vector<std::vector<TrkrDefs::cluskey>> local_chains;
     std::vector<TrackSeed_v2> local_unused;
@@ -333,26 +339,24 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         /// This will by definition return a single pair with each vector
         /// in the pair length 1 corresponding to the seed info
         std::vector<float> trackChi2;
-        timer.restart();
 
+        timer_mp.restart();
         auto seedpair = fitter->ALICEKalmanFilter(keylist_A, false, trackClusPositions, trackChi2);
 
-        timer.stop();
         if (Verbosity() > 3)
         {
-          std::cout << "single track ALICEKF time " << timer.elapsed() << std::endl;
+          std::cout << "single track ALICEKF time " << timer_mp.elapsed() << std::endl;
         }
 
-        timer.restart();
+        timer_mp.restart();
 
         /// circle fit back to update track parameters
         TrackSeedHelper::circleFitByTaubin(track, trackClusPositions, 7, 55);
         TrackSeedHelper::lineFit(track, trackClusPositions, 7, 55);
         track->set_phi(TrackSeedHelper::get_phi(track, trackClusPositions));
-        timer.stop();
         if (Verbosity() > 3)
         {
-          std::cout << "single track circle fit time " << timer.elapsed() << std::endl;
+          std::cout << "single track circle fit time " << timer_mp.elapsed() << std::endl;
         }
 
         if (seedpair.first.empty()|| seedpair.second.empty())
@@ -365,7 +369,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
           std::cout << "is tpc track" << std::endl;
         }
 
-        timer.restart();
+        timer_mp.restart();
 
         if (Verbosity())
         {
@@ -418,11 +422,9 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
           local_chains.push_back(std::move(kl.at(0)));
         }
 
-        timer.stop();
-
         if (Verbosity() > 3)
         {
-          const auto propagatetime = timer.elapsed();
+          const auto propagatetime = timer_mp.elapsed();
           std::cout << "propagate track time " << propagatetime << std::endl;
         }
       }
@@ -450,10 +452,13 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       unused_tracks.insert(unused_tracks.end(), std::make_move_iterator(local_unused.begin()), std::make_move_iterator(local_unused.end()));
     }
   }
+  std::cout << "PHSimpleKFProp::process_event - first seed loop time: " << timer.elapsed() << " ms" << std::endl;
 
   // sort merged list and remove duplicates
+  timer.restart();
   std::sort(new_chains.begin(),new_chains.end());
   new_chains.erase(std::unique(new_chains.begin(),new_chains.end()),new_chains.end());
+  std::cout << "PHSimpleKFProp::process_event - first cleanup time: " << timer.elapsed() << " ms" << std::endl;
 
   if( Verbosity() )
   {
@@ -484,22 +489,16 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
    * TODO: in principle this could also move to a thread
    * need to pay attention to duplicated seeds though
    */
-  PHTimer timer("KFPropTimer");
   timer.restart();
   std::vector<float> trackChi2;
   auto seeds = fitter->ALICEKalmanFilter(clean_chains, true, globalPositions, trackChi2);
-  timer.stop();
-
-  if (Verbosity())
-  {
-    const auto alicekftime = timer.elapsed();
-    std::cout << "full alice kf time all tracks " << alicekftime << std::endl;
-  }
+  std::cout << "PHSimpleKFProp::process_event - ALICEKalmanFilter time: " << timer.elapsed() << " ms" << std::endl;
 
   // reset track map
   _track_map->Reset();
 
   //  Move ghost rejection into publishSeeds, so that we don't publish rejected seeds
+  timer.restart();
   if (m_ghostrejection)
   {
     rejectAndPublishSeeds(seeds.first, globalPositions, trackChi2);
@@ -511,6 +510,8 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 
   // also publish unused seeds (not TPC)
   publishSeeds(unused_tracks);
+
+  std::cout << "PHSimpleKFProp::process_event - publishSeeds time: " << timer.elapsed() << " ms" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1436,6 +1437,9 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
 
   PHTimer timer("KFPropTimer");
 
+  // now do the ghost rejection *before* publishing the seeds to the _track_map
+  timer.restart();
+
   // testing with presets for rejection
   PHGhostRejection rejector(Verbosity(), seeds);
   rejector.set_phi_cut(_ghost_phi_cut);
@@ -1447,37 +1451,40 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
   // rejector.set_min_pt_cut(0.2);
   // rejector.set_must_span_sectors(true);
   // rejector.set_min_clusters(8);
-
-  for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
   {
-    // cut tracks with too-few clusters (or that don;t span a sector boundary, if desired)
-    if (rejector.cut_from_clusters(itrack))
+
+    for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
     {
-      continue;
+      // cut tracks with too-few clusters (or that don;t span a sector boundary, if desired)
+      if (rejector.cut_from_clusters(itrack))
+      {
+        continue;
+      }
+
+      auto& seed = seeds[itrack];
+      /// The ALICEKF gives a better charge determination at high pT
+      const int q = seed.get_charge();
+
+      PositionMap local;
+      std::transform(seed.begin_cluster_keys(), seed.end_cluster_keys(), std::inserter(local, local.end()),
+        [positions](const auto& key)
+        { return std::make_pair(key, positions.at(key)); });
+      TrackSeedHelper::circleFitByTaubin(&seed,local, 7, 55);
+      TrackSeedHelper::lineFit(&seed,local, 7, 55);
+      seed.set_phi(TrackSeedHelper::get_phi(&seed,local));
+      seed.set_qOverR(fabs(seed.get_qOverR()) * q);
     }
 
-    auto& seed = seeds[itrack];
-    /// The ALICEKF gives a better charge determination at high pT
-    const int q = seed.get_charge();
-
-    PositionMap local;
-    std::transform(seed.begin_cluster_keys(), seed.end_cluster_keys(), std::inserter(local, local.end()),
-                   [positions](const auto& key)
-                   { return std::make_pair(key, positions.at(key)); });
-    TrackSeedHelper::circleFitByTaubin(&seed,local, 7, 55);
-    TrackSeedHelper::lineFit(&seed,local, 7, 55);
-    seed.set_phi(TrackSeedHelper::get_phi(&seed,local));
-    seed.set_qOverR(fabs(seed.get_qOverR()) * q);
   }
+
+  std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - circle fit: " << timer.elapsed() << " ms" << std::endl;
 
   // now do the ghost rejection *before* publishing the seeds to the _track_map
   timer.restart();
   rejector.find_ghosts(trackChi2);
-  if (Verbosity() > 2)
-  {
-    std::cout << "ghost rejection find time " << timer.elapsed() << std::endl;
-  }
+  std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - ghost rejection: " << timer.elapsed() << " ms" << std::endl;
 
+  timer.restart();
   for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
   {
     if (rejector.is_rejected(itrack))
@@ -1506,6 +1513,8 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
                 << std::endl;
     }
   }
+  std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - publication: " << timer.elapsed() << " ms" << std::endl;
+
 }
 
 void PHSimpleKFProp::publishSeeds(const std::vector<TrackSeed_v2>& seeds)

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -273,8 +273,8 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   }
 
   const auto globalPositions = PrepareKDTrees();
-  std::cout << "PHSimpleKFProp::process_event - PrepareKDTrees time: " << timer.elapsed() << " ms" << std::endl;
-
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::process_event - PrepareKDTrees time: " << timer.elapsed() << " ms" << std::endl; }
 
   // list of cluster chains
   std::vector<std::vector<TrkrDefs::cluskey>> new_chains;
@@ -345,7 +345,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 
         if (Verbosity() > 3)
         {
-          std::cout << "single track ALICEKF time " << timer_mp.elapsed() << std::endl;
+          std::cout << "PHSimpleKFProp::process_event - single track ALICEKF time " << timer_mp.elapsed() << " ms" << std::endl;
         }
 
         timer_mp.restart();
@@ -356,7 +356,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         track->set_phi(TrackSeedHelper::get_phi(track, trackClusPositions));
         if (Verbosity() > 3)
         {
-          std::cout << "single track circle fit time " << timer_mp.elapsed() << std::endl;
+          std::cout << "PHSimpleKFProp::process_event - single track circle fit time " << timer_mp.elapsed() << " ms" << std::endl;
         }
 
         if (seedpair.first.empty()|| seedpair.second.empty())
@@ -424,8 +424,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 
         if (Verbosity() > 3)
         {
-          const auto propagatetime = timer_mp.elapsed();
-          std::cout << "propagate track time " << propagatetime << std::endl;
+          std::cout << "PHSimpleKFProp::process_event - propagate track time " << timer_mp.elapsed() << " ms" << std::endl;
         }
       }
       else
@@ -452,13 +451,16 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       unused_tracks.insert(unused_tracks.end(), std::make_move_iterator(local_unused.begin()), std::make_move_iterator(local_unused.end()));
     }
   }
-  std::cout << "PHSimpleKFProp::process_event - first seed loop time: " << timer.elapsed() << " ms" << std::endl;
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::process_event - first seed loop time: " << timer.elapsed() << " ms" << std::endl; }
 
   // sort merged list and remove duplicates
   timer.restart();
   std::sort(new_chains.begin(),new_chains.end());
   new_chains.erase(std::unique(new_chains.begin(),new_chains.end()),new_chains.end());
-  std::cout << "PHSimpleKFProp::process_event - first cleanup time: " << timer.elapsed() << " ms" << std::endl;
+
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::process_event - first cleanup time: " << timer.elapsed() << " ms" << std::endl; }
 
   if( Verbosity() )
   {
@@ -492,7 +494,8 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   timer.restart();
   std::vector<float> trackChi2;
   auto seeds = fitter->ALICEKalmanFilter(clean_chains, true, globalPositions, trackChi2);
-  std::cout << "PHSimpleKFProp::process_event - ALICEKalmanFilter time: " << timer.elapsed() << " ms" << std::endl;
+  if (Verbosity())
+  {  std::cout << "PHSimpleKFProp::process_event - ALICEKalmanFilter time: " << timer.elapsed() << " ms" << std::endl; }
 
   // reset track map
   _track_map->Reset();
@@ -511,7 +514,8 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   // also publish unused seeds (not TPC)
   publishSeeds(unused_tracks);
 
-  std::cout << "PHSimpleKFProp::process_event - publishSeeds time: " << timer.elapsed() << " ms" << std::endl;
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::process_event - publishSeeds time: " << timer.elapsed() << " ms" << std::endl; }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1479,12 +1483,14 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
 
   }
 
-  std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - circle fit: " << timer.elapsed() << " ms" << std::endl;
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - circle fit: " << timer.elapsed() << " ms" << std::endl; }
 
   // now do the ghost rejection *before* publishing the seeds to the _track_map
   timer.restart();
   rejector.find_ghosts(trackChi2);
-  std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - ghost rejection: " << timer.elapsed() << " ms" << std::endl;
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - ghost rejection: " << timer.elapsed() << " ms" << std::endl; }
 
   timer.restart();
   for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
@@ -1515,7 +1521,8 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
                 << std::endl;
     }
   }
-  std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - publication: " << timer.elapsed() << " ms" << std::endl;
+  if (Verbosity())
+  { std::cout << "PHSimpleKFProp::rejectAndPublishSeeds - publication: " << timer.elapsed() << " ms" << std::endl; }
 
 }
 

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -1451,8 +1451,10 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
   // rejector.set_min_pt_cut(0.2);
   // rejector.set_must_span_sectors(true);
   // rejector.set_min_clusters(8);
+  #pragma omp parallel
   {
 
+    #pragma omp for schedule(static)
     for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
     {
       // cut tracks with too-few clusters (or that don;t span a sector boundary, if desired)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This is a follow up to the first attempt at parallelizing PHSimpleKFProp
After some careful timing, the second slowest part of PHSimpleKFProp is the circle fit performed on all seeds in ::rejectAndPublishSeeds
Parallelizing this one is straight forward and leads to ~ another factor 2 improvement with respect to what was already achieved. 
This was tested on both Au-Au and pp with similar improvement in performances. 
I'll post some numbers as soon as higher statistics tests are completed. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

