### PR TITLE
feat: add crossing correction to z

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -226,7 +226,8 @@ libtrackbase_historic_io_la_LIBADD = \
 
 libtrackbase_historic_la_LIBADD = \
   libtrackbase_historic_io.la \
-  -ltrack
+  -ltrack \
+  -ltpc
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.h
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.h
@@ -19,7 +19,8 @@ namespace TrackAnalysisUtils
   DCAPair get_dca(SvtxTrack* track, Acts::Vector3& vertex);
 
   std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track);
-  float calc_dedx_calib(TrackSeed* tpcseed, TrkrClusterContainer* cluster_map,
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(TrackSeed* track);
+  float calc_dedx_calib(SvtxTrack* track, TrkrClusterContainer* cluster_map,
                         ActsGeometry* tgeometry,
                         // this is the thickness from R1[0],R1[1],R2[2], and R4[3]. You need
                         // to pass these from the geometry object, which keeps the dependencies

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.h
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.h
@@ -19,7 +19,7 @@ namespace TrackAnalysisUtils
   DCAPair get_dca(SvtxTrack* track, Acts::Vector3& vertex);
 
   std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track);
-  std::vector<TrkrDefs::cluskey> get_cluster_keys(TrackSeed* track);
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(TrackSeed* seed);
   float calc_dedx_calib(SvtxTrack* track, TrkrClusterContainer* cluster_map,
                         ActsGeometry* tgeometry,
                         // this is the thickness from R1[0],R1[1],R2[2], and R4[3]. You need


### PR DESCRIPTION
Adds the crossing correction to the z position in the calibrated dedx function

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

