### PR TITLE
KFP - fix in allPvInfo

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -119,6 +119,8 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   bool checkTrackAndVertexMatch(KFParticle vDaughters[], int nTracks, KFParticle vertex);
 
+  void set_dont_use_global_vertex(bool set_variable){ m_dont_use_global_vertex = set_variable; }
+
  protected:
   std::string m_mother_name_Tools;
   int m_num_intermediate_states {-1};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -1316,6 +1316,7 @@ void KFParticle_truthAndDetTools::allPVInfo(PHCompositeNode *topNode,
                                             std::vector<KFParticle> intermediates)
 {
   KFParticle_Tools kfpTupleTools;
+  kfpTupleTools.set_dont_use_global_vertex(m_dont_use_global_vertex_truth);
   std::vector<KFParticle> primaryVertices = kfpTupleTools.makeAllPrimaryVertices(topNode, m_vtx_map_node_name_nTuple);
 
   for (auto &primaryVertice : primaryVertices)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
If KFParticle is run with m_dont_use_global_vertex set to true, filling primary vertex info in KFParticle_Ntuple will break if a GlobalVertexMap is not provided. This happens because a new KFParticle_Tools object is instantiated in allPVInfo that defaults to expecting a GlobalVertexMap.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

