### PR TITLE
fix: tpc fee map rollback

### DIFF
--- a/calibrations/tpc/fillDigitalCurrentMaps/readDigitalCurrents.cc
+++ b/calibrations/tpc/fillDigitalCurrentMaps/readDigitalCurrents.cc
@@ -384,7 +384,7 @@ int readDigitalCurrents::process_event(PHCompositeNode *topNode)
         double phi_center = 0;
         if (_f_ccgc == 1)
         {
-          phi_center = layergeom_ccgc->get_phicenter(phibin, zside);
+          phi_center = layergeom_ccgc->get_phicenter(phibin);
         }
         else
         {

--- a/offline/QA/EventDisplay/TrackerEventDisplay.cc
+++ b/offline/QA/EventDisplay/TrackerEventDisplay.cc
@@ -201,7 +201,7 @@ void TrackerEventDisplay::makeJsonFile(PHCompositeNode* topNode)
               clusz = -clusz;
             }
             z = clusz;
-            phi_center = GeoLayer_local->get_phicenter(phibin, side);
+            phi_center = GeoLayer_local->get_phicenter(phibin);
             x = radius * cos(phi_center);
             y = radius * sin(phi_center);
 

--- a/offline/QA/Tracking/TpcClusterQA.cc
+++ b/offline/QA/Tracking/TpcClusterQA.cc
@@ -168,8 +168,8 @@ int TpcClusterQA::process_event(PHCompositeNode *topNode)
       auto hitpad = TpcDefs::getPad(hitkey);
       auto m_hittbin = TpcDefs::getTBin(hitkey);
       // Check TrackResiduals.cc
-      auto *geoLayer = geomContainer->GetLayerCellGeom(hitlayer);
-      auto phi = geoLayer->get_phicenter(hitpad, m_side);
+      auto geoLayer = geomContainer->GetLayerCellGeom(hitlayer);
+      auto phi = geoLayer->get_phicenter(hitpad);
       auto radius = geoLayer->get_radius();
       auto m_hitgx = radius * std::cos(phi);
       auto m_hitgy = radius * std::sin(phi);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -976,8 +976,8 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         m_hitpad = TpcDefs::getPad(hitkey);
         m_hittbin = TpcDefs::getTBin(hitkey);
 
-        auto *geoLayer = tpcGeom->GetLayerCellGeom(m_hitlayer);
-        auto phi = geoLayer->get_phicenter(m_hitpad, m_side);
+        auto geoLayer = tpcGeom->GetLayerCellGeom(m_hitlayer);
+        auto phi = geoLayer->get_phicenter(m_hitpad);
         auto radius = geoLayer->get_radius();
         float AdcClockPeriod = geoLayer->get_zstep();
         auto glob = geometry->getGlobalPositionTpc(m_hitsetkey, hitkey, phi, radius, AdcClockPeriod);

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -1179,8 +1179,8 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
             double radius = GeoLayer_local->get_radius();
             fx_hit[n_hit::nhitphibin] = (float) TpcDefs::getPad(hit_key);
             fx_hit[n_hit::nhittbin] = (float) TpcDefs::getTBin(hit_key);
-            fx_hit[n_hit::nhitphi] = GeoLayer_local->get_phicenter(fx_hit[n_hit::nhitphibin], fx_hit[n_hit::nhitzelem]);
-            float phi = GeoLayer_local->get_phicenter(TpcDefs::getPad(hit_key), fx_hit[n_hit::nhitzelem]);
+            fx_hit[n_hit::nhitphi] = GeoLayer_local->get_phicenter(fx_hit[n_hit::nhitphibin]);
+            float phi = GeoLayer_local->get_phicenter(TpcDefs::getPad(hit_key));
             float clockperiod = GeoLayer_local->get_zstep();
             auto glob = m_tGeometry->getGlobalPositionTpc(hitset_key, hit_key, phi, radius, clockperiod);
             

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -306,7 +306,7 @@ namespace
       PHG4TpcCylinderGeom *layergeom = my_data.geom_container->GetLayerCellGeom((int) coords[0]);
       
       double r = layergeom->get_radius();
-      double phi = layergeom->get_phi(coords[1], side);
+      double phi = layergeom->get_phi(coords[1]);
       double t = layergeom->get_zcenter(fabs(coords[2]));
       
       double hitzdriftlength = t * my_data.tGeometry->get_drift_velocity();

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -571,16 +571,16 @@ namespace
       double phiHigh_RLow = -999.0;
       if(ceil(result.Parameter(2)) < layergeomLow->get_phibins())
       {
-        phiHigh_RLow = layergeomLow->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+        phiHigh_RLow = layergeomLow->get_phi(ceil(result.Parameter(2)));
       }
       double phiHigh_RHigh = -999.0;
       if(ceil(result.Parameter(2)) < layergeomHigh->get_phibins())
       {
-        phiHigh_RHigh = layergeomHigh->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+        phiHigh_RHigh = layergeomHigh->get_phi(ceil(result.Parameter(2)));
       }
 
-      double phiLow_RLow = layergeomLow->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
-      double phiLow_RHigh = layergeomHigh->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+      double phiLow_RLow = layergeomLow->get_phi(floor(result.Parameter(2)));
+      double phiLow_RHigh = layergeomHigh->get_phi(floor(result.Parameter(2)));
 
       double meanR = (result.Parameter(1) - floor(result.Parameter(1))) * (RHigh - RLow) + RLow;
 

--- a/offline/packages/tpc/Tpc3DClusterizer.cc
+++ b/offline/packages/tpc/Tpc3DClusterizer.cc
@@ -459,13 +459,13 @@ void Tpc3DClusterizer::calc_cluster_parameter(std::vector<pointKeyLaser> &clusHi
     float coords[3] = {clusHit.first.get<0>(), clusHit.first.get<1>(), clusHit.first.get<2>()};
     std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> spechitkey = clusHit.second;
 
-    int side = TpcDefs::getSide(spechitkey.second);
+    //    int side = TpcDefs::getSide(spechitkey.second);
     // unsigned int sector= TpcDefs::getSectorId(spechitkey.second);
 
     PHG4TpcCylinderGeom *layergeom = m_geom_container->GetLayerCellGeom((int) coords[0]);
 
     double r = layergeom->get_radius();
-    double phi = layergeom->get_phi(coords[1], side);
+    double phi = layergeom->get_phi(coords[1]);
     double t = layergeom->get_zcenter(fabs(coords[2]));
     int tbin = coords[2];
     int lay = coords[0];//TrkrDefs::getLayer(spechitkey.second);

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -505,7 +505,7 @@ namespace
       training_hits = new TrainingHits;
       assert(training_hits);
       training_hits->radius = radius;
-      training_hits->phi = my_data.layergeom->get_phicenter(iphi_center + my_data.phioffset, my_data.side);
+      training_hits->phi = my_data.layergeom->get_phicenter(iphi_center + my_data.phioffset);
       double center_t = my_data.layergeom->get_zcenter(it_center + my_data.toffset) + my_data.sampa_tbias;
       training_hits->z = (my_data.m_tdriftmax - center_t) * my_data.tGeometry->get_drift_velocity();
       if (my_data.side == 0)
@@ -620,7 +620,7 @@ namespace
 
     // This is the global position
     double clusiphi = iphi_sum / adc_sum;
-    double clusphi = my_data.layergeom->get_phi(clusiphi, my_data.side);
+    double clusphi = my_data.layergeom->get_phi(clusiphi);
 
     float clusx = radius * cos(clusphi);
     float clusy = radius * sin(clusphi);

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -300,6 +300,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     {
       continue;
     }
+    varname = "phi";
     double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) + (sector % 12) * M_PI / 6;
     PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
     unsigned int phibin = layergeom->get_phibin(phi);
@@ -308,7 +309,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     uint16_t sampch = tpchit->get_sampachannel();
     //    uint16_t sam = tpchit->get_samples();
     max_time_range = tpchit->get_samples();
-    varname = "phi";  // + std::to_string(key);
+     
     int region = 0;
     if(layer > 15)
     {

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -309,7 +309,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     //    uint16_t sam = tpchit->get_samples();
     max_time_range = tpchit->get_samples();
     varname = "phi";  // + std::to_string(key);
-
+    int region = 0;
     if(layer > 15)
     {
       region = 1;

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -296,20 +296,20 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     std::string varname = "layer";
     int layer = m_cdbttree->GetIntValue(key, varname);
     // antenna pads will be in 0 layer
-    if (layer <= 6)
+    if (layer <= 0)
     {
       continue;
     }
+    double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) + (sector % 12) * M_PI / 6;
+    PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
+    unsigned int phibin = layergeom->get_phibin(phi);
 
     uint16_t sampadd = tpchit->get_sampaaddress();
     uint16_t sampch = tpchit->get_sampachannel();
     //    uint16_t sam = tpchit->get_samples();
     max_time_range = tpchit->get_samples();
     varname = "phi";  // + std::to_string(key);
-    double phi = ((side == 1 ? 1 : -1) * (m_cdbttree->GetDoubleValue(key, varname) - M_PI / 2.)) + ((sector % 12) * M_PI / 6);
-    PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
-    unsigned int phibin = layergeom->get_phibin(phi, side);
-    unsigned int region = 0;
+
     if(layer > 15)
     {
       region = 1;
@@ -318,6 +318,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     {
       region = 2;
     }
+
     hit_set_key = TpcDefs::genHitSetKey(layer, (mc_sectors[sector % 12]), side);
     hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
 

--- a/offline/packages/tpc/TpcCombinedRawDataUnpackerDebug.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpackerDebug.cc
@@ -278,9 +278,9 @@ int TpcCombinedRawDataUnpackerDebug::process_event(PHCompositeNode* topNode)
     uint16_t sam = tpchit->get_samples();
     max_time_range = sam;
     varname = "phi";  // + std::to_string(key);
-    double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) - M_PI/2. + (sector % 12) * M_PI / 6;
+    double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) + (sector % 12) * M_PI / 6;
     PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
-    unsigned int phibin = layergeom->get_phibin(phi, side);
+    unsigned int phibin = layergeom->get_phibin(phi);
     if (m_writeTree)
     {
       float fX[12];

--- a/offline/packages/tpc/TpcSimpleClusterizer.cc
+++ b/offline/packages/tpc/TpcSimpleClusterizer.cc
@@ -160,7 +160,7 @@ namespace
       }
 
       // update phi sums
-      double phi_center = my_data.layergeom->get_phicenter(iphi, my_data.side);
+      double phi_center = my_data.layergeom->get_phicenter(iphi);
       phi_sum += phi_center * adc;
       phi2_sum += square(phi_center) * adc;
 

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -563,7 +563,7 @@ void TpcDirectLaserReconstruction::process_track(SvtxTrack* track)
       const unsigned short phibin = TpcDefs::getPad(hitr->first);
       const unsigned short zbin = TpcDefs::getTBin(hitr->first);
 
-      const double phi = layergeom->get_phicenter(phibin, side);
+      const double phi = layergeom->get_phicenter(phibin);
       const double x = layer_center_radius * cos(phi);
       const double y = layer_center_radius * sin(phi);
 
@@ -1052,7 +1052,7 @@ void TpcDirectLaserReconstruction::process_track(SvtxTrack* track)
       const unsigned short phibin_2 = TpcDefs::getPad(hitr->first);
       const unsigned short zbin_2 = TpcDefs::getTBin(hitr->first);
 
-      const double phi_2 = layergeom_2->get_phicenter(phibin_2, side_2);
+      const double phi_2 = layergeom_2->get_phicenter(phibin_2);
       const double x_2 = layer_center_radius_2 * cos(phi_2);
       const double y_2 = layer_center_radius_2 * sin(phi_2);
 

--- a/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.cc
@@ -293,7 +293,7 @@ int PHG4TpcCylinderGeom::find_phibin(const double phi, int side) const
   // if (phi < phimin){
   //   norm_phi = phi + 2* M_PI;
   // }
-  //side = 0;
+  side = 0;
 
   int phi_bin = -1;
 
@@ -338,7 +338,7 @@ float PHG4TpcCylinderGeom::get_pad_float(const double phi, int side) const
   // if (phi < phimin){
   //   norm_phi = phi + 2* M_PI;
   // }
-  //side = 0;
+  side = 0;
 
   float phi_bin = -1;
 
@@ -393,9 +393,9 @@ int PHG4TpcCylinderGeom::get_phibin(const double phi, int side) const
     new_phi = phi + 2 * M_PI;
   }
   // Get phi-bin number
-  int phi_bin = find_phibin(new_phi, side);
+  int phi_bin = find_phibin(new_phi);
 
-  //side = 0;
+  side = 0;
   // If phi-bin is not defined, check that it is in the dead area and put it to the edge of sector
   if (phi_bin < 0)
   {
@@ -428,7 +428,7 @@ int PHG4TpcCylinderGeom::get_phibin(const double phi, int side) const
     }
     // exit(1);
 
-    phi_bin = find_phibin(new_phi, side);
+    phi_bin = find_phibin(new_phi);
     if (phi_bin < 0)
     {
       std::cout << PHWHERE << "Asking for bin for phi outside of phi range: " << phi << std::endl;
@@ -479,7 +479,7 @@ PHG4TpcCylinderGeom::get_phicenter_new(const int ibin) const
 }
 
 double
-PHG4TpcCylinderGeom::get_phicenter(const int ibin, const int side) const
+PHG4TpcCylinderGeom::get_phicenter(const int ibin) const
 {
   // double phi_center = -999;
   if (ibin < 0 || ibin > nphibins)
@@ -490,7 +490,7 @@ PHG4TpcCylinderGeom::get_phicenter(const int ibin, const int side) const
 
   check_binning_method_phi();
 
-  //const int side = 0;
+  const int side = 0;
   unsigned int pads_per_sector = nphibins / 12;
   unsigned int sector = ibin / pads_per_sector;
   double phi_center = (sector_max_Phi[side][sector] - (ibin + 0.5 - sector * pads_per_sector) * phistep);
@@ -502,7 +502,7 @@ PHG4TpcCylinderGeom::get_phicenter(const int ibin, const int side) const
 }
 
 double
-PHG4TpcCylinderGeom::get_phi(const float ibin, const int side) const
+PHG4TpcCylinderGeom::get_phi(const float ibin) const
 {
   // double phi_center = -999;
   if (ibin < 0 || ibin > nphibins)
@@ -513,7 +513,7 @@ PHG4TpcCylinderGeom::get_phi(const float ibin, const int side) const
 
   check_binning_method_phi();
 
-  //const int side = 0;
+  const int side = 0;
   unsigned int pads_per_sector = nphibins / 12;
   unsigned int sector = ibin / pads_per_sector;
   double phi = (sector_max_Phi[side][sector] - (ibin + 0.5 - sector * pads_per_sector) * phistep);

--- a/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
@@ -40,9 +40,9 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   virtual std::pair<double, double> get_etabounds(const int ibin) const;
   virtual double get_etacenter(const int ibin) const;
   virtual double get_zcenter(const int ibin) const;
-  virtual double get_phicenter(const int ibin, const int side = 0) const;
+  virtual double get_phicenter(const int ibin) const;
   virtual double get_phicenter_new(const int ibin) const;
-  virtual double get_phi(const float ibin, const int side = 0) const;
+  virtual double get_phi(const float ibin) const;
 
   virtual int get_etabin(const double eta) const;
   virtual int get_zbin(const double z) const;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1698,7 +1698,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             PHG4TpcCylinderGeom* local_GeoLayer = local_geom_container->GetLayerCellGeom(local_layer);
             phibin = (float) TpcDefs::getPad(hit_key);
             zbin = (float) TpcDefs::getTBin(hit_key);
-            phi = local_GeoLayer->get_phicenter(phibin, side);
+            phi = local_GeoLayer->get_phicenter(phibin);
             z = local_GeoLayer->get_zcenter(zbin);
             r = local_GeoLayer->get_radius();
             x = r*cos(phi);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -736,12 +736,6 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
   double outer_phi = atan2(outer_y, outer_x);
   double avge_z = (outer_z + inner_z) / 2.0;
 
-  unsigned int side = 0;
-  if (avge_z < 0)
-  {
-    side = 1;
-  } 
-
   // Now fold these with the expected diffusion and shaping widths
   // assume spread is +/- equals this many sigmas times diffusion and shaping when extending the size
   double sigmas = 2.0;
@@ -772,8 +766,8 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
     double g4min_phi = inner_phi - sigmas * std::sqrt(pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2)) / radius;
 
     // find the bins containing these max and min z edges
-    unsigned int phibinmin = layergeom->get_phibin(g4min_phi, side);
-    unsigned int phibinmax = layergeom->get_phibin(g4max_phi, side);
+    unsigned int phibinmin = layergeom->get_phibin(g4min_phi);
+    unsigned int phibinmax = layergeom->get_phibin(g4max_phi);
     unsigned int phibinwidth = phibinmax - phibinmin + 1;
     g4phisize = (double) phibinwidth * layergeom->get_phistep() * layergeom->get_radius();
 

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -19,7 +19,6 @@ AM_LDFLAGS = \
 
 libg4tpc_la_LIBADD = \
   -lphool \
-  -lcdbobjects \
   -lg4detectors \
   -lg4tracking_io \
   -lphg4hit \

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -17,8 +17,6 @@ class PHCompositeNode;
 class PHG4TpcDisplayAction;
 class PHG4Subsystem;
 class PHParameters;
-class CDBTTree;
-class CDBInterface;
 
 class PHG4TpcDetector : public PHG4Detector
 {
@@ -27,7 +25,9 @@ class PHG4TpcDetector : public PHG4Detector
   PHG4TpcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  ~PHG4TpcDetector(void) override;
+  ~PHG4TpcDetector(void) override
+  {
+  }
 
   //! construct
   void ConstructMe(G4LogicalVolume *world) override;
@@ -47,8 +47,7 @@ class PHG4TpcDetector : public PHG4Detector
   //! add geometry node
   /** this setups the relevant geometry needed for offline reconstruciton */
   void add_geometry_node();
-  CDBTTree *m_cdbttree{nullptr};
-  CDBInterface *m_cdb{nullptr};
+
   PHG4TpcDisplayAction *m_DisplayAction = nullptr;
   PHParameters *m_Params = nullptr;
   G4UserLimits *m_G4UserLimits = nullptr;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -362,7 +362,7 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
 
       tbin = TpcDefs::getTBin(hitr->first);
       phibin = TpcDefs::getPad(hitr->first);
-      double phi_center = layergeom->get_phicenter(phibin, side);
+      double phi_center = layergeom->get_phicenter(phibin);
       if (phi_center < 0)
       {
         phi_center += 2 * pi;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -71,7 +71,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   double sigmaT = std::numeric_limits<double>::signaling_NaN();
   std::array<double, 2> sigmaL{};
-  double phi_bin_width{};
+  std::array<double, 3> PhiBinWidth{};
   double drift_velocity = 8.0e-03;  // default value, override from macro
   float extended_readout_time = 0;  // ns
   int NTBins = std::numeric_limits<int>::max();
@@ -90,8 +90,8 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   double averageGEMGain = std::numeric_limits<double>::signaling_NaN();
   double polyaTheta = std::numeric_limits<double>::signaling_NaN();
 
-  std::array<std::vector<double>, NSides> sector_min_Phi;
-  std::array<std::vector<double>, NSides> sector_max_Phi;
+  std::array<std::array<std::vector<double>, NRSectors>, NSides> sector_min_Phi_sectors;
+  std::array<std::array<std::vector<double>, NRSectors>, NSides> sector_max_Phi_sectors;
 
   // return random distribution of number of electrons after amplification of GEM for each initial ionizing electron
   double getSingleEGEMAmplification();

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -226,7 +226,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track)
 
     // This is the global position
     double clusiphi = iphi_sum / adc_sum;
-    double clusphi = layergeom->get_phi(clusiphi, side);
+    double clusphi = layergeom->get_phi(clusiphi);
     /* double clusphi = phi_sum / adc_sum; */
     float clusx = radius * cos(clusphi);
     float clusy = radius * sin(clusphi);


### PR DESCRIPTION
This reverts the tpc fee map coresoftware changes, and adjusts modules that have since been modified to call the old `get_phi` function from the reconstruction. Need to do ample testing and cdb file orchestration still, but jenkins can get going on this


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

