### PR TITLE
Laser cluster fitting

### DIFF
--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -5,7 +5,7 @@
 #include <trackbase/LaserCluster.h>
 #include <trackbase/LaserClusterContainer.h>
 #include <trackbase/LaserClusterContainerv1.h>
-#include <trackbase/LaserClusterv1.h>
+#include <trackbase/LaserClusterv2.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHit.h>
@@ -33,6 +33,11 @@
 
 #include <TF1.h>
 #include <TFile.h>
+#include <TH3.h>
+//#include <TF3.h>
+//#include <ROOT/Fit/Fitter.h>
+#include <Fit/Fitter.h>
+//#include <Math/Functor.h>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/box.hpp>
@@ -47,6 +52,9 @@
 #include <string>
 #include <utility>  // for pair
 #include <vector>
+#include <set>
+#include <queue>
+#include <tuple>
 
 #include <pthread.h>
 
@@ -56,7 +64,15 @@ namespace bgi = boost::geometry::index;
 using point = bg::model::point<float, 3, bg::cs::cartesian>;
 using box = bg::model::box<point>;
 using specHitKey = std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey>;
+using adcKey = std::pair<unsigned int, specHitKey>;
 using pointKeyLaser = std::pair<point, specHitKey>;
+using hitData = std::pair<point, adcKey>;
+
+
+int layerMins[3] = {7,23,39};
+int layerMaxes[3] = {22, 38, 54};
+
+
 
 namespace
 {
@@ -68,6 +84,7 @@ namespace
     std::vector<unsigned int> layers;
     bool side = false;
     unsigned int sector = 0;
+    unsigned int module = 0;
     std::vector<LaserCluster *> cluster_vector;
     std::vector<TrkrDefs::cluskey> cluster_key_vector;
     double adc_threshold = 74.4;
@@ -75,36 +92,172 @@ namespace
     int layerMin = 1;
     int layerMax = 1;
     double tdriftmax = 0;
+    int eventNum = 0;
+    int Verbosity = 0;
+    TH3D *hitHist = nullptr;
   };
 
   pthread_mutex_t mythreadlock;
-  
-  void remove_hits(std::vector<pointKeyLaser> &clusHits, bgi::rtree<pointKeyLaser, bgi::quadratic<16>> &rtree, std::multimap<unsigned int, std::pair<std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey>, std::array<int, 3>>> &adcMap)
+
+  const std::vector<point> neighborOffsets = {
+    point(1, 0, 0), point(-1, 0, 0),
+    point(0, 1, 0), point(0, -1, 0),
+    point(0, 0, 1), point(0, 0, -1),
+    point(0, 0, 2), point(0, 0, -2)
+  };
+
+
+  double layerFunction(double *x, double *par)
+  {
+    double A = par[0];
+    double mu = par[1];
+
+
+    double binCenter = round(x[0]);
+    double overlapLow = std::max(binCenter - 0.5, mu - 0.5);
+    double overlapHigh = std::min(binCenter + 0.5, mu + 0.5);
+    double overlap = overlapHigh - overlapLow;
+    if(overlap <= 0.0)
+    {
+      return 0.0;
+    }
+    return A*overlap;
+    /*
+    if(fabs(x[0] - mu) < 1)
+    {
+      double frac = 1-fabs(mu - round(x[0]));
+      return A*(frac);
+    }
+    return 0.0;
+    */
+
+
+  }
+
+  double phiFunction(double *x, double *par)
+  {
+    if(par[2] < 0.0)
+    {
+      return 0.0;
+    }
+    return par[0] * TMath::Gaus(x[0],par[1],par[2],false);
+  }
+
+  double timeFunction(double *x, double *par)
+  {
+    if(par[2] < 0.0)
+    {
+      return 0.0;
+    }
+    double g = TMath::Gaus(x[0],par[1],par[2],true);
+    double cdf = 1 + TMath::Erfc(par[3]*(x[0]-par[1])/(sqrt(2.0)*par[2]));
+    return par[0]*g*cdf;
+  }
+
+  void findConnectedRegions3(std::vector<hitData> &clusHits, std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> &maxKey)
+  {
+    std::vector<std::vector<hitData>> regions;
+
+    std::vector<hitData> unvisited;
+    for(auto &clusHit : clusHits)
+    {
+      unvisited.push_back(clusHit);
+    }
+
+    while(!unvisited.empty())
+    {
+      std::vector<hitData> region;
+      std::queue<hitData> q;
+
+      unsigned int mIndex = 0;
+      int i=0;
+      for(auto hit : unvisited)
+      {
+        if(hit.second.second.first == maxKey.first && hit.second.second.second == maxKey.second)
+        {
+          mIndex = i;
+          break;
+        }
+        i++;
+      }
+
+      auto seed = unvisited[mIndex];
+      unvisited.erase(unvisited.begin()+mIndex);
+      q.push(seed);
+      region.push_back(seed);
+
+      while(!q.empty())
+      {
+        float ix = q.front().first.get<0>();
+        float iy = q.front().first.get<1>();
+        float iz = q.front().first.get<2>();
+        q.pop();
+
+        for (auto neigh : neighborOffsets)
+        {
+          float nx = ix + neigh.get<0>();
+          float ny = iy + neigh.get<1>();
+          float nz = iz + neigh.get<2>();
+
+          for(unsigned int v=0; v<unvisited.size(); v++)
+          {
+
+            if(fabs(unvisited[v].first.get<0>() - nx) < 0.01 && fabs(unvisited[v].first.get<1>() - ny) < 0.01 && fabs(unvisited[v].first.get<2>() - nz) < 0.01)
+            {
+              auto newSeed = unvisited[v];
+              unvisited.erase(unvisited.begin()+v);
+              q.push(newSeed);
+              region.push_back(newSeed);
+              break;
+            }
+          }
+        }
+      }
+      regions.push_back(region);
+
+    }
+
+    clusHits.clear();
+    for(auto hit : regions[0])
+    {
+      clusHits.push_back(hit);
+    }
+
+  }
+
+   
+  void remove_hits(std::vector<hitData> &clusHits, bgi::rtree<hitData, bgi::quadratic<16>> &rtree, std::multimap<unsigned int, pointKeyLaser> &adcMap)
   {
     for (auto &clusHit : clusHits)
     {
-      auto spechitkey = clusHit.second;
+      auto spechitkey = clusHit.second.second;
 
       rtree.remove(clusHit);
 
       for (auto iterAdc = adcMap.begin(); iterAdc != adcMap.end();)
       {
-	if(iterAdc->second.first == spechitkey)
-	{
-	  iterAdc = adcMap.erase(iterAdc);
-	  break;
-	}
-	else
-	{
-	  ++iterAdc;
-	}
+	      if(iterAdc->second.second == spechitkey)
+	      {
+	        iterAdc = adcMap.erase(iterAdc);
+	        break;
+	      }
+	      else
+	      {
+	        ++iterAdc;
+	      }
       }
     }
 
   }
 
-  void calc_cluster_parameter(std::vector<LaserCluster *> &laserClusters, std::vector<TrkrDefs::cluskey> &laserClusterKeys, std::vector<pointKeyLaser> &clusHits, std::multimap<unsigned int, std::pair<std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey>, std::array<int, 3>>> &adcMap, thread_data &my_data)
+  void calc_cluster_parameter(std::vector<hitData> &clusHits, thread_data &my_data, std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> maxADCKey)
   {
+
+
+
+    findConnectedRegions3(clusHits, maxADCKey);
+
+
     double rSum = 0.0;
     double phiSum = 0.0;
     double tSum = 0.0;
@@ -120,7 +273,7 @@ namespace
     
     unsigned int nHits = clusHits.size();
     
-    auto *clus = new LaserClusterv1;
+    auto *clus = new LaserClusterv2;
     
     int meanSide = 0;
     
@@ -131,21 +284,22 @@ namespace
     double meanLayer = 0.0;
     double meanIPhi = 0.0;
     double meanIT = 0.0;
-    
+
     for (auto &clusHit : clusHits)
     {
       float coords[3] = {clusHit.first.get<0>(), clusHit.first.get<1>(), clusHit.first.get<2>()};
-      std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> spechitkey = clusHit.second;
-      
+      std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> spechitkey = clusHit.second.second;
+      unsigned int adc = clusHit.second.first;
+
       int side = TpcDefs::getSide(spechitkey.second);
           
       if (side)
       {
-	meanSide++;
+	      meanSide++;
       }
       else
       {
-	meanSide--;
+	      meanSide--;
       }
       
       PHG4TpcCylinderGeom *layergeom = my_data.geom_container->GetLayerCellGeom((int) coords[0]);
@@ -157,95 +311,88 @@ namespace
       double hitzdriftlength = t * my_data.tGeometry->get_drift_velocity();
       double hitZ = my_data.tdriftmax * my_data.tGeometry->get_drift_velocity() - hitzdriftlength;
       
-      for (auto &iterKey : adcMap)
-      {
-	if (iterKey.second.first == spechitkey)
-	{
-	  double adc = iterKey.first;
 	  
-	  bool foundLayer = false;
-	  for (float i : usedLayer)
-	  {
-	    if (coords[0] == i)
+	    bool foundLayer = false;
+	    for (float i : usedLayer)
 	    {
-	      foundLayer = true;
-	      break;
+	      if (coords[0] == i)
+	      {
+	        foundLayer = true;
+	        break;
+	      }
 	    }
-	  }
 	  
-	  if (!foundLayer)
-	  {
-	    usedLayer.push_back(coords[0]);
-	  }
-	  
-	  bool foundIPhi = false;
-	  for (float i : usedIPhi)
-	  {
-	    if (coords[1] == i)
+	    if (!foundLayer)
 	    {
-	      foundIPhi = true;
-	      break;
+	      usedLayer.push_back(coords[0]);
 	    }
-	  }
 	  
-	  if (!foundIPhi)
-	  {
-	    usedIPhi.push_back(coords[1]);
-	  }
-	  
-	  bool foundIT = false;
-	  for (float i : usedIT)
-	  {
-	    if (coords[2] == i)
+	    bool foundIPhi = false;
+	    for (float i : usedIPhi)
 	    {
-	      foundIT = true;
-	      break;
+	      if (coords[1] == i)
+	      {
+	        foundIPhi = true;
+	        break;
+	      }
 	    }
+	  
+	    if (!foundIPhi)
+	    {
+	      usedIPhi.push_back(coords[1]);
+	    }
+	  
+	    bool foundIT = false;
+	    for (float i : usedIT)
+	    {
+	      if (coords[2] == i)
+	      {
+	        foundIT = true;
+	        break;
+	      }
+	    }
+	  
+	    if (!foundIT)
+	    {
+	      usedIT.push_back(coords[2]);
+	    }
+	  
+	    clus->addHit();
+	    clus->setHitLayer(clus->getNhits() - 1, coords[0]);
+	    clus->setHitIPhi(clus->getNhits() - 1, coords[1]);
+	    clus->setHitIT(clus->getNhits() - 1, coords[2]);
+	    clus->setHitX(clus->getNhits() - 1, r * cos(phi));
+	    clus->setHitY(clus->getNhits() - 1, r * sin(phi));
+	    clus->setHitZ(clus->getNhits() - 1, hitZ);
+	    clus->setHitAdc(clus->getNhits() - 1, (float) adc);
+	  
+	    rSum += r * adc;
+	    phiSum += phi * adc;
+	    tSum += t * adc;
+	  
+	    layerSum += coords[0] * adc;
+	    iphiSum += coords[1] * adc;
+	    itSum += coords[2] * adc;
+	  
+	    meanLayer += coords[0];
+	    meanIPhi += coords[1];
+	    meanIT += coords[2];
+	  
+	    adcSum += adc;
+	  
+	    if (adc > maxAdc)
+	    {
+	      maxAdc = adc;
+	      maxKey = spechitkey.second;
+	    }
+	  
 	  }
-	  
-	  if (!foundIT)
-	  {
-	    usedIT.push_back(coords[2]);
-	  }
-	  
-	  clus->addHit();
-	  clus->setHitLayer(clus->getNhits() - 1, coords[0]);
-	  clus->setHitIPhi(clus->getNhits() - 1, coords[1]);
-	  clus->setHitIT(clus->getNhits() - 1, coords[2]);
-	  clus->setHitX(clus->getNhits() - 1, r * cos(phi));
-	  clus->setHitY(clus->getNhits() - 1, r * sin(phi));
-	  clus->setHitZ(clus->getNhits() - 1, hitZ);
-	  clus->setHitAdc(clus->getNhits() - 1, (float) adc);
-	  
-	  rSum += r * adc;
-	  phiSum += phi * adc;
-	  tSum += t * adc;
-	  
-	  layerSum += coords[0] * adc;
-	  iphiSum += coords[1] * adc;
-	  itSum += coords[2] * adc;
-	  
-	  meanLayer += coords[0];
-	  meanIPhi += coords[1];
-	  meanIT += coords[2];
-	  
-	  adcSum += adc;
-	  
-	  if (adc > maxAdc)
-	  {
-	    maxAdc = adc;
-	    maxKey = spechitkey.second;
-	  }
-	  
-	  break;
-	}
-      }
-    }
     
     if (nHits == 0)
     {
       return;
     }
+
     
     double clusR = rSum / adcSum;
     double clusPhi = phiSum / adcSum;
@@ -260,10 +407,14 @@ namespace
       clusZ = -clusZ;
       for (int i = 0; i < (int) clus->getNhits(); i++)
       {
-	clus->setHitZ(i, -1 * clus->getHitZ(i));
+	      clus->setHitZ(i, -1 * clus->getHitZ(i));
       }
     }
     
+    std::sort(usedLayer.begin(), usedLayer.end());
+    std::sort(usedIPhi.begin(), usedIPhi.end());
+    std::sort(usedIT.begin(), usedIT.end());
+
     meanLayer = meanLayer / nHits;
     meanIPhi = meanIPhi / nHits;
     meanIT = meanIT / nHits;
@@ -276,8 +427,17 @@ namespace
     double sigmaWeightedIPhi = 0.0;
     double sigmaWeightedIT = 0.0;
     
+    pthread_mutex_lock(&mythreadlock);
+    my_data.hitHist = new TH3D(Form("hitHist_event%d_side%d_sector%d_module%d_cluster%d",my_data.eventNum,(int)my_data.side,(int)my_data.sector,(int)my_data.module,(int)my_data.cluster_vector.size()),";layer;iphi;it",usedLayer.size()+2,usedLayer[0]-1.5,*usedLayer.rbegin()+1.5,usedIPhi.size()+2,usedIPhi[0]-1.5,*usedIPhi.rbegin()+1.5,usedIT.size()+2,usedIT[0]-1.5,*usedIT.rbegin()+1.5);
+
+
+    //TH3D *hitHist = new TH3D(Form("hitHist_event%d_side%d_sector%d_module%d_cluster%d",my_data.eventNum,(int)my_data.side,(int)my_data.sector,(int)my_data.module,(int)my_data.cluster_vector.size()),";layer;iphi;it",usedLayer.size()+2,usedLayer[0]-1.5,*usedLayer.rbegin()+1.5,usedIPhi.size()+2,usedIPhi[0]-1.5,*usedIPhi.rbegin()+1.5,usedIT.size()+2,usedIT[0]-1.5,*usedIT.rbegin()+1.5);
+
     for (int i = 0; i < (int) clus->getNhits(); i++)
     {
+
+      my_data.hitHist->Fill(clus->getHitLayer(i), clus->getHitIPhi(i), clus->getHitIT(i), clus->getHitAdc(i));
+
       sigmaLayer += pow(clus->getHitLayer(i) - meanLayer, 2);
       sigmaIPhi += pow(clus->getHitIPhi(i) - meanIPhi, 2);
       sigmaIT += pow(clus->getHitIT(i) - meanIT, 2);
@@ -286,36 +446,265 @@ namespace
       sigmaWeightedIPhi += clus->getHitAdc(i) * pow(clus->getHitIPhi(i) - (iphiSum / adcSum), 2);
       sigmaWeightedIT += clus->getHitAdc(i) * pow(clus->getHitIT(i) - (itSum / adcSum), 2);
     }
-    
-    clus->setAdc(adcSum);
-    clus->setX(clusX);
-    clus->setY(clusY);
-    clus->setZ(clusZ);
-    clus->setLayer(layerSum / adcSum);
-    clus->setIPhi(iphiSum / adcSum);
-    clus->setIT(itSum / adcSum);
-    clus->setNLayers(usedLayer.size());
-    clus->setNIPhi(usedIPhi.size());
-    clus->setNIT(usedIT.size());
-    clus->setSDLayer(sqrt(sigmaLayer / nHits));
-    clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
-    clus->setSDIT(sqrt(sigmaIT / nHits));
-    clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
-    clus->setSDWeightedIPhi(sqrt(sigmaWeightedIPhi / adcSum));
-    clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
 
-    const auto ckey = TrkrDefs::genClusKey(maxKey, laserClusters.size());
-    laserClusters.push_back(clus);
-    laserClusterKeys.push_back(ckey);
+
+
+    double par_init[7] = {
+      maxAdc,
+      meanLayer,
+      meanIPhi, 0.75,
+      meanIT, 0.5, 1
+    };
+
+    double satThreshold = 900.0;
+    double sigma_ADC = 20.0;
+
+    auto nll = [&](const double* par)
+    {
+      double nll_val = 0.0;
+
+      int nx = my_data.hitHist->GetNbinsX();
+      int ny = my_data.hitHist->GetNbinsY();
+      int nz = my_data.hitHist->GetNbinsZ();
+
+      double parLayer[2] = {1.0,par[1]};
+      double parPhi[4] = {1.0,par[2],par[3]};
+      double parTime[4] = {1.0,par[4],par[5],par[6]};
+
+      double xyz[3];
+
+      for (int i = 1; i <= nx; ++i)
+      {
+        xyz[0] = my_data.hitHist->GetXaxis()->GetBinCenter(i);  
+        for (int j = 1; j <= ny; ++j)
+        {
+          xyz[1] = my_data.hitHist->GetYaxis()->GetBinCenter(j);    
+          for (int k = 1; k <= nz; ++k)
+          {
+            xyz[2] = my_data.hitHist->GetZaxis()->GetBinCenter(k);
+            double observed = my_data.hitHist->GetBinContent(i, j, k);
+
+            double expected = par[0]*layerFunction(&xyz[0], parLayer)*phiFunction(&xyz[1], parPhi)*timeFunction(&xyz[2], parTime);
+
+            if(observed <= my_data.adc_threshold)
+            {
+              double arg = (expected - my_data.adc_threshold) / (sqrt(2.0) * sigma_ADC);
+              double tail_prob = 0.5 * TMath::Erfc(arg);
+              nll_val -= log(tail_prob + 1e-12);
+            }
+            else if(observed < satThreshold)
+            {
+              double resid = (observed - expected) / sigma_ADC;
+              nll_val += 0.5 * (resid * resid + log(2 * TMath::Pi() * sigma_ADC * sigma_ADC));
+            }
+            else if(observed >= satThreshold)
+            {
+              double arg = (satThreshold - expected) / (sqrt(2.0) * sigma_ADC);
+              double tail_prob = 0.5 * TMath::Erfc(arg);
+              nll_val -= log(tail_prob + 1e-12);
+            }
+          }
+        }
+      }
+      return nll_val;
+    };
+
+    ROOT::Fit::Fitter *fit3D = new ROOT::Fit::Fitter;
+    //ROOT::Math::Functor fcn(nll, 7);
+    fit3D->SetFCN(7, nll, par_init);
+
+    fit3D->Config().ParSettings(0).SetName("amp");
+    fit3D->Config().ParSettings(0).SetStepSize(10);
+    fit3D->Config().ParSettings(0).SetLimits(0,5000);
+    fit3D->Config().ParSettings(1).SetName("mu_layer");
+    fit3D->Config().ParSettings(1).SetStepSize(0.1);
+    fit3D->Config().ParSettings(1).SetLimits(usedLayer[0],*usedLayer.rbegin());
+    fit3D->Config().ParSettings(2).SetName("mu_phi");
+    fit3D->Config().ParSettings(2).SetStepSize(0.1);
+    fit3D->Config().ParSettings(2).SetLimits(usedIPhi[0],*usedIPhi.rbegin());
+    fit3D->Config().ParSettings(3).SetName("sig_phi");
+    fit3D->Config().ParSettings(3).SetStepSize(0.1);
+    fit3D->Config().ParSettings(3).SetLimits(0.01,2);
+    fit3D->Config().ParSettings(4).SetName("mu_t");
+    fit3D->Config().ParSettings(4).SetStepSize(0.1);
+    fit3D->Config().ParSettings(4).SetLimits(usedIT[0],*usedIT.rbegin());
+    fit3D->Config().ParSettings(5).SetName("sig_t");
+    fit3D->Config().ParSettings(5).SetStepSize(0.1);
+    fit3D->Config().ParSettings(5).SetLimits(0.01,10);
+    fit3D->Config().ParSettings(6).SetName("lambda_t");
+    fit3D->Config().ParSettings(6).SetStepSize(0.01);
+    fit3D->Config().ParSettings(6).SetLimits(0,5);
+
+ 
+    if(usedLayer.size() == 1)
+    {
+      fit3D->Config().ParSettings(1).Fix();
+    }
+    /*
+    if(usedIPhi.size() <= 2)
+    {
+      fit3D->Config().ParSettings(2).Fix();
+    }
+    */
+
+    bool fitSuccess = fit3D->FitFCN();
+
+
+    if (my_data.Verbosity > 2)
+    {
+      std::cout << "fit success: " << fitSuccess << std::endl;
+    }
+    pthread_mutex_unlock(&mythreadlock);
+
+
+
+    if(fitSuccess)
+    {
+
+      const ROOT::Fit::FitResult& result = fit3D->Result();
+
+      clus->setAdc(adcSum);
+      clus->setLayer(result.Parameter(1));
+      clus->setIPhi(result.Parameter(2));
+      clus->setIT(result.Parameter(4));
+
+
+      PHG4TpcCylinderGeom *layergeomLow = my_data.geom_container->GetLayerCellGeom((int) floor(result.Parameter(1)));
+      PHG4TpcCylinderGeom *layergeomHigh = my_data.geom_container->GetLayerCellGeom((int) ceil(result.Parameter(1)));
+
+      double RLow = layergeomLow->get_radius();
+      double RHigh = layergeomHigh->get_radius();
+
+      double phiHigh_RLow = -999.0;
+      if(ceil(result.Parameter(2)) < layergeomLow->get_phibins())
+      {
+        phiHigh_RLow = layergeomLow->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+      }
+      double phiHigh_RHigh = -999.0;
+      if(ceil(result.Parameter(2)) < layergeomHigh->get_phibins())
+      {
+        phiHigh_RHigh = layergeomHigh->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+      }
+
+      double phiLow_RLow = layergeomLow->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+      double phiLow_RHigh = layergeomHigh->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+
+      double meanR = (result.Parameter(1) - floor(result.Parameter(1))) * (RHigh - RLow) + RLow;
+
+      double meanPhi_RLow = ((result.Parameter(2) - floor(result.Parameter(2)))) * (phiHigh_RLow - phiLow_RLow) + phiLow_RLow;
+      double meanPhi_RHigh = ((result.Parameter(2) - floor(result.Parameter(2)))) * (phiHigh_RHigh - phiLow_RHigh) + phiLow_RHigh;
+
+      double meanPhi = 0.5*(meanPhi_RLow + meanPhi_RHigh);
+      if(phiHigh_RLow == -999.0 && phiHigh_RHigh != -999.0)
+      {
+        meanPhi = meanPhi_RHigh;
+      }
+      else if(phiHigh_RLow != -999.0 && phiHigh_RHigh == -999.0)
+      {
+        meanPhi = meanPhi_RLow;
+      }
+      
+      /*
+      pthread_mutex_lock(&mythreadlock);
+      std::cout << "phiHigh_RLow: " << phiHigh_RLow << "   phiHigh_RHigh: " << phiHigh_RHigh << std::endl;
+      std::cout << "meanPhi: " << meanPhi << std::endl;
+      std::cout << "fit mode is " << (meanPhi != -999.0 ? "on" : "off") << std::endl;
+      pthread_mutex_unlock(&mythreadlock);
+      */
+
+      if(phiHigh_RLow == -999.0 && phiHigh_RHigh == -999.0)
+      {
+        clus->setAdc(adcSum);
+        clus->setX(clusX);
+        clus->setY(clusY);
+        clus->setZ(clusZ);
+        clus->setFitMode(false);
+        clus->setLayer(layerSum / adcSum);
+        clus->setIPhi(iphiSum / adcSum);
+        clus->setIT(itSum / adcSum);
+        clus->setNLayers(usedLayer.size());
+        clus->setNIPhi(usedIPhi.size());
+        clus->setNIT(usedIT.size());
+        clus->setSDLayer(sqrt(sigmaLayer / nHits));
+        clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
+        clus->setSDIT(sqrt(sigmaIT / nHits));
+        clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
+        clus->setSDWeightedIPhi(sqrt(sigmaWeightedIPhi / adcSum));
+        clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
+      }
+      else
+      {
+
+        clus->setAdc(adcSum);
+        clus->setX(meanR*cos(meanPhi));
+        clus->setY(meanR*sin(meanPhi));
+        clus->setZ(clusZ);
+        clus->setFitMode(true);
+        clus->setNLayers(usedLayer.size());
+        clus->setNIPhi(usedIPhi.size());
+        clus->setNIT(usedIT.size());
+        clus->setSDLayer(sqrt(sigmaLayer / nHits));
+        clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
+        clus->setSDIT(sqrt(sigmaIT / nHits));
+        clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
+        clus->setSDWeightedIPhi(result.Parameter(3));
+        clus->setSDWeightedIT(result.Parameter(5));
+      }
+    }
+    else
+    {
+      clus->setAdc(adcSum);
+      clus->setX(clusX);
+      clus->setY(clusY);
+      clus->setZ(clusZ);
+      clus->setFitMode(false);
+      clus->setLayer(layerSum / adcSum);
+      clus->setIPhi(iphiSum / adcSum);
+      clus->setIT(itSum / adcSum);
+      clus->setNLayers(usedLayer.size());
+      clus->setNIPhi(usedIPhi.size());
+      clus->setNIT(usedIT.size());
+      clus->setSDLayer(sqrt(sigmaLayer / nHits));
+      clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
+      clus->setSDIT(sqrt(sigmaIT / nHits));
+      clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
+      clus->setSDWeightedIPhi(sqrt(sigmaWeightedIPhi / adcSum));
+      clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
+    }
+
+    const auto ckey = TrkrDefs::genClusKey(maxKey, my_data.cluster_vector.size());
+    my_data.cluster_vector.push_back(clus);
+    my_data.cluster_key_vector.push_back(ckey);
     
+
+    if(fit3D)
+    {
+      delete fit3D;
+    }
+    
+    if(my_data.hitHist)
+    {
+      delete my_data.hitHist;
+      my_data.hitHist = nullptr;
+    }
+    
+
   }
   
 
   void ProcessModuleData(thread_data *my_data)
   {
     
-    bgi::rtree<pointKeyLaser, bgi::quadratic<16>> rtree;
-    std::multimap<unsigned int, std::pair<std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey>, std::array<int, 3>>> adcMap;
+    if (my_data->Verbosity > 2)
+    {
+      pthread_mutex_lock(&mythreadlock);
+      std::cout << "working on side: " << my_data->side << "   sector: " << my_data->sector << "   module: " << my_data->module << std::endl;
+      pthread_mutex_unlock(&mythreadlock);
+    }
+
+    bgi::rtree<hitData, bgi::quadratic<16>> rtree;
+
+    std::multimap<unsigned int, pointKeyLaser> adcMap;
 
     if (my_data->hitsets.size() == 0)
     {
@@ -334,44 +723,44 @@ namespace
 
       for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second; ++hitr)
       {
-	float_t fadc = hitr->second->getAdc();
-	unsigned short adc = 0;
-	if (fadc > my_data->adc_threshold)
-	{
-	  adc = (unsigned short) fadc;
-	}
-	else
-	{
-	  continue;
-	}
+	      float_t fadc = hitr->second->getAdc();
+	      unsigned short adc = 0;
+	      if (fadc > my_data->adc_threshold)
+	      {
+	        adc = (unsigned short) fadc;
+	      }
+	      else
+	      {
+	        continue;
+	      }
 	
-	int iphi = TpcDefs::getPad(hitr->first);
-	int it = TpcDefs::getTBin(hitr->first);
+	      int iphi = TpcDefs::getPad(hitr->first);
+	      int it = TpcDefs::getTBin(hitr->first);
+        
+	      if(fabs(it - my_data->peakTimeBin) > 5)
+	      {
+	        continue;
+	      }
 
-	if(fabs(it - my_data->peakTimeBin) > 3)
-	{
-	  continue;
-	}
+	      point coords = point((int) layer, iphi, it);
 
-	std::array<int, 3> coords = {(int) layer, iphi, it};
-
-	std::vector<pointKeyLaser> testduplicate;
-	rtree.query(bgi::intersects(box(point(layer - 0.001, iphi - 0.001, it - 0.001),
+	      std::vector<hitData> testduplicate;
+	      rtree.query(bgi::intersects(box(point(layer - 0.001, iphi - 0.001, it - 0.001),
 					point(layer + 0.001, iphi + 0.001, it + 0.001))),
 		    std::back_inserter(testduplicate));
-	if (!testduplicate.empty())
-	{
-	  testduplicate.clear();
-	  continue;
-	}
+	      if (!testduplicate.empty())
+	      {
+	        testduplicate.clear();
+	        continue;
+	      }
 
-	TrkrDefs::hitkey hitKey = TpcDefs::genHitKey(iphi, it);
+	      TrkrDefs::hitkey hitKey = TpcDefs::genHitKey(iphi, it);
 	
-	auto spechitkey = std::make_pair(hitKey, hitsetKey);
-	auto keyCoords = std::make_pair(spechitkey, coords);
-	adcMap.insert(std::make_pair(adc, keyCoords));
-	rtree.insert(std::make_pair(point(1.0*layer, 1.0*iphi, 1.0*it), spechitkey));
-
+	      auto spechitkey = std::make_pair(hitKey, hitsetKey);
+	      pointKeyLaser coordsKey = std::make_pair(coords, spechitkey);
+	      adcMap.insert(std::make_pair(adc, coordsKey));
+        auto adckey = std::make_pair(adc, spechitkey);
+	      rtree.insert(std::make_pair(point(1.0*layer, 1.0*iphi, 1.0*it), adckey));
       }
     }
     //finished filling rtree
@@ -381,19 +770,28 @@ namespace
       auto iterKey = adcMap.rbegin();
       if(iterKey == adcMap.rend())
       {
-	break;
+	      break;
       }
       
-      auto coords = iterKey->second.second;
-      int layer = coords[0];
-      int iphi = coords[1];
-      int it = coords[2];
 
-      std::vector<pointKeyLaser> clusHits;
-      
-      rtree.query(bgi::intersects(box(point(layer - my_data->layerMin, iphi - 2, it - 5), point(layer + my_data->layerMax, iphi + 2, it + 5))), std::back_inserter(clusHits));
+      auto coords = iterKey->second.first;
+      int layer = coords.get<0>();
+      int iphi = coords.get<1>();
+      int it = coords.get<2>();
+   
+      if (my_data->Verbosity > 2)
+      {
+        pthread_mutex_lock(&mythreadlock);
+        std::cout << "working on cluster " << my_data->cluster_vector.size() << "   side: " << my_data->side << "   sector: " << my_data->sector << "   module: " << (layer<23 ? 1 : (layer<39 ? 2 : 3) ) << std::endl;
+        pthread_mutex_unlock(&mythreadlock);
 
-      calc_cluster_parameter(my_data->cluster_vector, my_data->cluster_key_vector, clusHits, adcMap, *my_data);
+      }
+
+      std::vector<hitData> clusHits;
+
+      rtree.query(bgi::intersects(box(point(layer - my_data->layerMin, iphi - 6, it - 5), point(layer + my_data->layerMax, iphi + 6, it + 5))), std::back_inserter(clusHits));
+
+      calc_cluster_parameter(clusHits, *my_data, iterKey->second.second);
 
       remove_hits(clusHits, rtree, adcMap);
 
@@ -415,6 +813,8 @@ LaserClusterizer::LaserClusterizer(const std::string &name)
 
 int LaserClusterizer::InitRun(PHCompositeNode *topNode)
 {
+  TH1::AddDirectory(kFALSE);
+
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
@@ -562,78 +962,87 @@ int LaserClusterizer::process_event(PHCompositeNode *topNode)
       for (unsigned int mod=0; mod<3; mod++)
       {
 	
-	thread_pair_t &thread_pair = threads.emplace_back();
+        if(Verbosity() > 2)
+        {
+          std::cout << "making thread for side: " << s << "   sector: " << sec << "   module: " << mod << std::endl;
+        }
 
-	std::vector<TrkrHitSet *> hitsets;
-	std::vector<unsigned int> layers;
+	      thread_pair_t &thread_pair = threads.emplace_back();
 
-	std::vector<LaserCluster *> cluster_vector;
-	std::vector<TrkrDefs::cluskey> cluster_key_vector;
+	      std::vector<TrkrHitSet *> hitsets;
+	      std::vector<unsigned int> layers;
 
-	for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
-	     hitsetitr != hitsetrange.second;
-	     ++hitsetitr)
-	{
-	  unsigned int layer = TrkrDefs::getLayer(hitsetitr->first);
-	  int side = TpcDefs::getSide(hitsetitr->first);
-	  unsigned int sector = TpcDefs::getSectorId(hitsetitr->first);
-	  if (sector != sec || side != s)
-	  {
-	    continue;
-	  }
-	  if ((mod==0 && (layer<7 || layer>22)) || (mod==1 && (layer<=22 || layer>38) ) || (mod==2 && (layer<=38 || layer>54)))
-	  {
-	    continue;
-	  }
+	      std::vector<LaserCluster *> cluster_vector;
+	      std::vector<TrkrDefs::cluskey> cluster_key_vector;
 
-	  TrkrHitSet *hitset = hitsetitr->second;
+	      for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
+	          hitsetitr != hitsetrange.second;
+	          ++hitsetitr)
+	      {
+	        unsigned int layer = TrkrDefs::getLayer(hitsetitr->first);
+	        int side = TpcDefs::getSide(hitsetitr->first);
+	        unsigned int sector = TpcDefs::getSectorId(hitsetitr->first);
+	        if (sector != sec || side != s)
+	        {
+	          continue;
+	        }
+	        if ((mod==0 && (layer<7 || layer>22)) || (mod==1 && (layer<=22 || layer>38) ) || (mod==2 && (layer<=38 || layer>54)))
+	        {
+	          continue;
+	        }
+
+	        TrkrHitSet *hitset = hitsetitr->second;
 	  
-	  hitsets.push_back(hitset);
-	  layers.push_back(layer);
+	        hitsets.push_back(hitset);
+	        layers.push_back(layer);
 	  
-	}
+      	}
 
-	thread_pair.data.geom_container = m_geom_container;
-	thread_pair.data.tGeometry = m_tGeometry;
-	thread_pair.data.hitsets = hitsets;
-	thread_pair.data.layers = layers;
-	thread_pair.data.side = (bool)s;
-	thread_pair.data.sector = sec;
-	thread_pair.data.cluster_vector = cluster_vector;
-	thread_pair.data.cluster_key_vector = cluster_key_vector;
-	thread_pair.data.adc_threshold = m_adc_threshold;
-	thread_pair.data.peakTimeBin = m_laserEventInfo->getPeakSample(s);
-	thread_pair.data.layerMin = (m_lamination ? 2 : 1);
-	thread_pair.data.layerMax = (m_lamination ? 2 : 1);
-	thread_pair.data.tdriftmax = m_tdriftmax;
+	      thread_pair.data.geom_container = m_geom_container;
+	      thread_pair.data.tGeometry = m_tGeometry;
+	      thread_pair.data.hitsets = hitsets;
+	      thread_pair.data.layers = layers;
+	      thread_pair.data.side = (bool)s;
+	      thread_pair.data.sector = sec;
+        thread_pair.data.module = mod;
+	      thread_pair.data.cluster_vector = cluster_vector;
+	      thread_pair.data.cluster_key_vector = cluster_key_vector;
+	      thread_pair.data.adc_threshold = m_adc_threshold;
+	      thread_pair.data.peakTimeBin = m_laserEventInfo->getPeakSample(s);
+	      thread_pair.data.layerMin = 3;
+	      thread_pair.data.layerMax = 3;
+	      thread_pair.data.tdriftmax = m_tdriftmax;
+        thread_pair.data.eventNum = m_event;
+        thread_pair.data.Verbosity = Verbosity();
+        thread_pair.data.hitHist = nullptr;
 
-	int rc;
-	rc = pthread_create(&thread_pair.thread, &attr, ProcessModule, (void *) &thread_pair.data);
+	      int rc;
+	      rc = pthread_create(&thread_pair.thread, &attr, ProcessModule, (void *) &thread_pair.data);
 
-	if (rc)
-	{
-	  std::cout << "Error:unable to create thread," << rc << std::endl;
-	}
+	      if (rc)
+	      {
+	        std::cout << "Error:unable to create thread," << rc << std::endl;
+	      }
 
-	if (m_do_sequential)
-	{
-	  //wait for termination of thread
-	  int rc2 = pthread_join(thread_pair.thread, nullptr);
-	  if (rc2)
-	  {
-	    std::cout << "Error:unable to join," << rc2 << std::endl;
-	  }
+	      if (m_do_sequential)
+	      {
+	        //wait for termination of thread
+	        int rc2 = pthread_join(thread_pair.thread, nullptr);
+	        if (rc2)
+	        {
+	          std::cout << "Error:unable to join," << rc2 << std::endl;
+	        }
 
-	  //add clusters from thread to laserClusterContainer
-	  const auto &data(thread_pair.data);
-	  for(int index = 0; index < (int) data.cluster_vector.size(); ++index)
-	  {
-	    auto cluster = data.cluster_vector[index];
-	    const auto ckey = data.cluster_key_vector[index];
+      	  //add clusters from thread to laserClusterContainer
+	        const auto &data(thread_pair.data);
+	        for(int index = 0; index < (int) data.cluster_vector.size(); ++index)
+	        {
+	          auto cluster = data.cluster_vector[index];
+	          const auto ckey = data.cluster_key_vector[index];
 	    
-	    m_clusterlist->addClusterSpecifyKey(ckey, cluster);
-	  }
-	}
+      	    m_clusterlist->addClusterSpecifyKey(ckey, cluster);
+	        }
+	      }
       }
     }
   }
@@ -647,20 +1056,22 @@ int LaserClusterizer::process_event(PHCompositeNode *topNode)
       int rc2 = pthread_join(thread_pair.thread, nullptr);
       if (rc2)
       {
-	std::cout << "Error:unable to join," << rc2 << std::endl;
+	      std::cout << "Error:unable to join," << rc2 << std::endl;
       }
       
-      const auto &data(thread_pair.data);
+      //const auto &data(thread_pair.data);
       
-      for(int index = 0; index < (int) data.cluster_vector.size(); ++index)
+      for(int index = 0; index < (int) thread_pair.data.cluster_vector.size(); ++index)
       {
-	auto cluster = data.cluster_vector[index];
-	const auto ckey = data.cluster_key_vector[index];
+	      auto cluster = thread_pair.data.cluster_vector[index];
+	      const auto ckey = thread_pair.data.cluster_key_vector[index];
 	
-	m_clusterlist->addClusterSpecifyKey(ckey, cluster);
+	      m_clusterlist->addClusterSpecifyKey(ckey, cluster);
       }
     }
   }
+
+  threads.clear();
 
   if (Verbosity() > 1)
   {

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -563,11 +563,6 @@ namespace
 
       const ROOT::Fit::FitResult& result = fit3D->Result();
 
-      clus->setAdc(adcSum);
-      clus->setLayer(result.Parameter(1));
-      clus->setIPhi(result.Parameter(2));
-      clus->setIT(result.Parameter(4));
-
 
       PHG4TpcCylinderGeom *layergeomLow = my_data.geom_container->GetLayerCellGeom((int) floor(result.Parameter(1)));
       PHG4TpcCylinderGeom *layergeomHigh = my_data.geom_container->GetLayerCellGeom((int) ceil(result.Parameter(1)));
@@ -633,13 +628,15 @@ namespace
         clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
       }
       else
-      {
-
+      { 
         clus->setAdc(adcSum);
         clus->setX(meanR*cos(meanPhi));
         clus->setY(meanR*sin(meanPhi));
         clus->setZ(clusZ);
         clus->setFitMode(true);
+        clus->setLayer(result.Parameter(1));
+        clus->setIPhi(result.Parameter(2));
+        clus->setIT(result.Parameter(4));
         clus->setNLayers(usedLayer.size());
         clus->setNIPhi(usedIPhi.size());
         clus->setNIT(usedIT.size());

--- a/offline/packages/tpc/LaserClusterizer.h
+++ b/offline/packages/tpc/LaserClusterizer.h
@@ -46,6 +46,7 @@ class LaserClusterizer : public SubsysReco
   void set_max_time_samples(int val) { m_time_samples_max = val; }
   void set_lamination(bool val) { m_lamination = val; }
   void set_do_sequential(bool val) { m_do_sequential = val; }
+  void set_do_fitting(bool val) { m_do_fitting = val; }
 
  private:
   int m_event {-1};
@@ -66,6 +67,8 @@ class LaserClusterizer : public SubsysReco
   bool m_lamination {false};
 
   bool m_do_sequential {false};
+
+  bool m_do_fitting {true};
   
   double m_tdriftmax {0};
   double AdcClockPeriod {53.0};  // ns

--- a/offline/packages/tpc/LaserClusterizer.h
+++ b/offline/packages/tpc/LaserClusterizer.h
@@ -31,11 +31,6 @@ class PHG4TpcCylinderGeomContainer;
 class LaserClusterizer : public SubsysReco
 {
  public:
-  typedef boost::geometry::model::point<float, 3, boost::geometry::cs::cartesian> point;
-  typedef boost::geometry::model::box<point> box;
-  typedef std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> specHitKey;
-  typedef std::pair<point, specHitKey> pointKeyLaser;
-
   LaserClusterizer(const std::string &name = "LaserClusterizer");
   ~LaserClusterizer() override = default;
 

--- a/offline/packages/tpc/LaserEventIdentifier.cc
+++ b/offline/packages/tpc/LaserEventIdentifier.cc
@@ -124,9 +124,11 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
   if (!gl1pkt)
   {
     std::cout << "no GL1RAWHIT node" << std::endl;
+    m_laserEventInfo->setIsGl1LaserEvent(false);
+    m_laserEventInfo->setIsGl1LaserPileupEvent(false);
     //return Fun4AllReturnCodes::ABORTRUN;
   }
-  else
+  else if(m_runnumber > 66153)
   {
     if ((gl1pkt->getGTMAllBusyVector() & (1<<14)) == 0)
     {
@@ -152,6 +154,11 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
       isGl1LaserPileupEvent = false;
       prev_BCO = 0;
     }
+  }
+  else
+  {
+    m_laserEventInfo->setIsGl1LaserEvent(false);
+    m_laserEventInfo->setIsGl1LaserPileupEvent(false);
   }
 
   TrkrHitSetContainer::ConstRange hitsetrange = m_hits->getHitSets(TrkrDefs::TrkrId::tpcId);

--- a/offline/packages/tpc/LaserEventIdentifier.h
+++ b/offline/packages/tpc/LaserEventIdentifier.h
@@ -30,6 +30,8 @@ class LaserEventIdentifier : public SubsysReco
 
   void set_max_time_samples(int val) { m_time_samples_max = val; }
 
+  void set_runnumber(int runnum) { m_runnumber = runnum; }
+
   void set_debug(bool debug) { m_debug = debug; }
   void set_debug_name(const std::string &name) { m_debugFileName = name; }
  private:
@@ -53,6 +55,7 @@ class LaserEventIdentifier : public SubsysReco
   int peakSample1 = -999;
   float peakWidth0 = -999;
   float peakWidth1 = -999;
+  int m_runnumber = 0;
 
   uint64_t prev_BCO = 0;
 };

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
@@ -1802,7 +1802,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
         while(lowRMatch <= highRMatch)
         {
           int mid = lowRMatch + (highRMatch - lowRMatch)/2;
-          if(m_truth_RPeaks[mid] >= reco_pos[recoIndex].Perp())])
+          if(m_truth_RPeaks[mid] >= reco_pos[recoIndex].Perp())
           {
             upperBound = mid;
             highRMatch = mid - 1;

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
@@ -10,7 +10,7 @@
 #include <trackbase/CMFlashDifferenceContainerv1.h>
 #include <trackbase/CMFlashDifferencev1.h>
 #include <trackbase/LaserClusterContainerv1.h>
-#include <trackbase/LaserClusterv1.h>
+#include <trackbase/LaserCluster.h>
 #include <trackbase/TpcDefs.h>
 
 #include <ffaobjects/EventHeader.h>
@@ -38,6 +38,9 @@
 #include <iomanip>
 #include <set>
 #include <string>
+
+int layerMins[3] = {16,23,39};
+int layerMaxes[3] = {22, 38, 54};
 
 namespace
 {
@@ -1035,6 +1038,7 @@ int TpcCentralMembraneMatching::InitRun(PHCompositeNode* topNode)
     match_tree->Branch("rawPhi", &m_rawPhi);
     match_tree->Branch("staticR", &m_staticR);
     match_tree->Branch("staticPhi", &m_staticPhi);
+    match_tree->Branch("fitMode", &m_fitMode);
     match_tree->Branch("side", &m_side);
     match_tree->Branch("adc", &m_adc);
     match_tree->Branch("nhits", &m_nhits);
@@ -1266,6 +1270,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
   std::vector<TVector3> static_pos;
   std::vector<TVector3> raw_pos;
   std::vector<bool> reco_side;
+  std::vector<bool> fitMode;
   std::vector<unsigned int> reco_nhits;
   std::vector<unsigned int> reco_adc;
   std::vector<unsigned int> reco_nLayers;
@@ -1296,7 +1301,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
     m_event_index = eventHeader->get_EvtSequence();
   }
 
-  if (!m_corrected_CMcluster_map || m_corrected_CMcluster_map->size() < 100)
+  if (!m_corrected_CMcluster_map || m_corrected_CMcluster_map->size() < 1000)
   {
     if(!m_useHeader)
     {
@@ -1308,7 +1313,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
   
   if (Verbosity())
   {
-    std::cout << PHWHERE << "   working on event " << m_event_index << std::endl;
+    std::cout << PHWHERE << "   working on event " << m_event_index << " which has " << m_corrected_CMcluster_map->size() << " clusters" << std::endl;
   }
 
   // reset output distortion correction container histograms
@@ -1344,6 +1349,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
     // std::cout << "cluster " << clusterIndex << " side=" << side << "   sideKey=" << sideKey << "   are they the same? " << (side == sideKey ? "true" : "false") << std::endl;
     //  if(m_useOnly_nClus2 && nclus != 2) continue;
 
+
     nClus_gtMin++;
 
     // Do the static + average distortion corrections if the container was found
@@ -1374,6 +1380,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
     static_pos.push_back(tmp_static);
     raw_pos.push_back(tmp_raw);
     reco_side.push_back(side);
+    fitMode.push_back(cmclus->getFitMode());
     reco_nhits.push_back(nhits);
     reco_adc.push_back(adc);
     reco_nLayers.push_back(cmclus->getNLayers());
@@ -1787,14 +1794,34 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
       for(const auto& recoIndex : truthIndex)
       {
 
+            if(reco_nLayers[recoIndex] < 2 || reco_nLayers[recoIndex] > 3) continue;
+
+        int lowRMatch = 0;
+        int highRMatch = (int)m_truth_RPeaks.size()-1;
+        int upperBound = (int)m_truth_RPeaks.size();
+        while(lowRMatch <= highRMatch)
+        {
+          int mid = lowRMatch + (highRMatch - lowRMatch)/2;
+          if(m_truth_RPeaks[mid] >= reco_pos[recoIndex].Perp())])
+          {
+            upperBound = mid;
+            highRMatch = mid - 1;
+          }
+          else
+          {
+            lowRMatch = mid + 1;
+          }
+        }
+        if(upperBound < 1) upperBound = 1;
+
 	double dR = m_truth_pos[truth_index].Perp() - reco_pos[recoIndex].Perp();
-	if(fabs(dR) > 1.0)
+	if(fabs(dR) > 0.5 * (m_truth_RPeaks[upperBound] - m_truth_RPeaks[upperBound-1]))
 	{
 	  continue;
 	}
 
 	double dphi = delta_phi(m_truth_pos[truth_index].Phi() - reco_pos[recoIndex].Phi());
-	if(fabs(dphi) > m_phi_cut)
+	if(fabs(dphi) > 0.5*phiSpacing[upperBound-1])
 	{
 	  continue;
 	}
@@ -1847,6 +1874,7 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
       m_staticR = static_pos[i].Perp();
       m_staticPhi = static_pos[i].Phi();
       m_side = reco_side[i];
+      m_fitMode = fitMode[i];
       m_adc = reco_adc[i];
       m_nhits = reco_nhits[i];
       m_nLayers = reco_nLayers[i];

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.h
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.h
@@ -207,6 +207,7 @@ class TpcCentralMembraneMatching : public SubsysReco
   float m_staticR{0.0};
   float m_staticPhi{0.0};
   bool m_side{false};
+  bool m_fitMode{false};
   unsigned int m_adc{0};
   unsigned int m_nhits{0};
   unsigned int m_nLayers{0};
@@ -329,6 +330,8 @@ class TpcCentralMembraneMatching : public SubsysReco
   std::vector<double> m_truth_RPeaks{22.709, 23.841, 24.973, 26.1049, 27.2369, 28.3689, 29.5009, 30.6328, 31.7648, 32.8968, 34.0288, 35.1607, 36.2927, 37.4247, 38.5566, 39.6886, 42.1706, 44.2119, 46.2533, 48.2947, 50.3361, 52.3774, 54.4188, 56.4602, 59.4605, 61.6546, 63.8487, 66.0428, 68.2369, 70.431, 72.6251, 74.8192};
 
   //@}
+
+  std::vector<double> phiSpacing = {0.0749989, 0.0729917, 0.0711665, 0.0694996, 0.0679712, 0.0665648, 0.0652663, 0.0640638, 0.062947, 0.0619071, 0.0609364, 0.0600281, 0.0591765, 0.0583765, 0.0576234, 0.0569132, 0.0473084, 0.0462573, 0.045299, 0.0444217, 0.0436155, 0.0428722, 0.0421847, 0.0415468, 0.0325076, 0.0319331, 0.031398, 0.0308985, 0.0304311, 0.0299928, 0.029581, 0.0291934};
 
   bool m_fixShifts{false};
   bool m_fieldOn{true};

--- a/offline/packages/trackbase/LaserCluster.h
+++ b/offline/packages/trackbase/LaserCluster.h
@@ -50,6 +50,9 @@ class LaserCluster : public PHObject
   virtual float getZ() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setZ(float) {}
 
+  virtual bool getFitMode() const { return false; }
+  virtual void setFitMode(bool) {}
+
   virtual float getLayer() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setLayer(float) {}
   virtual float getIPhi() const { return std::numeric_limits<float>::quiet_NaN(); }

--- a/offline/packages/trackbase/LaserClusterv2.cc
+++ b/offline/packages/trackbase/LaserClusterv2.cc
@@ -1,0 +1,97 @@
+/**
+ * @file trackbase/LaserClusterv2.cc
+ * @author Ben Kimelman
+ * @date July 2025
+ * @brief Implementation of LaserClusterv2
+ */
+#include "LaserClusterv2.h"
+
+#include <cmath>
+#include <utility>          // for swap
+
+void LaserClusterv2::identify(std::ostream& os) const
+{
+  os << "---LaserClusterv2--------------------" << std::endl;
+
+  os << " fit? " << m_fitMode;
+  os << " (x,y,z) =  (" << m_pos[0];
+  os << ", " << m_pos[1] << ", ";
+  os << m_pos[2] << ") cm";
+
+  os << " adc = " << getAdc() << std::endl;
+
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
+
+  return;
+}
+
+int LaserClusterv2::isValid() const
+{
+  if(std::isnan(getX()))
+    {
+      return 0;
+    }
+  if(std::isnan(getY()))
+    {
+      return 0;
+    }
+  if(std::isnan(getZ()))
+    {
+      return 0;
+    }
+
+  if (m_adc == 0xFFFFFFFF)
+    {
+      return 0;
+    }
+
+  return 1;
+}
+
+void LaserClusterv2::CopyFrom( const LaserCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source )
+    {
+      return;
+    }
+ 
+  // parent class method
+  LaserCluster::CopyFrom( source );
+
+  setX( source.getX() );
+  setY( source.getY() );
+  setZ( source.getZ() );
+  setFitMode( source.getFitMode() );
+  setAdc( source.getAdc() );
+  setLayer( source.getLayer() );
+  setIPhi( source.getIPhi() );
+  setIT( source.getIT() );
+  setNhits( source.getNhits() );
+  setNLayers( source.getNLayers() );
+  setNIPhi( source.getNIPhi() );
+  setNIT( source.getNIT() );
+  setSDLayer( source.getSDLayer() );
+  setSDIPhi( source.getSDIPhi() );
+  setSDIT( source.getSDIT() );
+  setSDWeightedLayer( source.getSDWeightedLayer() );
+  setSDWeightedIPhi( source.getSDWeightedIPhi() );
+  setSDWeightedIT( source.getSDWeightedIT() );
+
+
+  for(int i=0; i<(int)source.getNhits(); i++){
+    addHit();
+    setHitLayer(i, source.getHitLayer(i));
+    setHitIPhi(i, source.getHitIPhi(i));
+    setHitIT(i, source.getHitIT(i));
+
+    setHitX(i, source.getHitX(i));
+    setHitY(i, source.getHitY(i));
+    setHitZ(i, source.getHitZ(i));
+    setHitAdc(i, source.getHitAdc(i));
+  }
+
+
+}
+

--- a/offline/packages/trackbase/LaserClusterv2.h
+++ b/offline/packages/trackbase/LaserClusterv2.h
@@ -1,0 +1,152 @@
+/**
+ * @file trackbase/LaserClusterv2.h
+ * @author Ben Kimelman
+ * @date July 2025
+ * @brief Version 2 of CMFLashCluster
+ */
+#ifndef TRACKBASE_LASERCLUSTERV2_H
+#define TRACKBASE_LASERCLUSTERV2_H
+
+#include "LaserCluster.h"
+
+#include <iostream>
+#include <vector>
+
+class PHObject;
+
+/**
+ * @brief Version 2 of LaserCluster
+ *
+ * Note - D. McGlinchey June 2018:
+ *   CINT does not like "override", so ignore where CINT
+ *   complains. Should be checked with ROOT 6 once
+ *   migration occurs.
+ */
+class LaserClusterv2 : public LaserCluster
+{
+ public:
+  //! ctor
+  LaserClusterv2() = default;
+
+  // PHObject virtual overloads
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override {}
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new LaserClusterv2(*this); }
+ 
+  //! copy content from base class
+  void CopyFrom( const LaserCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( LaserCluster* source ) override
+  { CopyFrom( *source ); }
+
+  //
+  // cluster position
+  //
+  float getX() const override { return m_pos[0]; }
+  void setX(float x) override { m_pos[0] = x; }
+  float getY() const override { return m_pos[1]; }
+  void setY(float y) override { m_pos[1] = y; }
+  float getZ() const override { return m_pos[2]; }
+  void setZ(float z) override { m_pos[2] = z; }
+
+  bool getFitMode() const override { return m_fitMode; }
+  void setFitMode(bool fitMode) override { m_fitMode = fitMode; }
+
+  float getLayer() const override { return m_posHardware[0]; }
+  void setLayer(float layer) override { m_posHardware[0] = layer; }
+  float getIPhi() const override { return m_posHardware[1]; }
+  void setIPhi(float iphi) override { m_posHardware[1] = iphi; }
+  float getIT() const override { return m_posHardware[2]; }
+  void setIT(float it) override { m_posHardware[2] = it; }
+
+  unsigned int getNhits() const override {return m_hitVec.size();}
+
+  //
+  // cluster info
+  //
+  unsigned int getAdc() const override { return m_adc; }
+  void setAdc(unsigned int adc) override { m_adc = adc; }
+
+  void setNLayers(unsigned int nLayers) override { m_nLayers = nLayers; }
+  unsigned int getNLayers() const override { return m_nLayers; }
+
+  void setNIPhi(unsigned int nIPhi) override { m_nIPhi = nIPhi; }
+  unsigned int getNIPhi() const override { return m_nIPhi; }
+
+  void setNIT(unsigned int nIT) override { m_nIT = nIT; }
+  unsigned int getNIT() const override { return m_nIT; }
+
+  void setSDLayer(float SDLayer) override { m_SDLayer = SDLayer; }
+  float getSDLayer() const override { return m_SDLayer; }
+
+  void setSDIPhi(float SDIPhi) override { m_SDIPhi = SDIPhi; }
+  float getSDIPhi() const override { return m_SDIPhi; }
+
+  void setSDIT(float SDIT) override { m_SDIT = SDIT; }
+  float getSDIT() const override { return m_SDIT; }
+
+  void setSDWeightedLayer(float SDLayer) override { m_SDWeightedLayer = SDLayer; }
+  float getSDWeightedLayer() const override { return m_SDWeightedLayer; }
+
+  void setSDWeightedIPhi(float SDIPhi) override { m_SDWeightedIPhi = SDIPhi; }
+  float getSDWeightedIPhi() const override { return m_SDWeightedIPhi; }
+
+  void setSDWeightedIT(float SDIT) override { m_SDWeightedIT = SDIT; }
+  float getSDWeightedIT() const override { return m_SDWeightedIT; }
+
+  void addHit() override {m_hitVec.push_back({0.0,0.0,0.0,0.0}); m_hitVecHardware.push_back({0.0,0.0,0.0}); }
+
+  void setHitLayer(int i, float layer) override {m_hitVecHardware[i][0] = layer; }
+  float getHitLayer(int i) const override { return m_hitVecHardware[i][0]; }
+
+  void setHitIPhi(int i, float iphi) override {m_hitVecHardware[i][1] = iphi; }
+  float getHitIPhi(int i) const override { return m_hitVecHardware[i][1]; }
+
+  void setHitIT(int i, float it) override {m_hitVecHardware[i][2] = it; }
+  float getHitIT(int i) const override { return m_hitVecHardware[i][2]; }
+
+  void setHitX(int i, float x) override {m_hitVec[i][0] = x; }
+  float getHitX(int i) const override { return m_hitVec[i][0]; }
+
+  void setHitY(int i, float y) override {m_hitVec[i][1] = y; }
+  float getHitY(int i) const override { return m_hitVec[i][1]; }
+
+  void setHitZ(int i, float z) override {m_hitVec[i][2] = z; }
+  float getHitZ(int i) const override { return m_hitVec[i][2]; }
+
+  void setHitAdc(int i, float adc) override {m_hitVec[i][3] = adc; }
+  float getHitAdc(int i) const override { return m_hitVec[i][3]; }
+
+
+ protected:
+
+  /// mean cluster position
+  float m_pos[3] = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()};
+  float m_posHardware[3] = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()};
+
+  bool m_fitMode{false};
+
+  std::vector<std::vector<float>> m_hitVec;
+  std::vector<std::vector<float>> m_hitVecHardware;
+
+  /// cluster sum adc
+  unsigned int m_adc = std::numeric_limits<unsigned int>::max();
+  
+  /// number of TPC clusters used to create this central mebrane cluster
+  unsigned int m_nhits = std::numeric_limits<unsigned int>::max();
+  unsigned int m_nLayers = std::numeric_limits<unsigned int>::max();
+  unsigned int m_nIPhi = std::numeric_limits<unsigned int>::max();
+  unsigned int m_nIT = std::numeric_limits<unsigned int>::max();
+  float m_SDLayer = std::numeric_limits<float>::quiet_NaN();
+  float m_SDIPhi = std::numeric_limits<float>::quiet_NaN();
+  float m_SDIT = std::numeric_limits<float>::quiet_NaN();
+  float m_SDWeightedLayer = std::numeric_limits<float>::quiet_NaN();
+  float m_SDWeightedIPhi = std::numeric_limits<float>::quiet_NaN();
+  float m_SDWeightedIT = std::numeric_limits<float>::quiet_NaN();
+
+  ClassDefOverride(LaserClusterv2, 1)
+};
+
+#endif //TRACKBASE_LASERCLUSTERV2_H

--- a/offline/packages/trackbase/LaserClusterv2LinkDef.h
+++ b/offline/packages/trackbase/LaserClusterv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class LaserClusterv2+;
+
+#endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -70,6 +70,7 @@ pkginclude_HEADERS = \
   LaserClusterContainer.h \
   LaserClusterContainerv1.h \
   LaserClusterv1.h \
+  LaserClusterv2.h \
   MagneticFieldOptions.h \
   MaterialWiper.h \
   MvtxDefs.h \
@@ -150,6 +151,7 @@ ROOTDICTS = \
   LaserClusterContainerv1_Dict.cc \
   LaserCluster_Dict.cc \
   LaserClusterv1_Dict.cc \
+  LaserClusterv2_Dict.cc \
   MvtxEventInfo_Dict.cc \
   MvtxEventInfov1_Dict.cc \
   MvtxEventInfov2_Dict.cc \
@@ -237,6 +239,7 @@ libtrack_io_la_SOURCES = \
   InttEventInfov1.cc \
   LaserClusterContainerv1.cc \
   LaserClusterv1.cc \
+  LaserClusterv2.cc \
   MvtxDefs.cc \
   MvtxEventInfo.cc \
   MvtxEventInfov1.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
New code to fit laser clusters. This does a better job of obtaining the parameter centroids and than the previous weighted average, which can be toggled on/off with an included function, which has a toggle in Trkr_GlobalVariables.C. Also, added protection for laser event identifying with new GL1 bit so that it's only used in runs after the bit was added.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
https://github.com/sPHENIX-Collaboration/macros/pull/1170
