### PR TITLE
make SyncObject::EventNumber() public

### DIFF
--- a/offline/framework/ffaobjects/EventHeaderv1.cc
+++ b/offline/framework/ffaobjects/EventHeaderv1.cc
@@ -1,7 +1,7 @@
 #include "EventHeaderv1.h"
 
-#include <cmath>  // for NAN
 #include <iostream>
+#include <limits>
 #include <utility>  // for pair
 
 void EventHeaderv1::Reset()
@@ -65,7 +65,7 @@ float EventHeaderv1::get_floatval(const std::string &name) const
   {
     return iter->second;
   }
-  return NAN;
+  return std::numeric_limits<float>::quiet_NaN();
 }
 
 void EventHeaderv1::set_intval(const std::string &name, const int64_t ival)

--- a/offline/framework/ffaobjects/RunHeaderv1.cc
+++ b/offline/framework/ffaobjects/RunHeaderv1.cc
@@ -1,6 +1,6 @@
 #include "RunHeaderv1.h"
 
-#include <cmath>    // for NAN
+#include <limits>
 #include <utility>  // for pair
 
 void RunHeaderv1::identify(std::ostream &out) const
@@ -39,7 +39,7 @@ float RunHeaderv1::get_floatval(const std::string &name) const
   {
     return iter->second;
   }
-  return NAN;
+  return std::numeric_limits<float>::quiet_NaN();
 }
 
 void RunHeaderv1::set_intval(const std::string &name, const int ival)

--- a/offline/framework/ffaobjects/RunHeaderv1.h
+++ b/offline/framework/ffaobjects/RunHeaderv1.h
@@ -33,7 +33,7 @@ class RunHeaderv1 : public RunHeader
   int get_intval(const std::string &name) const override;
 
  private:
-  int RunNumber = 0;
+  int RunNumber{0};
   std::map<std::string, int> m_IntRunProperties;
   std::map<std::string, float> m_FloatRunProperties;
 

--- a/offline/framework/ffaobjects/SyncObject.h
+++ b/offline/framework/ffaobjects/SyncObject.h
@@ -6,6 +6,7 @@
 #include <phool/PHObject.h>
 
 #include <iostream>
+#include <limits>
 
 ///
 class SyncObject : public PHObject
@@ -44,15 +45,16 @@ class SyncObject : public PHObject
   /// set Run Number
   virtual void RunNumber(const int /*ival*/) { return; }
 
- protected:
   /// get Event Number
-  virtual int EventNumber() const { return -9999; }
+  virtual int EventNumber() const { return std::numeric_limits<int>::min(); }
+
+protected:
   /// get Event Counter
-  virtual int EventCounter() const { return -9999; }
+  virtual int EventCounter() const { return std::numeric_limits<int>::min(); }
   /// get Run Number
-  virtual int RunNumber() const { return -9999; }
+  virtual int RunNumber() const { return std::numeric_limits<int>::min(); }
   /// get Segment Number
-  virtual int SegmentNumber() const { return -9999; }
+  virtual int SegmentNumber() const { return std::numeric_limits<int>::min(); }
 
  private:  // prevent doc++ from showing ClassDefOverride
   friend class SyncObjectv1;

--- a/offline/framework/ffaobjects/SyncObjectv1.cc
+++ b/offline/framework/ffaobjects/SyncObjectv1.cc
@@ -13,7 +13,7 @@ void SyncObjectv1::Reset()
   eventnumber = 0;
   runnumber = 0;
   eventcounter = 0;
-  segmentnumber = -999999;
+  segmentnumber = std::numeric_limits<int>::min();
   return;
 }
 

--- a/offline/framework/ffaobjects/SyncObjectv1.h
+++ b/offline/framework/ffaobjects/SyncObjectv1.h
@@ -47,21 +47,22 @@ class SyncObjectv1 : public SyncObject
   // cppcheck-suppress virtualCallInConstructor
   void SegmentNumber(const int ival) override { segmentnumber = ival; }
 
+  /// get Event Number
+  int EventNumber() const override { return eventnumber; }
+
  protected:
   /// get Event Counter
   int EventCounter() const override { return eventcounter; }
-  /// get Event Number
-  int EventNumber() const override { return eventnumber; }
   /// get Run Number
   int RunNumber() const override { return runnumber; }
   /// get Segment Number
   int SegmentNumber() const override { return segmentnumber; }
 
  private:
-  int eventcounter = 0;         // running counter
-  int eventnumber = 0;          // Event number
-  int runnumber = 0;            // Run number
-  int segmentnumber = -999999;  // segment number
+  int eventcounter{0};         // running counter
+  int eventnumber{0};          // Event number
+  int runnumber{0};            // Run number
+  int segmentnumber{std::numeric_limits<int>::min()};  // segment number
 
   ClassDefOverride(SyncObjectv1, 1)
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR makes the SyncObject::EventNUmber() method public. It can be used to extract the event number from our DSTs to set the first and last event in our datasets table

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

