### PR TITLE
feat: tpc variable zs thresholds

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -53,6 +53,36 @@ TpcCombinedRawDataUnpacker::~TpcCombinedRawDataUnpacker()
 {
   delete m_cdbttree;
 }
+void TpcCombinedRawDataUnpacker::ReadZeroSuppressedData()
+{
+  m_do_zs_emulation = true;
+  m_do_baseline_corr = false;
+  auto cdb = CDBInterface::instance();
+  std::string dir = cdb->getUrl("TPC_ZS_THRESHOLDS");
+
+  auto cdbtree = std::make_unique<CDBTTree>(dir);
+  std::ostringstream name;
+  if(dir.empty())
+ {
+  if(Verbosity() > 1)
+  {
+    std::cout << "use default tpc zs threshold of 20" << std::endl;
+  }
+  return;
+ }
+ 
+  for(int i=0; i<3; i++)
+  {
+    name.str("");
+    name << "R"<<i+1<<"ADUThreshold";
+    m_zs_threshold[i] = cdbtree->GetSingleFloatValue(name.str().c_str());
+    if(Verbosity() > 1)
+    {
+      std::cout << "Loading ADU threshold of " << m_zs_threshold[i] << " for region " << i << std::endl;
+    }
+  }
+
+}
 int TpcCombinedRawDataUnpacker::Init(PHCompositeNode* /*topNode*/)
 {
   std::cout << "TpcCombinedRawDataUnpacker::Init(PHCompositeNode *topNode) Initializing" << std::endl;
@@ -279,7 +309,15 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     double phi = ((side == 1 ? 1 : -1) * (m_cdbttree->GetDoubleValue(key, varname) - M_PI / 2.)) + ((sector % 12) * M_PI / 6);
     PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
     unsigned int phibin = layergeom->get_phibin(phi, side);
-
+    unsigned int region = 0;
+    if(layer > 15)
+    {
+      region = 1;
+    }
+    if( layer > 31)
+    {
+      region = 2;
+    }
     hit_set_key = TpcDefs::genHitSetKey(layer, (mc_sectors[sector % 12]), side);
     hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
 
@@ -292,7 +330,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     }
     TH2* feehist = nullptr;
     hpedestal = 60;
-    hpedwidth = m_zs_threshold;
+    hpedwidth = m_zs_threshold[region];
 
     unsigned int pad_key = create_pad_key(side, layer, phibin);
 
@@ -331,7 +369,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     auto fee_entries_it = feeentries_map.find(fee_key);
     std::vector<int>& fee_entries_vec = (*fee_entries_it).second;
 
-    float threshold_cut = m_zs_threshold;
+    float threshold_cut = m_zs_threshold[region];
 
     int nhitschan = 0;
 

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.h
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.h
@@ -35,15 +35,10 @@ class TpcCombinedRawDataUnpacker : public SubsysReco
   };
   void doBaselineCorr(bool val) { m_do_baseline_corr = val; }
   void doZSEmulation(bool val) { m_do_zs_emulation = val; }
-  void ReadZeroSuppressedData()
-  {
-    m_do_zs_emulation = true;
-    m_zs_threshold = 20;
-    m_do_baseline_corr = false;
-  }
+  void ReadZeroSuppressedData();
   void set_presampleShift(int b) { m_presampleShift = b; }
   void set_t0(int b) { m_t0 = b; }
-  void set_zs_threshold(int b) { m_zs_threshold = b; }
+  void set_zs_threshold(int threshold, int region) { m_zs_threshold[region] = threshold; }
   void set_baseline_nsigma(int b) { m_baseline_nsigma = b; }
   void skipNevent(int b) { startevt = b; }
   void useRawHitNodeName(const std::string &name) { m_TpcRawNodeName = name; }
@@ -124,7 +119,7 @@ class TpcCombinedRawDataUnpacker : public SubsysReco
   bool m_do_baseline_corr{false};
   int m_baseline_nsigma{2};
   bool m_do_zs_emulation{false};
-  int m_zs_threshold{20};
+  int m_zs_threshold[3] = {20}; // zs per TPC region
   std::string m_TpcRawNodeName{"TPCRAWHIT"};
   std::string outfile_name;
   std::map<unsigned int, chan_info> chan_map;                  // stays in place


### PR DESCRIPTION
This adds the zero suppression threshold as a cdb object to be read in at the hit unpacker level, and applied on a region by region basis. To be tested with the actually cdb files, starting this PR now to get jenkins goign

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

