### PR TITLE
fix: switch to old channel map

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -616,12 +616,12 @@ AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
 	  continue;
 	}
 	varname = "phi";  // + std::to_string(key);
-	double phi = ((side == 1 ? 1 : -1) * (m_cdbttree->GetDoubleValue(key, varname) - M_PI / 2.)) + ((sector % 12) * M_PI / 6);
+      double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) + (sector % 12) * M_PI / 6;
 	PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
-	unsigned int phibin = layergeom->get_phibin(phi, side);
+	unsigned int phibin = layergeom->get_phibin(phi);
 	//get global coords
 	double radius = layergeom->get_radius();  // returns center of layer
-	double chanphi = layergeom->get_phi(phibin, side);
+	double chanphi = layergeom->get_phi(phibin);
 	float chanx = radius * cos(chanphi);
 	float chany = radius * sin(chanphi);
     


### PR DESCRIPTION
The build failed because I merged Christof's dE/dx changes without pulling them and retesting the channel map revert. This fixes the TrackingDiagnostics build

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

