### PR TITLE
Improved--flexibility in KFP for detector info

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -35,9 +35,14 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
                   std::vector<KFParticle> intermediates);
 
   float calc_secondary_vertex_mass_noPID(std::vector<KFParticle> kfp_daughters);
-
+  
   bool fillConditionMet();
 
+  void GetDetailedTracking(bool set_variable = true) { 
+    m_get_detailed_tracking = set_variable; 
+    if(m_get_detailed_tracking){m_detector_info = true;}
+  }
+  
  protected:
   bool m_has_intermediates_nTuple {false};
   bool m_extrapolateTracksToSV_nTuple{true};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -1081,11 +1081,14 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
 
 void KFParticle_truthAndDetTools::initializeDetectorBranches(TTree *m_tree, int daughter_id, const std::string &daughter_number)
 {
-  m_tree->Branch((daughter_number + "_residual_x").c_str(), &residual_x[daughter_id]);
-  m_tree->Branch((daughter_number + "_residual_y").c_str(), &residual_y[daughter_id]);
-  m_tree->Branch((daughter_number + "_residual_z").c_str(), &residual_z[daughter_id]);
-  m_tree->Branch((daughter_number + "_layer").c_str(), &detector_layer[daughter_id]);
 
+  if(m_get_detailed_tracking){
+    m_tree->Branch((daughter_number + "_residual_x").c_str(), &residual_x[daughter_id]);
+    m_tree->Branch((daughter_number + "_residual_y").c_str(), &residual_y[daughter_id]);
+    m_tree->Branch((daughter_number + "_residual_z").c_str(), &residual_z[daughter_id]);
+    m_tree->Branch((daughter_number + "_layer").c_str(), &detector_layer[daughter_id]);
+  }
+  
   for (auto const &subdetector : Use)
   {
     if (subdetector.second)
@@ -1094,27 +1097,32 @@ void KFParticle_truthAndDetTools::initializeDetectorBranches(TTree *m_tree, int 
     }
   }
 }
-
 void KFParticle_truthAndDetTools::initializeSubDetectorBranches(TTree *m_tree, const std::string &detectorName, int daughter_id, const std::string &daughter_number)
 {
   if (detectorName == "MVTX")
   {
+    if(m_get_detailed_tracking){
     m_tree->Branch((daughter_number + "_" + detectorName + "_staveID").c_str(), &mvtx_staveID[daughter_id]);
     m_tree->Branch((daughter_number + "_" + detectorName + "_chipID").c_str(), &mvtx_chipID[daughter_id]);
+    }
     m_tree->Branch((daughter_number + "_" + detectorName + "_nHits").c_str(), &detector_nHits_MVTX[daughter_id]);
     m_tree->Branch((daughter_number + "_" + detectorName + "_nStates").c_str(), &detector_nStates_MVTX[daughter_id]);
   }
   if (detectorName == "INTT")
   {
+    if(m_get_detailed_tracking){
     m_tree->Branch((daughter_number + "_" + detectorName + "_ladderZID").c_str(), &intt_ladderZID[daughter_id]);
     m_tree->Branch((daughter_number + "_" + detectorName + "_ladderPhiID").c_str(), &intt_ladderPhiID[daughter_id]);
+    }
     m_tree->Branch((daughter_number + "_" + detectorName + "_nHits").c_str(), &detector_nHits_INTT[daughter_id]);
     m_tree->Branch((daughter_number + "_" + detectorName + "_nStates").c_str(), &detector_nStates_INTT[daughter_id]);
   }
   if (detectorName == "TPC")
   {
+    if(m_get_detailed_tracking){
     m_tree->Branch((daughter_number + "_" + detectorName + "_sectorID").c_str(), &tpc_sectorID[daughter_id]);
     m_tree->Branch((daughter_number + "_" + detectorName + "_side").c_str(), &tpc_side[daughter_id]);
+    }
     m_tree->Branch((daughter_number + "_" + detectorName + "_nHits").c_str(), &detector_nHits_TPC[daughter_id]);
     m_tree->Branch((daughter_number + "_" + detectorName + "_nStates").c_str(), &detector_nStates_TPC[daughter_id]);
   }
@@ -1185,13 +1193,15 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
         ladderPhiId = InttDefs::getLadderPhiId(cluster_key);
         ++detector_nHits_INTT[daughter_id];
       }
-
+      
+      if(m_get_detailed_tracking){
       mvtx_staveID[daughter_id].push_back(staveId);
       mvtx_chipID[daughter_id].push_back(chipId);
       intt_ladderZID[daughter_id].push_back(ladderZId);
       intt_ladderPhiID[daughter_id].push_back(ladderPhiId);
       tpc_sectorID[daughter_id].push_back(sectorId);
       tpc_side[daughter_id].push_back(side);
+      }
     }
   }
 
@@ -1223,12 +1233,14 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
         ++detector_nHits_TPOT[daughter_id];
       }
 
+      if(m_get_detailed_tracking){
       mvtx_staveID[daughter_id].push_back(staveId);
       mvtx_chipID[daughter_id].push_back(chipId);
       intt_ladderZID[daughter_id].push_back(ladderZId);
       intt_ladderPhiID[daughter_id].push_back(ladderPhiId);
       tpc_sectorID[daughter_id].push_back(sectorId);
       tpc_side[daughter_id].push_back(side);
+      }
     }
   }
 
@@ -1247,10 +1259,12 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
         continue;
       }
       auto global = geometry->getGlobalPosition(stateckey, cluster);
-
+      
+      if(m_get_detailed_tracking){
       residual_x[daughter_id].push_back(global.x() - tstate->get_x());
       residual_y[daughter_id].push_back(global.y() - tstate->get_y());
       residual_z[daughter_id].push_back(global.z() - tstate->get_z());
+      }
 
       uint8_t id = TrkrDefs::getTrkrId(stateckey);
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -83,7 +83,7 @@ class KFParticle_truthAndDetTools
     if (deltaPhi < -M_PI) deltaPhi += 2 * M_PI;
     return deltaPhi;
   }
-
+  
   // Functions to set cuts
   void set_emcal_radius_user(float set_variable) { m_emcal_radius_user = set_variable; }
   void set_emcal_e_low_cut(float set_variable) { m_emcal_e_low_cut = set_variable; }
@@ -91,8 +91,10 @@ class KFParticle_truthAndDetTools
   void set_dphi_cut_high(float set_variable) { m_dphi_cut_high = set_variable; }
   void set_dz_cut_low(float set_variable) { m_dz_cut_low = set_variable; }
   void set_dz_cut_high(float set_variable) { m_dz_cut_high = set_variable; }
-
- protected:
+  
+  
+  protected:
+  bool m_get_detailed_tracking{true};
   bool m_use_mbd_vertex_truth{false};
   bool m_dont_use_global_vertex_truth{false};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
In this PR:
- Renamed  `get_detailed_tracking()` to `GetDetailedTracking()` to be more consistent with other public functions. This function is now defined in `KFParticle_nTuple.h` so that it can also update `m_detector_info`. 
- Implemented Cameron's comments on previous PR; users will now automatically get all detector info when `GetDetailedTracking()` is used to set `m_get_detailed_tracking` to `true`. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR will allow the user to specify what detector info they would like KFP to store.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
[Here](https://github.com/sPHENIX-Collaboration/coresoftware/pull/3810) is the old PR I closed. I think I messed it up by syncing it to the main branch. 

