### PR TITLE
Kf particle

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1183,21 +1183,20 @@ float KFParticle_Tools::get_dEdx(PHCompositeNode *topNode, const KFParticle &dau
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   m_geom_container = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-  if(!m_cluster_map || !m_geom_container)
+  if(!m_cluster_map || !m_geom_container || !geometry)
   {
-    std::cout << "Can't continue in KFParticle_Tools::get_dEdx, returning -1" << std::endl;
     return -1.0;
   }
 
   SvtxTrack *daughter_track = toolSet.getTrack(daughter.Id(), m_dst_trackmap);
   TrackSeed *tpcseed = daughter_track->get_tpc_seed();
   float layerThicknesses[4] = {0.0, 0.0, 0.0, 0.0};
-      // These are randomly chosen layer thicknesses for the TPC, to get the
-      // correct region thicknesses in an easy to pass way to the helper fxn
-      layerThicknesses[0] = m_geom_container->GetLayerCellGeom(7)->get_thickness();
-      layerThicknesses[1] = m_geom_container->GetLayerCellGeom(8)->get_thickness();
-      layerThicknesses[2] = m_geom_container->GetLayerCellGeom(27)->get_thickness();
-      layerThicknesses[3] = m_geom_container->GetLayerCellGeom(50)->get_thickness();
+  // These are randomly chosen layer thicknesses for the TPC, to get the
+  // correct region thicknesses in an easy to pass way to the helper fxn
+  layerThicknesses[0] = m_geom_container->GetLayerCellGeom(7)->get_thickness();
+  layerThicknesses[1] = m_geom_container->GetLayerCellGeom(8)->get_thickness();
+  layerThicknesses[2] = m_geom_container->GetLayerCellGeom(27)->get_thickness();
+  layerThicknesses[3] = m_geom_container->GetLayerCellGeom(50)->get_thickness();
 
   return TrackAnalysisUtils::calc_dedx(tpcseed, m_cluster_map, geometry, layerThicknesses);
     

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -234,7 +234,7 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
     m_tree->Branch(TString(daughter_number) + "_track_ID", &m_calculated_daughter_trid[i], TString(daughter_number) + "_track_ID/I");
     m_tree->Branch(TString(daughter_number) + "_PDG_ID", &m_calculated_daughter_pdgID[i], TString(daughter_number) + "_PDG_ID/I");
     m_tree->Branch(TString(daughter_number) + "_Covariance", &m_calculated_daughter_cov[i], TString(daughter_number) + "_Covariance[21]/F", 21);
-    if (m_use_PID_nTuple) m_tree->Branch(TString(daughter_number) + "_calculated_dEdx", &m_calculated_daughter_dedx[i], TString(daughter_number) + "_calculated_dEdx/F");
+    m_tree->Branch(TString(daughter_number) + "_calculated_dEdx", &m_calculated_daughter_dedx[i], TString(daughter_number) + "_calculated_dEdx/F");
     //m_tree->Branch(TString(daughter_number) + "_expected_pion_dEdx", &m_calculated_daughter_expected_dedx_pion[i], TString(daughter_number) + "_expected_pion_dEdx/F");
     //m_tree->Branch(TString(daughter_number) + "_expected_kaon_dEdx", &m_calculated_daughter_expected_dedx_kaon[i], TString(daughter_number) + "_expected_kaon_dEdx/F");
     //m_tree->Branch(TString(daughter_number) + "_expected_proton_dEdx", &m_calculated_daughter_expected_dedx_proton[i], TString(daughter_number) + "_expected_proton_dEdx/F");
@@ -524,7 +524,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     SvtxTrackMap *thisTrackMap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name_nTuple.c_str());
     SvtxTrack *thisTrack = getTrack(daughterArray[i].Id(), thisTrackMap);
     m_calculated_daughter_bunch_crossing[i] = thisTrack->get_crossing(); 
-    if (m_use_PID_nTuple) m_calculated_daughter_dedx[i] = kfpTupleTools.get_dEdx(topNode, daughterArray[i]);
+    m_calculated_daughter_dedx[i] = kfpTupleTools.get_dEdx(topNode, daughterArray[i]);
     //m_calculated_daughter_expected_dedx_pion[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 211);
     //m_calculated_daughter_expected_dedx_kaon[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 321);
     //m_calculated_daughter_expected_dedx_proton[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 2212);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -62,7 +62,6 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   bool m_use_intermediate_name {false};
   bool m_get_charge_conjugate_nTuple {false};
   bool m_use_fake_pv_nTuple {false};
-  bool m_use_PID_nTuple {false};
   std::vector<std::string> m_intermediate_name_ntuple;
 
  private:

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -391,7 +391,7 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void requireTrackVertexBunchCrossingMatch(bool require = true) { m_require_track_and_vertex_match = require; }
 
-  void usePID(bool use = true){ m_use_PID = m_use_PID_nTuple = use; }
+  void usePID(bool use = true){ m_use_PID = use; }
  
   void setPIDacceptFraction(float frac = 0.2){ m_dEdx_band_width = frac; }
 

--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -216,8 +216,14 @@ int DecayFinder::parseDecayDescriptor()
       }
       if (findParticle(daughter))
       {
-        m_daughters_ID.push_back(abs(get_pdgcode(daughter)));
+        int daughter_ID = abs(get_pdgcode(daughter));
+        m_daughters_ID.push_back(daughter_ID);
         daughters_charge.push_back(get_charge(daughter));
+
+        if (daughter_ID == 22)
+        {
+          m_hasPhotonDaughter = m_allowPhotons = true; 
+        }
       }
       else
       {
@@ -705,7 +711,7 @@ void DecayFinder::searchGeant4Record(int barcode, int pid, std::vector<int> deca
         hasPi0 = true;
       }
 
-      if ((!m_allowPhotons && particleID == 22) || (!m_allowPi0 && particleID == 111))
+      if ((!m_allowPhotons && particleID == 22) || (!m_hasPhotonDaughter && particleID == 22) || (!m_allowPi0 && particleID == 111))
       {
         breakLoop = true;
         break;
@@ -726,7 +732,7 @@ void DecayFinder::searchGeant4Record(int barcode, int pid, std::vector<int> deca
           decayChain.push_back(std::make_pair(std::make_pair(embedding_id, g4particle->get_barcode()), particleID));
         }
       }  // Now check if it's part of the other resonance list
-      else if ((m_allowPhotons && particleID == 22) || (m_allowPi0 && particleID == 111))
+      else if ((m_allowPhotons && !m_hasPhotonDaughter && particleID == 22) || (m_allowPi0 && particleID == 111))
       {
         continue;
       }
@@ -810,11 +816,11 @@ bool DecayFinder::checkIfCorrectHepMCParticle(HepMC::GenParticle* particle, bool
             std::cout << "--------greatgrandchildren->pdg_id(): " << (*greatgrandchildren)->pdg_id() << std::endl;
           }
 
-          if ((m_allowPhotons && (*greatgrandchildren)->pdg_id() == 22) || (m_allowPi0 && (*greatgrandchildren)->pdg_id() == 111))
+          if ((m_allowPhotons && !m_hasPhotonDaughter && (*greatgrandchildren)->pdg_id() == 22) || (m_allowPi0 && (*greatgrandchildren)->pdg_id() == 111))
           {
             continue;
           }
-          else if ((!m_allowPhotons && (*greatgrandchildren)->pdg_id() == 22) || (!m_allowPi0 && (*greatgrandchildren)->pdg_id() == 111))
+          else if ((!m_hasPhotonDaughter && (*greatgrandchildren)->pdg_id() == 22) || (!m_allowPhotons && (*greatgrandchildren)->pdg_id() == 22) || (!m_allowPi0 && (*greatgrandchildren)->pdg_id() == 111))
           {
             break;
           }
@@ -851,11 +857,11 @@ bool DecayFinder::checkIfCorrectHepMCParticle(HepMC::GenParticle* particle, bool
           }
         }
       }
-      else if ((m_allowPhotons && (*grandchildren)->pdg_id() == 22) || (m_allowPi0 && (*grandchildren)->pdg_id() == 111))
+      else if ((m_allowPhotons && !m_hasPhotonDaughter && (*grandchildren)->pdg_id() == 22) || (m_allowPi0 && (*grandchildren)->pdg_id() == 111))
       {
         continue;
       }
-      else if ((!m_allowPhotons && (*grandchildren)->pdg_id() == 22) || (!m_allowPi0 && (*grandchildren)->pdg_id() == 111))
+      else if ((!m_hasPhotonDaughter && (*grandchildren)->pdg_id() == 22) || (!m_allowPhotons && (*grandchildren)->pdg_id() == 22) || (!m_allowPi0 && (*grandchildren)->pdg_id() == 111))
       {
         break;
       }
@@ -894,10 +900,10 @@ bool DecayFinder::checkIfCorrectHepMCParticle(HepMC::GenParticle* particle, bool
 
     acceptParticle = compareDecays(requiredIntermediateDecayProducts, actualIntermediateDecayProducts);
   }
-  else if ((particle->pdg_id() == 22) || (particle->pdg_id() == 111))
-  {
-    return false;
-  }
+  //else if ((particle->pdg_id() == 22) || (particle->pdg_id() == 111))
+  //{
+  //  return false;
+  //}
   else
   {
     if (Verbosity() >= VERBOSITY_MAX)
@@ -983,10 +989,10 @@ bool DecayFinder::checkIfCorrectGeant4Particle(PHG4Particle* particle, bool& has
 
     acceptParticle = compareDecays(requiredIntermediateDecayProducts, actualIntermediateDecayProducts);
   }
-  else if ((particle->get_pid() == 22) || (particle->get_pid() == 111))
-  {
-    return false;
-  }
+  //else if ((particle->get_pid() == 22) || (particle->get_pid() == 111))
+  //{
+  //  return false;
+  //}
   else
   {
     if (Verbosity() >= VERBOSITY_MAX)

--- a/offline/packages/decayfinder/DecayFinder.h
+++ b/offline/packages/decayfinder/DecayFinder.h
@@ -186,6 +186,7 @@ class DecayFinder : public SubsysReco
   bool m_triggerOnDecay = false;
   bool m_allowPi0 = false;
   bool m_allowPhotons = false;
+  bool m_hasPhotonDaughter = false;
 
   int m_mother_ID = 0;
   std::vector<int> m_intermediates_ID;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

In response to issues seen in the eta -> yy analysis, I have removed the checks that would stop DecayFinder from classifying a photon as a final state particle so it can be used for efficiencies.

Appears to work as intended

```
Fun4AllServer::run - processing event 35 from run 1
parent->pdg_id(): 221
--children->pdg_id(): 22
This is a child you were looking for
This is a final state track
pT = 0.207, eta = -0.001
The track passed the pT requirement, the track passed the eta requirement.
--children->pdg_id(): 22
This is a child you were looking for
This is a final state track
pT = 0.794, eta = 0.603
The track passed the pT requirement, the track passed the eta requirement.
Printing required decay products: 22, 22, 
Printing actual decay products: 22, 22, 
*
* These vectors match
*

---------------- DecayFinderNode: myFinder_DecayMap information ----------------
Particle embedding ID: 1, particle barcode: 62, particle PDG ID: 221
Particle embedding ID: 1, particle barcode: 111, particle PDG ID: 22
Particle embedding ID: 1, particle barcode: 112, particle PDG ID: 22
--------------------------------------------------------------------------------------
---------------DecayFinder information---------------
Module name: myFinder
Decay descriptor: eta -> gamma^0 gamma^0
Number of generated decays: 30
  Number of decays that failed pT requirement: 1
  Number of decays that failed eta requirement: 13
  Number of decays that failed pT and eta requirements: 15
Number of decays that could be reconstructed: 1
  Number of reconstructable mothers with associated photon: 1
  Number of reconstructable mothers with associated Pi0: 0
  Number of reconstructable mothers with associated photon and Pi0: 0
  Number of reconstructable mothers with no associated photons or Pi0s: 0
-----------------------------------------------------
```

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

