### PR TITLE
fix:histoname typo

### DIFF
--- a/offline/QA/Tracking/TpcSeedsQA.cc
+++ b/offline/QA/Tracking/TpcSeedsQA.cc
@@ -1244,7 +1244,7 @@ void TpcSeedsQA::createHistos()
     h_clusphisizegeq1pt_side1[region]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
     hm->registerHisto(h_clusphisizegeq1pt_side1[region]);
 
-    h_cluster_phisize1_fraction_side0[region] = new TH1F(std::format("{}sclusphisize1frac_side0_{}", getHistoPrefix(), region).c_str(),
+    h_cluster_phisize1_fraction_side0[region] = new TH1F(std::format("{}clusphisize1frac_side0_{}", getHistoPrefix(), region).c_str(),
                                                          std::format("Fraction of TPC Cluster Phi Size == 1, side 0, region_{}", region).c_str(), 100, 0, 1);
     h_cluster_phisize1_fraction_side0[region]->GetXaxis()->SetTitle("Fraction");
     hm->registerHisto(h_cluster_phisize1_fraction_side0[region]);


### PR DESCRIPTION
Finally managed to clear my eyes and find this hidden single letter typo in the qa histogram name that was causing the tpc seeds qa to not properly draw

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

