### PR TITLE
Add EMCal BadChi2 IB Propagation - CaloTowerStatus

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -2,6 +2,7 @@
 #include "CaloTowerDefs.h"
 
 #include <calobase/TowerInfo.h>  // for TowerInfo
+#include <calobase/TowerInfoDefs.h>
 #include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfoContainerv1.h>
 #include <calobase/TowerInfoContainerv2.h>
@@ -215,6 +216,23 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+void CaloTowerStatus::emcal_propogate_isBadChi2(const std::vector<std::vector<int>> &badChi2_IB_vec)
+{
+  unsigned int ntowers = m_raw_towers->size();
+  for (unsigned int channel = 0; channel < ntowers; channel++)
+  {
+    std::pair<int, int> sector_ib = TowerInfoDefs::getEMCalSectorIB(channel);
+    int sector = sector_ib.first;
+    int ib = sector_ib.second;
+    int badChi2_towers = badChi2_IB_vec[sector][ib];
+    float badChi2_IB_frac = badChi2_towers * 1. / emcal_channel_per_ib;
+    if(badChi2_IB_frac > m_badChi2_IB_threshold)
+    {
+      m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
+    }
+  }
+}
+
 //____________________________________________________________________________..
 int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
 {
@@ -223,6 +241,9 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
   float mean_time = 0;
   int hotMap_val = 0;
   float z_score = 0;
+
+  std::vector<std::vector<int>> badChi2_IB_vec(emcal_sector, std::vector<int>(emcal_ib_per_sector, 0));
+
   for (unsigned int channel = 0; channel < ntowers; channel++)
   {
     unsigned int key = m_raw_towers->encode_key(channel);
@@ -275,8 +296,23 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
     if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic),badChi2_treshold_max))
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
+
+      if(m_dettype == CaloTowerDefs::CEMC)
+      {
+        std::pair<int, int> sector_ib = TowerInfoDefs::getEMCalSectorIB(channel);
+        int sector = sector_ib.first;
+        int ib = sector_ib.second;
+        ++badChi2_IB_vec[sector][ib];
+      }
     }
   }
+
+  // propagate the isBadChi2 status to entire interface board if threshold is exceeded
+  if (m_dettype == CaloTowerDefs::CEMC)
+  {
+    emcal_propogate_isBadChi2(badChi2_IB_vec);
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -95,8 +95,16 @@ class CaloTowerStatus : public SubsysReco
     m_isSim = isSim;
     return;
   }
+  void set_badChi2_IB_threshold(float badChi2_IB_threshold)
+  {
+    m_badChi2_IB_threshold = badChi2_IB_threshold;
+    return;
+  }
 
  private:
+
+  void emcal_propogate_isBadChi2(const std::vector<std::vector<int>> &badChi2_IB_vec);
+
   TowerInfoContainer *m_raw_towers{nullptr};
 
   CDBTTree *m_cdbttree_chi2{nullptr};
@@ -135,6 +143,11 @@ class CaloTowerStatus : public SubsysReco
   float z_score_threshold = {5};
   float z_score_threshold_default = {5};
   float time_cut = 2;  // number of samples from the mean time for the channel in the run
+
+  int emcal_sector = {64};
+  int emcal_ib_per_sector = {6};
+  int emcal_channel_per_ib = {64};
+  float m_badChi2_IB_threshold = {0.5};
 };
 
 #endif  // CALOTOWERBUILDER_H


### PR DESCRIPTION
- Add feature to flag each tower in the EMCal interface board as having badChi2 if the majority of the towers in the interface board have a badChi2.
- Default threshold is set to 0.5 (half of the interface board), but can be adjusted as desired.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

