### PR TITLE
Calo packet skimmer histogram counting

### DIFF
--- a/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.cc
+++ b/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.cc
@@ -1,7 +1,7 @@
-
 #include "CaloPacketSkimmer.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
@@ -10,11 +10,16 @@
 #include <ffarawobjects/CaloPacketContainer.h>
 #include <variant>
 
+#include <qautils/QAHistManagerDef.h>
+
 #include <phool/getClass.h>
 
+
+#include <cassert>
 #include <iostream>  // for operator<<, basic_ostream
 #include <map>       // for operator!=, _Rb_tree_iterator
 #include <utility>   // for pair
+#include <TH1.h>
 
 static const std::map<CaloTowerDefs::DetectorSystem, std::string> nodemap{
     {CaloTowerDefs::CEMC, "CEMCPackets"},
@@ -43,6 +48,13 @@ int CaloPacketSkimmer::InitRun(PHCompositeNode * /*topNode*/)
     std::cout << std::endl;
   }
 
+  auto* hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  h_aborted_events = new TH1D("h_caloskimmer_aborted_events", "Aborted Events", 1, 0, 1);
+  h_aborted_events->SetDirectory(nullptr);
+  hm->registerHisto(h_aborted_events);
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -61,8 +73,9 @@ int CaloPacketSkimmer::process_event(PHCompositeNode *topNode)
     {
       if (Verbosity() > 1)
       {
-        std::cout << "CaloPacketSkimmer: Skipping event due to failure in detector: " << getDetectorName(det) << std::endl;
+        std::cout << "CaloPacketSkimmer::process_event - Detector " << getDetectorName(det) << " failed" << std::endl;
       }
+      h_aborted_events->Fill(1); // Increment histogram for aborted events
       return ret;
     }
   }

--- a/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.cc
+++ b/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.cc
@@ -55,6 +55,10 @@ int CaloPacketSkimmer::InitRun(PHCompositeNode * /*topNode*/)
   h_aborted_events->SetDirectory(nullptr);
   hm->registerHisto(h_aborted_events);
 
+  h_kept_events = new TH1D("h_caloskimmer_kept_events", "Kept Events", 1, 0, 1);
+  h_kept_events->SetDirectory(nullptr);
+  hm->registerHisto(h_kept_events);
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -80,6 +84,7 @@ int CaloPacketSkimmer::process_event(PHCompositeNode *topNode)
     }
   }
 
+  h_kept_events->Fill(1); // Increment histogram for kept events
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.h
+++ b/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.h
@@ -25,7 +25,7 @@ class CaloPacketSkimmer : public SubsysReco
   {
     m_CaloDetectors = {CaloTowerDefs::CEMC, CaloTowerDefs::HCALIN,
                        CaloTowerDefs::HCALOUT, CaloTowerDefs::SEPD,
-                       CaloTowerDefs::ZDC};
+                       CaloTowerDefs::ZDC, CaloTowerDefs::MBD};
   }
 
   void set_detector_on(CaloTowerDefs::DetectorSystem det)
@@ -44,7 +44,7 @@ class CaloPacketSkimmer : public SubsysReco
  private:
   std::vector<CaloTowerDefs::DetectorSystem> m_CaloDetectors{
       CaloTowerDefs::CEMC, CaloTowerDefs::HCALIN, CaloTowerDefs::HCALOUT,
-      CaloTowerDefs::SEPD, CaloTowerDefs::ZDC};
+      CaloTowerDefs::SEPD, CaloTowerDefs::ZDC, CaloTowerDefs::MBD};
   bool m_UseOfflinePacketFlag{true};
   bool m_PacketNodesFlag{false};
 

--- a/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.h
+++ b/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <TH1D.h>
 
 class PHCompositeNode;
 
@@ -90,6 +91,8 @@ class CaloPacketSkimmer : public SubsysReco
       return {0, 0};  // Invalid range
     }
   }
+
+  TH1D* h_aborted_events{nullptr};
 };
 
 #endif

--- a/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.h
+++ b/offline/packages/Skimmers/CaloPacket/CaloPacketSkimmer.h
@@ -93,6 +93,7 @@ class CaloPacketSkimmer : public SubsysReco
   }
 
   TH1D* h_aborted_events{nullptr};
+  TH1D* h_kept_events{nullptr};
 };
 
 #endif

--- a/offline/packages/Skimmers/CaloPacket/Makefile.am
+++ b/offline/packages/Skimmers/CaloPacket/Makefile.am
@@ -24,7 +24,8 @@ libCaloPacketSkimmer_la_LIBADD = \
   -lSubsysReco \
   -lcalo_io \
   -lffarawobjects \
-  -lg4jets
+  -lg4jets \
+  -lqautils
 
 
 BUILT_SOURCES = testexternals.cc


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

add two histogram counting for kept events and skipped events


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

