### PR TITLE
fix: use uncalib dedx

### DIFF
--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.h
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.h
@@ -19,12 +19,14 @@ namespace TrackAnalysisUtils
   DCAPair get_dca(SvtxTrack* track, Acts::Vector3& vertex);
 
   std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track);
-  float calc_dedx(TrackSeed* tpcseed, TrkrClusterContainer* cluster_map,
-                  ActsGeometry* tgeometry,
-                  // this is the thickness from R1[0],R1[1],R2[2], and R4[3]. You need
-                  // to pass these from the geometry object, which keeps the dependencies
-                  // of this helper class minimal. This will also help us catch any changes
-                  // when/if the tpc geometry changes in the future. This is to get us going
+  float calc_dedx_calib(TrackSeed* tpcseed, TrkrClusterContainer* cluster_map,
+                        ActsGeometry* tgeometry,
+                        // this is the thickness from R1[0],R1[1],R2[2], and R4[3]. You need
+                        // to pass these from the geometry object, which keeps the dependencies
+                        // of this helper class minimal. This will also help us catch any changes
+                        // when/if the tpc geometry changes in the future. This is to get us going
+                        float thickness_per_region[4]);
+  float calc_dedx(TrackSeed* tpcseed, TrkrClusterContainer* clustermap, ActsGeometry* tgeometry,
                   float thickness_per_region[4]);
 
 };  // namespace TrackAnalysisUtils


### PR DESCRIPTION
Something about the new dedx function without the calibration has changed the behavior significantly. This changes the consolidated function to use the old version until we get the calibrations into the cdb, after which we can easily switch.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

