### PR TITLE
make verbosity setting static for cdbttree

### DIFF
--- a/offline/database/cdbobjects/CDBHistos.cc
+++ b/offline/database/cdbobjects/CDBHistos.cc
@@ -82,7 +82,7 @@ void CDBHistos::LoadCalibrations()
 
 void CDBHistos::Print() const
 {
-  for (auto &iter : m_HistoMap)
+  for (const auto &iter : m_HistoMap)
   {
     std::cout << "histogram " << iter.first << ", type "
               << iter.second->IsA()->GetName() << std::endl;

--- a/offline/database/cdbobjects/CDBTF.cc
+++ b/offline/database/cdbobjects/CDBTF.cc
@@ -3,8 +3,8 @@
 #include <TClass.h>       // for TClass
 #include <TCollection.h>  // for TIter
 #include <TDirectory.h>   // for TDirectoryAtomicAdapter, TDirectory, gDirec...
-#include <TFile.h>
 #include <TF1.h>
+#include <TFile.h>
 #include <TKey.h>
 #include <TList.h>    // for TList
 #include <TObject.h>  // for TObject
@@ -65,14 +65,14 @@ void CDBTF::LoadCalibrations()
   TIter next(list);
   TKey *key;
   TObject *obj;
-  TF1*t1 = nullptr;
+  TF1 *t1 = nullptr;
   while ((key = (TKey *) next()))
   {
     obj = key->ReadObj();
     if ((obj->InheritsFrom("TF1")))
     {
       fin->GetObject(obj->GetName(), t1);
-      //t1->SetDirectory(nullptr);
+      // t1->SetDirectory(nullptr);
       m_TFMap.insert(std::make_pair(obj->GetName(), t1));
     }
   }
@@ -82,7 +82,7 @@ void CDBTF::LoadCalibrations()
 
 void CDBTF::Print() const
 {
-  for (auto &iter : m_TFMap)
+  for (const auto &iter : m_TFMap)
   {
     std::cout << "TF " << iter.first << ", type "
               << iter.second->IsA()->GetName() << std::endl;

--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -20,6 +20,8 @@
 #include <set>      // for set
 #include <utility>  // for pair, make_pair
 
+int CDBTTree::verbosity = 0;  // the verbosity can be set by the static SetVerbosity(int v) method
+
 CDBTTree::CDBTTree(const std::string &fname)
   : m_Filename(fname)
 {
@@ -228,7 +230,7 @@ void CDBTTree::WriteMultipleCDBTTree()
 void CDBTTree::SetSingleFloatValue(const std::string &name, float value)
 {
   std::string fieldname = "F" + name;
-  if (m_SingleFloatEntryMap.find(fieldname) == m_SingleFloatEntryMap.end())
+  if (!m_SingleFloatEntryMap.contains(fieldname))
   {
     if (m_Locked[SingleEntries])
     {
@@ -245,7 +247,7 @@ void CDBTTree::SetSingleFloatValue(const std::string &name, float value)
 void CDBTTree::SetSingleDoubleValue(const std::string &name, double value)
 {
   std::string fieldname = "D" + name;
-  if (m_SingleDoubleEntryMap.find(fieldname) == m_SingleDoubleEntryMap.end())
+  if (!m_SingleDoubleEntryMap.contains(fieldname))
   {
     if (m_Locked[SingleEntries])
     {
@@ -262,7 +264,7 @@ void CDBTTree::SetSingleDoubleValue(const std::string &name, double value)
 void CDBTTree::SetSingleIntValue(const std::string &name, int value)
 {
   std::string fieldname = "I" + name;
-  if (m_SingleIntEntryMap.find(fieldname) == m_SingleIntEntryMap.end())
+  if (!m_SingleIntEntryMap.contains(fieldname))
   {
     if (m_Locked[SingleEntries])
     {
@@ -279,7 +281,7 @@ void CDBTTree::SetSingleIntValue(const std::string &name, int value)
 void CDBTTree::SetSingleUInt64Value(const std::string &name, uint64_t value)
 {
   std::string fieldname = "g" + name;
-  if (m_SingleUInt64EntryMap.find(fieldname) == m_SingleUInt64EntryMap.end())
+  if (!m_SingleUInt64EntryMap.contains(fieldname))
   {
     if (m_Locked[SingleEntries])
     {
@@ -591,7 +593,7 @@ void CDBTTree::LoadCalibrations()
       std::map<std::string, float> tmp_floatvalmap;
       for (auto &field : floatvalmap)
       {
-        if (std::isfinite(field.second))
+        if (!std::isnan(field.second))
         {
           tmp_floatvalmap.insert(std::make_pair(field.first, field.second));
         }
@@ -604,7 +606,7 @@ void CDBTTree::LoadCalibrations()
       std::map<std::string, double> tmp_doublevalmap;
       for (auto &field : doublevalmap)
       {
-        if (std::isfinite(field.second))
+        if (!std::isnan(field.second))
         {
           tmp_doublevalmap.insert(std::make_pair(field.first, field.second));
         }
@@ -641,7 +643,7 @@ void CDBTTree::LoadCalibrations()
       }
     }
   }
-  for (auto ttree : m_TTree)
+  for (auto *ttree : m_TTree)
   {
     delete ttree;
     ttree = nullptr;
@@ -660,7 +662,7 @@ float CDBTTree::GetSingleFloatValue(const std::string &name, int verbose)
   auto singleiter = m_SingleFloatEntryMap.find(fieldname);
   if (singleiter == m_SingleFloatEntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " in single float calibrations" << std::endl;
       std::cout << "Existing values:" << std::endl;
@@ -686,10 +688,10 @@ float CDBTTree::GetFloatValue(int channel, const std::string &name, int verbose)
   auto channelmapiter = m_FloatEntryMap.find(channel);
   if (channelmapiter == m_FloatEntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << PHWHERE << " Could not find channel " << channel
-		<< " for " << name << " in float calibrations" << std::endl;
+                << " for " << name << " in float calibrations" << std::endl;
     }
     return std::numeric_limits<float>::quiet_NaN();
   }
@@ -697,7 +699,7 @@ float CDBTTree::GetFloatValue(int channel, const std::string &name, int verbose)
   auto calibiter = channelmapiter->second.find(fieldname);
   if (calibiter == channelmapiter->second.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " among float calibrations of channel " << channel << std::endl;
     }
@@ -716,7 +718,7 @@ double CDBTTree::GetSingleDoubleValue(const std::string &name, int verbose)
   auto singleiter = m_SingleDoubleEntryMap.find(fieldname);
   if (singleiter == m_SingleDoubleEntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " in single double calibrations" << std::endl;
       std::cout << "Existing values:" << std::endl;
@@ -742,10 +744,10 @@ double CDBTTree::GetDoubleValue(int channel, const std::string &name, int verbos
   auto channelmapiter = m_DoubleEntryMap.find(channel);
   if (channelmapiter == m_DoubleEntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << PHWHERE << " Could not find channel " << channel
-		<< " for " << name << " in double calibrations" << std::endl;
+                << " for " << name << " in double calibrations" << std::endl;
     }
     return std::numeric_limits<double>::quiet_NaN();
   }
@@ -753,7 +755,7 @@ double CDBTTree::GetDoubleValue(int channel, const std::string &name, int verbos
   auto calibiter = channelmapiter->second.find(fieldname);
   if (calibiter == channelmapiter->second.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " among double calibrations for channel " << channel << std::endl;
     }
@@ -772,7 +774,7 @@ int CDBTTree::GetSingleIntValue(const std::string &name, int verbose)
   auto singleiter = m_SingleIntEntryMap.find(fieldname);
   if (singleiter == m_SingleIntEntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " in single int calibrations" << std::endl;
       std::cout << "Existing values:" << std::endl;
@@ -798,10 +800,10 @@ int CDBTTree::GetIntValue(int channel, const std::string &name, int verbose)
   auto channelmapiter = m_IntEntryMap.find(channel);
   if (channelmapiter == m_IntEntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << PHWHERE << " Could not find channel " << channel
-		<< " for " << name << " in int calibrations" << std::endl;
+                << " for " << name << " in int calibrations" << std::endl;
     }
     return std::numeric_limits<int>::min();
   }
@@ -809,7 +811,7 @@ int CDBTTree::GetIntValue(int channel, const std::string &name, int verbose)
   auto calibiter = channelmapiter->second.find(fieldname);
   if (calibiter == channelmapiter->second.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " among int calibrations for channel " << channel << std::endl;
     }
@@ -828,7 +830,7 @@ uint64_t CDBTTree::GetSingleUInt64Value(const std::string &name, int verbose)
   auto singleiter = m_SingleUInt64EntryMap.find(fieldname);
   if (singleiter == m_SingleUInt64EntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find " << name << " in single uint64 calibrations" << std::endl;
       std::cout << "Existing values:" << std::endl;
@@ -854,7 +856,7 @@ uint64_t CDBTTree::GetUInt64Value(int channel, const std::string &name, int verb
   auto channelmapiter = m_UInt64EntryMap.find(channel);
   if (channelmapiter == m_UInt64EntryMap.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << "Could not find channel " << channel << " in unint64 calibrations" << std::endl;
     }
@@ -864,10 +866,10 @@ uint64_t CDBTTree::GetUInt64Value(int channel, const std::string &name, int verb
   auto calibiter = channelmapiter->second.find(fieldname);
   if (calibiter == channelmapiter->second.end())
   {
-    if (verbose > 0)
+    if (verbosity > 0 || verbose > 0)
     {
       std::cout << PHWHERE << " Could not find channel " << channel
-		<< " for " << name << " in uint64_t calibrations" << std::endl;
+                << " for " << name << " in uint64_t calibrations" << std::endl;
     }
     return std::numeric_limits<uint64_t>::max();
   }

--- a/offline/database/cdbobjects/CDBTTree.h
+++ b/offline/database/cdbobjects/CDBTTree.h
@@ -13,6 +13,7 @@ class CDBTTree
   CDBTTree() = default;
   explicit CDBTTree(const std::string &fname);
   ~CDBTTree();
+  static void SetVerbosity(int v) { verbosity = v; }
   void SetFloatValue(int channel, const std::string &name, float value);
   void SetDoubleValue(int channel, const std::string &name, double value);
   void SetIntValue(int channel, const std::string &name, int value);
@@ -27,16 +28,16 @@ class CDBTTree
   void WriteSingleCDBTTree();
   void WriteMultipleCDBTTree();
   void Print();
-  void SetFilename(const std::string &fname) {m_Filename = fname;}
+  void SetFilename(const std::string &fname) { m_Filename = fname; }
   void LoadCalibrations();
-  float GetSingleFloatValue(const std::string &name, int verbose = 1);
-  float GetFloatValue(int channel, const std::string &name, int verbose = 1);
-  double GetSingleDoubleValue(const std::string &name, int verbose = 1);
-  double GetDoubleValue(int channel, const std::string &name, int verbose = 1);
-  int GetSingleIntValue(const std::string &name, int verbose = 1);
-  int GetIntValue(int channel, const std::string &name, int verbose = 1);
-  uint64_t GetSingleUInt64Value(const std::string &name, int verbose = 1);
-  uint64_t GetUInt64Value(int channel, const std::string &name, int verbose = 1);
+  float GetSingleFloatValue(const std::string &name, int verbose = 0);
+  float GetFloatValue(int channel, const std::string &name, int verbose = 0);
+  double GetSingleDoubleValue(const std::string &name, int verbose = 0);
+  double GetDoubleValue(int channel, const std::string &name, int verbose = 0);
+  int GetSingleIntValue(const std::string &name, int verbose = 0);
+  int GetIntValue(int channel, const std::string &name, int verbose = 0);
+  uint64_t GetSingleUInt64Value(const std::string &name, int verbose = 0);
+  uint64_t GetUInt64Value(int channel, const std::string &name, int verbose = 0);
 
  private:
   enum
@@ -46,6 +47,7 @@ class CDBTTree
   };
   const std::string m_TTreeName[2] = {"Single", "Multiple"};
   TTree *m_TTree[2] = {nullptr};
+  static int verbosity;
   bool m_Locked[2] = {false};
 
   std::string m_Filename;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
By default the CDBTTree verbosity was enabled so it complained if a non existing value was requested. The problem is that NaN is used as an initializer which then is indistinguishable if NaN was the actual calibration constant. Now the verbosity has to be enabled to get those messages via a static variable which you can set in the macro via: CDBTTree::SetVerbosity(int). THe old mechanics to set the verbosity in the method is still working, just the default was changed to 0 (silent)
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

