### PR TITLE
embedding id is set in PHHepMCGenHelper

### DIFF
--- a/generators/phhepmc/Fun4AllHepMCInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.cc
@@ -45,8 +45,6 @@ Fun4AllHepMCInputManager::Fun4AllHepMCInputManager(const std::string &name, cons
   : Fun4AllInputManager(name, nodename, topnodename)
   , topNodeName(topnodename)
 {
-  set_embedding_id(0);  // default embedding ID. Welcome to change via macro
-
   Fun4AllServer *se = Fun4AllServer::instance();
   topNode = se->topNode(topNodeName);
   PHNodeIterator iter(topNode);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Cleanup - there was a duplicate setting of the embedding id in the Fun4AllHepMCInputManager ctor and the PHHepMCGenHelper initializer to the same value (0). This should not change any behavior

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

