### PR TITLE
feat: ntpc clus per sector to event tree

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1633,6 +1633,7 @@ void TrackResiduals::createBranches()
     m_eventtree->Branch("ntpcseed", &m_ntpcseed, "m_ntpcseed/I");
     m_eventtree->Branch("ntracks", &m_ntracks_all, "m_ntracks_all/I");
     m_eventtree->Branch("mbdcharge",&m_totalmbd, "m_totalmbd/F");
+    m_eventtree->Branch("ntpcClusSector", &m_ntpc_clus_sector);
   }
 
   m_failedfits = new TTree("failedfits", "tree with seeds from failed Acts fits");
@@ -2161,7 +2162,7 @@ void TrackResiduals::fillEventTree(PHCompositeNode* topNode)
   m_nmms_all = 0;
   m_nsiseed = 0;
   m_ntpcseed = 0;
-
+  m_ntpc_clus_sector.resize(24, 0);
   m_nsiseed = silseedmap->size();
   m_ntpcseed = tpcseedmap->size();
   m_ntracks_all = trackmap->size();
@@ -2196,6 +2197,8 @@ void TrackResiduals::fillEventTree(PHCompositeNode* topNode)
       auto range = clustermap->getClusters(hitsetkey);
       int nclus = std::distance(range.first, range.second);
       int tpcside = TrkrDefs::getZElement(hitsetkey);
+      int sector = TpcDefs::getSectorId(hitsetkey);
+
       switch (det)
       {
       case TrkrDefs::TrkrId::mvtxId:
@@ -2205,6 +2208,11 @@ void TrackResiduals::fillEventTree(PHCompositeNode* topNode)
         m_nintt_all += nclus;
         break;
       case TrkrDefs::TrkrId::tpcId:
+        if(tpcside == 1)
+        {
+          sector += 12;
+        }
+        m_ntpc_clus_sector[sector] += nclus;
         if (tpcside == 0)
         {
           m_ntpc_clus0 += nclus;

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -147,6 +147,7 @@ class TrackResiduals : public SubsysReco
   int m_nsiseed = std::numeric_limits<int>::quiet_NaN();
   int m_ntpcseed = std::numeric_limits<int>::quiet_NaN();
   int m_ntracks_all = std::numeric_limits<int>::quiet_NaN();
+  std::vector<int> m_ntpc_clus_sector;
 
   //! Track level quantities
   uint64_t m_bco = std::numeric_limits<uint64_t>::quiet_NaN();


### PR DESCRIPTION
Adds the number of tpc clusters per event per sector to the event tree for DC diagnostics

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

