### PR TITLE
fix: ntpc qa plot

### DIFF
--- a/offline/QA/Tracking/TpcSeedsQA.cc
+++ b/offline/QA/Tracking/TpcSeedsQA.cc
@@ -557,15 +557,10 @@ int TpcSeedsQA::process_event(PHCompositeNode *topNode)
       if (pt > 1)
       {
         h_ntrack_pos->Fill(eta, phi);
-        if (trackvtx)
+        
+        if(std::fabs(eta)<1.2)
         {
-          float vz = trackvtx->get_z();
-          float eta_min = cal_tpc_eta_min_max(vz).first;
-          float eta_max = cal_tpc_eta_min_max(vz).second;
-          if (eta > eta_min && eta < eta_max)
-          {
-            h_ntpc_pos->Fill(ntpc);
-          }
+          h_ntpc_pos->Fill(ntpc);
         }
         h_ntpot_pos->Fill(nmms);
         h_ntpc_quality_pos->Fill(ntpc, quality);
@@ -589,16 +584,10 @@ int TpcSeedsQA::process_event(PHCompositeNode *topNode)
       if (pt > 1)
       {
         h_ntrack_neg->Fill(eta, phi);
-        if (trackvtx)
-        {
-          float vz = trackvtx->get_z();
-          float eta_min = cal_tpc_eta_min_max(vz).first;
-          float eta_max = cal_tpc_eta_min_max(vz).second;
-          if (eta > eta_min && eta < eta_max)
+        if (std::fabs(eta)<1.2)
           {
             h_ntpc_neg->Fill(ntpc);
           }
-        }
         h_ntpot_neg->Fill(nmms);
         h_ntpc_quality_neg->Fill(ntpc, quality);
         h_avgnclus_eta_phi_neg->Fill(eta, phi, ntpc);

--- a/offline/QA/Tracking/TpcSeedsQA.cc
+++ b/offline/QA/Tracking/TpcSeedsQA.cc
@@ -557,8 +557,8 @@ int TpcSeedsQA::process_event(PHCompositeNode *topNode)
       if (pt > 1)
       {
         h_ntrack_pos->Fill(eta, phi);
-        
-        if(std::fabs(eta)<1.2)
+
+        if (std::fabs(eta) < 1.2)
         {
           h_ntpc_pos->Fill(ntpc);
         }
@@ -584,10 +584,10 @@ int TpcSeedsQA::process_event(PHCompositeNode *topNode)
       if (pt > 1)
       {
         h_ntrack_neg->Fill(eta, phi);
-        if (std::fabs(eta)<1.2)
-          {
-            h_ntpc_neg->Fill(ntpc);
-          }
+        if (std::fabs(eta) < 1.2)
+        {
+          h_ntpc_neg->Fill(ntpc);
+        }
         h_ntpot_neg->Fill(nmms);
         h_ntpc_quality_neg->Fill(ntpc, quality);
         h_avgnclus_eta_phi_neg->Fill(eta, phi, ntpc);


### PR DESCRIPTION
This fixes the ntpc qa plot bug such that the histogram is filled

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

