### PR TITLE
Fix sepd simgeo

### DIFF
--- a/offline/packages/NodeDump/DumpEpdGeom.cc
+++ b/offline/packages/NodeDump/DumpEpdGeom.cc
@@ -5,6 +5,7 @@
 #include <calobase/TowerInfoDefs.h>
 #include <epd/EpdGeom.h>
 
+#include <iomanip>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -19,6 +20,7 @@ DumpEpdGeom::DumpEpdGeom(const std::string &NodeName)
 
 int DumpEpdGeom::process_Node(PHNode *myNode)
 {
+  const auto original_precision = (*fout).precision();
   EpdGeom *epdgeom = nullptr;
   MyNode_t *thisNode = static_cast<MyNode_t *>(myNode);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
   if (thisNode)
@@ -27,6 +29,7 @@ int DumpEpdGeom::process_Node(PHNode *myNode)
   }
   if (epdgeom)
   {
+    (*fout).precision(std::numeric_limits<float>::max_digits10);
     for (int iarm = 0; iarm < 2; iarm++)
     {
       for (int irad = 0; irad < 16; irad++)
@@ -44,6 +47,7 @@ int DumpEpdGeom::process_Node(PHNode *myNode)
           *fout << "get_z: " << epdgeom->get_z(key) << std::endl;
         }
       }
+      (*fout).precision(original_precision);
     }
   }
   return 0;

--- a/offline/packages/NodeDump/DumpMbdVertexMap.h
+++ b/offline/packages/NodeDump/DumpMbdVertexMap.h
@@ -11,7 +11,7 @@ class DumpMbdVertexMap : public DumpObject
 {
  public:
   explicit DumpMbdVertexMap(const std::string &NodeName);
-  ~DumpMbdVertexMap() override {}
+  ~DumpMbdVertexMap() override = default;
 
  protected:
   int process_Node(PHNode *mynode) override;

--- a/offline/packages/NodeDump/DumpTowerInfoContainer.cc
+++ b/offline/packages/NodeDump/DumpTowerInfoContainer.cc
@@ -18,6 +18,7 @@ DumpTowerInfoContainer::DumpTowerInfoContainer(const std::string &NodeName)
 
 int DumpTowerInfoContainer::process_Node(PHNode *myNode)
 {
+  const auto original_precision = (*fout).precision();
   TowerInfoContainer *towerinfocontainer = nullptr;
   MyNode_t *thisNode = static_cast<MyNode_t *>(myNode);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
   if (thisNode)
@@ -26,13 +27,16 @@ int DumpTowerInfoContainer::process_Node(PHNode *myNode)
   }
   if (towerinfocontainer)
   {
+    (*fout).precision(std::numeric_limits<float>::max_digits10);
     unsigned int nchannels = towerinfocontainer->size();
     *fout << "size: " << towerinfocontainer->size() << std::endl;
     for (unsigned int channel = 0; channel < nchannels; channel++)
     {
       TowerInfo *rawtwr = towerinfocontainer->get_tower_at_channel(channel);
       *fout << "time: " << rawtwr->get_time() << std::endl;
+//      (*fout).precision(std::numeric_limits<decltype(rawtwr->get_energy())>::max_digits10);
       *fout << "energy: " << rawtwr->get_energy() << std::endl;
+//      (*fout).precision(std::numeric_limits<decltype(rawtwr->get_time_float())>::max_digits10);
       *fout << "time_float: " << rawtwr->get_time_float() << std::endl;
       *fout << "chi2: " << rawtwr->get_chi2() << std::endl;
       *fout << "pedestal: " << rawtwr->get_pedestal() << std::endl;
@@ -47,6 +51,7 @@ int DumpTowerInfoContainer::process_Node(PHNode *myNode)
         *fout << "waveform_value[" << j << "]: " << rawtwr->get_waveform_value(j) << std::endl;
       }
     }
+    (*fout).precision(original_precision);
   }
   return 0;
 }

--- a/offline/packages/NodeDump/DumpTruthVertexMap.cc
+++ b/offline/packages/NodeDump/DumpTruthVertexMap.cc
@@ -1,0 +1,51 @@
+#include "DumpTruthVertexMap.h"
+
+#include <globalvertex/TruthVertex.h>
+#include <globalvertex/TruthVertexMap.h>
+
+#include <phool/PHIODataNode.h>
+
+#include <map>
+#include <ostream>
+#include <string>
+#include <utility>
+
+using MyNode_t = PHIODataNode<TruthVertexMap>;
+
+DumpTruthVertexMap::DumpTruthVertexMap(const std::string &NodeName)
+  : DumpObject(NodeName)
+{
+  return;
+}
+
+int DumpTruthVertexMap::process_Node(PHNode *myNode)
+{
+  const auto original_precision = (*fout).precision();
+  TruthVertexMap *truthvertexmap = nullptr;
+  MyNode_t *thisNode = static_cast<MyNode_t *>(myNode);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+  if (thisNode)
+  {
+    truthvertexmap = thisNode->getData();
+  }
+  if (truthvertexmap)
+  {
+    (*fout).precision(std::numeric_limits<float>::max_digits10);
+    TruthVertexMap::ConstIter biter_beg = truthvertexmap->begin();
+    TruthVertexMap::ConstIter biter_end = truthvertexmap->end();
+    *fout << "size: " << truthvertexmap->size() << std::endl;
+    for (TruthVertexMap::ConstIter biter = biter_beg; biter != biter_end; ++biter)
+    {
+      *fout << "id: " << biter->second->get_id() << std::endl;
+      *fout << "t: " << biter->second->get_t() << std::endl;
+      *fout << "t_err: " << biter->second->get_t_err() << std::endl;
+      *fout << "x: " << biter->second->get_x() << std::endl;
+      *fout << "x_err: " << biter->second->get_x_err() << std::endl;
+      *fout << "y: " << biter->second->get_y() << std::endl;
+      *fout << "y_err: " << biter->second->get_y_err() << std::endl;
+      *fout << "z: " << biter->second->get_z() << std::endl;
+      *fout << "z_err: " << biter->second->get_z_err() << std::endl;
+    }
+    (*fout).precision(original_precision);
+  }
+  return 0;
+}

--- a/offline/packages/NodeDump/DumpTruthVertexMap.h
+++ b/offline/packages/NodeDump/DumpTruthVertexMap.h
@@ -1,0 +1,20 @@
+#ifndef NODEDUMP_DUMPTRUTHVERTEXMAP_H
+#define NODEDUMP_DUMPTRUTHVERTEXMAP_H
+
+#include "DumpObject.h"
+
+#include <string>
+
+class PHNode;
+
+class DumpTruthVertexMap : public DumpObject
+{
+ public:
+  explicit DumpTruthVertexMap(const std::string &NodeName);
+  ~DumpTruthVertexMap() override = default;
+
+ protected:
+  int process_Node(PHNode *mynode) override;
+};
+
+#endif

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -75,6 +75,7 @@ libphnodedump_la_SOURCES = \
   DumpTrkrHitSetContainer.cc \
   DumpTrkrClusterCrossingAssoc.cc \
   DumpTrkrHitTruthAssoc.cc \
+  DumpTruthVertexMap.cc \
   DumpZdcinfo.cc \
   PHNodeDump.cc
 
@@ -91,6 +92,7 @@ libphnodedump_la_LIBADD = \
   -lffarawobjects \
   -lg4detectors_io \
   -lg4mbd_io \
+  -lglobalvertex_io \
   -lHepMC \
   -ljetbase_io \
   -lmbd_io \

--- a/offline/packages/NodeDump/PHNodeDump.cc
+++ b/offline/packages/NodeDump/PHNodeDump.cc
@@ -61,6 +61,7 @@
 #include "DumpTrkrClusterHitAssoc.h"
 #include "DumpTrkrHitSetContainer.h"
 #include "DumpTrkrHitTruthAssoc.h"
+#include "DumpTruthVertexMap.h"
 #include "DumpZdcinfo.h"
 
 #include <ffaobjects/EventHeader.h>
@@ -91,7 +92,7 @@ PHNodeDump::~PHNodeDump()
 
 int PHNodeDump::AddIgnore(const std::string &name)
 {
-  if (ignore.find(name) != ignore.end())
+  if (ignore.contains(name))
   {
     std::cout << PHWHERE << " "
               << name << "already in ignore list" << std::endl;
@@ -103,7 +104,7 @@ int PHNodeDump::AddIgnore(const std::string &name)
 
 int PHNodeDump::Select(const std::string &name)
 {
-  if (exclusive.find(name) != exclusive.end())
+  if (exclusive.contains(name))
   {
     std::cout << PHWHERE << " "
               << name << "already in exclusive list" << std::endl;
@@ -175,7 +176,7 @@ int PHNodeDump::AddDumpObject(const std::string &NodeName, PHNode *node)
   DumpObject *newdump;
   if (!exclusive.empty())
   {
-    if (exclusive.find(NodeName) == exclusive.end())
+    if (!exclusive.contains(NodeName))
     {
       std::cout << "Exclusive find: Ignoring " << NodeName << std::endl;
       newdump = new DumpObject(NodeName);
@@ -183,7 +184,7 @@ int PHNodeDump::AddDumpObject(const std::string &NodeName, PHNode *node)
       return initdump(NodeName, newdump);
     }
   }
-  if (ignore.find(NodeName) != ignore.end())
+  if (ignore.contains(NodeName))
   {
     std::cout << "Ignoring " << NodeName << std::endl;
     newdump = new DumpObject(NodeName);
@@ -435,6 +436,10 @@ int PHNodeDump::AddDumpObject(const std::string &NodeName, PHNode *node)
       else if (tmp->InheritsFrom("TrkrHitTruthAssoc"))
       {
         newdump = new DumpTrkrHitTruthAssoc(NodeName);
+      }
+      else if (tmp->InheritsFrom("TruthVertexMap"))
+      {
+        newdump = new DumpTruthVertexMap(NodeName);
       }
       else if (tmp->InheritsFrom("Zdcinfo"))
       {

--- a/simulation/g4simulation/g4epd/PHG4EPDModuleReco.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDModuleReco.cc
@@ -6,7 +6,7 @@
 #include <calobase/TowerInfoDefs.h>
 
 #include <epd/EPDDefs.h>
-#include <epd/EpdGeomV1.h>
+#include <epd/EpdGeomV2.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -37,6 +37,8 @@ PHG4EPDModuleReco::PHG4EPDModuleReco(const std::string &name)
   , PHParameterInterface(name)
 {
   InitializeParameters();
+  FillTilePhiArray();
+  FillTilePhi0Array();
 }
 
 int PHG4EPDModuleReco::InitRun(PHCompositeNode *topNode)
@@ -69,7 +71,7 @@ int PHG4EPDModuleReco::InitRun(PHCompositeNode *topNode)
   EpdGeom *epdGeom = findNode::getClass<EpdGeom>(topNode, "TOWERGEOM_EPD");
   if (!epdGeom)
   {
-    epdGeom = new EpdGeomV1();
+    epdGeom = new EpdGeomV2();
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(epdGeom, "TOWERGEOM_EPD", "PHObject");
     DetNode->addNode(newNode);
   }
@@ -198,18 +200,6 @@ int PHG4EPDModuleReco::Getphimap(int phiindex)
   return phimap[phiindex];
 }
 
-float PHG4EPDModuleReco::GetTilePhi(int thisphi)
-{
-  static const float tilephi[24] = {0.13089969, 0.39269908, 0.65449847, 0.91629786, 1.17809725, 1.43989663, 1.70169602, 1.96349541, 2.2252948, 2.48709418, 2.74889357, 3.01069296, 3.27249235, 3.53429174, 3.79609112, 4.05789051, 4.3196899, 4.58148929, 4.84328867, 5.10508806, 5.36688745, 5.62868684, 5.89048623, 6.15228561};
-  return tilephi[thisphi];
-}
-
-float PHG4EPDModuleReco::GetTilePhi0(int thisphi0)
-{
-  static const float tilephi0[12] = {0.26179939, 0.78539816, 1.30899694, 1.83259571, 2.35619449, 2.87979327, 3.40339204, 3.92699082, 4.45058959, 4.97418837, 5.49778714, 6.02138592};
-  return tilephi0[thisphi0];
-}
-
 float PHG4EPDModuleReco::GetTileR(int thisr)
 {
   static const float tileR[16] = {6.8, 11.2, 15.6, 20.565, 26.095, 31.625, 37.155, 42.685, 48.215, 53.745, 59.275, 64.805, 70.335, 75.865, 81.395, 86.925};
@@ -266,14 +256,6 @@ int PHG4EPDModuleReco::ResetEvent(PHCompositeNode * /*topNode*/)
   // this only works for initializing to zero
   m_EpdTile_Calib_e = {};
   m_EpdTile_e = {};
-  // if you ever want to initialize to a different value, do it this way:
-  //   for (auto &entry : epd_tile_calib_e)
-  //   {
-  //     for (auto &entry1 : entry)
-  //     {
-  // entry1.fill(NAN);
-  //     }
-  //   }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -281,4 +263,36 @@ void PHG4EPDModuleReco::Detector(const std::string &detector)
 {
   m_Detector = detector;
   m_Hitnodename = "G4HIT_" + m_Detector;
+}
+
+void PHG4EPDModuleReco::FillTilePhiArray()
+{
+  size_t i = 0;
+  for (float &iter : m_tilephi)
+  {
+    iter = ((2 * i + 1) * M_PI) / 24;
+    i++;
+  }
+  return;
+}
+
+void PHG4EPDModuleReco::FillTilePhi0Array()
+{
+  size_t i = 0;
+  for (float &iter : m_tilephi0)
+  {
+    iter = ((2 * i + 1) * M_PI) / 12;
+    i++;
+  }
+  return;
+}
+
+float PHG4EPDModuleReco::GetTilePhi(int thisphi)
+{
+  return m_tilephi.at(thisphi);
+}
+
+float PHG4EPDModuleReco::GetTilePhi0(int thisphi0)
+{
+  return m_tilephi0.at(thisphi0);
 }

--- a/simulation/g4simulation/g4epd/PHG4EPDModuleReco.h
+++ b/simulation/g4simulation/g4epd/PHG4EPDModuleReco.h
@@ -8,7 +8,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <array>
-#include <cmath>
+#include <limits>
 #include <string>
 
 class PHCompositeNode;
@@ -58,6 +58,8 @@ class PHG4EPDModuleReco : public SubsysReco, public PHParameterInterface
   void set_timing_window(const double tmi, const double tma);
 
  private:
+  void FillTilePhiArray();
+  void FillTilePhi0Array();
   int Getrmap(int rindex);
   int Getphimap(int phiindex);
   float GetTilePhi(int thisphi);
@@ -66,21 +68,23 @@ class PHG4EPDModuleReco : public SubsysReco, public PHParameterInterface
   float GetTileZ(int thisz);
   void CreateNodes(PHCompositeNode *topNode);
 
-  std::string m_Detector;
-  std::string m_Hitnodename;
-  std::string m_EPDSimTowerNodePrefix = "SIM";
-  std::string m_EPDCalibTowerNodePrefix = "CALIB";
+  double m_EpdMpv {std::numeric_limits<double>::quiet_NaN()};
+  double tmin {std::numeric_limits<double>::quiet_NaN()};
+  double tmax {std::numeric_limits<double>::quiet_NaN()};
+  double m_DeltaT {std::numeric_limits<double>::quiet_NaN()};
 
-  std::string m_TowerInfoNodeName;
-  std::string m_TowerInfoNodeName_calib;
+  std::array<float, 24> m_tilephi{};
+  std::array<float, 12> m_tilephi0{};
   std::array<std::array<std::array<double, 31>, 12>, 2> m_EpdTile_e = {};
   std::array<std::array<std::array<double, 31>, 12>, 2> m_EpdTile_Calib_e = {};
 
-  double m_EpdMpv = NAN;
+  std::string m_Detector;
+  std::string m_Hitnodename;
+  std::string m_EPDSimTowerNodePrefix {"SIM"};
+  std::string m_EPDCalibTowerNodePrefix {"CALIB"};
 
-  double tmin = NAN;
-  double tmax = NAN;
-  double m_DeltaT = NAN;
+  std::string m_TowerInfoNodeName;
+  std::string m_TowerInfoNodeName_calib;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR copies the phi and phi0 initialization used in the sepdreco code (which just derives them from dividing 4pi into phi slices instead of using long magic floats). When running the diff, some phi angles show a deviation of 10^-8 which is irrelevant and does not affect the results for the significant digits.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

