### PR TITLE
fix: truth clustering in evaluator

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -805,10 +805,10 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
     // multiply total number of bins that include the edges by the bin size
     g4zsize = (double) binwidth * layergeom->get_zstep();
   }
-  else if (radius > 5 && radius < 20)  // INTT
+  else if (radius > 6 && radius < 20)  // INTT
   {
     // All we have is the position and layer number
-
+  
     CylinderGeomIntt* layergeom = dynamic_cast<CylinderGeomIntt*>(_intt_geom_container->GetLayerGeom(layer));
 
     // inner location


### PR DESCRIPTION
The truth clustering in the evaluator bombs out when shifting the mvtx because the layer geometry is obtained based on the truth cluster radius. Right now that is set to be outside of 5 cm for the INTT, when in reality it should be larger since the MVTX is now shifted in such a way that some staves are at radii of 5 cm.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

