### PR TITLE
Phfield cleanup

### DIFF
--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -54,13 +54,18 @@ bool ALICEKF::checknan(double val, const std::string& name, int num) const
   return std::isnan(val);
 }
 
+
+ALICEKF::ALICEKF( TrkrClusterContainer* cmap, PHField* B, unsigned int min_clusters, double max_sin_phi, int verbosity):
+  _B(B),
+  _min_clusters_per_track(min_clusters),
+  _cluster_map(cmap),
+  _v(verbosity),
+  _max_sin_phi(max_sin_phi),
+  _ClusErrPara(new ClusterErrorPara)
+{}
+
 double ALICEKF::get_Bz(double x, double y, double z) const
 {
-  //  if(_use_const_field) return _const_field;
-  if (_use_const_field || fabs(z) > 105.5)
-  {
-    return _const_field;
-  }
   double p[4] = {x * cm, y * cm, z * cm, 0. * cm};
   double bfield[3];
 
@@ -732,11 +737,11 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     int track_charge = 0;
     if (trackSeed.GetQPt() < 0)
     {
-      track_charge = -1 * trackSeed.GetSignCosPhi();  // * _fieldDir;
+      track_charge = -1 * trackSeed.GetSignCosPhi();
     }
     else
     {
-      track_charge = 1 * trackSeed.GetSignCosPhi();  // * _fieldDir;
+      track_charge = 1 * trackSeed.GetSignCosPhi();
     }
 
     double sinphi = sin(track_phi);  // who had the idea to use s here?????

--- a/offline/packages/trackreco/ALICEKF.h
+++ b/offline/packages/trackreco/ALICEKF.h
@@ -2,8 +2,6 @@
 #define ALICEKF_H
 
 #include <phfield/PHField.h>
-#include <phfield/PHFieldConfigv1.h>
-#include <phfield/PHFieldUtility.h>
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
@@ -26,25 +24,9 @@ using TrackSeedAliceSeedMap = std::pair<std::vector<TrackSeed_v2>, std::vector<G
 class ALICEKF
 {
  public:
-  ALICEKF(PHCompositeNode* topNode,
-          TrkrClusterContainer* cmap,
-          PHField* B,
-          double fieldDir,
-          unsigned int min_clusters,
-          double max_sin_phi,
-          int verbosity)
-  {
-    if (!topNode) std::cout << "no topnode, too bad..." << std::endl;
-    _B = B;
-    _cluster_map = cmap;
-    _fieldDir = fieldDir;
-    _max_sin_phi = max_sin_phi;
-    _v = verbosity;
-    _min_clusters_per_track = min_clusters;
-    _ClusErrPara = new ClusterErrorPara();
-  }
+  ALICEKF( TrkrClusterContainer* cmap, PHField* B, unsigned int min_clusters, double max_sin_phi, int verbosity);
 
-  ~ALICEKF() { delete _ClusErrPara; }
+  ~ALICEKF() = default;
 
   explicit ALICEKF(const ALICEKF&) = delete;
   ALICEKF& operator=(const ALICEKF&) = delete;
@@ -63,32 +45,36 @@ class ALICEKF
   void repairCovariance(Eigen::Matrix<double, 6, 6>& cov) const;
   bool checknan(double val, const std::string& msg, int num) const;
   double get_Bz(double x, double y, double z) const;
-  void useConstBField(bool opt) { _use_const_field = opt; }
+
+  //! used for fast momentum calculation
   void setConstBField(float b) { _const_field = b; }
-  void useFixedClusterError(bool opt) { _use_fixed_clus_error = opt; }
+
+void useFixedClusterError(bool opt) { _use_fixed_clus_error = opt; }
   void setFixedClusterError(int i, double val) { _fixed_clus_error.at(i) = val; }
   double getClusterError(TrkrCluster* c, TrkrDefs::cluskey key, Acts::Vector3 global, int i, int j) const;
   std::vector<double> GetCircleClusterResiduals(const std::vector<std::pair<double, double>>& pts, double R, double X0, double Y0) const;
   std::vector<double> GetLineClusterResiduals(const std::vector<std::pair<double, double>>& pts, double A, double B) const;
   double get_Bzconst() const { return _Bzconst; }
 
-  ClusterErrorPara* _ClusErrPara;
-
  private:
+  int Verbosity() const
+  { return _v; }
+
   PHField* _B = nullptr;
   size_t _min_clusters_per_track = 20;
   TrkrClusterContainer* _cluster_map = nullptr;
-  int Verbosity() const
-  {
-    return _v;
-  }
 
   int _v = 0;
-  double _Bzconst = 10. * 0.000299792458f;
-  double _fieldDir = -1;
+  static constexpr double _Bzconst = 10. * 0.000299792458f;
   double _max_sin_phi = 1.;
-  bool _use_const_field = false;
+
+  //! used for fast momentum calculation
   float _const_field = 1.4;
+
+  // cluster error parametrization
+  std::unique_ptr<ClusterErrorPara> _ClusErrPara;
+
+  // cluster errors
   bool _use_fixed_clus_error = true;
   std::array<double, 3> _fixed_clus_error = {.2, .2, .5};
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -594,7 +594,7 @@ void MakeActsGeometry::buildActsSurfaces()
     argstr.insert( argstr.end(),
     {
       "--bf-constant-tesla", fld.str().c_str(),
-      "--bf-bscalor", std::to_string(m_magFieldRescale)
+      "--bf-map-fieldscale-tesla", std::to_string(m_magFieldRescale)
     });
 
   } else {

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -91,7 +91,7 @@
 
 namespace
 {
-  /// navigate Acts volumes to find one matching a given name (recursive)
+  // navigate Acts volumes to find one matching a given name (recursive)
   // NOLINTNEXTLINE(misc-no-recursion)
   TrackingVolumePtr find_volume_by_name(const Acts::TrackingVolume *master, const std::string &name)
   {
@@ -128,6 +128,24 @@ namespace
   inline T get_r(const T &x, const T &y)
   {
     return std::sqrt(square(x) + square(y));
+  }
+
+  // returns true if magnetic field string corresponds to constant value
+  bool isConstantField(const std::string &name, double &fieldstrength)
+  {
+
+    std::istringstream stringline(name);
+    stringline >> fieldstrength;
+    if (stringline.fail())
+    {
+      // conversion to double fails -> we have a string (means fieldmap)
+      fieldstrength = std::numeric_limits<double>::quiet_NaN();
+      return false;
+    }
+    else
+    {
+      return true;
+    }
   }
 
 }  // namespace
@@ -178,7 +196,10 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  /// Set the actsGeometry struct to be put on the node tree
+  // load relevant magnetic field map on the node tree
+
+
+  // Set the actsGeometry struct to be put on the node tree
   ActsTrackingGeometry trackingGeometry;
   trackingGeometry.tGeometry = m_tGeometry;
   trackingGeometry.magField = m_magneticField;
@@ -243,7 +264,7 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
 
 int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
 {
-  /// Add the TPC surfaces to the copy of the TGeoManager.
+  // Add the TPC surfaces to the copy of the TGeoManager.
   // this also adds the micromegas surfaces
   // Do this before anything else, so that the geometry is finalized
 
@@ -257,7 +278,7 @@ int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
   // There is a check for existing acts fake surfaces in editTPCGeometry
   editTPCGeometry(topNode);
 
-  /// Export the new geometry to a root file for examination
+  // Export the new geometry to a root file for examination
   if (Verbosity() > 3)
   {
     PHGeomUtility::ExportGeomtry(topNode, "sPHENIXActsGeom.root");
@@ -269,10 +290,10 @@ int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  /// Run Acts layer builder
+  // Run Acts layer builder
   buildActsSurfaces();
 
-  /// Create a map of sensor TGeoNode pointers using the TrkrDefs:: hitsetkey as the key
+  // Create a map of sensor TGeoNode pointers using the TrkrDefs:: hitsetkey as the key
   // makeTGeoNodeMap(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -285,7 +306,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
   PHGeomTGeo *geomNode = PHGeomUtility::GetGeomTGeoNode(topNode, true);
   assert(geomNode);
 
-  /// Reset the geometry node, which we will recreate with the TPC edits
+  // Reset the geometry node, which we will recreate with the TPC edits
   if (geomNode->isValid())
   {
     geomNode->Reset();
@@ -377,8 +398,8 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
     }
   }
 
-  /// Make a check for the fake surfaces. If we have more than 0
-  /// then we've built the fake surfaces and we should not do it again
+  // Make a check for the fake surfaces. If we have more than 0
+  // then we've built the fake surfaces and we should not do it again
   if (nfakesurfaces > 0)
   {
     return;
@@ -498,9 +519,10 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol,
 void MakeActsGeometry::buildActsSurfaces()
 {
   // define int argc and char* argv to provide options to processGeometry
-  const int argc = 20;
+  static constexpr int argc = 20;
   char *arg[argc];
   m_magFieldRescale = 1;
+
   // if(Verbosity() > 0)
   std::cout << PHWHERE << "Magnetic field " << m_magField
             << " with rescale " << m_magFieldRescale << std::endl;
@@ -508,49 +530,59 @@ void MakeActsGeometry::buildActsSurfaces()
   std::string responseFile, materialFile;
   setMaterialResponseFile(responseFile, materialFile);
 
-  // Response file contains arguments necessary for geometry building
-  std::istringstream stringline(m_magField);
-  double fieldstrength = std::numeric_limits<double>::quiet_NaN();
-  stringline >> fieldstrength;
-
-  std::ostringstream fld;
-  fld.str("");
-  fld << "0:0:" << m_magField;
-  std::string argstr[argc]{
-      "-n1",
-      "--geo-tgeo-jsonconfig", responseFile,
-      "--mat-input-type", "file",
-      "--mat-input-file", materialFile,
-      "--bf-constant-tesla", fld.str().c_str(),
-      "--bf-bscalor"};
-
-  argstr[9] = std::to_string(m_magFieldRescale);
-
-  /// Alter args if using field map
-  if (stringline.fail())
+  // arguments
+  // material and response file contains arguments necessary for geometry building
+  std::vector<std::string> argstr =
   {
-    if (std::filesystem::path(m_magField).extension() != ".root")
+    "-n1",
+    "--geo-tgeo-jsonconfig", responseFile,
+    "--mat-input-type", "file",
+    "--mat-input-file", materialFile
+  };
+
+  double fieldstrength = std::numeric_limits<double>::quiet_NaN();
+  if( isConstantField( m_magField, fieldstrength ) )
+  {
+    std::ostringstream fld;
+    fld.str("");
+    fld << "0:0:" << fieldstrength;
+
+    argstr.insert( argstr.end(),
     {
-      m_magField = CDBInterface::instance()->getUrl(m_magField);
-    }
+      "--bf-constant-tesla", fld.str().c_str(),
+      "--bf-bscalor", std::to_string(m_magFieldRescale)
+    });
+
+  } else {
+
+    // get field from cdb
+    if (std::filesystem::path(m_magField).extension() != ".root")
+    { m_magField = CDBInterface::instance()->getUrl(m_magField); }
+
+    // update arguments
     if (std::filesystem::exists(m_magField))
     {
-      argstr[7] = "--bf-map-file";
-      argstr[8] = m_magField;
-      argstr[9] = "--bf-map-tree";
-      argstr[10] = "fieldmap";
-      argstr[11] = "--bf-map-lengthscale-mm";
-      argstr[12] = "10";
-      argstr[13] = "--bf-map-fieldscale-tesla";
-      argstr[14] = std::to_string(m_magFieldRescale);
+      argstr.insert( argstr.end(),
+      {
+        "--bf-map-file", m_magField,
+        "--bf-map-tree", "fieldmap",
+        "--bf-map-lengthscale-mm", "10",
+        "--bf-map-fieldscale-tesla", std::to_string(m_magFieldRescale)
+      });
     }
   }
+
   //  if(Verbosity() > 0)
-  std::cout << "Mag field now " << m_magField << " with rescale "
-            << m_magFieldRescale << std::endl;
+  std::cout << "Mag field now " << m_magField << " with rescale " << m_magFieldRescale << std::endl;
+
+  // convert arguments to char**
+  if( argstr.size() > argc )
+  {
+    std::cout << "MakeActsGeometry::buildActsSurfaces - there are too many arguments to be passed to makeGeometry" << std::endl;
+  }
 
   // Set vector of chars to arguments needed
-  for (int i = 0; i < argc; ++i)
+  for (size_t i = 0; i < argstr.size(); ++i)
   {
     if (Verbosity() > 1)
     {
@@ -564,20 +596,22 @@ void MakeActsGeometry::buildActsSurfaces()
   // acts/Examples/Run/Common/src/GeometryExampleBase::ProcessGeometry() in MakeActsGeometry()
   // so we get access to the results. The layer builder magically gets the TGeoManager
 
-  makeGeometry(argc, arg, m_detector);
+  makeGeometry(argstr.size(), arg, m_detector);
 
-  for (auto &i : arg)
+  for (size_t i = 0; i < argstr.size(); ++i)
   {
     // NOLINTNEXTLINE(hicpp-no-malloc)
-    free(i);
+    free(arg[i]);
   }
 }
+
+
 void MakeActsGeometry::setMaterialResponseFile(std::string &responseFile,
                                                std::string &materialFile)
 {
   responseFile = "tgeo-sphenix-mms.json";
   materialFile = "sphenix-mm-material.json";
-  /// Check to see if files exist locally - if not, use defaults
+  // Check to see if files exist locally - if not, use defaults
   std::ifstream file;
 
   file.open(responseFile);
@@ -608,19 +642,19 @@ void MakeActsGeometry::setMaterialResponseFile(std::string &responseFile,
 void MakeActsGeometry::makeGeometry(int argc, char *argv[],
                                     ActsExamples::TGeoDetectorWithOptions &detector)
 {
-  /// setup and parse options
+  // setup and parse options
   boost::program_options::options_description desc;
   ActsExamples::Options::addGeometryOptions(desc);
   ActsExamples::Options::addMaterialOptions(desc);
   ActsExamples::Options::addMagneticFieldOptions(desc);
 
-  /// Add specific options for this geometry
+  // Add specific options for this geometry
   detector.addOptions(desc);
   auto vm = ActsExamples::Options::parse(desc, argc, argv);
 
-  /// The geometry, material and decoration
+  // The geometry, material and decoration
   auto geometry = build(vm, detector);
-  /// Geometry is a pair of (tgeoTrackingGeometry, tgeoContextDecorators)
+  // Geometry is a pair of (tgeoTrackingGeometry, tgeoContextDecorators)
 
   m_tGeometry = geometry.first;
   if (m_useField)
@@ -678,7 +712,7 @@ MakeActsGeometry::build(const boost::program_options::variables_map &vm,
 
   readTGeoLayerBuilderConfigsFile(path, config);
 
-  /// Return the geometry and context decorators
+  // Return the geometry and context decorators
   return detector.m_detector.finalize(config, matDeco);
 }
 
@@ -718,8 +752,8 @@ void MakeActsGeometry::readTGeoLayerBuilderConfigsFile(const std::string &path,
 
 void MakeActsGeometry::unpackVolumes()
 {
-  /// m_tGeometry is a TrackingGeometry pointer
-  /// vol is a TrackingVolume pointer
+  // m_tGeometry is a TrackingGeometry pointer
+  // vol is a TrackingVolume pointer
   auto vol = m_tGeometry->highestTrackingVolume();
 
   if (Verbosity() > 3)
@@ -784,7 +818,7 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
   auto tpcLayerArray = tpcVolume->confinedLayers();
   auto tpcLayerVector = tpcLayerArray->arrayObjects();
 
-  /// Need to unfold each layer that Acts builds
+  // Need to unfold each layer that Acts builds
   for (auto &i : tpcLayerVector)
   {
     auto surfaceArray = i->surfaceArray();
@@ -792,15 +826,15 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
     {
       continue;
     }
-    /// surfaceVector is a vector of surfaces corresponding to the tpc layer
-    /// that acts builds
+    // surfaceVector is a vector of surfaces corresponding to the tpc layer
+    // that acts builds
     auto surfaceVector = surfaceArray->surfaces();
     for (auto &j : surfaceVector)
     {
       auto surf = j->getSharedPtr();
       auto vec3d = surf->center(m_geoCtxt);
 
-      /// convert to cm
+      // convert to cm
       std::vector<double> world_center = {vec3d(0) / 10.0,
                                           vec3d(1) / 10.0,
                                           vec3d(2) / 10.0};
@@ -808,8 +842,8 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
       TrkrDefs::hitsetkey hitsetkey = getTpcHitSetKeyFromCoords(world_center);
       unsigned int layer = TrkrDefs::getLayer(hitsetkey);
 
-      /// If there is already an entry for this hitsetkey, add the surface
-      /// to its corresponding vector
+      // If there is already an entry for this hitsetkey, add the surface
+      // to its corresponding vector
       // std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
       std::map<unsigned int, std::vector<Surface>>::iterator mapIter;
       // mapIter = m_clusterSurfaceMapTpcEdit.find(hitsetkey);
@@ -821,7 +855,7 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
       }
       else
       {
-        /// Otherwise make a new map entry
+        // Otherwise make a new map entry
         std::vector<Surface> dumvec;
         dumvec.push_back(surf);
         std::pair<unsigned int, std::vector<Surface>> tmp =
@@ -842,7 +876,7 @@ void MakeActsGeometry::makeMmMapPairs(TrackingVolumePtr &mmVolume)
   const auto mmLayerArray = mmVolume->confinedLayers();
   const auto mmLayerVector = mmLayerArray->arrayObjects();
 
-  /// Need to unfold each layer that Acts builds
+  // Need to unfold each layer that Acts builds
   for (const auto &i : mmLayerVector)
   {
     auto surfaceArray = i->surfaceArray();
@@ -851,8 +885,8 @@ void MakeActsGeometry::makeMmMapPairs(TrackingVolumePtr &mmVolume)
       continue;
     }
 
-    /// surfaceVector is a vector of surfaces corresponding to the micromegas layer
-    /// that acts builds
+    // surfaceVector is a vector of surfaces corresponding to the micromegas layer
+    // that acts builds
     const auto surfaceVector = surfaceArray->surfaces();
 
     for (auto j : surfaceVector)
@@ -860,7 +894,7 @@ void MakeActsGeometry::makeMmMapPairs(TrackingVolumePtr &mmVolume)
       auto surface = j->getSharedPtr();
       auto vec3d = surface->center(m_geoCtxt);
 
-      /// convert to cm
+      // convert to cm
       TVector3 world_center(
           vec3d(0) / Acts::UnitConstants::cm,
           vec3d(1) / Acts::UnitConstants::cm,
@@ -963,9 +997,9 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
 
       std::vector<double> world_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
 
-      /// The Acts geometry builder combines layers 4 and 5 together,
-      /// and layers 6 and 7 together. We need to use the radius to figure
-      /// out which layer to use to get the layergeom
+      // The Acts geometry builder combines layers 4 and 5 together,
+      // and layers 6 and 7 together. We need to use the radius to figure
+      // out which layer to use to get the layergeom
       double layer_rad = (m_inttSurvey) ? sqrt(pow(world_center[0] - m_inttbarrelcenter_survey_x, 2) + pow(world_center[1] - m_inttbarrelcenter_survey_y, 2)) : sqrt(pow(world_center[0], 2) + pow(world_center[1], 2));
 
       unsigned int layer = 0;
@@ -1075,7 +1109,7 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
 	  std::cout << PHWHERE << " Did not find associatedDetectorElement, have to quit! " << std::endl;
 	  exit(1);
 	}
-      
+
       Acts::GeometryIdentifier id = detelement->surface().geometryId();
       unsigned int volume = id.volume();
       unsigned int actslayer = id.layer();
@@ -1115,9 +1149,9 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
 	  std::cout << "detelement: volume " << volume << " actslayer " << actslayer << " sphlayer " << sphlayer
 		    << " sensor " << sensor << " stave " << stave << " chip " << chip << std::endl;
 	}
-      
+
       // Add this surface to the map
-      std::pair<TrkrDefs::hitsetkey, Surface> tmp = make_pair(hitsetkey, surf);      
+      std::pair<TrkrDefs::hitsetkey, Surface> tmp = make_pair(hitsetkey, surf);
       m_clusterSurfaceMapSilicon.insert(tmp);
 
       if (Verbosity() > 10)
@@ -1316,7 +1350,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getInttHitSetKeyFromCoords(unsigned int la
 // 	std::cout << " node " << node->GetName() << " is the MVTX wrapper"
 // 		  << std::endl;
 //
-//       /// The Mvtx has an additional wrapper that needs to be unpacked
+//       // The Mvtx has an additional wrapper that needs to be unpacked
 //       TObjArray *mvtxArray = node->GetNodes();
 //       TIter mvtxObj(mvtxArray);
 //       while(TObject *mvtx = mvtxObj())
@@ -1328,7 +1362,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getInttHitSetKeyFromCoords(unsigned int la
 // 	  std::string mvtxav1("av_1");
 // 	  std::string mvtxNodeName = mvtxNode->GetName();
 //
-// 	  /// We only want the av_1 nodes
+// 	  // We only want the av_1 nodes
 // 	  if(mvtxNodeName.compare(0, mvtxav1.length(), mvtxav1) == 0)
 // 	    getMvtxKeyFromNode(mvtxNode);
 // 	}
@@ -1344,8 +1378,8 @@ TrkrDefs::hitsetkey MakeActsGeometry::getInttHitSetKeyFromCoords(unsigned int la
 // 		  << std::endl;
 //       getInttKeyFromNode(node);
 //     }
-//     /// Put placeholders for the TPC and MMs. Because we modify the geometry
-//     /// within TGeoVolume, we don't need a mapping to the TGeoNode
+//     // Put placeholders for the TPC and MMs. Because we modify the geometry
+//     // within TGeoVolume, we don't need a mapping to the TGeoNode
 //     else if (node_str.compare(0, tpc.length(), tpc) == 0)  // is it in the TPC?
 //       {
 // 	if(Verbosity() > 2)
@@ -1631,8 +1665,8 @@ void MakeActsGeometry::getMvtxKeyFromNode(TGeoNode *gnode)
 
 void MakeActsGeometry::setPlanarSurfaceDivisions()
 {
-  /// These are arbitrary tpc subdivisions, and may change
-  /// Setup how TPC boxes will be built for Acts::Surfaces
+  // These are arbitrary tpc subdivisions, and may change
+  // Setup how TPC boxes will be built for Acts::Surfaces
   m_surfStepZ = (m_maxSurfZ - m_minSurfZ) / (double) m_nSurfZ;
   m_moduleStepPhi = 2.0 * M_PI / 12.0;
   m_modulePhiStart = -M_PI;
@@ -1653,10 +1687,10 @@ void MakeActsGeometry::setPlanarSurfaceDivisions()
 int MakeActsGeometry::createNodes(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
-  /// Get the DST Node
+  // Get the DST Node
   PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
 
-  /// Check that it is there
+  // Check that it is there
   if (!parNode)
   {
     std::cout << "PAR Node missing, creating it" << std::endl;
@@ -1665,10 +1699,10 @@ int MakeActsGeometry::createNodes(PHCompositeNode *topNode)
   }
 
   PHNodeIterator pariter(parNode);
-  /// Get the tracking subnode
+  // Get the tracking subnode
   PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(pariter.findFirst("PHCompositeNode", "SVTX"));
 
-  /// Check that it is there
+  // Check that it is there
   if (!svtxNode)
   {
     svtxNode = new PHCompositeNode("SVTX");

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -623,7 +623,7 @@ void MakeActsGeometry::buildActsSurfaces()
   assert(argstr.size()<argc);
 
   // print arguments
-  // if (Verbosity() > 1)
+  if (Verbosity() > 1)
   {
     std::cout << "MakeActsGeometry::buildActsSurfaces - arguments: " << std::endl;
     for( const auto& arg:argstr ) { std::cout << arg << ", "; }

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -576,10 +576,7 @@ void MakeActsGeometry::buildActsSurfaces()
   std::cout << "Mag field now " << m_magField << " with rescale " << m_magFieldRescale << std::endl;
 
   // convert arguments to char**
-  if( argstr.size() > argc )
-  {
-    std::cout << "MakeActsGeometry::buildActsSurfaces - there are too many arguments to be passed to makeGeometry" << std::endl;
-  }
+  assert(argstr.size()<argc);
 
   // Set vector of chars to arguments needed
   for (size_t i = 0; i < argstr.size(); ++i)

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -520,7 +520,7 @@ void MakeActsGeometry::buildActsSurfaces()
 {
   // define int argc and char* argv to provide options to processGeometry
   static constexpr int argc = 20;
-  char *arg[argc];
+  char *argv[argc];
   m_magFieldRescale = 1;
 
   // if(Verbosity() > 0)
@@ -578,27 +578,32 @@ void MakeActsGeometry::buildActsSurfaces()
   // convert arguments to char**
   assert(argstr.size()<argc);
 
+  // print arguments
+  // if (Verbosity() > 1)
+  {
+    std::cout << "MakeActsGeometry::buildActsSurfaces - arguments: " << std::endl;
+    for( const auto& arg:argstr ) { std::cout << arg << ", "; }
+    std::cout << std::endl;
+  }
+
+
   // Set vector of chars to arguments needed
   for (size_t i = 0; i < argstr.size(); ++i)
   {
-    if (Verbosity() > 1)
-    {
-      std::cout << argstr[i] << ", ";
-    }
     // need a copy, since .c_str() returns a const char * and process geometry will not take a const
-    arg[i] = strdup(argstr[i].c_str());
+    argv[i] = strdup(argstr[i].c_str());
   }
 
   // We replicate the relevant functionality of
   // acts/Examples/Run/Common/src/GeometryExampleBase::ProcessGeometry() in MakeActsGeometry()
   // so we get access to the results. The layer builder magically gets the TGeoManager
 
-  makeGeometry(argstr.size(), arg, m_detector);
+  makeGeometry(argstr.size(), argv, m_detector);
 
   for (size_t i = 0; i < argstr.size(); ++i)
   {
     // NOLINTNEXTLINE(hicpp-no-malloc)
-    free(arg[i]);
+    free(argv[i]);
   }
 }
 

--- a/offline/packages/trackreco/PHCosmicsFilter.h
+++ b/offline/packages/trackreco/PHCosmicsFilter.h
@@ -4,7 +4,7 @@
 /*!
  *  \file RPHCosmicsFilter.h
  *  \RTree based hough tracking for cosmics
- *  \author Christof Roland 
+ *  \author Christof Roland
  */
 
 
@@ -75,8 +75,6 @@
 #include <tuple>
 #include <vector>
 
-
-class PHField;
 class TGeoManager;
 
 
@@ -136,7 +134,7 @@ class PHCosmicsFilter : public SubsysReco
   void set_create_tracks(bool b){_create_tracks = b;}
   void set_max_distance_to_origin(float val){ _max_dist_to_origin = val;}
   void set_min_nclusters(int n){ _min_nclusters = n;}
-  
+
  protected:
   int Setup(PHCompositeNode *topNode);
   int GetNodes(PHCompositeNode* topNode);

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -85,7 +85,6 @@
 #include <utility>
 #include <vector>
 
-class PHField;
 class TGeoManager;
 namespace genfit
 {

--- a/offline/packages/trackreco/PHLineLaserReco.h
+++ b/offline/packages/trackreco/PHLineLaserReco.h
@@ -4,7 +4,7 @@
 /*!
  *  \file RPHLinelaserreco.h
  *  \RTree based hough tracking for cosmics
- *  \author Christof Roland 
+ *  \author Christof Roland
  */
 
 
@@ -77,7 +77,6 @@
 #include <vector>
 
 
-class PHField;
 class TGeoManager;
 
 
@@ -207,7 +206,7 @@ class PHLineLaserReco : public SubsysReco
   int m_nrun = std::numeric_limits<int>::quiet_NaN();
   int m_nseg = std::numeric_limits<int>::quiet_NaN();
   int m_njob = std::numeric_limits<int>::quiet_NaN();
-  
+
   float m_hitx = std::numeric_limits<float>::quiet_NaN();
   float m_hity = std::numeric_limits<float>::quiet_NaN();
   float m_hitz = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/trackreco/PHRaveVertexing.cc
+++ b/offline/packages/trackreco/PHRaveVertexing.cc
@@ -55,7 +55,6 @@
 #include <utility>
 #include <vector>
 
-class PHField;
 class TGeoManager;
 namespace genfit { class AbsTrackRep; }
 
@@ -105,8 +104,8 @@ int PHRaveVertexing::InitRun(PHCompositeNode* topNode)
 {
   CreateNodes(topNode);
 
-  TGeoManager* tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
-  PHField* field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
+  auto tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
+  auto field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
   //_fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5);
   _fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
@@ -114,7 +113,7 @@ int PHRaveVertexing::InitRun(PHCompositeNode* topNode)
                                           "RKTrackRep", false);
   if (!_fitter)
   {
-    std::cout << PHWHERE << " PHGenFit::Fitter::getInstance returned nullptr" 
+    std::cout << PHWHERE << " PHGenFit::Fitter::getInstance returned nullptr"
 	      << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
@@ -187,8 +186,8 @@ int PHRaveVertexing::process_event(PHCompositeNode* topNode)
 	  }
 	if(nmvtx < _nmvtx_required) continue;
 	if(Verbosity() > 1) std::cout << " track " << iter->first << "  has nmvtx at least " << nmvtx << std::endl;
-      } 
-    
+      }
+
     //auto genfit_track = shared_ptr<genfit::Track> (TranslateSvtxToGenFitTrack(svtx_track));
     auto genfit_track = TranslateSvtxToGenFitTrack(svtx_track);
     if (!genfit_track)

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -17,8 +17,6 @@
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 #include <phfield/PHField.h>
-#include <phfield/PHFieldConfig.h>
-#include <phfield/PHFieldConfigv1.h>
 #include <phfield/PHFieldUtility.h>
 
 // tpc distortion correction
@@ -41,9 +39,6 @@
 #include <phool/PHTimer.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
-
-#include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
-#include <Acts/MagneticField/MagneticFieldProvider.hpp>
 
 #include <TSystem.h>
 
@@ -77,18 +72,12 @@ PHSimpleKFProp::PHSimpleKFProp(const std::string& name)
 {}
 
 //______________________________________________________
-PHSimpleKFProp::~PHSimpleKFProp()
-{
-  if( m_own_fieldmap )
-  { delete _field_map; }
-}
-
-//______________________________________________________
 int PHSimpleKFProp::End(PHCompositeNode* /*unused*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//______________________________________________________
 int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
 {
   int ret = get_nodes(topNode);
@@ -97,49 +86,9 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
     return ret;
   }
 
-  PHFieldConfigv1 fcfg;
-  fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
-
-  if (std::filesystem::path(m_magField).extension() != ".root")
-  { m_magField = CDBInterface::instance()->getUrl(m_magField); }
-
-  if (!_use_const_field)
-  {
-    if (!std::filesystem::exists(m_magField))
-    {
-      if (m_magField.empty())
-      { m_magField = "empty string"; }
-      std::cout << PHWHERE << "Fieldmap " << m_magField << " does not exist" << std::endl;
-      gSystem->Exit(1);
-    }
-
-    fcfg.set_filename(m_magField);
-  }
-  else
-  {
-    fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::kFieldUniform);
-    fcfg.set_magfield_rescale(_const_field);
-  }
-
-  // compare field config from that on node tree
-  /*
-   * if the magnetic field is already on the node tree PHFieldUtility::GetFieldConfigNode returns the existing configuration.
-   * One must then check wheter the two configurations are identical, to decide whether one must use the field from node tree or create our own.
-   * Otherwise the configuration passed as argument is stored on the node tree.
-   */
-  const auto node_fcfg = PHFieldUtility::GetFieldConfigNode(&fcfg, topNode);
-  if( fcfg == *node_fcfg )
-  {
-    // both configurations are identical, use field map from node tree
-    std::cout << "PHSimpleKFProp::InitRun - using node tree field map" << std::endl;
-    _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
-    m_own_fieldmap = false;
-  } else {
-    // both configurations differ. Use our own field map
-    std::cout << "PHSimpleKFProp::InitRun - using own field map" << std::endl;
-    _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
-    m_own_fieldmap = true;
-  }
+  // load magnetic field from node tree
+  /* note: if field is not found it is created with default configuration, as defined in PHFieldUtility */
+  _field_map = PHFieldUtility::GetFieldMapNode();
 
   // alice kalman filter
   fitter = std::make_unique<ALICEKF>(topNode, _cluster_map, _field_map, _fieldDir, _min_clusters_per_track, _max_sin_phi, Verbosity());
@@ -148,14 +97,10 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
   fitter->setCF4Fraction(CF4_frac);
   fitter->setNitrogenFraction(N2_frac);
   fitter->setIsobutaneFraction(isobutane_frac);
-  fitter->useConstBField(_use_const_field);
-  fitter->setConstBField(_const_field);
   fitter->useFixedClusterError(_use_fixed_clus_err);
   fitter->setFixedClusterError(0, _fixed_clus_err.at(0));
   fitter->setFixedClusterError(1, _fixed_clus_err.at(1));
   fitter->setFixedClusterError(2, _fixed_clus_err.at(2));
-  // _field_map = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
-  // m_Cache = magField->makeCache(m_tGeometry->magFieldContext);
 
   // assign number of threads
   std::cout << "PHSimpleKFProp::InitRun - m_num_threads: " << m_num_threads << std::endl;
@@ -164,13 +109,10 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//___________________________________________________________________________
 double PHSimpleKFProp::get_Bz(double x, double y, double z) const
 {
-  if (_use_const_field || std::abs(z) > 105.5)
-  {
-    return _const_field;
-  }
-  double p[4] = {x * cm, y * cm, z * cm, 0. * cm};
+  double p[4] = {x*cm, y*cm, z*cm, 0.};
   double bfield[3];
 
   // check thread number. Use uncached field accessor for all but thread 0.
@@ -181,21 +123,10 @@ double PHSimpleKFProp::get_Bz(double x, double y, double z) const
     _field_map->GetFieldValue_nocache(p, bfield);
   }
 
-  /*  Acts::Vector3 loc(0,0,0);
-  int mfex = (magField != nullptr);
-  int tgex = (m_tGeometry != nullptr);
-  std::cout << " getting acts field " << mfex << " " << tgex << std::endl;
-  auto Cache =  m_tGeometry->magField->makeCache(m_tGeometry->magFieldContext);
-  auto bf = m_tGeometry->magField->getField(loc,Cache);
-  if(bf.ok())
-    {
-      Acts::Vector3 val = bf.value();
-      std::cout << "bz big: " <<  bfield[2]/tesla << " bz acts: " << val(2) << std::endl;
-    }
-  */
   return bfield[2] / tesla;
 }
 
+//___________________________________________________________________________
 int PHSimpleKFProp::get_nodes(PHCompositeNode* topNode)
 {
 
@@ -1111,23 +1042,9 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
     std::cout << "track (x,y,z) = (" << track_x << ", " << track_y << ", " << track_z << ")" << std::endl;
   }
 
-  double track_px = NAN;
-  double track_py = NAN;
-  double track_pz = NAN;
-  if (_use_const_field)
-  {
-    float pt = fabs(1. / track->get_qOverR()) * (0.3 / 100) * _const_field;
-    float phi = track->get_phi();
-    track_px = pt * std::cos(phi);
-    track_py = pt * std::sin(phi);
-    track_pz = pt * std::cosh(track->get_eta()) * std::cos(track->get_theta());
-  }
-  else
-  {
-    track_px = track->get_px();
-    track_py = track->get_py();
-    track_pz = track->get_pz();
-  }
+  double track_px = track->get_px();
+  double track_py = track->get_py();
+  double track_pz = track->get_pz();
 
   if (Verbosity() > 1)
   {
@@ -1157,17 +1074,18 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
     second_index = 1;
   }
 
-  double xc = track->get_X0();
-  double yc = track->get_Y0();
-  double cluster_x = trkGlobPos.at(inner_index)(0);
-  double cluster_y = trkGlobPos.at(inner_index)(1);
-  double dy = cluster_y - yc;
-  double dx = cluster_x - xc;
-  double phi = atan2(dy, dx);
-  double second_dx = trkGlobPos.at(second_index)(0) - xc;
-  double second_dy = trkGlobPos.at(second_index)(1) - yc;
-  double second_phi = atan2(second_dy, second_dx);
-  double dphi = second_phi - phi;
+  const double xc = track->get_X0();
+  const double yc = track->get_Y0();
+  const double cluster_x = trkGlobPos.at(inner_index)(0);
+  const double cluster_y = trkGlobPos.at(inner_index)(1);
+  const double dy = cluster_y - yc;
+  const double dx = cluster_x - xc;
+
+  double phi = std::atan2(dy, dx);
+  const double second_dx = trkGlobPos.at(second_index)(0) - xc;
+  const double second_dy = trkGlobPos.at(second_index)(1) - yc;
+  const double second_phi = std::atan2(second_dy, second_dx);
+  const double dphi = second_phi - phi;
 
   if (dphi > 0)
   {
@@ -1178,7 +1096,8 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
     phi -= M_PI / 2.0;
   }
 
-  double pt = sqrt(track_px * track_px + track_py * track_py);
+  const double pt = std::sqrt(square(track_px)+square(track_py));
+
   // rotate track momentum vector (pz stays the same)
   track_px = pt * cos(phi);
   track_py = pt * sin(phi);

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -88,10 +88,10 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
 
   // load magnetic field from node tree
   /* note: if field is not found it is created with default configuration, as defined in PHFieldUtility */
-  _field_map = PHFieldUtility::GetFieldMapNode();
+  _field_map = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
   // alice kalman filter
-  fitter = std::make_unique<ALICEKF>(topNode, _cluster_map, _field_map, _fieldDir, _min_clusters_per_track, _max_sin_phi, Verbosity());
+  fitter = std::make_unique<ALICEKF>(_cluster_map, _field_map, _min_clusters_per_track, _max_sin_phi, Verbosity());
   fitter->setNeonFraction(Ne_frac);
   fitter->setArgonFraction(Ar_frac);
   fitter->setCF4Fraction(CF4_frac);

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -117,7 +117,6 @@ class PHSimpleKFProp : public SubsysReco
   size_t _min_clusters_per_track = 3;
 
   //! internal field conversion to get the right particle sign
-  double _fieldDir = -1;
 
   double _max_sin_phi = 1.;
   bool _pp_mode = false;

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -44,25 +44,30 @@ class PHSimpleKFProp : public SubsysReco
 {
  public:
   PHSimpleKFProp(const std::string& name = "PHSimpleKFProp");
-  ~PHSimpleKFProp() override;
+  ~PHSimpleKFProp() override = default;
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
   int End(PHCompositeNode* topNode) override;
 
-  void set_field_dir(const double rescale)
-  {
-    _fieldDir = 1;
-    if (rescale > 0)
-    {
-      _fieldDir = -1;
-    }
-  }
+  // noop
+  void set_field_dir(const double)
+  {}
+
+  // noop
+  void magFieldFile(const std::string&)
+  {}
+
+  // noop
+  void useConstBField(bool)
+  {}
+
+  // noop
+  void setConstBField(float)
+  {}
+
   void ghostRejection(bool set_value = true) { m_ghostrejection = set_value; }
-  void magFieldFile(const std::string& fname) { m_magField = fname; }
   void set_max_window(double s) { _max_dist = s; }
-  void useConstBField(bool opt) { _use_const_field = opt; }
-  void setConstBField(float b) { _const_field = b; }
   void useFixedClusterError(bool opt) { _use_fixed_clus_err = opt; }
   void setFixedClusterError(int i, double val) { _fixed_clus_err.at(i) = val; }
   void use_truth_clusters(bool truth)
@@ -110,7 +115,10 @@ class PHSimpleKFProp : public SubsysReco
   // double _Bz = 1.4*_Bzconst;
   double _max_dist = .05;
   size_t _min_clusters_per_track = 3;
+
+  //! internal field conversion to get the right particle sign
   double _fieldDir = -1;
+
   double _max_sin_phi = 1.;
   bool _pp_mode = false;
   unsigned int _max_seeds = 0;
@@ -121,7 +129,6 @@ class PHSimpleKFProp : public SubsysReco
 
   //! magnetic field map
   PHField* _field_map = nullptr;
-  bool m_own_fieldmap = false;
 
   /// acts geometry
   ActsGeometry* m_tgeometry = nullptr;
@@ -210,28 +217,39 @@ class PHSimpleKFProp : public SubsysReco
   void publishSeeds(const std::vector<TrackSeed_v2>&);
 
   int _max_propagation_steps = 200;
-  std::string m_magField;
-  bool _use_const_field = false;
-  float _const_field = 1.4;
+
+  //! fixed cluster errors
   bool _use_fixed_clus_err = false;
+
+  //! fixed cluster errors
   std::array<double, 3> _fixed_clus_err = {.2, .2, .5};
+
+  //! keep track of used clusters in previous iteration for iterative tracking
   TrkrClusterIterationMapv1* _iteration_map = nullptr;
+
+  //! iteration number
   int _n_iteration = 0;
 
+  //!@name TPC gas. Needed for Kalman Filter
+  //@{
   double Ne_frac = 0.00;
   double Ar_frac = 0.75;
   double CF4_frac = 0.20;
   double N2_frac = 0.00;
   double isobutane_frac = 0.05;
+  //@}
 
+  //!@name ghost rejection cuts
+  //@{
   double _ghost_phi_cut = std::numeric_limits<double>::max();
   double _ghost_eta_cut = std::numeric_limits<double>::max();
   double _ghost_x_cut = std::numeric_limits<double>::max();
   double _ghost_y_cut = std::numeric_limits<double>::max();
   double _ghost_z_cut = std::numeric_limits<double>::max();
+  //@}
 
-  // number of threads
-  /*
+  //! number of threads
+  /**
    * default is 0. This corresponds to allocating as many threads as available on the host
    * on CONDOR, by default, this results in only one thread allocated
    * being allocated unless several cores are allocated to the job

--- a/offline/packages/trackreco/PHStreakFinder.h
+++ b/offline/packages/trackreco/PHStreakFinder.h
@@ -1,7 +1,7 @@
 /*!
  *  \file RPHStreakFinder.h
  *  \RTree based hough tracking for cosmics
- *  \author Christof Roland 
+ *  \author Christof Roland
  */
 
 
@@ -66,7 +66,6 @@
 #include <memory>
 #include <tuple>
 
-class PHField;
 class TGeoManager;
 
 using namespace Eigen;
@@ -153,7 +152,7 @@ class PHStreakFinder : public SubsysReco
   void set_create_tracks(bool b){_create_tracks = b;}
   void set_max_distance_to_origin(float val){ _max_dist_to_origin = val;}
   void set_min_nclusters(int n){ _min_nclusters = n;}
-  
+
  protected:
   int Setup(PHCompositeNode *topNode);
   int GetNodes(PHCompositeNode* topNode);

--- a/offline/packages/trackreco/PrelimDistortionCorrection.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.cc
@@ -14,8 +14,6 @@
 
 #include <phfield/PHField.h>
 #include <phfield/PHFieldUtility.h>
-#include <phfield/PHFieldConfig.h>
-#include <phfield/PHFieldConfigv1.h>
 
 #include <phool/PHTimer.h>
 #include <phool/getClass.h>
@@ -61,42 +59,15 @@ int PrelimDistortionCorrection::InitRun(PHCompositeNode* topNode)
   int ret = get_nodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret; }
 
-  PHFieldConfigv1 fcfg;
-  fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
+  // both configurations are identical, use field map from node tree
+  _field_map = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
-  // load magnetic field map from CDB
-  auto magField = CDBInterface::instance()->getUrl("FIELDMAP_TRACKING");
-  fcfg.set_filename(magField);
-
-  // compare field config from that on node tree
-  /*
-   * if the magnetic field is already on the node tree PHFieldUtility::GetFieldConfigNode returns the existing configuration.
-   * One must then check wheter the two configurations are identical, to decide whether one must use the field from node tree or create our own.
-   * Otherwise the configuration passed as argument is stored on the node tree.
-   */
-  const auto node_fcfg = PHFieldUtility::GetFieldConfigNode(&fcfg, topNode);
-  if( fcfg == *node_fcfg )
-  {
-    // both configurations are identical, use field map from node tree
-    std::cout << "PrelimDistortionCorrection::InitRun - using field map found from node tree" << std::endl;
-    _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
-    m_own_fieldmap = false;
-  } else {
-    // both configurations differ. Use our own field map
-    std::cout << "PrelimDistortionCorrection::InitRun - using own field map" << std::endl;
-    _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
-    m_own_fieldmap = true;
-  }
-
-  fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map, _fieldDir,
-				     _min_clusters_per_track,_max_sin_phi,Verbosity());
+  fitter = std::make_unique<ALICEKF>(_cluster_map,_field_map, _min_clusters_per_track,_max_sin_phi,Verbosity());
   fitter->setNeonFraction(Ne_frac);
   fitter->setArgonFraction(Ar_frac);
   fitter->setCF4Fraction(CF4_frac);
   fitter->setNitrogenFraction(N2_frac);
   fitter->setIsobutaneFraction(isobutane_frac);
-  fitter->useConstBField(_use_const_field);
-  fitter->setConstBField(_const_field);
   fitter->useFixedClusterError(_use_fixed_clus_err);
   fitter->setFixedClusterError(0,_fixed_clus_err.at(0));
   fitter->setFixedClusterError(1,_fixed_clus_err.at(1));

--- a/offline/packages/trackreco/PrelimDistortionCorrection.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.cc
@@ -12,9 +12,6 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
-#include <g4detectors/PHG4TpcCylinderGeom.h>
-#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
-
 #include <phfield/PHField.h>
 #include <phfield/PHFieldUtility.h>
 #include <phfield/PHFieldConfig.h>
@@ -50,13 +47,6 @@
 PrelimDistortionCorrection::PrelimDistortionCorrection(const std::string& name)
   : SubsysReco(name)
 {}
-
-//______________________________________________________
-PrelimDistortionCorrection::~PrelimDistortionCorrection()
-{
-  if( m_own_fieldmap )
-  { delete _field_map; }
-}
 
 //___________________________________________________________________________________________
 int PrelimDistortionCorrection::End(PHCompositeNode* /*unused*/)
@@ -171,19 +161,6 @@ int PrelimDistortionCorrection::get_nodes(PHCompositeNode* topNode)
   {
     std::cerr << PHWHERE << "PrelimDistortionCorrection::get_nodes - ERROR: Can't find TrackSeedContainer " << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  PHG4TpcCylinderGeomContainer *geom_container =
-      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-  if (!geom_container)
-  {
-    std::cerr << PHWHERE << "PrelimDistortionCorrection::get_nodes - ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
-
-  for(int i=7;i<=54;i++)
-  {
-    radii.push_back(geom_container->GetLayerCellGeom(i)->get_radius());
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -331,7 +308,7 @@ int PrelimDistortionCorrection::process_event(PHCompositeNode* /*topNode*/)
 }
 
 //____________________________________________________________________________________________________________
-void PrelimDistortionCorrection::publishSeeds(std::vector<TrackSeed_v2>& seeds, PositionMap& positions)
+void PrelimDistortionCorrection::publishSeeds(std::vector<TrackSeed_v2>& seeds, const PrelimDistortionCorrection::PositionMap& positions) const
 {
   int seed_index = 0;
   for(auto& seed: seeds )

--- a/offline/packages/trackreco/PrelimDistortionCorrection.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.h
@@ -82,9 +82,6 @@ class PrelimDistortionCorrection : public SubsysReco
   int get_nodes(PHCompositeNode *topNode);
 
   size_t _min_clusters_per_track = 3;
-
-  //! internal conversion factor
-  double _fieldDir = -1;
   double _max_sin_phi = 1.;
   bool _pp_mode = false;
 
@@ -94,7 +91,6 @@ class PrelimDistortionCorrection : public SubsysReco
 
   //! magnetic field map
   PHField* _field_map = nullptr;
-  bool m_own_fieldmap = false;
 
   /// acts geometry
   ActsGeometry *_tgeometry = nullptr;
@@ -109,8 +105,6 @@ class PrelimDistortionCorrection : public SubsysReco
 
   std::unique_ptr<ALICEKF> fitter;
 
-  bool _use_const_field = false;
-  float _const_field = 1.4;
   bool _use_fixed_clus_err = false;
   std::array<double,3> _fixed_clus_err = {.1,.1,.1};
 

--- a/offline/packages/trackreco/PrelimDistortionCorrection.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.h
@@ -14,7 +14,6 @@
 #include <fun4all/SubsysReco.h>
 #include <tpc/TpcDistortionCorrection.h>
 #include <trackbase/TrkrDefs.h>
-#include <Acts/MagneticField/MagneticFieldProvider.hpp>
 
 #include <Eigen/Core>
 
@@ -28,32 +27,35 @@ class PHCompositeNode;
 class PHField;
 class TpcDistortionCorrectionContainer;
 class TrkrClusterContainer;
-class TrkrClusterIterationMapv1;
 class SvtxTrackMap;
 class TrackSeedContainer;
 class TrackSeed_v2;
 
-using PositionMap = std::map<TrkrDefs::cluskey, Acts::Vector3>;
-
 class PrelimDistortionCorrection : public SubsysReco
 {
- public:
+  public:
+
   PrelimDistortionCorrection(const std::string &name = "PrelimDistortionCorrection");
-  ~PrelimDistortionCorrection() override;
+
+  //! default destructor
+  ~PrelimDistortionCorrection() override = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
-  void set_field_dir(const double rescale)
-  {
-    _fieldDir = 1;
-    if(rescale > 0)
-      { _fieldDir = -1; }
-  }
-  void set_max_window(double s){_max_dist = s;}
-  void useConstBField(bool opt){_use_const_field = opt;}
-  void setConstBField(float b) { _const_field = b; }
+  //! noop
+  void set_field_dir(double)
+  {}
+
+  //! noop
+  void useConstBField(bool)
+  {}
+
+  //! noop
+  void setConstBField(float)
+  {}
+
   void useFixedClusterError(bool opt){_use_fixed_clus_err = opt;}
   void setFixedClusterError(int i, double val){_fixed_clus_err.at(i) = val;}
   void use_truth_clusters(bool truth) { _use_truth_clusters = truth; }
@@ -68,7 +70,8 @@ class PrelimDistortionCorrection : public SubsysReco
  private:
 
   //! put refitted seeds on map
-  void publishSeeds(std::vector<TrackSeed_v2>& seeds, PositionMap &positions);
+  using PositionMap = std::map<TrkrDefs::cluskey, Acts::Vector3>;
+  void publishSeeds(std::vector<TrackSeed_v2>& seeds, const PositionMap &positions) const;
 
   /// tpc distortion correction utility class
   TpcDistortionCorrection m_distortionCorrection;
@@ -77,17 +80,10 @@ class PrelimDistortionCorrection : public SubsysReco
 
   /// fetch node pointers
   int get_nodes(PHCompositeNode *topNode);
-  std::vector<double> radii;
-  std::vector<double> _vertex_x;
-  std::vector<double> _vertex_y;
-  std::vector<double> _vertex_z;
-  std::vector<double> _vertex_xerr;
-  std::vector<double> _vertex_yerr;
-  std::vector<double> _vertex_zerr;
-  std::vector<double> _vertex_ids;
-  //double _Bz = 1.4*_Bzconst;
-  double _max_dist = .05;
+
   size_t _min_clusters_per_track = 3;
+
+  //! internal conversion factor
   double _fieldDir = -1;
   double _max_sin_phi = 1.;
   bool _pp_mode = false;

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
@@ -12,13 +12,9 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
-#include <g4detectors/PHG4TpcCylinderGeom.h>
-#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 #include <phfield/PHField.h>
 #include <phfield/PHFieldUtility.h>
-#include <phfield/PHFieldConfig.h>
-#include <phfield/PHFieldConfigv1.h>
 
 #include <phool/PHTimer.h>
 #include <phool/getClass.h>
@@ -51,13 +47,6 @@ PrelimDistortionCorrectionAuAu::PrelimDistortionCorrectionAuAu(const std::string
   : SubsysReco(name)
 {}
 
-//______________________________________________________
-PrelimDistortionCorrectionAuAu::~PrelimDistortionCorrectionAuAu()
-{
-  if( m_own_fieldmap )
-  { delete _field_map; }
-}
-
 //___________________________________________________________________________________________
 int PrelimDistortionCorrectionAuAu::End(PHCompositeNode* /*unused*/)
 {
@@ -71,32 +60,8 @@ int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
   int ret = get_nodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret; }
 
-  PHFieldConfigv1 fcfg;
-  fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
-
-  // load magnetic field map from CDB
-  auto magField = CDBInterface::instance()->getUrl("FIELDMAP_TRACKING");
-  fcfg.set_filename(magField);
-
-  // compare field config from that on node tree
-  /*
-   * if the magnetic field is already on the node tree PHFieldUtility::GetFieldConfigNode returns the existing configuration.
-   * One must then check wheter the two configurations are identical, to decide whether one must use the field from node tree or create our own.
-   * Otherwise the configuration passed as argument is stored on the node tree.
-   */
-  const auto node_fcfg = PHFieldUtility::GetFieldConfigNode(&fcfg, topNode);
-  if( fcfg == *node_fcfg )
-  {
-    // both configurations are identical, use field map from node tree
-    std::cout << "PrelimDistortionCorrectionAuAu::InitRun - using field map found from node tree" << std::endl;
-    _field_map = PHFieldUtility::GetFieldMapNode(&fcfg, topNode);
-    m_own_fieldmap = false;
-  } else {
-    // both configurations differ. Use our own field map
-    std::cout << "PrelimDistortionCorrectionAuAu::InitRun - using own field map" << std::endl;
-    _field_map = PHFieldUtility::BuildFieldMap(&fcfg);
-    m_own_fieldmap = true;
-  }
+  // load magnetic field from node tree
+  _field_map = PHFieldUtility::GetFieldMapNode();
 
   fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map, _fieldDir,
 				     _min_clusters_per_track,_max_sin_phi,Verbosity());
@@ -105,14 +70,10 @@ int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
   fitter->setCF4Fraction(CF4_frac);
   fitter->setNitrogenFraction(N2_frac);
   fitter->setIsobutaneFraction(isobutane_frac);
-  fitter->useConstBField(_use_const_field);
-  fitter->setConstBField(_const_field);
   fitter->useFixedClusterError(_use_fixed_clus_err);
   fitter->setFixedClusterError(0,_fixed_clus_err.at(0));
   fitter->setFixedClusterError(1,_fixed_clus_err.at(1));
   fitter->setFixedClusterError(2,_fixed_clus_err.at(2));
-  //  _field_map = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
-  // m_Cache = magField->makeCache(m_tGeometry->magFieldContext);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -171,19 +132,6 @@ int PrelimDistortionCorrectionAuAu::get_nodes(PHCompositeNode* topNode)
   {
     std::cerr << PHWHERE << "PrelimDistortionCorrectionAuAu::get_nodes - ERROR: Can't find TrackSeedContainer " << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  PHG4TpcCylinderGeomContainer *geom_container =
-      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-  if (!geom_container)
-  {
-    std::cerr << PHWHERE << "PrelimDistortionCorrectionAuAu::get_nodes - ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
-
-  for(int i=7;i<=54;i++)
-  {
-    radii.push_back(geom_container->GetLayerCellGeom(i)->get_radius());
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -332,7 +280,7 @@ int PrelimDistortionCorrectionAuAu::process_event(PHCompositeNode* /*topNode*/)
 }
 
 //____________________________________________________________________________________________________________
-void PrelimDistortionCorrectionAuAu::publishSeeds(std::vector<TrackSeed_v2>& seeds, PositionMap& positions)
+void PrelimDistortionCorrectionAuAu::publishSeeds(std::vector<TrackSeed_v2>& seeds, const PrelimDistortionCorrectionAuAu::PositionMap& positions) const
 {
   int seed_index = 0;
   for(auto& seed: seeds )

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.cc
@@ -61,10 +61,9 @@ int PrelimDistortionCorrectionAuAu::InitRun(PHCompositeNode* topNode)
   if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret; }
 
   // load magnetic field from node tree
-  _field_map = PHFieldUtility::GetFieldMapNode();
+  _field_map = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
-  fitter = std::make_unique<ALICEKF>(topNode,_cluster_map,_field_map, _fieldDir,
-				     _min_clusters_per_track,_max_sin_phi,Verbosity());
+  fitter = std::make_unique<ALICEKF>(_cluster_map,_field_map, _min_clusters_per_track,_max_sin_phi,Verbosity());
   fitter->setNeonFraction(Ne_frac);
   fitter->setArgonFraction(Ar_frac);
   fitter->setCF4Fraction(CF4_frac);

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
@@ -14,7 +14,6 @@
 #include <fun4all/SubsysReco.h>
 #include <tpc/TpcDistortionCorrection.h>
 #include <trackbase/TrkrDefs.h>
-#include <Acts/MagneticField/MagneticFieldProvider.hpp>
 
 #include <Eigen/Core>
 
@@ -28,32 +27,36 @@ class PHCompositeNode;
 class PHField;
 class TpcDistortionCorrectionContainer;
 class TrkrClusterContainer;
-class TrkrClusterIterationMapv1;
 class SvtxTrackMap;
 class TrackSeedContainer;
 class TrackSeed_v2;
 
-using PositionMap = std::map<TrkrDefs::cluskey, Acts::Vector3>;
-
 class PrelimDistortionCorrectionAuAu : public SubsysReco
 {
  public:
+
+  //! constructor
   PrelimDistortionCorrectionAuAu(const std::string &name = "PrelimDistortionCorrectionAuAu");
-  ~PrelimDistortionCorrectionAuAu() override;
+
+  //! default destructor
+  ~PrelimDistortionCorrectionAuAu() override = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
-  void set_field_dir(const double rescale)
-  {
-    _fieldDir = 1;
-    if(rescale > 0)
-      { _fieldDir = -1; }
-  }
-  void set_max_window(double s){_max_dist = s;}
-  void useConstBField(bool opt){_use_const_field = opt;}
-  void setConstBField(float b) { _const_field = b; }
+  // noop
+  void set_field_dir(double)
+  {}
+
+  // noop
+  void useConstBField(bool)
+  {}
+
+  // noop
+  void setConstBField(float)
+  {}
+
   void useFixedClusterError(bool opt){_use_fixed_clus_err = opt;}
   void setFixedClusterError(int i, double val){_fixed_clus_err.at(i) = val;}
   void use_truth_clusters(bool truth) { _use_truth_clusters = truth; }
@@ -68,7 +71,8 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
  private:
 
   //! put refitted seeds on map
-  void publishSeeds(std::vector<TrackSeed_v2>& seeds, PositionMap &positions);
+  using PositionMap = std::map<TrkrDefs::cluskey, Acts::Vector3>;
+  void publishSeeds(std::vector<TrackSeed_v2>& seeds, const PositionMap &positions) const;
 
   /// tpc distortion correction utility class
   TpcDistortionCorrection m_distortionCorrection;
@@ -77,18 +81,12 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
 
   /// fetch node pointers
   int get_nodes(PHCompositeNode *topNode);
-  std::vector<double> radii;
-  std::vector<double> _vertex_x;
-  std::vector<double> _vertex_y;
-  std::vector<double> _vertex_z;
-  std::vector<double> _vertex_xerr;
-  std::vector<double> _vertex_yerr;
-  std::vector<double> _vertex_zerr;
-  std::vector<double> _vertex_ids;
-  //double _Bz = 1.4*_Bzconst;
-  double _max_dist = .05;
+
   size_t _min_clusters_per_track = 3;
+
+  //! internal sign flip for field direction to get the correct charge from kalman filter
   double _fieldDir = -1;
+
   double _max_sin_phi = 1.;
   bool _pp_mode = false;
 
@@ -98,7 +96,6 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
 
   //! magnetic field map
   PHField* _field_map = nullptr;
-  bool m_own_fieldmap = false;
 
   /// acts geometry
   ActsGeometry *_tgeometry = nullptr;
@@ -113,8 +110,6 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
 
   std::unique_ptr<ALICEKF> fitter;
 
-  bool _use_const_field = false;
-  float _const_field = 1.4;
   bool _use_fixed_clus_err = false;
   std::array<double,3> _fixed_clus_err = {.1,.1,.1};
 

--- a/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
+++ b/offline/packages/trackreco/PrelimDistortionCorrectionAuAu.h
@@ -83,10 +83,6 @@ class PrelimDistortionCorrectionAuAu : public SubsysReco
   int get_nodes(PHCompositeNode *topNode);
 
   size_t _min_clusters_per_track = 3;
-
-  //! internal sign flip for field direction to get the correct charge from kalman filter
-  double _fieldDir = -1;
-
   double _max_sin_phi = 1.;
   bool _pp_mode = false;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
As discussed on Monday, this cleans up loading PHField from our various subsysreco.

- MakeActsGeometry is now responsible for building the magnetic field with the proper configuration as either setup in the macro or found on the node tree (for instance when runing simulations). 
- PHSimpleKFProp, PrelimDistortionCorrection, PHGenfitTrkFitter now gets whatever is on the node tree
- all the subsysreco specific flags to set the map name, or implement constant magnetic field are now Noop. They will be removed once the corresponding macros are updated. 
- it is still possible to centraly use a constant magnetic field, by setting G4MAGNET::magfield and G4MAGNET::magfield_tracking to e.g. "1.4" in the calling macro.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

