### PR TITLE
clang-tidy G4TPC

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -42,7 +42,7 @@ class PHG4TpcDetector : public PHG4Detector
   int ConstructTpcCageVolume(G4LogicalVolume *tpc_envelope);
   int ConstructTpcExternalSupports(G4LogicalVolume *logicWorld);
 
-  void CreateCompositeMaterial(const std::string &compositeName, std::vector<std::string> materialName, const std::vector<double> &thickness);
+  static void CreateCompositeMaterial(const std::string &compositeName, std::vector<std::string> materialName, const std::vector<double> &thickness);
 
   //! add geometry node
   /** this setups the relevant geometry needed for offline reconstruciton */

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
@@ -24,6 +24,7 @@
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>  // for gsl_rng_alloc
 
+#include <algorithm>
 #include <cstdlib>  // for exit
 #include <iostream>
 #include <limits>
@@ -38,11 +39,12 @@ PHG4TpcDigitizer::PHG4TpcDigitizer(const std::string &name)
   , Pedestal(50000)                                                       // electrons
   , ChargeToPeakVolts(20)                                                 // mV/fC
   , ADCSignalConversionGain(std::numeric_limits<float>::signaling_NaN())  // will be assigned in PHG4TpcDigitizer::InitRun
-  , ADCNoiseConversionGain(std::numeric_limits<float>::signaling_NaN())   // will be assigned in PHG4TpcDigitizer::InitRun
+  , ADCNoiseConversionGain(std::numeric_limits<float>::signaling_NaN())
+  , RandomGenerator(gsl_rng_alloc(gsl_rng_mt19937))  // will be assigned in PHG4TpcDigitizer::InitRun
 {
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
   std::cout << Name() << " random seed: " << seed << std::endl;
-  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+
   gsl_rng_set(RandomGenerator, seed);
 
   if (Verbosity() > 0)
@@ -67,7 +69,7 @@ int PHG4TpcDigitizer::InitRun(PHCompositeNode *topNode)
   // The noise is by definition the RMS noise width voltage divided by ChargeToPeakVolts
   ADCNoiseConversionGain = ChargeToPeakVolts * 1.60e-04;  // 20 (or 30) mV/fC * fC/electron
 
-  ADCThreshold_mV = ADCThreshold *  ADCNoiseConversionGain;
+  ADCThreshold_mV = ADCThreshold * ADCNoiseConversionGain;
 
   //-------------
   // Add Hit Node
@@ -92,11 +94,11 @@ int PHG4TpcDigitizer::InitRun(PHCompositeNode *topNode)
   if (Verbosity() > 0)
   {
     std::cout << "====================== PHG4TpcDigitizer::InitRun() =====================" << std::endl;
-    for (auto & tpiter : _max_adc)
+    for (auto &tpiter : _max_adc)
     {
       std::cout << " Max ADC in Layer #" << tpiter.first << " = " << tpiter.second << std::endl;
     }
-    for (auto & tpiter : _energy_scale)
+    for (auto &tpiter : _energy_scale)
     {
       std::cout << " Energy per ADC in Layer #" << tpiter.first << " = " << 1.0e6 * tpiter.second << " keV" << std::endl;
     }
@@ -119,8 +121,10 @@ void PHG4TpcDigitizer::CalculateCylinderCellADCScale(PHCompositeNode *topNode)
 
   PHG4TpcCylinderGeomContainer *geom_container = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
 
-  if (!geom_container) { return;
-}
+  if (!geom_container)
+  {
+    return;
+  }
 
   PHG4TpcCylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
   for (PHG4TpcCylinderGeomContainer::ConstIterator layeriter = layerrange.first;
@@ -133,15 +137,13 @@ void PHG4TpcDigitizer::CalculateCylinderCellADCScale(PHCompositeNode *topNode)
     float length = (layeriter->second)->get_zstep() * _drift_velocity;
 
     float minpath = pitch;
-    if (length < minpath) { minpath = length;
-}
-    if (thickness < minpath) { minpath = thickness;
-}
+    minpath = std::min(length, minpath);
+    minpath = std::min(thickness, minpath);
     float mip_e = 0.003876 * minpath;
 
-    if (_max_adc.find(layer) == _max_adc.end())
+    if (!_max_adc.contains(layer))
     {
-// cppcheck-suppress stlFindInsert
+      // cppcheck-suppress stlFindInsert
       _max_adc[layer] = 255;
       _energy_scale[layer] = mip_e / 64;
     }
@@ -170,28 +172,28 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
   // Thus a MIP produces a charge value out of the GEM stack of 64000/6.242x10^18 = 10.2 fC
 
   // SAMPA:
-  // See https://indico.cern.ch/event/489996/timetable/#all.detailed 
+  // See https://indico.cern.ch/event/489996/timetable/#all.detailed
   //      "SAMPA Chip: the New ASIC for the ALICE Tpc and MCH Upgrades", M Bregant
   // The SAMPA has a maximum output voltage of 2200 mV (but the pedestal is about 200 mV)
   // The SAMPA shaper is set to 80 ns peaking time
   // The ADC Digitizes the SAMPA shaper output into 1024 channels
-  // Conversion gains of 20 mV/fC or 30 mV/fC are possible - 1 fC charge input produces a peak voltage out of 
+  // Conversion gains of 20 mV/fC or 30 mV/fC are possible - 1 fC charge input produces a peak voltage out of
   // the shaper of 20 or 30 mV
   //   At 30 mV/fC, the input signal saturates at 2.2 V / 30 mV/fC = 73 fC (say 67 with pedestal not at zero)
   //   At 20 mV/fC, the input signal saturates at 2.2 V / 20 mV/fC = 110 fC (say 100 fC with pedestal not at zero) - assume 20 mV/fC
   // The equivalent noise charge RMS at 20 mV/fC was measured (w/o detector capacitance) at 490 electrons
-  //      - note: this appears to be just the pedestal RMS voltage spread divided by the conversion gain, so it is a bit of a 
+  //      - note: this appears to be just the pedestal RMS voltage spread divided by the conversion gain, so it is a bit of a
   //         funny number (see below)
   //      - it is better to think of noise and signal in terms of voltage at the input of the ADC
   // Bregant's slides say 670 electrons ENC for the full chip with 18 pf detector, as in ALICE - should use that number
 
   // Signal:
-  // To normalize the signal in each cell, take the entire charge on the pad and multiply by 20 mV/fC to get the adc 
+  // To normalize the signal in each cell, take the entire charge on the pad and multiply by 20 mV/fC to get the adc
   //       input AT THE PEAK of the shaper
   // The cell contents should thus be multipied by the normalization given by:
   // V_peak = Q_pad (electrons) * 1.6e-04 fC/electron * 20 mV/fC
   // From the sims, for 80 ns and 18.8 MHz, if we take the input charge and spread it a across the shaping time (which is how it has always been done, and is
-  // not the best way to think about it, because the ADC does not see charge it sees voltage out of a charge integrating 
+  // not the best way to think about it, because the ADC does not see charge it sees voltage out of a charge integrating
   //     preamp followed by a shaper), to get
   // the voltage at the ADC input right, then the values of Q_(pad,z) have to be scaled up by 2.4
   // V_(pad,z) = 2.4 * Q_(pad,z) (electrons) * 1.6e-04 fC/electron * 20 mV/fC = Q_(pad,z) * 7.68e-03 (in mV)
@@ -199,17 +201,17 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
   // Remember that Q_(pad,z) is the GEM output charge
 
   // Noise:
-  // The ENC is defined as the RMS spread of the ADC pedestal distribution coming out from the SAMPA 
+  // The ENC is defined as the RMS spread of the ADC pedestal distribution coming out from the SAMPA
   //      divided by the corresponding conversion gain.
   // The full range of the ADC input is 2.2V (which will become 1024 adc counts, i.e. 1024 ADU's).
   // If you see the RMS of the pedestal in adc counts as 1 at the gain of 20mV/fC, the ENC would be defined by:
   //             (2200 [mV]) * (1/1024) / (20[mV/fC]) / (1.6*10^-4 [fC]) = 671 [electrons]
-  // The RMS noise voltage would be: 
+  // The RMS noise voltage would be:
   //     V_RMS = ENC (electrons) *1.6e-04 fC/electron * 20 mV/fC = ENC (electrons) * 3.2e-03 (in mV)
   // The ADC readout would be:  ADU = V_RMS * (1024 ADU / 2200 mV) = V_RMS * 0.465
 
   // The cells that we need to digitize here contain as the energy "edep", which is the number of electrons out of the GEM stack
-  // distributed over the pads and ADC time bins according to the output time distribution of the SAMPA shaper 
+  // distributed over the pads and ADC time bins according to the output time distribution of the SAMPA shaper
   //      - not what really happens, see above
   // We convert to volts at the input to the ADC and add noise generated with the RMS value of the noise voltage at the ADC input
   // We assume the pedestal is zero, for simplicity, so the noise fluctuates above and below zero
@@ -243,397 +245,352 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
     exit(1);
   }
 
-
   //-------------
   // Digitization
   //-------------
 
-  // Loop over all TPC layers 
-  for(unsigned int layer = TpcMinLayer; layer < TpcMinLayer+TpcNLayers; ++layer)
+  // Loop over all TPC layers
+  for (unsigned int layer = TpcMinLayer; layer < TpcMinLayer + TpcNLayers; ++layer)
+  {
+    // we need the geometry object for this layer
+    PHG4TpcCylinderGeom *layergeom = geom_container->GetLayerCellGeom(layer);
+    if (!layergeom)
     {
-      // we need the geometry object for this layer
-      PHG4TpcCylinderGeom *layergeom = geom_container->GetLayerCellGeom(layer);
-      if (!layergeom) { exit(1);
-}
+      exit(1);
+    }
 
-      int nphibins = layergeom->get_phibins();
-      if(Verbosity() > 1) { 
-        std::cout << "    nphibins " << nphibins << std::endl;
-}
-      
-      for(unsigned int side = 0; side < 2; ++side)
-	{
-	  
-	  if(Verbosity() > 1) { 
-	    std::cout << "TPC layer " << layer << " side " << side << std::endl;
-}
-	  
-	  // for this layer and side, use a vector of a vector of cells for each phibin
-	  phi_sorted_hits.clear();
-	  for (int iphi = 0; iphi < nphibins; iphi++)
-	    {
-	      phi_sorted_hits.emplace_back();
-	    }
-      
-	  // Loop over all hitsets containing signals for this layer and add them to phi_sorted_hits for their phibin
-	  TrkrHitSetContainer::ConstRange hitset_range = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId, layer);
-	  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range.first;
-	       hitset_iter != hitset_range.second;
-	       ++hitset_iter)
-	    {
+    int nphibins = layergeom->get_phibins();
+    if (Verbosity() > 1)
+    {
+      std::cout << "    nphibins " << nphibins << std::endl;
+    }
 
-	      // we have an iterator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
-	      // get the hitset key
-	      TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
-	      unsigned int this_side = TpcDefs::getSide(hitsetkey);	  
-	      // skip this hitset if it is not on this side
-	      if(this_side != side) { continue; 
-}
+    for (unsigned int side = 0; side < 2; ++side)
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << "TPC layer " << layer << " side " << side << std::endl;
+      }
 
-	      if (Verbosity() > 2) {
-		if (layer == print_layer) {
-		  std::cout << "new: PHG4TpcDigitizer:  processing signal hits for layer " << layer 
-			    << " hitsetkey " << hitsetkey << " side " << side << std::endl;
-}
-}
-	  
-	      // get all of the hits from this hitset
-	      TrkrHitSet *hitset = hitset_iter->second;
-	      TrkrHitSet::ConstRange hit_range = hitset->getHits();
-	      for (TrkrHitSet::ConstIterator hit_iter = hit_range.first;
-		   hit_iter != hit_range.second;
-		   ++hit_iter)
-		{
-		  // Fill the vector of signal hits for each phibin
-		  unsigned int phibin = TpcDefs::getPad(hit_iter->first);
-		  phi_sorted_hits[phibin].push_back(hit_iter);
-		}
-	      // For this hitset we now have the signal hits sorted into vectors for each phi
-	    }
-	  
-	  // Process one phi bin at a time
-	  if(Verbosity() > 1) { std::cout << "    phi_sorted_hits size " <<  phi_sorted_hits.size() << " ntbins " << layergeom->get_zbins() << std::endl;
-}
+      // for this layer and side, use a vector of a vector of cells for each phibin
+      phi_sorted_hits.clear();
+      for (int iphi = 0; iphi < nphibins; iphi++)
+      {
+        phi_sorted_hits.emplace_back();
+      }
 
-	  for (unsigned int iphi = 0; iphi < phi_sorted_hits.size(); iphi++)
-	    {
-	      // Make a fixed length vector to indicate whether each time bin is signal or noise
-	      int ntbins = layergeom->get_zbins();
-	      is_populated.clear();
-	      is_populated.assign(ntbins, 2);  // mark all as noise only, for now
-	      
-	      // add an empty vector of hits for each t bin
-	      t_sorted_hits.clear();
-	      for (int it = 0; it < ntbins; it++)
-		{
-		  t_sorted_hits.emplace_back();
-		}
-	      
-	      // add a signal hit from phi_sorted_hits for each t bin that has one
-	      for (unsigned int it = 0; it < phi_sorted_hits[iphi].size(); it++)
-		{
-		  int tbin = TpcDefs::getTBin(phi_sorted_hits[iphi][it]->first);
-		  is_populated[tbin] = 1;  // this bin is a associated with a hit
-		  t_sorted_hits[tbin].push_back(phi_sorted_hits[iphi][it]);
-		  
-		  if (Verbosity() > 2) {
-		    if (layer == print_layer)
-		      {
-			TrkrDefs::hitkey hitkey = phi_sorted_hits[iphi][it]->first;
-			std::cout << "iphi " << iphi << " adding existing signal hit to t vector for layer " << layer 
-				  << " side " << side
-				  << " tbin " << tbin << "  hitkey " << hitkey
-				  << " pad " << TpcDefs::getPad(hitkey)
-				  << " t bin " << TpcDefs::getTBin(hitkey) 
-				  << "  energy " << (phi_sorted_hits[iphi][it]->second)->getEnergy()
-				  << std::endl;
-		      }
-}
-		}
-	      
-	      adc_input.clear();
-	      adc_hitid.clear();
-	      // initialize entries to zero for each t bin
-	      adc_input.assign(ntbins, 0.0); 
-	      adc_hitid.assign(ntbins, 0); 
+      // Loop over all hitsets containing signals for this layer and add them to phi_sorted_hits for their phibin
+      TrkrHitSetContainer::ConstRange hitset_range = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId, layer);
+      for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range.first;
+           hitset_iter != hitset_range.second;
+           ++hitset_iter)
+      {
+        // we have an iterator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
+        // get the hitset key
+        TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+        unsigned int this_side = TpcDefs::getSide(hitsetkey);
+        // skip this hitset if it is not on this side
+        if (this_side != side)
+        {
+          continue;
+        }
 
-	      // Now for this phibin we process all bins ordered by t into hits with noise
-	      //======================================================
-	      // For this step we take the edep value and convert it to mV at the ADC input
-	      // See comments above for how to do this for signal and noise
-	      
-	      for (int it = 0; it < ntbins; it++)
-		{
-		  if (is_populated[it] == 1)
-		    {
-		      // This tbin has a hit, add noise
-		      float signal_with_noise =  add_noise_to_bin( (t_sorted_hits[it][0]->second)->getEnergy()) ;
-		      adc_input[it] = signal_with_noise ;
-		      adc_hitid[it] = t_sorted_hits[it][0]->first;
+        if (Verbosity() > 2)
+        {
+          if (layer == print_layer)
+          {
+            std::cout << "new: PHG4TpcDigitizer:  processing signal hits for layer " << layer
+                      << " hitsetkey " << hitsetkey << " side " << side << std::endl;
+          }
+        }
 
-		      if (Verbosity() > 2) {
-			if (layer == print_layer) {
-			  std::cout << "existing signal hit: layer " << layer << " iphi " << iphi << " it " << it 
-				    << " edep " << (t_sorted_hits[it][0]->second)->getEnergy()
-				    << " adc gain " << ADCSignalConversionGain 
-				    << " signal with noise " <<  signal_with_noise
-				    << " adc_input " << adc_input[it] << std::endl;
-}
-}
-		    }
-		  else if (is_populated[it] == 2)
-		    {
-		      if(!skip_noise)
-			{
-			  // This t bin does not have a filled cell, add noise
-			  float noise =  add_noise_to_bin(0.0);
-			  adc_input[it]= noise;
-			  adc_hitid[it] = 0;              // there is no hit, just add a placeholder in the vector for now, replace it later
-			  
-			  if (Verbosity() > 2) {
-			    if (layer == print_layer) {
-			      std::cout << "noise hit: layer " << layer << " side " << side << " iphi " << iphi << " it " << it
-					<< " adc gain " << ADCSignalConversionGain
-					<< " noise " << noise 
-					<< " adc_input " << adc_input[it] << std::endl;
-}
-}
-			}
-		    }
-		  else
-		    {
-		      // Cannot happen
-		      std::cout << "Impossible value of is_populated, it = " << it 
-				<< " is_populated = " << is_populated[it] << std::endl;
-		      exit(-1);
-		    }
-		}
-	      
-	      // Now we can digitize the entire stream of t bins for this phi bin
-	      int binpointer = 0;
-	      
-	      // Since we now store the local z of the hit as time of arrival at the readout plane, 
-	      // there is no difference between north and south
-	      // The first to arrive is always bin 0
-	      
-	      for (int it = 0; it < ntbins; it++)
-		{
-		  if (it < binpointer) { continue;
-}
+        // get all of the hits from this hitset
+        TrkrHitSet *hitset = hitset_iter->second;
+        TrkrHitSet::ConstRange hit_range = hitset->getHits();
+        for (TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+             hit_iter != hit_range.second;
+             ++hit_iter)
+        {
+          // Fill the vector of signal hits for each phibin
+          unsigned int phibin = TpcDefs::getPad(hit_iter->first);
+          phi_sorted_hits[phibin].push_back(hit_iter);
+        }
+        // For this hitset we now have the signal hits sorted into vectors for each phi
+      }
 
-		  // optionally do not trigger on bins with no signal
-		  if( (is_populated[it] == 2) && skip_noise) 
-		    {
-		      binpointer++;
-		      continue;		  
-		    }
+      // Process one phi bin at a time
+      if (Verbosity() > 1)
+      {
+        std::cout << "    phi_sorted_hits size " << phi_sorted_hits.size() << " ntbins " << layergeom->get_zbins() << std::endl;
+      }
 
-		  // convert threshold in "equivalent electrons" to mV
-		  if (adc_input[it] > ADCThreshold_mV)  
-		    {
-		      // digitize this bin and the following 4 bins
-		      
-		      if (Verbosity() > 2) {
-			if (layer == print_layer) { 
-			  std::cout << std::endl
-				    << "Hit above threshold of " 
-				    << ADCThreshold * ADCNoiseConversionGain << " for phibin " << iphi
-				    << " it " << it << " with adc_input " << adc_input[it] 
-				    << " digitize this and 4 following bins: " << std::endl;
-}
-}
-		      
-		      for (int itup = 0; itup < 5; itup++)
-			{
-			  if (it + itup < ntbins && it + itup >= 0)  // stay within the bin limits
-			    {
-			      float input = 0;
-			      if( (is_populated[it+itup] == 2) && skip_noise)
-				{
-				  input =  add_noise_to_bin(0.0);  // no noise added to this bin previously because skip_noise is true
-				}
-			      else
-				{
-				  input = adc_input[it + itup];
-				}	
-			      // input voltage x 1024 channels over 2200 mV max range
-			      unsigned int adc_output  = (unsigned int) (input * 1024.0 / 2200.0);  
+      for (unsigned int iphi = 0; iphi < phi_sorted_hits.size(); iphi++)
+      {
+        // Make a fixed length vector to indicate whether each time bin is signal or noise
+        int ntbins = layergeom->get_zbins();
+        is_populated.clear();
+        is_populated.assign(ntbins, 2);  // mark all as noise only, for now
 
-			      if (input < 0) { adc_output = 0;
-}
-			      if (adc_output > 1023) { adc_output = 1023;
-}
-			      
-			      // Get the hitkey
-			      TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, it + itup);
-			      TrkrHit *hit = nullptr;
-			      
-			      if (Verbosity() > 2) {
-				if (layer == print_layer) { 
-				  std::cout << "    Digitizing:  iphi " << iphi << "  it+itup " << it + itup 
-					    << " adc_hitid " << adc_hitid[it + itup]
-					    << " is_populated " << is_populated[it + itup]
-					    << "  adc_input " << adc_input[it + itup] 
-					    << " ADCThreshold " << ADCThreshold * ADCNoiseConversionGain
-					    << " adc_output " << adc_output 
-					    << " hitkey " << hitkey
-					    << " side " << side
-					    << "  binpointer " << binpointer
-					    << std::endl;			  
-}
-}
-			      
-			      if (is_populated[it+itup] == 1)
-				{
-				  // this is a signal hit, it already exists
-				  hit = t_sorted_hits[it+itup][0]->second;  // pointer valid only for signal hits
-				}
-			      else
-				{
-				  // Hit does not exist yet, have to make one
-				  // we need the hitset key, requires (layer, sector, side)
-				  unsigned int sector = 12 * iphi / nphibins;
-				  TrkrDefs::hitsetkey hitsetkey = TpcDefs::genHitSetKey(layer, sector, side);
-				  auto hitset_iter = trkrhitsetcontainer->findOrAddHitSet(hitsetkey);
-				  
-				  hit = new TrkrHitv2();
-				  hitset_iter->second->addHitSpecificKey(hitkey, hit);
-				  
-				  if (Verbosity() > 2) {
-				    if (layer == print_layer) { 
-				      std::cout << "      adding noise TrkrHit for iphi " << iphi 
-						<< " tbin " << it + itup
-						<< " side " << side
-						<< " created new hit with hitkey " << hitkey
-						<< " energy " << adc_input[it + itup] << " adc " << adc_output 
-						<< "  binpointer " << binpointer
-						<< std::endl;
-}
-}
-				  
-				}
-			      
-			      hit->setAdc(adc_output);
-			      
-			    }              // end boundary check
-			  binpointer++;  // skip this bin in future
-			}                // end itup loop
-		      
-		    }  //  adc threshold if
-		  else
-		    {
-		      // set adc value to zero if there is a hit
-		      // we need the hitset key, requires (layer, sector, side)
-		      unsigned int sector = 12 * iphi / nphibins;
-		      TrkrDefs::hitsetkey hitsetkey = TpcDefs::genHitSetKey(layer, sector, side);
-		      auto hitset = trkrhitsetcontainer->findHitSet(hitsetkey);
-		      if(hitset)
-			{
-			  // Get the hitkey
-			  TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, it);
-			  TrkrHit *hit = nullptr;
-			  hit = hitset->getHit(hitkey);
-			  if (hit)
-			    {
-			      hit->setAdc(0);
-			    }
-			}
-		      // bin below threshold, move on
-		      binpointer++;
-		    }  // end adc threshold if/else
-		}    // end time bin loop
-	    }      // end phibins loop
-	}  // end loop over sides     
-    } // end loop over TPC layers
-  
+        // add an empty vector of hits for each t bin
+        t_sorted_hits.clear();
+        for (int it = 0; it < ntbins; it++)
+        {
+          t_sorted_hits.emplace_back();
+        }
+
+        // add a signal hit from phi_sorted_hits for each t bin that has one
+        for (unsigned int it = 0; it < phi_sorted_hits[iphi].size(); it++)
+        {
+          int tbin = TpcDefs::getTBin(phi_sorted_hits[iphi][it]->first);
+          is_populated[tbin] = 1;  // this bin is a associated with a hit
+          t_sorted_hits[tbin].push_back(phi_sorted_hits[iphi][it]);
+
+          if (Verbosity() > 2)
+          {
+            if (layer == print_layer)
+            {
+              TrkrDefs::hitkey hitkey = phi_sorted_hits[iphi][it]->first;
+              std::cout << "iphi " << iphi << " adding existing signal hit to t vector for layer " << layer
+                        << " side " << side
+                        << " tbin " << tbin << "  hitkey " << hitkey
+                        << " pad " << TpcDefs::getPad(hitkey)
+                        << " t bin " << TpcDefs::getTBin(hitkey)
+                        << "  energy " << (phi_sorted_hits[iphi][it]->second)->getEnergy()
+                        << std::endl;
+            }
+          }
+        }
+
+        adc_input.clear();
+        adc_hitid.clear();
+        // initialize entries to zero for each t bin
+        adc_input.assign(ntbins, 0.0);
+        adc_hitid.assign(ntbins, 0);
+
+        // Now for this phibin we process all bins ordered by t into hits with noise
+        //======================================================
+        // For this step we take the edep value and convert it to mV at the ADC input
+        // See comments above for how to do this for signal and noise
+
+        for (int it = 0; it < ntbins; it++)
+        {
+          if (is_populated[it] == 1)
+          {
+            // This tbin has a hit, add noise
+            float signal_with_noise = add_noise_to_bin((t_sorted_hits[it][0]->second)->getEnergy());
+            adc_input[it] = signal_with_noise;
+            adc_hitid[it] = t_sorted_hits[it][0]->first;
+
+            if (Verbosity() > 2)
+            {
+              if (layer == print_layer)
+              {
+                std::cout << "existing signal hit: layer " << layer << " iphi " << iphi << " it " << it
+                          << " edep " << (t_sorted_hits[it][0]->second)->getEnergy()
+                          << " adc gain " << ADCSignalConversionGain
+                          << " signal with noise " << signal_with_noise
+                          << " adc_input " << adc_input[it] << std::endl;
+              }
+            }
+          }
+          else if (is_populated[it] == 2)
+          {
+            if (!skip_noise)
+            {
+              // This t bin does not have a filled cell, add noise
+              float noise = add_noise_to_bin(0.0);
+              adc_input[it] = noise;
+              adc_hitid[it] = 0;  // there is no hit, just add a placeholder in the vector for now, replace it later
+
+              if (Verbosity() > 2)
+              {
+                if (layer == print_layer)
+                {
+                  std::cout << "noise hit: layer " << layer << " side " << side << " iphi " << iphi << " it " << it
+                            << " adc gain " << ADCSignalConversionGain
+                            << " noise " << noise
+                            << " adc_input " << adc_input[it] << std::endl;
+                }
+              }
+            }
+          }
+          else
+          {
+            // Cannot happen
+            std::cout << "Impossible value of is_populated, it = " << it
+                      << " is_populated = " << is_populated[it] << std::endl;
+            exit(-1);
+          }
+        }
+
+        // Now we can digitize the entire stream of t bins for this phi bin
+        int binpointer = 0;
+
+        // Since we now store the local z of the hit as time of arrival at the readout plane,
+        // there is no difference between north and south
+        // The first to arrive is always bin 0
+
+        for (int it = 0; it < ntbins; it++)
+        {
+          if (it < binpointer)
+          {
+            continue;
+          }
+
+          // optionally do not trigger on bins with no signal
+          if ((is_populated[it] == 2) && skip_noise)
+          {
+            binpointer++;
+            continue;
+          }
+
+          // convert threshold in "equivalent electrons" to mV
+          if (adc_input[it] > ADCThreshold_mV)
+          {
+            // digitize this bin and the following 4 bins
+
+            if (Verbosity() > 2)
+            {
+              if (layer == print_layer)
+              {
+                std::cout << std::endl
+                          << "Hit above threshold of "
+                          << ADCThreshold * ADCNoiseConversionGain << " for phibin " << iphi
+                          << " it " << it << " with adc_input " << adc_input[it]
+                          << " digitize this and 4 following bins: " << std::endl;
+              }
+            }
+
+            for (int itup = 0; itup < 5; itup++)
+            {
+              if (it + itup < ntbins && it + itup >= 0)  // stay within the bin limits
+              {
+                float input = 0;
+                if ((is_populated[it + itup] == 2) && skip_noise)
+                {
+                  input = add_noise_to_bin(0.0);  // no noise added to this bin previously because skip_noise is true
+                }
+                else
+                {
+                  input = adc_input[it + itup];
+                }
+                // input voltage x 1024 channels over 2200 mV max range
+                unsigned int adc_output = (unsigned int) (input * 1024.0 / 2200.0);
+
+                if (input < 0)
+                {
+                  adc_output = 0;
+                }
+                adc_output = std::min<unsigned int>(adc_output, 1023);
+
+                // Get the hitkey
+                TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, it + itup);
+                TrkrHit *hit = nullptr;
+
+                if (Verbosity() > 2)
+                {
+                  if (layer == print_layer)
+                  {
+                    std::cout << "    Digitizing:  iphi " << iphi << "  it+itup " << it + itup
+                              << " adc_hitid " << adc_hitid[it + itup]
+                              << " is_populated " << is_populated[it + itup]
+                              << "  adc_input " << adc_input[it + itup]
+                              << " ADCThreshold " << ADCThreshold * ADCNoiseConversionGain
+                              << " adc_output " << adc_output
+                              << " hitkey " << hitkey
+                              << " side " << side
+                              << "  binpointer " << binpointer
+                              << std::endl;
+                  }
+                }
+
+                if (is_populated[it + itup] == 1)
+                {
+                  // this is a signal hit, it already exists
+                  hit = t_sorted_hits[it + itup][0]->second;  // pointer valid only for signal hits
+                }
+                else
+                {
+                  // Hit does not exist yet, have to make one
+                  // we need the hitset key, requires (layer, sector, side)
+                  unsigned int sector = 12 * iphi / nphibins;
+                  TrkrDefs::hitsetkey hitsetkey = TpcDefs::genHitSetKey(layer, sector, side);
+                  auto hitset_iter = trkrhitsetcontainer->findOrAddHitSet(hitsetkey);
+
+                  hit = new TrkrHitv2();
+                  hitset_iter->second->addHitSpecificKey(hitkey, hit);
+
+                  if (Verbosity() > 2)
+                  {
+                    if (layer == print_layer)
+                    {
+                      std::cout << "      adding noise TrkrHit for iphi " << iphi
+                                << " tbin " << it + itup
+                                << " side " << side
+                                << " created new hit with hitkey " << hitkey
+                                << " energy " << adc_input[it + itup] << " adc " << adc_output
+                                << "  binpointer " << binpointer
+                                << std::endl;
+                    }
+                  }
+                }
+
+                hit->setAdc(adc_output);
+
+              }  // end boundary check
+              binpointer++;  // skip this bin in future
+            }  // end itup loop
+
+          }  //  adc threshold if
+          else
+          {
+            // set adc value to zero if there is a hit
+            // we need the hitset key, requires (layer, sector, side)
+            unsigned int sector = 12 * iphi / nphibins;
+            TrkrDefs::hitsetkey hitsetkey = TpcDefs::genHitSetKey(layer, sector, side);
+            auto *hitset = trkrhitsetcontainer->findHitSet(hitsetkey);
+            if (hitset)
+            {
+              // Get the hitkey
+              TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, it);
+              TrkrHit *hit = nullptr;
+              hit = hitset->getHit(hitkey);
+              if (hit)
+              {
+                hit->setAdc(0);
+              }
+            }
+            // bin below threshold, move on
+            binpointer++;
+          }  // end adc threshold if/else
+        }  // end time bin loop
+      }  // end phibins loop
+    }  // end loop over sides
+  }  // end loop over TPC layers
+
   //======================================================
   if (Verbosity() > 5)
-    {
-      std::cout << "From PHG4TpcDigitizer: hitsetcontainer dump at end before cleaning:" << std::endl;
-    }
+  {
+    std::cout << "From PHG4TpcDigitizer: hitsetcontainer dump at end before cleaning:" << std::endl;
+  }
   std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> delete_hitkey_list;
-  
+
   // Clean up undigitized hits - we want all hitsets for the Tpc
   // This loop is pretty efficient because the remove methods all take a specified hitset as input
   TrkrHitSetContainer::ConstRange hitset_range_now = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
   for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range_now.first;
        hitset_iter != hitset_range_now.second;
        ++hitset_iter)
-    {
-      // we have an iterator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
-      TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
-      const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
-      const int sector = TpcDefs::getSectorId(hitsetkey);
-      const int side = TpcDefs::getSide(hitsetkey);
-      if (Verbosity() > 5) {
-	std::cout << "PHG4TpcDigitizer: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << std::endl;
-}
-      
-      // get all of the hits from this hitset
-      TrkrHitSet *hitset = hitset_iter->second;
-      TrkrHitSet::ConstRange hit_range = hitset->getHits();
-      for (TrkrHitSet::ConstIterator hit_iter = hit_range.first;
-	   hit_iter != hit_range.second;
-	   ++hit_iter)
-	{
-	  TrkrDefs::hitkey hitkey = hit_iter->first;
-	  TrkrHit *tpchit = hit_iter->second;
-	  
-	  if (Verbosity() > 5) {
-	    std::cout << "    layer " << layer << "  hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) 
-		      << " t bin " << TpcDefs::getTBin(hitkey)
-		      << " adc " << tpchit->getAdc() << std::endl;
-}
-	  
-	  if (tpchit->getAdc() == 0)
-	    {
-	      if (Verbosity() > 20)
-		{
-		  std::cout << "                       --   this hit not digitized - delete it" << std::endl;
-		}
-	      // screws up the iterator to delete it here, store the hitkey for later deletion
-	      delete_hitkey_list.emplace_back(hitsetkey, hitkey);
-	    }
-	}
-    }
-  
-  // delete all undigitized hits
-  for (auto & i : delete_hitkey_list)
-    {
-      TrkrHitSet *hitset = trkrhitsetcontainer->findHitSet(i.first);
-      const unsigned int layer = TrkrDefs::getLayer(i.first);
-      hitset->removeHit(i.second);
-      if (Verbosity() > 20) {
-	if (layer == print_layer) {
-	  std::cout << "removed hit with hitsetkey " << i.first
-		    << " and hitkey " << i.second << std::endl;
-}
-}
-      
-      // should also delete all entries with this hitkey from the TrkrHitTruthAssoc map
-      //hittruthassoc->removeAssoc(delete_hitkey_list[i].first, delete_hitkey_list[i].second);   // Slow! Commented out by ADF 9/6/2022
-    }
-  
-  // Final hitset dump
-  if (Verbosity() > 5) {
-    std::cout << "From PHG4TpcDigitizer: hitsetcontainer dump at end after cleaning:" << std::endl;
-}
-  // We want all hitsets for the Tpc
-  TrkrHitSetContainer::ConstRange hitset_range_final = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range_final.first;
-       hitset_iter != hitset_range_now.second;
-       ++hitset_iter)
   {
-    // we have an itrator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
+    // we have an iterator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
     TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
     const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
-    if (layer != print_layer) { continue;
-}
     const int sector = TpcDefs::getSectorId(hitsetkey);
     const int side = TpcDefs::getSide(hitsetkey);
-    if (Verbosity() > 5 && layer == print_layer) {
+    if (Verbosity() > 5)
+    {
       std::cout << "PHG4TpcDigitizer: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << std::endl;
-}
+    }
 
     // get all of the hits from this hitset
     TrkrHitSet *hitset = hitset_iter->second;
@@ -644,10 +601,84 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
     {
       TrkrDefs::hitkey hitkey = hit_iter->first;
       TrkrHit *tpchit = hit_iter->second;
-      if (Verbosity() > 5) {
+
+      if (Verbosity() > 5)
+      {
+        std::cout << "    layer " << layer << "  hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey)
+                  << " t bin " << TpcDefs::getTBin(hitkey)
+                  << " adc " << tpchit->getAdc() << std::endl;
+      }
+
+      if (tpchit->getAdc() == 0)
+      {
+        if (Verbosity() > 20)
+        {
+          std::cout << "                       --   this hit not digitized - delete it" << std::endl;
+        }
+        // screws up the iterator to delete it here, store the hitkey for later deletion
+        delete_hitkey_list.emplace_back(hitsetkey, hitkey);
+      }
+    }
+  }
+
+  // delete all undigitized hits
+  for (auto &i : delete_hitkey_list)
+  {
+    TrkrHitSet *hitset = trkrhitsetcontainer->findHitSet(i.first);
+    const unsigned int layer = TrkrDefs::getLayer(i.first);
+    hitset->removeHit(i.second);
+    if (Verbosity() > 20)
+    {
+      if (layer == print_layer)
+      {
+        std::cout << "removed hit with hitsetkey " << i.first
+                  << " and hitkey " << i.second << std::endl;
+      }
+    }
+
+    // should also delete all entries with this hitkey from the TrkrHitTruthAssoc map
+    // hittruthassoc->removeAssoc(delete_hitkey_list[i].first, delete_hitkey_list[i].second);   // Slow! Commented out by ADF 9/6/2022
+  }
+
+  // Final hitset dump
+  if (Verbosity() > 5)
+  {
+    std::cout << "From PHG4TpcDigitizer: hitsetcontainer dump at end after cleaning:" << std::endl;
+  }
+  // We want all hitsets for the Tpc
+  TrkrHitSetContainer::ConstRange hitset_range_final = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range_final.first;
+       hitset_iter != hitset_range_now.second;
+       ++hitset_iter)
+  {
+    // we have an itrator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
+    TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+    const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+    if (layer != print_layer)
+    {
+      continue;
+    }
+    const int sector = TpcDefs::getSectorId(hitsetkey);
+    const int side = TpcDefs::getSide(hitsetkey);
+    if (Verbosity() > 5 && layer == print_layer)
+    {
+      std::cout << "PHG4TpcDigitizer: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << std::endl;
+    }
+
+    // get all of the hits from this hitset
+    TrkrHitSet *hitset = hitset_iter->second;
+    TrkrHitSet::ConstRange hit_range = hitset->getHits();
+    for (TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+         hit_iter != hit_range.second;
+         ++hit_iter)
+    {
+      TrkrDefs::hitkey hitkey = hit_iter->first;
+      TrkrHit *tpchit = hit_iter->second;
+      if (Verbosity() > 5)
+      {
         std::cout << "      LAYER " << layer << " hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) << " t bin " << TpcDefs::getTBin(hitkey)
                   << " adc " << tpchit->getAdc() << std::endl;
-}
+      }
 
       if (tpchit->getAdc() == 0)
       {
@@ -656,7 +687,7 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
     }
   }
 
-  //hittruthassoc->identify();
+  // hittruthassoc->identify();
 
   return;
 }
@@ -664,10 +695,10 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
 float PHG4TpcDigitizer::add_noise_to_bin(float signal)
 {
   // add noise to the signal and return adc input voltage
-  float adc_input_voltage = signal * ADCSignalConversionGain;  // mV, see comments above
-  float noise_voltage = ( Pedestal + added_noise() ) * ADCNoiseConversionGain;  // mV - from definition of noise charge and pedestal charge
+  float adc_input_voltage = signal * ADCSignalConversionGain;                 // mV, see comments above
+  float noise_voltage = (Pedestal + added_noise()) * ADCNoiseConversionGain;  // mV - from definition of noise charge and pedestal charge
   adc_input_voltage += noise_voltage;
-  
+
   return adc_input_voltage;
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -44,15 +44,15 @@ class PHG4TpcDigitizer : public SubsysReco
   void SetTpcMinLayer(const int minlayer) { TpcMinLayer = minlayer; };
   void SetADCThreshold(const float thresh) { ADCThreshold = thresh; };
   void SetENC(const float enc) { TpcEnc = enc; };
-  void set_drift_velocity(float vd) {_drift_velocity = vd;}
-  void set_skip_noise_flag(const bool skip) {skip_noise = skip;}
+  void set_drift_velocity(float vd) { _drift_velocity = vd; }
+  void set_skip_noise_flag(const bool skip) { skip_noise = skip; }
 
  private:
   void CalculateCylinderCellADCScale(PHCompositeNode *topNode);
   void DigitizeCylinderCells(PHCompositeNode *topNode);
   float added_noise();
   float add_noise_to_bin(float signal);
-  
+
   unsigned int TpcMinLayer;
   unsigned int TpcNLayers;
   float ADCThreshold;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -42,34 +42,34 @@ namespace
 
   // utility
   template <class T>
-  inline constexpr T square(const T& x)
+  constexpr T square(const T& x)
   {
     return x * x;
   }
 
   // unique detector id for all direct lasers
-  static const int detId = PHG4HitDefs::get_volume_id("PHG4TpcDirectLaser");
+  const int detId = PHG4HitDefs::get_volume_id("PHG4TpcDirectLaser");
 
   ///@name units
   //@{
-  static constexpr double cm = 1.0;
+  constexpr double cm = 1.0;
   //@}
 
   /// speed of light, in cm per ns
-  static constexpr double speed_of_light = GSL_CONST_MKSA_SPEED_OF_LIGHT * 1e-7;
+  constexpr double speed_of_light = GSL_CONST_MKSA_SPEED_OF_LIGHT * 1e-7;
 
   /// length of generated G4Hits along laser track
-  static constexpr double maxHitLength = 1. * cm;
+  constexpr double maxHitLength = 1. * cm;
 
   /// TPC half length
-  static constexpr double halflength_tpc = 105.5 * cm;
+  constexpr double halflength_tpc = 105.5 * cm;
 
   // inner and outer radii of field cages/TPC
-  static constexpr double begin_CM = 20. * cm;
-  static constexpr double end_CM = 78. * cm;
+  constexpr double begin_CM = 20. * cm;
+  constexpr double end_CM = 78. * cm;
 
   // half the thickness of the CM;
-  static constexpr double halfwidth_CM = 0.5 * cm;
+  constexpr double halfwidth_CM = 0.5 * cm;
 
   //_____________________________________________________________
   std::optional<TVector3> central_membrane_intersection(const TVector3& start, const TVector3& direction)
@@ -175,7 +175,7 @@ namespace
     {
       return (ofc_dist > 0) ? ofc_strike : std::nullopt;
     }
-    else if (ofc_dist < 0)
+    if (ofc_dist < 0)
     {
       return ifc_strike;
     }
@@ -212,7 +212,7 @@ int PHG4TpcDirectLaser::InitRun(PHCompositeNode* topNode)
     std::cout << "Fun4AllDstPileupMerger::load_nodes - creating node G4TruthInfo" << std::endl;
 
     PHNodeIterator iter(topNode);
-    auto dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    auto* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
     if (!dstNode)
     {
       std::cout << PHWHERE << "DST Node missing, aborting." << std::endl;
@@ -225,7 +225,7 @@ int PHG4TpcDirectLaser::InitRun(PHCompositeNode* topNode)
 
   // load and check G4Hit node
   hitnodename = "G4HIT_" + detector;
-  auto* g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  auto* g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   if (!g4hit)
   {
     std::cout << Name() << " Could not locate G4HIT node " << hitnodename << std::endl;
@@ -239,7 +239,7 @@ int PHG4TpcDirectLaser::InitRun(PHCompositeNode* topNode)
   {
     // find DST node and check
     PHNodeIterator iter(topNode);
-    auto dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    auto* dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
     if (!dstNode)
     {
       std::cout << PHWHERE << "DST Node missing, aborting." << std::endl;
@@ -248,7 +248,7 @@ int PHG4TpcDirectLaser::InitRun(PHCompositeNode* topNode)
 
     // find or create SVTX node
     iter = PHNodeIterator(dstNode);
-    auto node = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
+    auto* node = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
     if (!node)
     {
       dstNode->addNode(node = new PHCompositeNode("SVTX"));
@@ -303,7 +303,7 @@ int PHG4TpcDirectLaser::process_event(PHCompositeNode* topNode)
   assert(m_g4truthinfo);
 
   // load g4hit container
-  m_g4hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  m_g4hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   assert(m_g4hitcontainer);
 
   // load track map
@@ -577,14 +577,14 @@ void PHG4TpcDirectLaser::AppendLaserTrack(double theta, double phi, const PHG4Tp
   {
     // add vertex
     const auto vtxid = m_g4truthinfo->maxvtxindex() + 1;
-    const auto vertex = new PHG4VtxPoint_t(pos.x(), pos.y(), pos.z(), 0, vtxid);
+    auto* const vertex = new PHG4VtxPoint_t(pos.x(), pos.y(), pos.z(), 0, vtxid);
     m_g4truthinfo->AddVertex(vtxid, vertex);
 
     // increment track id
     trackid = m_g4truthinfo->maxtrkindex() + 1;
 
     // create new g4particle
-    auto particle = new PHG4Particle_t();
+    auto* particle = new PHG4Particle_t();
     particle->set_track_id(trackid);
     particle->set_vtx_id(vtxid);
     particle->set_parent_id(0);
@@ -675,7 +675,7 @@ void PHG4TpcDirectLaser::AppendLaserTrack(double theta, double phi, const PHG4Tp
     }
 
     // from phg4tpcsteppingaction.cc
-    auto hit = new PHG4Hit_t;
+    auto* hit = new PHG4Hit_t;
     hit->set_trkid(trackid);
     hit->set_layer(99);
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -21,7 +21,7 @@
 namespace
 {
   template <class T>
-  inline constexpr T square(const T& x)
+  constexpr T square(const T& x)
   {
     return x * x;
   }
@@ -225,10 +225,8 @@ double PHG4TpcDistortion::get_reaches_readout(double r, double phi, double z) co
   {
     return get_distortion('R', r, phi, z);
   }
-  else
-  {
-    return 1;
-  }
+
+  return 1;
 }
 
 double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double z) const

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -72,7 +72,7 @@
 namespace
 {
   template <class T>
-  inline constexpr T square(const T &x)
+  constexpr T square(const T &x)
   {
     return x * x;
   }
@@ -109,8 +109,8 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     exit(1);
   }
-  auto runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
-  auto parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
+  auto *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  auto *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
   const std::string paramnodename = "G4CELLPARAM_" + detector;
   const std::string geonodename = "G4CELLPAR_" + detector;
   const std::string tpcgeonodename = "G4GEO_" + detector;
@@ -128,7 +128,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   if (!hitsetcontainer)
   {
     PHNodeIterator dstiter(dstNode);
-    auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    auto *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode("TRKR");
@@ -136,7 +136,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     }
 
     hitsetcontainer = new TrkrHitSetContainerv1;
-    auto newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
+    auto *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
     DetNode->addNode(newNode);
   }
 
@@ -144,7 +144,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   if (!hittruthassoc)
   {
     PHNodeIterator dstiter(dstNode);
-    auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    auto *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode("TRKR");
@@ -152,7 +152,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     }
 
     hittruthassoc = new TrkrHitTruthAssocv1;
-    auto newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
+    auto *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
     DetNode->addNode(newNode);
   }
 
@@ -160,7 +160,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   if (!truthtracks)
   {
     PHNodeIterator dstiter(dstNode);
-    auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    auto *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode("TRKR");
@@ -168,7 +168,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     }
 
     truthtracks = new TrkrTruthTrackContainerv1();
-    auto newNode = new PHIODataNode<PHObject>(truthtracks, "TRKR_TRUTHTRACKCONTAINER", "PHObject");
+    auto *newNode = new PHIODataNode<PHObject>(truthtracks, "TRKR_TRUTHTRACKCONTAINER", "PHObject");
     DetNode->addNode(newNode);
   }
 
@@ -176,7 +176,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   if (!truthclustercontainer)
   {
     PHNodeIterator dstiter(dstNode);
-    auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    auto *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode("TRKR");
@@ -184,7 +184,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     }
 
     truthclustercontainer = new TrkrClusterContainerv4;
-    auto newNode = new PHIODataNode<PHObject>(truthclustercontainer, "TRKR_TRUTHCLUSTERCONTAINER", "PHObject");
+    auto *newNode = new PHIODataNode<PHObject>(truthclustercontainer, "TRKR_TRUTHCLUSTERCONTAINER", "PHObject");
     DetNode->addNode(newNode);
   }
 
@@ -194,7 +194,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
 
   UpdateParametersWithMacro();
   PHNodeIterator runIter(runNode);
-  auto RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
+  auto *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
   if (!RunDetNode)
   {
     RunDetNode = new PHCompositeNode(detector);
@@ -204,7 +204,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
 
   // save this to the parNode for use
   PHNodeIterator parIter(parNode);
-  auto ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
+  auto *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
   if (!ParDetNode)
   {
     ParDetNode = new PHCompositeNode(detector);
@@ -214,11 +214,11 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
 
   // find Tpc Geo
   PHNodeIterator tpcpariter(ParDetNode);
-  auto tpcparams = findNode::getClass<PHParametersContainer>(ParDetNode, tpcgeonodename);
+  auto *tpcparams = findNode::getClass<PHParametersContainer>(ParDetNode, tpcgeonodename);
   if (!tpcparams)
   {
     const std::string runparamname = "G4GEOPARAM_" + detector;
-    auto tpcpdbparams = findNode::getClass<PdbParameterMapContainer>(RunDetNode, runparamname);
+    auto *tpcpdbparams = findNode::getClass<PdbParameterMapContainer>(RunDetNode, runparamname);
     if (tpcpdbparams)
     {
       tpcparams = new PHParametersContainer(detector);
@@ -260,24 +260,24 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   // diffusion and drift velocity for 400kV for NeCF4 50/50 from calculations:
   // http://skipper.physics.sunysb.edu/~prakhar/tpc/HTML_Gases/split.html
 
-  double Ne_dEdx = 1.56; // keV/cm
-  double Ne_NTotal = 43; // Number/cm
+  double Ne_dEdx = 1.56;  // keV/cm
+  double Ne_NTotal = 43;  // Number/cm
   double Ne_frac = tpcparam->get_double_param("Ne_frac");
 
-  double Ar_dEdx = 2.44; // keV/cm
-  double Ar_NTotal = 94; // Number/cm
+  double Ar_dEdx = 2.44;  // keV/cm
+  double Ar_NTotal = 94;  // Number/cm
   double Ar_frac = tpcparam->get_double_param("Ar_frac");
 
-  double CF4_dEdx = 7; // keV/cm
-  double CF4_NTotal = 100; // Number/cm
+  double CF4_dEdx = 7;      // keV/cm
+  double CF4_NTotal = 100;  // Number/cm
   double CF4_frac = tpcparam->get_double_param("CF4_frac");
 
-  double N2_dEdx = 2.127;   // keV/cm https://pdg.lbl.gov/2024/AtomicNuclearProperties/HTML/nitrogen_gas.html
-  double N2_NTotal = 25;    // Number/cm (probably not right but has a very small impact)
+  double N2_dEdx = 2.127;  // keV/cm https://pdg.lbl.gov/2024/AtomicNuclearProperties/HTML/nitrogen_gas.html
+  double N2_NTotal = 25;   // Number/cm (probably not right but has a very small impact)
   double N2_frac = tpcparam->get_double_param("N2_frac");
 
   double isobutane_dEdx = 5.93;   // keV/cm
-  double isobutane_NTotal = 195;    // Number/cm
+  double isobutane_NTotal = 195;  // Number/cm
   double isobutane_frac = tpcparam->get_double_param("isobutane_frac");
 
   if (m_use_PDG_gas_params)
@@ -289,22 +289,14 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     Ar_NTotal = 97;
 
     CF4_dEdx = 6.382;
-    CF4_NTotal = 120; 
+    CF4_NTotal = 120;
   }
 
-  double Tpc_NTot = (Ne_NTotal * Ne_frac)
-                  + (Ar_NTotal * Ar_frac)
-                  + (CF4_NTotal * CF4_frac)
-                  + (N2_NTotal * N2_frac)
-                  + (isobutane_NTotal * isobutane_frac);
+  double Tpc_NTot = (Ne_NTotal * Ne_frac) + (Ar_NTotal * Ar_frac) + (CF4_NTotal * CF4_frac) + (N2_NTotal * N2_frac) + (isobutane_NTotal * isobutane_frac);
 
-  double Tpc_dEdx = (Ne_dEdx * Ne_frac)
-                  + (Ar_dEdx * Ar_frac)
-                  + (CF4_dEdx * CF4_frac)
-                  + (N2_dEdx * N2_frac)
-                  + (isobutane_dEdx * isobutane_frac);
+  double Tpc_dEdx = (Ne_dEdx * Ne_frac) + (Ar_dEdx * Ar_frac) + (CF4_dEdx * CF4_frac) + (N2_dEdx * N2_frac) + (isobutane_dEdx * isobutane_frac);
 
-  electrons_per_gev = (Tpc_NTot / Tpc_dEdx) * 1e6; 
+  electrons_per_gev = (Tpc_NTot / Tpc_dEdx) * 1e6;
 
   // min_time to max_time is the time window for accepting drifted electrons after the trigger
   min_time = 0.0;
@@ -317,7 +309,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     std::cout << PHWHERE << " drift velocity " << drift_velocity << " extended_readout_time " << get_double_param("extended_readout_time") << " max time cutoff " << max_time << std::endl;
   }
 
-  auto se = Fun4AllServer::instance();
+  auto *se = Fun4AllServer::instance();
   dlong = new TH1F("difflong", "longitudinal diffusion", 100, diffusion_long - diffusion_long / 2., diffusion_long + diffusion_long / 2.);
   se->registerHisto(dlong);
   dtrans = new TH1F("difftrans", "transversal diffusion", 100, diffusion_trans - diffusion_trans / 2., diffusion_trans + diffusion_trans / 2.);
@@ -384,14 +376,14 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     if (!mClusHitsVerbose)
     {
       PHNodeIterator dstiter(dstNode);
-      auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+      auto *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
       if (!DetNode)
       {
         DetNode = new PHCompositeNode("TRKR");
         dstNode->addNode(DetNode);
       }
       mClusHitsVerbose = new ClusHitsVerbosev1();
-      auto newNode = new PHIODataNode<PHObject>(mClusHitsVerbose, "Trkr_TruthClusHitsVerbose", "PHObject");
+      auto *newNode = new PHIODataNode<PHObject>(mClusHitsVerbose, "Trkr_TruthClusHitsVerbose", "PHObject");
       DetNode->addNode(newNode);
     }
   }
@@ -425,7 +417,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   }
 
   // g4hits
-  auto g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
+  auto *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   if (!g4hit)
   {
     std::cout << "Could not locate g4 hit node " << hitnodename << std::endl;
@@ -439,7 +431,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   //  int count_electrons = 0;
 
   //  double ecollectedhits = 0.0;
-//  int ncollectedhits = 0;
+  //  int ncollectedhits = 0;
   double ihit = 0;
   unsigned int dump_interval = 5000;  // dump temp_hitsetcontainer to the node tree after this many g4hits
   unsigned int dump_counter = 0;
@@ -551,7 +543,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     }
 
     int notReachingReadout = 0;
-//    int notInAcceptance = 0;
+    //    int notInAcceptance = 0;
     for (unsigned int i = 0; i < n_electrons; i++)
     {
       // We choose the electron starting position at random from a flat
@@ -670,7 +662,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       // remove electrons outside of our acceptance. Careful though, electrons from just inside 30 cm can contribute in the 1st active layer readout, so leave a little margin
       if (rad_final < min_active_radius - 2.0 || rad_final > max_active_radius + 1.0)
       {
-//        notInAcceptance++;
+        //        notInAcceptance++;
         continue;
       }
 
@@ -784,7 +776,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
             eg4hit += temp_tpchit->getEnergy();
             //            ecollectedhits += temp_tpchit->getEnergy();
-//            ncollectedhits++;
+            //            ncollectedhits++;
           }
 
           // find or add this hit to the node tree
@@ -936,16 +928,16 @@ void PHG4TpcElectronDrift::set_seed(const unsigned int seed)
 
 void PHG4TpcElectronDrift::SetDefaultParameters()
 {
-  //longitudinal diffusion for 50:50 Ne:CF4 is 0.012, transverse is 0.004, drift velocity is 0.008
-  //longitudinal diffusion for 60:40 Ar:CF4 is 0.012, transverse is 0.004, drift velocity is 0.008 (chosen to be the same at 50/50 Ne:CF4)
-  //longitudinal diffusion for 65:25:10 Ar:CF4:N2 is 0.013613, transverse is 0.005487, drift velocity is 0.006965
-  //longitudinal diffusion for 75:20:05 Ar:CF4:i-C4H10 is 0.014596, transverse is 0.005313, drift velocity is 0.007550
+  // longitudinal diffusion for 50:50 Ne:CF4 is 0.012, transverse is 0.004, drift velocity is 0.008
+  // longitudinal diffusion for 60:40 Ar:CF4 is 0.012, transverse is 0.004, drift velocity is 0.008 (chosen to be the same at 50/50 Ne:CF4)
+  // longitudinal diffusion for 65:25:10 Ar:CF4:N2 is 0.013613, transverse is 0.005487, drift velocity is 0.006965
+  // longitudinal diffusion for 75:20:05 Ar:CF4:i-C4H10 is 0.014596, transverse is 0.005313, drift velocity is 0.007550
 
   set_default_double_param("diffusion_long", 0.014596);   // cm/SQRT(cm)
   set_default_double_param("diffusion_trans", 0.005313);  // cm/SQRT(cm)
-  set_default_double_param("drift_velocity", 0.00755);  // cm/ns
-  set_default_double_param("Ne_frac", 0.00); 
-  set_default_double_param("Ar_frac", 0.75); 
+  set_default_double_param("drift_velocity", 0.00755);    // cm/ns
+  set_default_double_param("Ne_frac", 0.00);
+  set_default_double_param("Ar_frac", 0.75);
   set_default_double_param("CF4_frac", 0.20);
   set_default_double_param("N2_frac", 0.00);
   set_default_double_param("isobutane_frac", 0.05);

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -189,7 +189,8 @@ void PHG4TpcEndCapDetector::CreateCompositeMaterial(
   assert(materialName.size() == thickness.size());
 
   // sum up the areal density and total thickness so we can divvy it out
-  double totalArealDensity = 0, totalThickness = 0;
+  double totalArealDensity = 0;
+  double totalThickness = 0;
   for (std::vector<double>::size_type i = 0; i < thickness.size(); i++)
   {
     tempmat = GetDetectorMaterial(materialName[i]);
@@ -240,7 +241,7 @@ void PHG4TpcEndCapDetector ::AddLayer(  //
       _depth * _percentage_filled / 100. / 2.,
       0, CLHEP::twopi);
 
-  auto material = GetDetectorMaterial(_material);
+  auto *material = GetDetectorMaterial(_material);
   if (material == nullptr)
   {
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error: missing material " << _material << std::endl;
@@ -267,7 +268,7 @@ void PHG4TpcEndCapDetector::ConstructWagonWheel(G4AssemblyVolume *assmeblyvol,
   assert(n_radial_modules >= 1);
 
   const std::string material_name(m_Params->get_string_param("wagon_wheel_material"));
-  auto material = GetDetectorMaterial(material_name);
+  auto *material = GetDetectorMaterial(material_name);
   if (material == nullptr)
   {
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error: missing material " << m_Params->get_string_param("wagon_wheel_material") << std::endl;
@@ -486,7 +487,7 @@ void PHG4TpcEndCapDetector::ConstructElectronics(G4AssemblyVolume *assmeblyvol,
     }
 
     const std::string electronics_cooling_block_material_name(m_Params->get_string_param("electronics_cooling_block_material"));
-    auto material = GetDetectorMaterial(electronics_cooling_block_material_name);
+    auto *material = GetDetectorMaterial(electronics_cooling_block_material_name);
     if (material == nullptr)
     {
       std::cout << __PRETTY_FUNCTION__ << " Fatal Error: missing material " << m_Params->get_string_param("electronics_cooling_block_material_name") << std::endl;
@@ -552,8 +553,8 @@ void PHG4TpcEndCapDetector::ConstructElectronics(G4AssemblyVolume *assmeblyvol,
         m_DisplayAction->AddVolume(log_vol, "cooling_block");
 
       }  //     for (int sector_id = 0; sector_id < n_sectors; ++sector_id)
-    }    // for (int ring_id = 0; ring_id <= n_radial_modules; ++ring_id)
-  }      // electronics_cooling_block_material  if (electronics_cooling_block_thickness>0)
+    }  // for (int ring_id = 0; ring_id <= n_radial_modules; ++ring_id)
+  }  // electronics_cooling_block_material  if (electronics_cooling_block_thickness>0)
 
   ///////////////////////////////////////////////
   // electronics

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -70,10 +70,10 @@ class PHG4TpcEndCapDetector : public PHG4Detector
       double _percentage_filled = 100  //! percentage filled//
   );
 
-  void CreateCompositeMaterial(               //
+  static void CreateCompositeMaterial(        //
       const std::string &compositeName,       //! desired name for the new material
       std::vector<std::string> materialName,  //! vector of the names of the component materials in G4
-      const std::vector<double> &thickness           //! thickness of this particular layer (assuming 100 percent filled)
+      const std::vector<double> &thickness    //! thickness of this particular layer (assuming 100 percent filled)
   );
 };
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.cc
@@ -278,8 +278,8 @@ bool PHG4TpcEndCapSteppingAction::UserSteppingAction(const G4Step *aStep, bool /
       }
       if (geantino)
       {
-        //implement your own here://
-        // if you want to do something special for geantinos (normally you do not)
+        // implement your own here://
+        //  if you want to do something special for geantinos (normally you do not)
         m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way
                               // geantinos survive the g4hit compression
         if (whichactive > 0)
@@ -291,8 +291,8 @@ bool PHG4TpcEndCapSteppingAction::UserSteppingAction(const G4Step *aStep, bool /
       {
         m_Hit->set_edep(m_EdepSum);
       }
-      //implement your own here://
-      // what you set here will be saved in the output
+      // implement your own here://
+      //  what you set here will be saved in the output
       if (whichactive > 0)
       {
         m_Hit->set_eion(m_EionSum);

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -42,7 +42,7 @@
 namespace
 {
   template <class T>
-  inline constexpr T square(const T &x)
+  constexpr T square(const T &x)
   {
     return x * x;
   }
@@ -99,7 +99,7 @@ PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name)
   std::cout << "PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name) Calling ctor" << std::endl;
 }
 
-bool PHG4TpcPadBaselineShift::is_in_sector_boundary(int phibin, int sector, PHG4TpcCylinderGeom *layergeom)
+bool PHG4TpcPadBaselineShift::is_in_sector_boundary(int phibin, int sector, PHG4TpcCylinderGeom *layergeom) const
 {
   bool reject_it = false;
 
@@ -172,14 +172,14 @@ int PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  auto geom =
+  auto *geom =
       findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   if (!geom)
   {
     std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
+  AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
 
   std::cout << "PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
@@ -343,7 +343,7 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
       {
         continue;  // zbin is unsigned int, <0 cannot happen
       }
-      adcval[zbin] = (unsigned short) adc;
+      adcval[zbin] = adc;
       sumADC += adc;
     }
     // Define ion-induced charge

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
@@ -40,7 +40,7 @@ class PHG4TpcPadBaselineShift : public SubsysReco
   void set_drift_velocity(float vd) { _drift_velocity = vd; }
 
  private:
-  bool is_in_sector_boundary(int phibin, int sector, PHG4TpcCylinderGeom *layergeom);
+  bool is_in_sector_boundary(int phibin, int sector, PHG4TpcCylinderGeom *layergeom) const;
 
   TrkrHitSetContainer *m_hits{nullptr};
   TrkrClusterContainer *m_clusterlist{nullptr};

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -23,14 +23,16 @@ class PHG4TpcPadPlane : public SubsysReco, public PHParameterInterface
   PHG4TpcPadPlane(const std::string &name = "PHG4TpcPadPlane");
 
   int process_event(PHCompositeNode *) final
-  { return 0; }
+  {
+    return 0;
+  }
 
-  virtual void SetDriftVelocity(double /*vd*/) {return;}
+  virtual void SetDriftVelocity(double /*vd*/) { return; }
   virtual void SetReadoutTime(float) { return; }
   int InitRun(PHCompositeNode *topNode) override;
   virtual void UpdateInternalParameters() { return; }
   //  virtual void MapToPadPlane(PHG4CellContainer * /*g4cells*/, const double /*x_gem*/, const double /*y_gem*/, const double /*t_gem*/, const unsigned int /*side*/, PHG4HitContainer::ConstIterator /*hiter*/, TNtuple * /*ntpad*/, TNtuple * /*nthit*/) {}
-  virtual void MapToPadPlane(TpcClusterBuilder& /*builder*/, TrkrHitSetContainer * /*single_hitsetcontainer*/, TrkrHitSetContainer * /*hitsetcontainer*/, TrkrHitTruthAssoc * /*hittruthassoc*/, const double /*x_gem*/, const double /*y_gem*/, const double /*t_gem*/, const unsigned int /*side*/, PHG4HitContainer::ConstIterator /*hiter*/, TNtuple * /*ntpad*/, TNtuple * /*nthit*/)=0;// { return {}; }
+  virtual void MapToPadPlane(TpcClusterBuilder & /*builder*/, TrkrHitSetContainer * /*single_hitsetcontainer*/, TrkrHitSetContainer * /*hitsetcontainer*/, TrkrHitTruthAssoc * /*hittruthassoc*/, const double /*x_gem*/, const double /*y_gem*/, const double /*t_gem*/, const unsigned int /*side*/, PHG4HitContainer::ConstIterator /*hiter*/, TNtuple * /*ntpad*/, TNtuple * /*nthit*/) = 0;  // { return {}; }
   void Detector(const std::string &name) { detector = name; }
 
  protected:

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -26,9 +26,9 @@
 
 #include <phool/phool.h>  // for PHWHERE
 
+#include <TF1.h>
 #include <TFile.h>
 #include <TH2.h>
-#include <TF1.h>
 #include <TSystem.h>
 
 #include <gsl/gsl_randist.h>
@@ -49,7 +49,7 @@ namespace
 {
   //! convenient square function
   template <class T>
-  inline constexpr T square(const T &x)
+  constexpr T square(const T &x)
   {
     return x * x;
   }
@@ -67,19 +67,19 @@ namespace
     return std::exp(-square(x / sigma) / 2) / (sigma * std::sqrt(2 * M_PI));
   }
 
-  static constexpr unsigned int print_layer = 18;
+  constexpr unsigned int print_layer = 18;
 
 }  // namespace
 
 PHG4TpcPadPlaneReadout::PHG4TpcPadPlaneReadout(const std::string &name)
   : PHG4TpcPadPlane(name)
+  , RandomGenerator(gsl_rng_alloc(gsl_rng_mt19937))
 {
   InitializeParameters();
   // if(m_flagToUseGain==1)
   ReadGain();
-  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
-  gsl_rng_set(RandomGenerator, PHRandomSeed());  // fixed seed is handled in this funtcion
 
+  gsl_rng_set(RandomGenerator, PHRandomSeed());  // fixed seed is handled in this funtcion
 
   return;
 }
@@ -87,7 +87,7 @@ PHG4TpcPadPlaneReadout::PHG4TpcPadPlaneReadout(const std::string &name)
 PHG4TpcPadPlaneReadout::~PHG4TpcPadPlaneReadout()
 {
   gsl_rng_free(RandomGenerator);
-  for (auto his : h_gain)
+  for (auto *his : h_gain)
   {
     delete his;
   }
@@ -105,53 +105,60 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
   const std::string seggeonodename = "CYLINDERCELLGEOM_SVTX";
   GeomContainer = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, seggeonodename);
   assert(GeomContainer);
-  if(m_use_module_gain_weights)
+  if (m_use_module_gain_weights)
+  {
+    int side;
+    int region;
+    int sector;
+    double weight;
+    std::ifstream weights_file(m_tpc_module_gain_weights_file);
+    if (!weights_file.is_open())
     {
-      int side, region, sector;
-      double weight;
-      std::ifstream weights_file(m_tpc_module_gain_weights_file);
-      if(!weights_file.is_open()) 
-	{
-	  std::cout << ".In PHG4TpcPadPlaneReadout: Option to use module gain weights enabled, but weights file not found. Aborting." << std::endl;
-	  return Fun4AllReturnCodes::ABORTEVENT;
-	}
+      std::cout << ".In PHG4TpcPadPlaneReadout: Option to use module gain weights enabled, but weights file not found. Aborting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
 
-      for(int iside =0; iside < 2; ++iside)
-	{
-	  for(int isec = 0; isec < 12; ++isec)
-	    {
-	      for(int ir = 0; ir < 3; ++ir)
-		{
-		  weights_file >> side >> region >> sector >> weight;
-		  m_module_gain_weight[side][region][sector] = weight;
-		  std::cout << " iside " << iside << " side " << side << " ir " << ir 
-			    << " region " << region << " isec " << isec 
-			    << " sector " << sector << " weight " << weight << std::endl;
-		}
-	    }
-	}
-    }  
-
-  if(m_useLangau)
+    for (int iside = 0; iside < 2; ++iside)
     {
-      int side, region, sector;
-      double par0; double par1; double par2; double par3;
-      std::ifstream pars_file(m_tpc_langau_pars_file);
-      if(!pars_file.is_open()) 
-	{
-	  std::cout << ".In PHG4TpcPadPlaneReadout: Option to use Langau parameters enabled, but parameter file not found. Aborting." << std::endl;
-	  return Fun4AllReturnCodes::ABORTEVENT;
-	}
+      for (int isec = 0; isec < 12; ++isec)
+      {
+        for (int ir = 0; ir < 3; ++ir)
+        {
+          weights_file >> side >> region >> sector >> weight;
+          m_module_gain_weight[side][region][sector] = weight;
+          std::cout << " iside " << iside << " side " << side << " ir " << ir
+                    << " region " << region << " isec " << isec
+                    << " sector " << sector << " weight " << weight << std::endl;
+        }
+      }
+    }
+  }
 
-      for(int iside =0; iside < 2; ++iside)
-	{
-	  for(int isec = 0; isec < 12; ++isec)
-	    {
-	      for(int ir = 0; ir < 3; ++ir)
-		{
-		  pars_file >> side >> region >> sector >> par0 >> par1 >> par2 >> par3;
-		  flangau[side][region][sector] = new TF1((boost::format("flangau_%d_%d_%d") % side % region % sector).str().c_str(), [](double *x, double *par) 
-		  {
+  if (m_useLangau)
+  {
+    int side;
+    int region;
+    int sector;
+    double par0;
+    double par1;
+    double par2;
+    double par3;
+    std::ifstream pars_file(m_tpc_langau_pars_file);
+    if (!pars_file.is_open())
+    {
+      std::cout << ".In PHG4TpcPadPlaneReadout: Option to use Langau parameters enabled, but parameter file not found. Aborting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    for (int iside = 0; iside < 2; ++iside)
+    {
+      for (int isec = 0; isec < 12; ++isec)
+      {
+        for (int ir = 0; ir < 3; ++ir)
+        {
+          pars_file >> side >> region >> sector >> par0 >> par1 >> par2 >> par3;
+          flangau[side][region][sector] = new TF1((boost::format("flangau_%d_%d_%d") % side % region % sector).str().c_str(), [](double *x, double *par)
+                                                  {
 		    Double_t invsq2pi = 0.3989422804014;
 		    Double_t mpshift  = -0.22278298;
 		    Double_t np = 100.0;
@@ -160,7 +167,8 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
 		    Double_t mpc;
 		    Double_t fland;
 		    Double_t sum = 0.0;
-		    Double_t xlow,xupp;
+		    Double_t xlow;
+		    Double_t xupp;
 		    Double_t step;
 		    Double_t i;
 		    mpc = par[1] - mpshift * par[0]; 
@@ -178,20 +186,16 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
 		      sum += fland * TMath::Gaus(x[0],xx,par[3]);
 		    }
       
-		    return (par[2] * step * sum * invsq2pi / par[3]);
-		  }, 0, 5000, 4);
+		    return (par[2] * step * sum * invsq2pi / par[3]); }, 0, 5000, 4);
 
-
-		  flangau[side][region][sector]->SetParameters(par0,par1,par2,par3);
-		  //std::cout << " iside " << iside << " side " << side << " ir " << ir 
-		  //	    << " region " << region << " isec " << isec 
-		  //	    << " sector " << sector << " weight " << weight << std::endl;
-		}
-	    }
-	}
-    } 
-
-  
+          flangau[side][region][sector]->SetParameters(par0, par1, par2, par3);
+          // std::cout << " iside " << iside << " side " << side << " ir " << ir
+          //	    << " region " << region << " isec " << isec
+          //	    << " sector " << sector << " weight " << weight << std::endl;
+        }
+      }
+    }
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -209,11 +213,11 @@ double PHG4TpcPadPlaneReadout::getSingleEGEMAmplification()
   //         and yes, the parameter you're looking for is of course the slope, which is the inverse gain.
   double nelec = gsl_ran_exponential(RandomGenerator, averageGEMGain);
   if (m_usePolya)
-  { 
+  {
     double y;
     double xmax = 5000;
     double ymax = 0.376;
-    while (true) 
+    while (true)
     {
       nelec = gsl_ran_flat(RandomGenerator, 0, xmax);
       y = gsl_rng_uniform(RandomGenerator) * ymax;
@@ -246,11 +250,11 @@ double PHG4TpcPadPlaneReadout::getSingleEGEMAmplification(double weight)
     double y;
     double xmax = 5000;
     double ymax = 0.376;
-    while (true) 
+    while (true)
     {
       nelec = gsl_ran_flat(RandomGenerator, 0, xmax);
       y = gsl_rng_uniform(RandomGenerator) * ymax;
-      if (y <= pow((1 + polyaTheta) * (nelec / q_bar), polyaTheta) * exp(-(1 + polyaTheta) * (nelec / q_bar))) 
+      if (y <= pow((1 + polyaTheta) * (nelec / q_bar), polyaTheta) * exp(-(1 + polyaTheta) * (nelec / q_bar)))
       {
         break;
       }
@@ -264,13 +268,11 @@ double PHG4TpcPadPlaneReadout::getSingleEGEMAmplification(double weight)
 //_________________________________________________________
 double PHG4TpcPadPlaneReadout::getSingleEGEMAmplification(TF1 *f)
 {
-  double nelec = f->GetRandom(0,5000);
+  double nelec = f->GetRandom(0, 5000);
   // Put gain reading here
 
   return nelec;
 }
-
-
 
 void PHG4TpcPadPlaneReadout::MapToPadPlane(
     TpcClusterBuilder &tpc_truth_clusterer,
@@ -387,72 +389,72 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(
     nelec = nelec * gain_weight;
   }
 
-  if(m_use_module_gain_weights)
-    {
-      double phistep = 30.0;
-      int sector = 0;
-
-      if( (phi_gain*180.0/M_PI) >=15 && (phi_gain*180.0 / M_PI) < 345)
-	{
-	  sector = 1 + (int) ( (phi_gain*180.0/M_PI - 15) / phistep);
-	} 
-      else
-	{
-	  sector = 0;
-	}
-
-      int this_region = -1;
-      for (int iregion = 0; iregion < 3; ++iregion)
-	{
-	  if (rad_gem < MaxRadius[iregion] && rad_gem > MinRadius[iregion])
-	    {
-	      this_region = iregion;
-	    }
-	}
-      if(this_region > -1) 
-	{
-	  gain_weight = m_module_gain_weight[side][this_region][sector];
-	}
-      // regenerate nelec with the new distribution
-      //    double original_nelec = nelec; 
-      nelec = getSingleEGEMAmplification(gain_weight);
-      //  std::cout << " side " << side << " this_region " << this_region 
-      //	<<  " sector " << sector << " original nelec " 
-      //	<< original_nelec << " new nelec " << nelec << std::endl;
-    }
-
-  if(m_useLangau)
+  if (m_use_module_gain_weights)
   {
     double phistep = 30.0;
     int sector = 0;
-    
-    if( (phi_gain*180.0/M_PI) >=15 && (phi_gain*180.0 / M_PI) < 345)
+
+    if ((phi_gain * 180.0 / M_PI) >= 15 && (phi_gain * 180.0 / M_PI) < 345)
     {
-      sector = 1 + (int) ( (phi_gain*180.0/M_PI - 15) / phistep);
-    } 
+      sector = 1 + (int) ((phi_gain * 180.0 / M_PI - 15) / phistep);
+    }
     else
     {
       sector = 0;
     }
-    
+
     int this_region = -1;
     for (int iregion = 0; iregion < 3; ++iregion)
     {
       if (rad_gem < MaxRadius[iregion] && rad_gem > MinRadius[iregion])
       {
-	this_region = iregion;
+        this_region = iregion;
       }
     }
-    if(this_region > -1) 
+    if (this_region > -1)
+    {
+      gain_weight = m_module_gain_weight[side][this_region][sector];
+    }
+    // regenerate nelec with the new distribution
+    //    double original_nelec = nelec;
+    nelec = getSingleEGEMAmplification(gain_weight);
+    //  std::cout << " side " << side << " this_region " << this_region
+    //	<<  " sector " << sector << " original nelec "
+    //	<< original_nelec << " new nelec " << nelec << std::endl;
+  }
+
+  if (m_useLangau)
+  {
+    double phistep = 30.0;
+    int sector = 0;
+
+    if ((phi_gain * 180.0 / M_PI) >= 15 && (phi_gain * 180.0 / M_PI) < 345)
+    {
+      sector = 1 + (int) ((phi_gain * 180.0 / M_PI - 15) / phistep);
+    }
+    else
+    {
+      sector = 0;
+    }
+
+    int this_region = -1;
+    for (int iregion = 0; iregion < 3; ++iregion)
+    {
+      if (rad_gem < MaxRadius[iregion] && rad_gem > MinRadius[iregion])
+      {
+        this_region = iregion;
+      }
+    }
+    if (this_region > -1)
     {
       nelec = getSingleEGEMAmplification(flangau[side][this_region][sector]);
     }
-    else 
+    else
     {
       nelec = getSingleEGEMAmplification();
     }
   }
-  
+
   // std::cout<<"PHG4TpcPadPlaneReadout::MapToPadPlane gain_weight = "<<gain_weight<<std::endl;
   /* pass_data.neff_electrons = nelec; */
 
@@ -621,7 +623,7 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(
       */
 
     }  // end of loop over adc T bins
-  }    // end of loop over zigzag pads
+  }  // end of loop over zigzag pads
   /* pass_data.phi_integral = phi_integral; */
   /* pass_data.time_integral = t_integral; */
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -33,12 +33,12 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   int InitRun(PHCompositeNode *topNode) override;
 
   void UseGain(const int flagToUseGain);
-  void SetUseModuleGainWeights(const int flag) {m_use_module_gain_weights = flag;}
-  void SetModuleGainWeightsFileName(const std::string &name) {m_tpc_module_gain_weights_file = name;}
+  void SetUseModuleGainWeights(const int flag) { m_use_module_gain_weights = flag; }
+  void SetModuleGainWeightsFileName(const std::string &name) { m_tpc_module_gain_weights_file = name; }
   void ReadGain();
-  void SetUsePolyaGEMGain(const int flagPolya) {m_usePolya = flagPolya;}
-  void SetUseLangauGEMGain(const int flagLangau) {m_useLangau = flagLangau;}
-  void SetLangauParsFileName(const std::string &name) {m_tpc_langau_pars_file = name;}
+  void SetUsePolyaGEMGain(const int flagPolya) { m_usePolya = flagPolya; }
+  void SetUseLangauGEMGain(const int flagLangau) { m_useLangau = flagLangau; }
+  void SetLangauParsFileName(const std::string &name) { m_tpc_langau_pars_file = name; }
 
   void SetDriftVelocity(double vd) override { drift_velocity = vd; }
   void SetReadoutTime(float t) override { extended_readout_time = t; }
@@ -96,7 +96,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   // return random distribution of number of electrons after amplification of GEM for each initial ionizing electron
   double getSingleEGEMAmplification();
   double getSingleEGEMAmplification(double weight);
-  double getSingleEGEMAmplification(TF1 *f);
+  static double getSingleEGEMAmplification(TF1 *f);
   bool m_usePolya = false;
 
   bool m_useLangau = false;
@@ -106,18 +106,15 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   std::array<TH2 *, 2> h_gain{nullptr};
 
-  double m_module_gain_weight[2][3][12] = { 
-    { {1,1,1,1,1,1,1,1,1,1,1,1},
-      {1,1,1,1,1,1,1,1,1,1,1,1},
-      {1,1,1,1,1,1,1,1,1,1,1,1} },
-    { {1,1,1,1,1,1,1,1,1,1,1,1},
-      {1,1,1,1,1,1,1,1,1,1,1,1},
-      {1,1,1,1,1,1,1,1,1,1,1,1} } 
-  };
+  double m_module_gain_weight[2][3][12] = {
+      {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+       {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+       {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+      {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+       {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+       {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}};
 
   TF1 *flangau[2][3][12] = {{{nullptr}}};
-
-  
 };
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
@@ -311,10 +311,8 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
     // return true to indicate the hit was used
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 //____________________________________________________________________________..
@@ -344,7 +342,7 @@ void PHG4TpcSteppingAction::SetHitNodeName(const std::string& type, const std::s
     m_HitNodeName = name;
     return;
   }
-  else if (type == "G4HIT_ABSORBER")
+  if (type == "G4HIT_ABSORBER")
   {
     m_AbsorberNodeName = name;
     return;

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -217,7 +217,7 @@ void PHG4TpcSubsystem::SetDefaultParameters()
 
   set_default_double_param("maxdriftlength", 105.5);       // cm
   set_default_double_param("extended_readout_time", 0.0);  // ns
-  set_default_double_param("tpc_adc_clock", 53.326184);         // ns, for 18.8 MHz clock
+  set_default_double_param("tpc_adc_clock", 53.326184);    // ns, for 18.8 MHz clock
 
   set_default_double_param("tpc_sector_phi_inner", 0.5024);  // 2 * M_PI / 12 );//sector size in phi for R1 sector
   set_default_double_param("tpc_sector_phi_mid", 0.5087);    // 2 * M_PI / 12 );//sector size in phi for R2 sector
@@ -227,10 +227,10 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_int_param("ntpc_phibins_mid", 1536);    // 128 * 12
   set_default_int_param("ntpc_phibins_outer", 2304);  // 192 * 12
 
-  set_default_double_param("TPC_gas_temperature", 15.0); //in celcius
-  set_default_double_param("TPC_gas_pressure", 1.0); //in atmospheres
-  set_default_double_param("Ne_frac", 0.00); 
-  set_default_double_param("Ar_frac", 0.75); 
+  set_default_double_param("TPC_gas_temperature", 15.0);  // in celcius
+  set_default_double_param("TPC_gas_pressure", 1.0);      // in atmospheres
+  set_default_double_param("Ne_frac", 0.00);
+  set_default_double_param("Ar_frac", 0.75);
   set_default_double_param("CF4_frac", 0.20);
   set_default_double_param("N2_frac", 0.00);
   set_default_double_param("isobutane_frac", 0.05);

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -15,6 +15,7 @@
 
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
+#include <algorithm>
 #include <boost/format.hpp>
 
 #include <algorithm>
@@ -28,7 +29,7 @@
 namespace
 {
   template <class T>
-  inline constexpr T square(const T &x)
+  constexpr T square(const T& x)
   {
     return x * x;
   }
@@ -109,8 +110,12 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track)
     const double threshold = sum_adc * m_pixel_thresholdrat;
 
     // FIXME -- see why the hits are so scattered
-    std::set<int> v_iphi, v_it;                                    // FIXME
-    std::map<int, unsigned int> m_iphi, m_it, m_iphiCut, m_itCut;  // FIXME
+    std::set<int> v_iphi;
+    std::set<int> v_it;  // FIXME
+    std::map<int, unsigned int> m_iphi;
+    std::map<int, unsigned int> m_it;
+    std::map<int, unsigned int> m_iphiCut;
+    std::map<int, unsigned int> m_itCut;  // FIXME
     for (auto iter = ihit_list.first; iter != ihit_list.second; ++iter)
     {
       unsigned int adc = iter->second->getAdc();
@@ -164,22 +169,10 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track)
         pnew.first->second += adc;
       }
 
-      if (iphi > phibinhi)
-      {
-        phibinhi = iphi;
-      }
-      if (iphi < phibinlo)
-      {
-        phibinlo = iphi;
-      }
-      if (it > tbinhi)
-      {
-        tbinhi = it;
-      }
-      if (it < tbinlo)
-      {
-        tbinlo = it;
-      }
+      phibinhi = std::max(iphi, phibinhi);
+      phibinlo = std::min(iphi, phibinlo);
+      tbinhi = std::max(it, tbinhi);
+      tbinlo = std::min(it, tbinlo);
 
       iphi_sum += iphi * adc;
       // phi2_sum += square(phi_center)*adc;
@@ -362,7 +355,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track)
     Acts::Vector3 local = surface->transform(m_tGeometry->geometry().getGeoContext()).inverse() * global;
     local /= Acts::UnitConstants::cm;
 
-    auto cluster = new TrkrClusterv4;  //
+    auto* cluster = new TrkrClusterv4;  //
     cluster->setAdc(adc_sum);
     /* cluster->setOverlap(ntouch); */
     /* cluster->setEdge(nedge); */
@@ -430,7 +423,7 @@ void TpcClusterBuilder::clear_hitsetkey_cnt()
 }
 
 void TpcClusterBuilder::print(
-    TrkrTruthTrackContainer* truth_tracks, int nclusprint)
+    TrkrTruthTrackContainer* truth_tracks, int nclusprint) const
 {
   std::cout << " ------------- content of TrkrTruthTrackContainer ---------- " << std::endl;
   auto& tmap = truth_tracks->getMap();
@@ -477,10 +470,10 @@ void TpcClusterBuilder::print_file(
     auto& track = _pair.second;
     fout << " id( " << track->getTrackid() << ")  phi:eta:pt(" << track->getPhi() << ":" << track->getPseudoRapidity() << ":" << track->getPt() << ") nclusters("
          << track->getClusters().size() << ") ";
-//    int nclus = 0;
+    //    int nclus = 0;
     for (auto cluskey : track->getClusters())
     {
-      auto C = m_clusterlist->findCluster(cluskey);
+      auto* C = m_clusterlist->findCluster(cluskey);
       fout << " "
            << ((int) TrkrDefs::getHitSetKeyFromClusKey(cluskey)) << ":" << ((int) TrkrDefs::getClusIndex(cluskey)) << "->adc:X:phisize:Y:zsize("
            << C->getAdc() << ":"
@@ -488,7 +481,7 @@ void TpcClusterBuilder::print_file(
            << C->getPhiSize() << ":"
            << C->getLocalY() << ":"
            << C->getZSize() << ") ";
-//      ++nclus;
+      //      ++nclus;
     }
     fout << std::endl;
   }

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -43,7 +43,7 @@ class TrkrTruthTrackContainer;
 class TpcClusterBuilder
 {
  public:
-  TpcClusterBuilder(){};
+  TpcClusterBuilder() {};
   ~TpcClusterBuilder()
   {
     delete m_hits;
@@ -57,7 +57,7 @@ class TpcClusterBuilder
   void cluster_hits(TrkrTruthTrack* track);
   void addhitset(TrkrDefs::hitsetkey, TrkrDefs::hitkey, float neffelectrons);
   void set_current_track(TrkrTruthTrack* _trkrtruthtrack);
-  void print(TrkrTruthTrackContainer*, int nclusprint = -1);
+  void print(TrkrTruthTrackContainer*, int nclusprint = -1) const;
   void print_file(TrkrTruthTrackContainer*, const std::string&);
   void set_verbosity(int verbosity_level) { verbosity = verbosity_level; }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Earlier attempts to tidy up G4TPC exhibited strange QA behavior. When tidying each class sequentially and checking one-by-one after each tidy, QAG4SimulationTpc and QAG4SimulationTracking output appear self-consistent. Let's see what Jenkins says.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

