### PR TITLE
KFP updates: DST, vertex, track-calo matching

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -177,7 +177,10 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
   SvtxTrack *dummyMother = nullptr;  
   while (!dummyMother)
   {
-    dummyMother = m_recoTrackMap->insertWithKey(m_recoTrack, resonanceCounter);
+    if (!m_recoTrackMap->get(resonanceCounter))
+    {
+      dummyMother = m_recoTrackMap->insertWithKey(m_recoTrack, resonanceCounter);
+    }
     --resonanceCounter;
   }
   m_recoTrack->Reset();
@@ -192,7 +195,10 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
       SvtxTrack *dummyIntermediate = nullptr;  
       while (!dummyIntermediate)
       {
-	dummyIntermediate = m_recoTrackMap->insertWithKey(m_recoTrack, resonanceCounter);
+        if (!m_recoTrackMap->get(resonanceCounter))
+	{
+	  dummyIntermediate = m_recoTrackMap->insertWithKey(m_recoTrack, resonanceCounter);
+	}
         --resonanceCounter;
       }
       m_recoTrack->Reset();
@@ -212,14 +218,20 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
       SvtxTrack *dummyDaughter = nullptr;  
       while (!dummyDaughter)
       {
-        dummyDaughter = m_recoTrackMap->insertWithKey(m_recoTrack, daughterCounter);
+        if (!m_recoTrackMap->get(daughterCounter))
+	{
+          dummyDaughter = m_recoTrackMap->insertWithKey(m_recoTrack, daughterCounter);
+	}
         ++daughterCounter;
       }
     }
     else
     {
       m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap);
-      m_recoTrackMap->insertWithKey(m_recoTrack, daughterArray[k].Id());
+      if (!m_recoTrackMap->get(daughterArray[k].Id()))
+      {
+        m_recoTrackMap->insertWithKey(m_recoTrack, daughterArray[k].Id());
+      }
     }
   }
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -203,6 +203,7 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
   if (!m_dst_globalvertexmap)
   {
     std::cout << "Can't continue in KFParticle_Tools::makeAllPrimaryVertices" << std::endl;
+    return primaryVertices;
   }
 
   for (GlobalVertexMap::ConstIter iter = m_dst_globalvertexmap->begin(); iter != m_dst_globalvertexmap->end(); ++iter)
@@ -407,6 +408,7 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFPart
     if (!m_dst_globalvertexmap)
     {
       std::cout << "Can't continue in KFParticle_Tools::makeAllPrimaryVertices" << std::endl;
+      return 0;
     }
     auto associated_gvertex = m_dst_globalvertexmap->get(vertex.Id());
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -175,32 +175,45 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
 
   if (m_dont_use_global_vertex)
   {
-    for (SvtxVertexMap::ConstIter iter = m_dst_vertexmap->begin(); iter != m_dst_vertexmap->end(); ++iter)
+    if (m_use_mbd_vertex)
     {
-      m_dst_vertex = iter->second;
-      primaryVertices.push_back(makeVertex(topNode));
-      primaryVertices[vertexID].SetId(iter->first);
-      ++vertexID;
+      for (MbdVertexMap::ConstIter iter = m_dst_mbdvertexmap->begin(); iter != m_dst_mbdvertexmap->end(); ++iter)
+      {
+        m_dst_mbdvertex = iter->second;
+        primaryVertices.push_back(makeVertex(topNode));
+        primaryVertices[vertexID].SetId(iter->first);
+        ++vertexID;
+      }
+    }
+    else
+    {
+       for (SvtxVertexMap::ConstIter iter = m_dst_vertexmap->begin(); iter != m_dst_vertexmap->end(); ++iter)
+      {
+        m_dst_vertex = iter->second;
+        primaryVertices.push_back(makeVertex(topNode));
+        primaryVertices[vertexID].SetId(iter->first);
+        ++vertexID;
+      }
     }
 
     return primaryVertices;
   }
 
-  auto globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
-  if (!globalvertexmap)
+  m_dst_globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+  if (!m_dst_globalvertexmap)
   {
     std::cout << "Can't continue in KFParticle_Tools::makeAllPrimaryVertices" << std::endl;
   }
 
-  for (GlobalVertexMap::ConstIter iter = globalvertexmap->begin(); iter != globalvertexmap->end(); ++iter)
+  for (GlobalVertexMap::ConstIter iter = m_dst_globalvertexmap->begin(); iter != m_dst_globalvertexmap->end(); ++iter)
   {
-    GlobalVertex *gvertex = iter->second;
+    m_dst_globalvertex = iter->second;
     
     GlobalVertex::VTXTYPE whichVtx = m_use_mbd_vertex ? GlobalVertex::MBD : GlobalVertex::SVTX; 
 
-    auto svtxiter = gvertex->find_vertexes(whichVtx);
+    auto svtxiter = m_dst_globalvertex->find_vertexes(whichVtx);
     // check that it contains a track vertex
-    if (svtxiter == gvertex->end_vertexes())
+    if (svtxiter == m_dst_globalvertex->end_vertexes())
     {
       continue;
     }
@@ -219,7 +232,7 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
       }
 
       primaryVertices.push_back(makeVertex(topNode));
-      primaryVertices[vertexID].SetId(gvertex->get_id());
+      primaryVertices[vertexID].SetId(m_dst_globalvertex->get_id());
       ++vertexID;
     }
   }
@@ -351,6 +364,8 @@ void KFParticle_Tools::getTracksFromBC(PHCompositeNode *topNode, const int &bunc
     vtxMN = vertexMapName;
   }
 
+  nTracks = 0;
+  nPVs = 0;
   m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, vtxMN);
   for (SvtxVertexMap::ConstIter iter = m_dst_vertexmap->begin(); iter != m_dst_vertexmap->end(); ++iter)
   {
@@ -380,10 +395,37 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFPart
     vtxMN = vertexMapName;
   }
 
-  m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, vertexMapName);
-  SvtxVertex* associated_vertex = m_dst_vertexmap->get(vertex.Id());
+  SvtxVertex* associated_vertex = nullptr;
+  if (m_dont_use_global_vertex)
+  {
+    m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, vtxMN);
+    associated_vertex = m_dst_vertexmap->get(vertex.Id());
+  }
+  else
+  {
+    m_dst_globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+    if (!m_dst_globalvertexmap)
+    {
+      std::cout << "Can't continue in KFParticle_Tools::makeAllPrimaryVertices" << std::endl;
+    }
+    auto associated_gvertex = m_dst_globalvertexmap->get(vertex.Id());
 
-  return associated_vertex->size_tracks();   
+    auto svtxiter = associated_gvertex->find_vertexes(GlobalVertex::SVTX);
+    auto svtxvertexvector = svtxiter->second;
+
+    for (auto &gvertex : svtxvertexvector)
+    {
+      associated_vertex = m_dst_vertexmap->find(gvertex->get_id())->second;
+    }
+  }
+  if (associated_vertex)
+  {
+    return associated_vertex->size_tracks();
+  }
+  else
+  {
+    return 0;
+  }
 }
 
 /*const*/ bool KFParticle_Tools::isGoodTrack(const KFParticle &particle, const std::vector<KFParticle> &primaryVertices)
@@ -1234,9 +1276,44 @@ bool KFParticle_Tools::checkTrackAndVertexMatch(KFParticle vDaughters[], int nTr
 {
   bool vertexAndTrackMatch = true;
 
-  m_dst_vertex = m_dst_vertexmap->get(vertex.Id());
+  int vertexCrossing = 1e5;
 
-  int vertexCrossing = m_dst_vertex->get_beam_crossing();
+  if (m_dont_use_global_vertex)
+  {
+    if (m_use_mbd_vertex)
+    {
+      m_dst_mbdvertex = m_dst_mbdvertexmap->get(vertex.Id());
+      vertexCrossing = m_dst_mbdvertex->get_beam_crossing();
+    }
+    else
+    {
+      m_dst_vertex = m_dst_vertexmap->get(vertex.Id());
+      vertexCrossing = m_dst_vertex->get_beam_crossing();
+    }
+  }
+  else
+  {
+    m_dst_globalvertex = m_dst_globalvertexmap->get(vertex.Id());
+
+    GlobalVertex::VTXTYPE whichVtx = m_use_mbd_vertex ? GlobalVertex::MBD : GlobalVertex::SVTX; 
+
+    auto svtxiter = m_dst_globalvertex->find_vertexes(whichVtx);
+    auto svtxvertexvector = svtxiter->second;
+
+    for (auto &gvertex : svtxvertexvector)
+    {
+      if (m_use_mbd_vertex)
+      {
+        m_dst_mbdvertex = m_dst_mbdvertexmap->find(gvertex->get_id())->second;
+        vertexCrossing = m_dst_mbdvertex->get_beam_crossing();
+      }
+      else
+      {
+        m_dst_vertex = m_dst_vertexmap->find(gvertex->get_id())->second;
+        vertexCrossing = m_dst_vertex->get_beam_crossing();
+      }
+    }
+  }
 
   for (int i = 0; i < nTracks; ++i)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -43,6 +43,8 @@ class SvtxVertexMap;
 class SvtxTrackMap;
 class SvtxVertex;
 class SvtxTrack;
+class GlobalVertexMap;
+class GlobalVertex;
 class TrkrClusterContainer;
 class PHG4TpcCylinderGeomContainer;
 
@@ -258,6 +260,8 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   std::string m_vtx_map_node_name;
   std::string m_trk_map_node_name;
+  GlobalVertexMap *m_dst_globalvertexmap {nullptr};
+  GlobalVertex *m_dst_globalvertex {nullptr};
   MbdVertexMap *m_dst_mbdvertexmap {nullptr};
   MbdVertex *m_dst_mbdvertex {nullptr};
   SvtxTrackMap *m_dst_trackmap {nullptr};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -672,7 +672,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     fillTriggerBranches(topNode);
   }
 
-  if (isTrackEMCalmatch)
+  if (fillConditionMet())
   {
     m_tree->Fill();
   }
@@ -710,4 +710,22 @@ float KFParticle_nTuple::calc_secondary_vertex_mass_noPID(std::vector<KFParticle
   }
 
   return mother_noPID.GetMass();
+}
+
+bool KFParticle_nTuple::fillConditionMet()
+{
+  // return true if this is a track-only analysis
+  if (!m_calo_info)
+  {
+    return true;
+  }
+
+  // return true if do not require track-calo matching
+  if (!m_require_track_emcal_match)
+  {
+    return true;
+  }
+
+  // if requiring track-calo matching, the match result is returned
+  return isTrackEMCalmatch;
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -294,8 +294,9 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
 
   m_tree->Branch("secondary_vertex_mass_pionPID", &m_sv_mass, "secondary_vertex_mass_pionPID/F");
 
-  m_tree->Branch("nPrimaryVertices", &m_nPVs, "nPrimaryVertices/I");
-  m_tree->Branch("nEventTracks", &m_multiplicity, "nEventTracks/I");
+  m_tree->Branch("nPrimaryVerticesOfBC", &m_nPVs, "nPrimaryVerticesOfBC/I");
+  m_tree->Branch("nTracksOfBC", &m_multiplicity, "nTracksOfBC/I");
+  m_tree->Branch("nTracksOfVertex", &m_nTracksOfVertex, "nTracksOfVertex/I");
 
   m_tree->Branch("runNumber", &m_runNumber, "runNumber/I");
   m_tree->Branch("eventNumber", &m_evtNumber, "eventNumber/I");
@@ -480,6 +481,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     }
   }
 
+  isTrackEMCalmatch = true;
   for (int i = 0; i < m_num_tracks_nTuple; ++i)
   {
     m_calculated_daughter_mass[i] = daughterArray[i].GetMass();
@@ -527,9 +529,14 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     //m_calculated_daughter_expected_dedx_kaon[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 321);
     //m_calculated_daughter_expected_dedx_proton[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 2212);
 
+    bool tempEMCalmatch = false;
     if (m_calo_info)
     {
-      fillCaloBranch(topNode, m_tree, daughterArray[i], i);
+      fillCaloBranch(topNode, m_tree, daughterArray[i], i, tempEMCalmatch);
+      if (m_require_track_emcal_match && !tempEMCalmatch)
+      {
+        isTrackEMCalmatch = false;
+      }
     }
     if (m_truth_matching)
     {
@@ -631,7 +638,11 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
   // cannot retrieve vertex map info from fake PV, hence the second condition
   if (m_constrain_to_vertex_nTuple && !m_use_fake_pv_nTuple)
   {
-    m_multiplicity = kfpTupleTools.getTracksFromVertex(topNode, vertex_fillbranch, m_vtx_map_node_name_nTuple);
+    m_nTracksOfVertex = kfpTupleTools.getTracksFromVertex(topNode, vertex_fillbranch, m_vtx_map_node_name_nTuple);
+  }
+  else
+  {
+    m_nTracksOfVertex = 0;
   }
 
   PHNodeIterator nodeIter(topNode);
@@ -661,7 +672,10 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     fillTriggerBranches(topNode);
   }
 
-  m_tree->Fill();
+  if (isTrackEMCalmatch)
+  {
+    m_tree->Fill();
+  }
 
   if (m_truth_matching || m_detector_info)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -48,6 +48,8 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   bool m_get_trigger_info {false};
   bool m_detector_info {false};
   bool m_calo_info {false};
+  bool m_require_track_emcal_match {false};
+  bool isTrackEMCalmatch {true};
   std::string m_mother_name;
   // std::string m_vtx_map_node_name_nTuple;
   bool m_use_intermediate_name {false};
@@ -186,6 +188,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
 
   int m_nPVs = -1;
   int m_multiplicity = -1;
+  int m_nTracksOfVertex = -1;
 
   int m_runNumber = -1;
   int m_evtNumber = -1;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -36,6 +36,8 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
 
   float calc_secondary_vertex_mass_noPID(std::vector<KFParticle> kfp_daughters);
 
+  bool fillConditionMet();
+
  protected:
   bool m_has_intermediates_nTuple {false};
   bool m_extrapolateTracksToSV_nTuple{true};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -379,6 +379,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void getCaloInfo(bool caloinfo = true) { m_calo_info = caloinfo; }
 
+  void requireTrackEMCalMatch(bool require = true) { m_require_track_emcal_match = require; }
+
   void getAllPVInfo(bool pvinfo = true) { m_get_all_PVs = pvinfo; }
 
   void bunchCrossingZeroOnly(bool bcZeroOnly = true) { m_bunch_crossing_zero_only = bcZeroOnly; }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -492,7 +492,7 @@ The following function matches tracks to calo clusters. As of 7/1/2025, this onl
 To run EMCal matching, DST_CALO files must be read into the Fun4All server. 
 */
 void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
-                                                 TTree * /*m_tree*/, const KFParticle &daughter, int daughter_id)
+                                                 TTree * /*m_tree*/, const KFParticle &daughter, int daughter_id, bool &isTrackEMCalmatch)
 {
   dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name_nTuple);
   if (!dst_trackmap)
@@ -506,13 +506,10 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
 
   if (!clustersEM)
   {
-    // clustersEM = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_CEMC");
     clustersEM = findNode::getClass<RawClusterContainer>(topNode, "CLUSTERINFO_CEMC");
     if (!clustersEM)
     {
-      // std::cout << "TrackCaloMatch::process_event : FATAL ERROR, cannot find cluster container " << "CLUSTER_CEMC" << std::endl;
-      std::cout << __FILE__ << "::" << __func__ << " : FATAL ERROR, cannot find cluster container " << "CLUSTER_CEMC" << std::endl;
-      // return Fun4AllReturnCodes::ABORTEVENT;
+      std::cout << __FILE__ << "::" << __func__ << " : FATAL ERROR, cannot find cluster container " << "CLUSTERINFO_CEMC" << std::endl;
     }
   }
   // if (!EMCalGeo)
@@ -655,15 +652,15 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   index = -1;
   // int ijk = 0; // nothing is being done with this variable in the end
 
-  clustersEM->identify();
+  //clustersEM->identify();
 
   if (thisState != nullptr)
   {
-    _track_phi_emc = std::atan2(thisState->get_y(), thisState->get_x());
-    _track_eta_emc = std::asinh(thisState->get_z() / std::sqrt((thisState->get_x() * thisState->get_x()) + (thisState->get_y() * thisState->get_y())));
     _track_x_emc = thisState->get_x();
     _track_y_emc = thisState->get_y();
     _track_z_emc = thisState->get_z();
+    _track_phi_emc = std::atan2(_track_y_emc, _track_x_emc);
+    _track_eta_emc = std::asinh(_track_z_emc / std::sqrt((_track_x_emc * _track_x_emc) + (_track_y_emc * _track_y_emc)));
 
     // Create objects, containers, iterators for clusters
     cluster = nullptr;
@@ -684,12 +681,15 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       }
 
       // Get cluster information
-      _emcal_phi = std::atan2(cluster->get_y(), cluster->get_x());
-      _emcal_eta = std::asinh(cluster->get_z() / std::sqrt((cluster->get_x() * cluster->get_x()) + (cluster->get_y() * cluster->get_y())));
       _emcal_x = cluster->get_x();
       _emcal_y = cluster->get_y();
+      _emcal_z = cluster->get_z();
       radius_scale = m_emcal_radius_user / std::sqrt((_emcal_x * _emcal_x) + (_emcal_y * _emcal_y));
-      _emcal_z = radius_scale * cluster->get_z();
+      _emcal_x *= radius_scale;
+      _emcal_y *= radius_scale;
+      _emcal_z *= radius_scale;
+      _emcal_phi = std::atan2(_emcal_y, _emcal_y);
+      _emcal_eta = std::asinh(_emcal_z / std::sqrt((_emcal_x * _emcal_x) + (_emcal_y * _emcal_y)));
       // _emcal_3x3 = get_e3x3(cluster, _towersEM, 0); //0 for emcal
       // _emcal_5x5 = get_e5x5(cluster, _towersEM, 0); //0 for emcal
       _emcal_3x3 = std::numeric_limits<float>::quiet_NaN();
@@ -699,7 +699,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       // Variables to determine potential matches
       float dphi = PiRange(_track_phi_emc - _emcal_phi);
       float dz = _track_z_emc - _emcal_z;
-      float deta = _emcal_eta - _track_eta_emc;
+      float deta = _track_eta_emc - _emcal_eta;
       float tmparg = caloRadiusEMCal * dphi;
       float dr = std::sqrt((tmparg * tmparg) + (dz * dz));  // sqrt((R*dphi)^2 + (dz)^2
       // float dr = sqrt((dphi*dphi + deta*deta)); //previous version
@@ -752,6 +752,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     }
   }
 
+  /*
   // Print out statements
   if (index != -1)
   {
@@ -760,6 +761,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     std::cout << "track projected x = " << _track_x_emc << " , y = " << _track_y_emc << " , z = " << _track_z_emc << " , phi = " << _track_phi_emc << " , eta = " << _track_eta_emc << std::endl;
     std::cout << "track px = " << track->get_px() << " , py = " << track->get_py() << " , pz = " << track->get_pz() << " , pt = " << track->get_pt() << " , p = " << track->get_p() << " , charge = " << track->get_charge() << std::endl;
   }
+  */
 
   // Save values to the branches!
   if (index == -1)
@@ -770,6 +772,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_cluster_energy[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    isTrackEMCalmatch = false;
   }
   else
   {
@@ -779,6 +782,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_cluster_energy[daughter_id] = v_emcal_clusE[index];
+    isTrackEMCalmatch = true;
   }
 
   // HCAL*******************************************************
@@ -1237,6 +1241,11 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
     {
       auto stateckey = tstate->get_cluskey();
       TrkrCluster *cluster = dst_clustermap->findCluster(stateckey);
+      if (!cluster)
+      {
+	// do not have associated cluster, could be track states projected to calo system
+        continue;
+      }
       auto global = geometry->getGlobalPosition(stateckey, cluster);
 
       residual_x[daughter_id].push_back(global.x() - tstate->get_x());

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -60,7 +60,7 @@ class KFParticle_truthAndDetTools
   int getHepMCInfo(PHCompositeNode *topNode, TTree *m_tree, const KFParticle &daughter, int daughter_id);
 
   void initializeCaloBranches(TTree *m_tree, int daughter_id, const std::string &daughter_number);
-  void fillCaloBranch(PHCompositeNode *topNode, TTree *m_tree, const KFParticle &daughter, int daughter_id);
+  void fillCaloBranch(PHCompositeNode *topNode, TTree *m_tree, const KFParticle &daughter, int daughter_id, bool &isTrackEMCalmatch);
 
   void initializeDetectorBranches(TTree *m_tree, int daughter_id, const std::string &daughter_number);
   void initializeSubDetectorBranches(TTree *m_tree, const std::string &detectorName, int daughter_id, const std::string &daughter_number);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Several changes on KFParticle 
1. In the previous KFParticle, if multiple mother/intermediate particle is reconstructed in an event, trackmap need to be inserted multiple times. Due to duplicate keys, there are lots of warnings. In the current update, I add a check before ``insertWithKey`` to avoid warnings.
2. In track-calo matching study, track states at calo radius will be created, which do not have trkr cluster associated with. Therefore, if we call ``getGlobalPosition`` function, there will have many warnings, like surface not found. In the current update, I check if cluster is valid or not. If not, just continue to avoid warnings.
3. Add ``requireTrackEMCalMatch `` function to require daughter tracks must be matched with EMCal, which helps to minize output nTuples for quarkonium analysis. Plus some cosmetic modification on code. If we disable either ``getCaloInfo``, or ``requireTrackEMCalMatch``, the basic functionality is not affected, and they are set to false by default, so track-only analysis will not be influenced.
4. Update Vertex-related code in the ``KFParticle_Tools``. In the previous code, If enabling GlobalVertexMap, code will crash, because in some functions, we still search for GlobalVertex id in SvtxTrackMap which is not self-consistent. I basically update ``KFParticle_Tools::makeAllPrimaryVertices``, ``KFParticle_Tools ::getTracksFromBC``, ``KFParticle_Tools::getTracksFromVertex``, ``KFParticle_Tools::checkTrackAndVertexMatch`` functions. I also modify ``KFParticle_nTuple`` a bit, make more clear about
4.1 number of vertices for a given bunch crossing -- ``nPrimaryVerticesOfBC``
4.2 number of tracks for a given bunch crossing -- ``nTracksOfBC``
4.3 number of tracks associated with a given vertex -- ``nTracksOfVertex``

@cdean-github Please review it if they are reasonable. Thanks!

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

