### PR TITLE
EpdReco calibration fixes

### DIFF
--- a/offline/packages/epd/EpdReco.h
+++ b/offline/packages/epd/EpdReco.h
@@ -43,6 +43,7 @@ class EpdReco : public SubsysReco
 
   std::array<float, 24> tilephi{};
   std::array<float, 12> tilephi0{};
+  std::array<float, 744> m_calibration_constants{};
 };
 
 #endif  // EPD_EPDRECO_H


### PR DESCRIPTION

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Fixed CDB field lookup name (changed from sepd_calib to mip_calib), changed CDB lookups to use encoded keys instead of channel number, moved cdbttree lookup to InitRun(), and added bad/uncalibrated channel handling.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

