### PR TITLE
fix: remove trackbase_historic dependency in mvtx

### DIFF
--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -63,8 +63,7 @@ libmvtx_la_LIBADD = \
   -lmvtx_decoder \
   -lphg4hit \
   -lSubsysReco \
-  -ltrack_io \
-  -ltrackbase_historic_io
+  -ltrack_io
 
 # sources for io library
 libmvtx_io_la_SOURCES = \


### PR DESCRIPTION
Our packages a rats nest of dependencies that is starting to make certain developments difficult. This fixes one unnecessary dependency

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

