### PR TITLE
Detailed Calorimeter Geometry to Default

### DIFF
--- a/offline/packages/CaloBase/RawTowerGeomv5.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv5.cc
@@ -19,38 +19,38 @@ RawTowerGeomv5::RawTowerGeomv5(const RawTowerGeom& geom0)
   _vertices.resize(_nVtx);
   for (int i = 0; i < _nVtx; i++)
   {
-    _vertices[i].x = geom0.get_vertex_x(i);
-    _vertices[i].y = geom0.get_vertex_y(i);
-    _vertices[i].z = geom0.get_vertex_z(i);
+    _vertices[i].SetX(geom0.get_vertex_x(i));
+    _vertices[i].SetY(geom0.get_vertex_y(i));
+    _vertices[i].SetZ(geom0.get_vertex_z(i));
   }
 
-  _center.x = geom0.get_center_x();
-  _center.y = geom0.get_center_y();
-  _center.z = geom0.get_center_z();
+  _center.SetX(geom0.get_center_x());
+  _center.SetY(geom0.get_center_y());
+  _center.SetZ(geom0.get_center_z());
 
-  _center_int.x = geom0.get_center_int_x();
-  _center_int.y = geom0.get_center_int_y();
-  _center_int.z = geom0.get_center_int_z();
+  _center_int.SetX(geom0.get_center_int_x());
+  _center_int.SetY(geom0.get_center_int_y());
+  _center_int.SetZ(geom0.get_center_int_z());
   
-  _center_ext.x = geom0.get_center_ext_x();
-  _center_ext.y = geom0.get_center_ext_y();
-  _center_ext.z = geom0.get_center_ext_z();
+  _center_ext.SetX(geom0.get_center_ext_x());
+  _center_ext.SetY(geom0.get_center_ext_y());
+  _center_ext.SetZ(geom0.get_center_ext_z());
 
-  _center_low_eta.x = geom0.get_center_low_eta_x();
-  _center_low_eta.y = geom0.get_center_low_eta_y();
-  _center_low_eta.z = geom0.get_center_low_eta_z();
+  _center_low_eta.SetX(geom0.get_center_low_eta_x());
+  _center_low_eta.SetY(geom0.get_center_low_eta_y());
+  _center_low_eta.SetZ(geom0.get_center_low_eta_z());
 
-  _center_high_eta.x = geom0.get_center_high_eta_x();
-  _center_high_eta.y = geom0.get_center_high_eta_y();
-  _center_high_eta.z = geom0.get_center_high_eta_z();
+  _center_high_eta.SetX(geom0.get_center_high_eta_x());
+  _center_high_eta.SetY(geom0.get_center_high_eta_y());
+  _center_high_eta.SetZ(geom0.get_center_high_eta_z());
 
-  _center_low_phi.x = geom0.get_center_low_phi_x();
-  _center_low_phi.y = geom0.get_center_low_phi_y();
-  _center_low_phi.z = geom0.get_center_low_phi_z();
+  _center_low_phi.SetX(geom0.get_center_low_phi_x());
+  _center_low_phi.SetY(geom0.get_center_low_phi_y());
+  _center_low_phi.SetZ(geom0.get_center_low_phi_z());
 
-  _center_high_phi.x = geom0.get_center_high_phi_x();
-  _center_high_phi.y = geom0.get_center_high_phi_y();
-  _center_high_phi.z = geom0.get_center_high_phi_z();
+  _center_high_phi.SetX(geom0.get_center_high_phi_x());
+  _center_high_phi.SetY(geom0.get_center_high_phi_y());
+  _center_high_phi.SetZ(geom0.get_center_high_phi_z());
 }
 
 void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
@@ -80,103 +80,103 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
   bool face_low_phi[_nVtx] = {false, true, true, false, false, true, true, false};
   bool face_high_phi[_nVtx] = {true, false, false, true, true, false, false, true};
 
-  _center.x = 0;
-  _center.y = 0;
-  _center.z = 0;
-  _center_int.x = 0;
-  _center_int.y = 0;
-  _center_int.z = 0;
-  _center_ext.x = 0;
-  _center_ext.y = 0;
-  _center_ext.z = 0;
-  _center_low_eta.x = 0;
-  _center_low_eta.y = 0;
-  _center_low_eta.z = 0;
-  _center_high_eta.x = 0;
-  _center_high_eta.y = 0;
-  _center_high_eta.z = 0;
-  _center_low_phi.x = 0;
-  _center_low_phi.y = 0;
-  _center_low_phi.z = 0;
-  _center_high_phi.x = 0;
-  _center_high_phi.y = 0;
-  _center_high_phi.z = 0;
+  _center.SetX(0);
+  _center.SetY(0);
+  _center.SetZ(0);
+  _center_int.SetX(0);
+  _center_int.SetY(0);
+  _center_int.SetZ(0);
+  _center_ext.SetX(0);
+  _center_ext.SetY(0);
+  _center_ext.SetZ(0);
+  _center_low_eta.SetX(0);
+  _center_low_eta.SetY(0);
+  _center_low_eta.SetZ(0);
+  _center_high_eta.SetX(0);
+  _center_high_eta.SetY(0);
+  _center_high_eta.SetZ(0);
+  _center_low_phi.SetX(0);
+  _center_low_phi.SetY(0);
+  _center_low_phi.SetZ(0);
+  _center_high_phi.SetX(0);
+  _center_high_phi.SetY(0);
+  _center_high_phi.SetZ(0);
   _vertices.resize(_nVtx);
   for (int i = 0; i < _nVtx; i++)
   {
-    _vertices[i].x = vertices[i*3+0];
-    _vertices[i].y = vertices[i*3+1];
-    _vertices[i].z = vertices[i*3+2];
+    _vertices[i].SetX(vertices[i*3+0]);
+    _vertices[i].SetY(vertices[i*3+1]);
+    _vertices[i].SetZ(vertices[i*3+2]);
 
-    _center.x += _vertices[i].x;
-    _center.y += _vertices[i].y;
-    _center.z += _vertices[i].z;
+    _center.SetX(_center.x() + _vertices[i].x());
+    _center.SetY(_center.y() + _vertices[i].y());
+    _center.SetZ(_center.z() + _vertices[i].z());
 
     if (face_inside[i])
     {
-      _center_int.x += _vertices[i].x;
-      _center_int.y += _vertices[i].y;
-      _center_int.z += _vertices[i].z;
+      _center_int.SetX(_center_int.x() + _vertices[i].x());
+      _center_int.SetY(_center_int.y() + _vertices[i].y());
+      _center_int.SetZ(_center_int.z() + _vertices[i].z());
     }
     if (face_outside[i])
     {
-      _center_ext.x += _vertices[i].x;
-      _center_ext.y += _vertices[i].y;
-      _center_ext.z += _vertices[i].z;
+      _center_ext.SetX(_center_ext.x() + _vertices[i].x());
+      _center_ext.SetY(_center_ext.y() + _vertices[i].y());
+      _center_ext.SetZ(_center_ext.z() + _vertices[i].z());
     }
     if (face_low_eta[i])
     {
-      _center_low_eta.x += _vertices[i].x;
-      _center_low_eta.y += _vertices[i].y;
-      _center_low_eta.z += _vertices[i].z;
+      _center_low_eta.SetX(_center_low_eta.x() + _vertices[i].x());
+      _center_low_eta.SetY(_center_low_eta.y() + _vertices[i].y());
+      _center_low_eta.SetZ(_center_low_eta.z() + _vertices[i].z());
     }
     if (face_high_eta[i])
     {
-      _center_high_eta.x += _vertices[i].x;
-      _center_high_eta.y += _vertices[i].y;
-      _center_high_eta.z += _vertices[i].z;
+      _center_high_eta.SetX(_center_high_eta.x() + _vertices[i].x());
+      _center_high_eta.SetY(_center_high_eta.y() + _vertices[i].y());
+      _center_high_eta.SetZ(_center_high_eta.z() + _vertices[i].z());
     }
     if (face_low_phi[i])
     {
-      _center_low_phi.x += _vertices[i].x;
-      _center_low_phi.y += _vertices[i].y;
-      _center_low_phi.z += _vertices[i].z;
+      _center_low_phi.SetX(_center_low_phi.x() + _vertices[i].x());
+      _center_low_phi.SetY(_center_low_phi.y() + _vertices[i].y());
+      _center_low_phi.SetZ(_center_low_phi.z() + _vertices[i].z());
     }
     if (face_high_phi[i])
     {
-      _center_high_phi.x += _vertices[i].x;
-      _center_high_phi.y += _vertices[i].y;
-      _center_high_phi.z += _vertices[i].z;
+      _center_high_phi.SetX(_center_high_phi.x() + _vertices[i].x());
+      _center_high_phi.SetY(_center_high_phi.y() + _vertices[i].y());
+      _center_high_phi.SetZ(_center_high_phi.z() + _vertices[i].z());
     }
   }
 
-  _center.x /= (float) _nVtx;
-  _center.y /= (float) _nVtx;
-  _center.z /= (float) _nVtx;
+  _center.SetX(_center.x() / (float) _nVtx);
+  _center.SetY(_center.y() / (float) _nVtx);
+  _center.SetZ(_center.z() / (float) _nVtx);
 
-  _center_int.x /= (float) _nVtx / 2.;
-  _center_int.y /= (float) _nVtx / 2.;
-  _center_int.z /= (float) _nVtx / 2.;
+  _center_int.SetX(_center_int.x() / (float) _nVtx * 2.);
+  _center_int.SetY(_center_int.y() / (float) _nVtx * 2.);
+  _center_int.SetZ(_center_int.z() / (float) _nVtx * 2.);
 
-  _center_ext.x /= (float) _nVtx / 2.;
-  _center_ext.y /= (float) _nVtx / 2.;
-  _center_ext.z /= (float) _nVtx / 2.;
+  _center_ext.SetX(_center_ext.x() / (float) _nVtx * 2.);
+  _center_ext.SetY(_center_ext.y() / (float) _nVtx * 2.);
+  _center_ext.SetZ(_center_ext.z() / (float) _nVtx * 2.);
   
-  _center_low_eta.x /= (float) _nVtx / 2.;
-  _center_low_eta.y /= (float) _nVtx / 2.;
-  _center_low_eta.z /= (float) _nVtx / 2.;
+  _center_low_eta.SetX(_center_low_eta.x() / (float) _nVtx * 2.);
+  _center_low_eta.SetY(_center_low_eta.y() / (float) _nVtx * 2.);
+  _center_low_eta.SetZ(_center_low_eta.z() / (float) _nVtx * 2.);
 
-  _center_high_eta.x /= (float) _nVtx / 2.;
-  _center_high_eta.y /= (float) _nVtx / 2.;
-  _center_high_eta.z /= (float) _nVtx / 2.;
+  _center_high_eta.SetX(_center_high_eta.x() / (float) _nVtx * 2.);
+  _center_high_eta.SetY(_center_high_eta.y() / (float) _nVtx * 2.);
+  _center_high_eta.SetZ(_center_high_eta.z() / (float) _nVtx * 2.);
 
-  _center_low_phi.x /= (float) _nVtx / 2.;
-  _center_low_phi.y /= (float) _nVtx / 2.;
-  _center_low_phi.z /= (float) _nVtx / 2.;
+  _center_low_phi.SetX(_center_low_phi.x() / (float) _nVtx * 2.);
+  _center_low_phi.SetY(_center_low_phi.y() / (float) _nVtx * 2.);
+  _center_low_phi.SetZ(_center_low_phi.z() / (float) _nVtx * 2.);
 
-  _center_high_phi.x /= (float) _nVtx / 2.;
-  _center_high_phi.y /= (float) _nVtx / 2.;
-  _center_high_phi.z /= (float) _nVtx / 2.;
+  _center_high_phi.SetX(_center_high_phi.x() / (float) _nVtx * 2.);
+  _center_high_phi.SetY(_center_high_phi.y() / (float) _nVtx * 2.);
+  _center_high_phi.SetZ(_center_high_phi.z() / (float) _nVtx * 2.);
 
 
 
@@ -185,14 +185,14 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
 
 double RawTowerGeomv5::get_center_radius() const
 {
-  return std::sqrt(_center.x * _center.x +
-                   _center.y * _center.y);
+  return std::sqrt(_center.x() * _center.x() +
+                   _center.y() * _center.y());
 }
 
 double RawTowerGeomv5::get_theta() const
 {
-  double radius = sqrt(_center.x * _center.x + _center.y * _center.y);
-  double theta = atan2(radius, _center.z);
+  double radius = sqrt(_center.x() * _center.x() + _center.y() * _center.y());
+  double theta = atan2(radius, _center.z());
   return theta;
 }
 
@@ -206,7 +206,7 @@ double RawTowerGeomv5::get_eta() const
 
 double RawTowerGeomv5::get_phi() const
 {
-  return atan2(_center.y, _center.x);
+  return atan2(_center.y(), _center.x());
 }
 
 void RawTowerGeomv5::identify(std::ostream& os) const

--- a/offline/packages/CaloBase/RawTowerGeomv5.h
+++ b/offline/packages/CaloBase/RawTowerGeomv5.h
@@ -8,21 +8,15 @@
 #include <iostream>
 #include <limits>
 
+#include <TVector3.h>
+
 typedef std::pair<double,double> vertex_t;
 typedef std::vector<vertex_t> vertices_t;
-
-struct point_coordinates {
-  double R;
-  double eta;
-  double phi;
-  double x;
-  double y;
-  double z;
-};
 
 class RawTowerGeomv5 : public RawTowerGeom
 {
  public:
+
   RawTowerGeomv5() {}
   RawTowerGeomv5(RawTowerDefs::keytype id);
   RawTowerGeomv5(const RawTowerGeom& geom0);
@@ -40,17 +34,17 @@ class RawTowerGeomv5 : public RawTowerGeom
 
   void set_center_x(double x) override
   {
-    _center.x = x;
+    _center.SetX(x);
     return;
   }
   void set_center_y(double y) override
   {
-    _center.y = y;
+    _center.SetY(y);
     return;
   }
   void set_center_z(double z) override
   {
-    _center.z = z;
+    _center.SetZ(z);
     return;
   }
   void set_rotx(double rotx) override
@@ -71,86 +65,66 @@ class RawTowerGeomv5 : public RawTowerGeom
 
   void set_vertices(const std::vector<double>&) override;
 
-  double get_center_x() const override { return _center.x; }
-  double get_center_y() const override { return _center.y; }
-  double get_center_z() const override { return _center.z; }
-  double get_center_int_x() const override { return _center_int.x; }
-  double get_center_int_y() const override { return _center_int.y; }
-  double get_center_int_z() const override { return _center_int.z; }
-  double get_center_ext_x() const override { return _center_ext.x; }
-  double get_center_ext_y() const override { return _center_ext.y; }
-  double get_center_ext_z() const override { return _center_ext.z; }
-  double get_center_low_eta_x() const override { return _center_low_eta.x; }
-  double get_center_low_eta_y() const override { return _center_low_eta.y; }
-  double get_center_low_eta_z() const override { return _center_low_eta.z; }
-  double get_center_high_eta_x() const override { return _center_high_eta.x; }
-  double get_center_high_eta_y() const override { return _center_high_eta.y; }
-  double get_center_high_eta_z() const override { return _center_high_eta.z; }
-  double get_center_low_phi_x() const override { return _center_low_phi.x; }
-  double get_center_low_phi_y() const override { return _center_low_phi.y; }
-  double get_center_low_phi_z() const override { return _center_low_phi.z; }
-  double get_center_high_phi_x() const override { return _center_high_phi.x; }
-  double get_center_high_phi_y() const override { return _center_high_phi.y; }
-  double get_center_high_phi_z() const override { return _center_high_phi.z; }
+  double get_center_x() const override { return _center.x(); }
+  double get_center_y() const override { return _center.y(); }
+  double get_center_z() const override { return _center.z(); }
+  double get_center_int_x() const override { return _center_int.x(); }
+  double get_center_int_y() const override { return _center_int.y(); }
+  double get_center_int_z() const override { return _center_int.z(); }
+  double get_center_ext_x() const override { return _center_ext.x(); }
+  double get_center_ext_y() const override { return _center_ext.y(); }
+  double get_center_ext_z() const override { return _center_ext.z(); }
+  double get_center_low_eta_x() const override { return _center_low_eta.x(); }
+  double get_center_low_eta_y() const override { return _center_low_eta.y(); }
+  double get_center_low_eta_z() const override { return _center_low_eta.z(); }
+  double get_center_high_eta_x() const override { return _center_high_eta.x(); }
+  double get_center_high_eta_y() const override { return _center_high_eta.y(); }
+  double get_center_high_eta_z() const override { return _center_high_eta.z(); }
+  double get_center_low_phi_x() const override { return _center_low_phi.x(); }
+  double get_center_low_phi_y() const override { return _center_low_phi.y(); }
+  double get_center_low_phi_z() const override { return _center_low_phi.z(); }
+  double get_center_high_phi_x() const override { return _center_high_phi.x(); }
+  double get_center_high_phi_y() const override { return _center_high_phi.y(); }
+  double get_center_high_phi_z() const override { return _center_high_phi.z(); }
   double get_rotx() const override { return _rotx; }
   double get_roty() const override { return _roty; }
   double get_rotz() const override { return _rotz; }
-  double get_vertex_x(int i) const override { return _vertices[i].x; }
-  double get_vertex_y(int i) const override { return _vertices[i].y; }
-  double get_vertex_z(int i) const override { return _vertices[i].z; }
+  double get_vertex_x(int i) const override { return _vertices[i].x(); }
+  double get_vertex_y(int i) const override { return _vertices[i].y(); }
+  double get_vertex_z(int i) const override { return _vertices[i].z(); }
   double get_center_radius() const override;
   double get_eta() const override;
   double get_phi() const override;
   double get_theta() const override;
 
  protected:
+  
   RawTowerDefs::keytype _towerid{std::numeric_limits<RawTowerDefs::keytype>::max()};
 
   static constexpr int _nVtx = 8;
-  point_coordinates _center{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN()};
-  point_coordinates _center_int{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
+  TVector3 _center{std::numeric_limits<double>:: quiet_NaN(),
+                   std::numeric_limits<double>:: quiet_NaN(),
+                   std::numeric_limits<double>:: quiet_NaN()};
+  TVector3 _center_int{std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN()};
-  point_coordinates _center_ext{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
+  TVector3 _center_ext{std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN()};
-  point_coordinates _center_low_eta{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
+  TVector3 _center_low_eta{std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN()};
-  point_coordinates _center_high_eta{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
+  TVector3 _center_high_eta{std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN()};
-  point_coordinates _center_low_phi{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
+  TVector3 _center_low_phi{std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN()};
-  point_coordinates _center_high_phi{std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
-                  std::numeric_limits<double>:: quiet_NaN(),
+  TVector3 _center_high_phi{std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN(),
                   std::numeric_limits<double>:: quiet_NaN()};
 
-  std::vector<point_coordinates> _vertices;
+  std::vector<TVector3> _vertices;
   double _rotx{std::numeric_limits<double>:: quiet_NaN()};
   double _roty{std::numeric_limits<double>:: quiet_NaN()};
   double _rotz{std::numeric_limits<double>:: quiet_NaN()};

--- a/offline/packages/CaloReco/BEmcRec.cc
+++ b/offline/packages/CaloReco/BEmcRec.cc
@@ -24,8 +24,6 @@
 BEmcRec::BEmcRec() : fModules(new std::vector<EmcModule>), fClusters(new std::vector<EmcCluster>)
 {
   fTowerGeom.clear();
-  
-  
 }
 
 // ///////////////////////////////////////////////////////////////////////////
@@ -86,6 +84,7 @@ void BEmcRec::PrintTowerGeometry(const std::string& fname)
       }
     }
   }
+  outfile.close();
 }
 
 void BEmcRec::PrintTowerGeometryDetailed(const std::string& fname)
@@ -120,6 +119,20 @@ void BEmcRec::PrintTowerGeometryDetailed(const std::string& fname)
       }
     }
   }
+  outfile.close();
+}
+
+void BEmcRec::ClearInitialDetailedGeometry()
+{
+  // Contrary to the fTowerGeom node,
+  // fTowerGeomDetailed is only used optionally for PrintTowerGeomDetailed()
+  // Memory should be released once it becomes unnecessary
+
+  for (int ich = 0; ich < (int) fTowerGeomDetailed.size(); ich++)
+  {
+    delete fTowerGeomDetailed[ich];
+  }
+  fTowerGeomDetailed.clear();
 }
 
 bool BEmcRec::GetTowerGeometry(int ix, int iy, TowerGeom& geom)
@@ -185,7 +198,7 @@ bool BEmcRec::SetTowerGeometry(int ix, int iy, const RawTowerGeom& raw_geom0)
   
   if (m_UseDetailedGeometry)
   {
-    // copy the input geometry inside fTowerGeomDetailed (only for debugging)
+    // copy the input geometry inside fTowerGeomDetailed (only for print)
     RawTowerGeomv5 *geom_detailed = new RawTowerGeomv5(raw_geom0); 
     fTowerGeomDetailed[ich] = geom_detailed;
   }

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -165,8 +165,8 @@ class BEmcRec
   BEmcProfile *_emcprof {nullptr};
 
  protected:
-  bool m_UseDetailedGeometry {false};
-  // Use a more detailed calorimeter geometry
+  bool m_UseDetailedGeometry {true};
+  // Use a more detailed calorimeter geometry (default)
   // Only available for CEMC
 
   bool m_UseCorrectPosition = true;

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -57,6 +57,7 @@ class BEmcRec
   bool CompleteTowerGeometry();
   void PrintTowerGeometry(const std::string &fname);
   void PrintTowerGeometryDetailed(const std::string &fname);
+  void ClearInitialDetailedGeometry();
 
   void SetPlanarGeometry() { bCYL = false; }
   void SetCylindricalGeometry() { bCYL = true; }

--- a/offline/packages/CaloReco/CaloGeomMapping.h
+++ b/offline/packages/CaloReco/CaloGeomMapping.h
@@ -48,7 +48,7 @@ class CaloGeomMapping : public SubsysReco
   std::string m_TowerGeomNodeName;
   RawTowerGeomContainer *m_RawTowerGeomContainer {nullptr};
   RawTowerDefs::CalorimeterId m_caloid;
-  bool m_UseDetailedGeometry {false};
+  bool m_UseDetailedGeometry {true};
   // Use a more detailed calorimeter geometry
   // Only available for CEMC
 };

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -192,10 +192,23 @@ int RawClusterBuilderTemplate::InitRun(PHCompositeNode *topNode)
       else
       {
         std::cout << "RawClusterBuilderTemplate::InitRun - Detailed geometry not implemented for detector " << detector << ". The former geometry is used instead" << std::endl;
+        m_UseDetailedGeometry = false;
+        bemc->set_UseDetailedGeometry(false);
       }
     }
   }
   RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, m_TowerGeomNodeName);
+
+  if (!towergeom && m_UseDetailedGeometry)
+  {
+    std::cout << "RawClusterBuilderTemplate::InitRun - Detailed geometry node " << m_TowerGeomNodeName << " is not available. "
+              << "Switching to the former geometry node TOWERGEOM_" << detector << "." << std::endl;
+    m_UseDetailedGeometry = false;
+    m_TowerGeomNodeName = "TOWERGEOM_" + detector;
+    bemc->set_UseDetailedGeometry(false);
+    towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, m_TowerGeomNodeName);
+  }
+  
   if (!towergeom)
   {
     std::cout << PHWHERE << ": Could not find node " << m_TowerGeomNodeName << std::endl;
@@ -297,7 +310,7 @@ int RawClusterBuilderTemplate::InitRun(PHCompositeNode *topNode)
       bemc->PrintTowerGeometry(fname);
     }
   }
-
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -350,6 +363,8 @@ int RawClusterBuilderTemplate::process_event(PHCompositeNode *topNode)
     }
   }
 
+  // At this stage, it is more efficient to read the simple geometry node (no DETAILED)
+  // Indeed, we only need to know the calorimeter ID
   m_TowerGeomNodeName = "TOWERGEOM_" + detector;
   RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, m_TowerGeomNodeName);
   if (!towergeom)

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -310,6 +310,9 @@ int RawClusterBuilderTemplate::InitRun(PHCompositeNode *topNode)
       bemc->PrintTowerGeometry(fname);
     }
   }
+  // Release memory taken by the RawTowerGeom objects in BEmcRec
+  // Does nothing if the former geometry is used
+  bemc->ClearInitialDetailedGeometry();
   
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -121,8 +121,8 @@ class RawClusterBuilderTemplate : public SubsysReco
   std::string m_towerInfo_nodename;
 
 
-  bool m_UseDetailedGeometry {false};
-  // Use a more detailed calorimeter geometry
+  bool m_UseDetailedGeometry {true};
+  // Use a more detailed calorimeter geometry (default)
   // Only available for CEMC
 
   int m_UseAltZVertex{1};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

The local struct `point_coordinates` in `RawTowerGeomv5.h` is replaced by `TVector3` so that `RawTowerGeomv5` can be properly written into a DST/RUN file.

In addition, this PR sets the detailed EMCal Geometry node (`TOWERGEOM_CEMC_DETAILED`) to default when applicable 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

