### PR TITLE
Improvements to sEPD software

### DIFF
--- a/offline/packages/CaloReco/CaloTowerCalib.cc
+++ b/offline/packages/CaloReco/CaloTowerCalib.cc
@@ -237,6 +237,13 @@ int CaloTowerCalib::process_event(PHCompositeNode *topNode)
     float calibconst = cdbttree->GetFloatValue(key, m_fieldname);
     bool isZS = caloinfo_raw->get_isZS();
 
+    if (calibconst <= 0)
+    {
+      _calib_towers->get_tower_at_channel(channel)->set_energy(0.0);
+      _calib_towers->get_tower_at_channel(channel)->set_isNoCalib(true);
+      continue;
+    }
+
     if (isZS && m_doZScrosscalib)
     {
       float crosscalibconst = cdbttree_ZScrosscalib->GetFloatValue(key, m_fieldname_ZScrosscalib);
@@ -249,11 +256,6 @@ int CaloTowerCalib::process_event(PHCompositeNode *topNode)
     else
     {
       _calib_towers->get_tower_at_channel(channel)->set_energy(raw_amplitude * calibconst);
-    }
-   
-    if (calibconst == 0)
-    {
-      _calib_towers->get_tower_at_channel(channel)->set_isNoCalib(true);
     }
     if(m_dotimecalib)
     {


### PR DESCRIPTION
This PR adds support for applying the sEPD calibration in CaloTowerCalib and for adding the sEPD geometry to the node tree using the RawTowerGeomContainer, in keeping with the conventions followed by calorimeter software.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
As discussed at the BulkTG meeting: https://indico.bnl.gov/event/29269/
Note that this requires the calibrations file to use the tower key to index channels.

## TODOs (if applicable)
Consider moving sEPDGeomMapping functionality into CaloGeomMapping.
Change sEPD calibration files to store (1/MPV) rather than MPV so that no special cases are needed in CaloTowerCalib.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

Corresponding changes in production macros at this PR: https://github.com/sPHENIX-Collaboration/macros/pull/1176