### PR TITLE
Add EMCal Mapping: towerIndex -> (sector, ib)

### DIFF
--- a/offline/packages/CaloBase/TowerInfoDefs.cc
+++ b/offline/packages/CaloBase/TowerInfoDefs.cc
@@ -233,6 +233,20 @@ unsigned int TowerInfoDefs::getCaloTowerEtaBin(const unsigned int key)
   return etabin;
 }
 
+// convert from emcal tower index to (sector, interface board)
+std::pair<int, int> TowerInfoDefs::getEMCalSectorIB(const unsigned int towerIndex)
+{
+  constexpr int channels_per_sector = 384;
+  constexpr int channels_per_ib = 64;
+
+  int k = towerIndex / channels_per_sector;
+
+  int sector = (k % 2) ? (k - 1) / 2 : (k / 2) + 32;
+  int ib = (towerIndex % channels_per_sector) / channels_per_ib;
+
+  return std::make_pair(sector, ib);
+}
+
 unsigned int TowerInfoDefs::encode_epd(const unsigned int towerIndex)  // convert from tower index to key
 {
   constexpr unsigned int channels_per_sector = 31;

--- a/offline/packages/CaloBase/TowerInfoDefs.h
+++ b/offline/packages/CaloBase/TowerInfoDefs.h
@@ -24,6 +24,7 @@ namespace TowerInfoDefs
   unsigned int get_epd_phibin(unsigned int key);
   unsigned int getCaloTowerPhiBin(const unsigned int key);
   unsigned int getCaloTowerEtaBin(const unsigned int key);
+  std::pair<int, int> getEMCalSectorIB(unsigned int towerIndex);
 
   unsigned int get_mbd_arm(const unsigned int key);
   unsigned int get_mbd_side(const unsigned int key);  // side is same as arm


### PR DESCRIPTION
- Add getEMCalSectorIB: EMCal Mapping from tower index to (sector, interface board)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the functionality to map the EMCal tower index to its respective sector and interface board number. Below is a verification plot that shows the result of the mapping.
<img width="2900" height="1000" alt="emcal-sector-ib-map" src="https://github.com/user-attachments/assets/7d882513-e913-46aa-addf-5d61cf7ae054" />


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

