### PR TITLE
feat: improve intt matching in silicon seeding

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -96,7 +96,7 @@ int PHActsSiliconSeeding::Init(PHCompositeNode* /*topNode*/)
     printSeedConfigs(sfCfg);
   }
   // vector containing the map of z bins in the top and bottom layers
- 
+
   m_bottomBinFinder = std::make_unique<const Acts::GridBinFinder<2ul>>(
       nphineighbors, zBinNeighborsBottom);
   m_topBinFinder = std::make_unique<const Acts::GridBinFinder<2ul>>(
@@ -135,7 +135,9 @@ int PHActsSiliconSeeding::process_event(PHCompositeNode* topNode)
       std::cerr << PHWHERE << "Cluster Iteration Map missing, aborting." << std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
-  } else {
+  }
+  else
+  {
     // reset seed container on first iteration
     m_seedContainer->Reset();
   }
@@ -147,7 +149,6 @@ int PHActsSiliconSeeding::process_event(PHCompositeNode* topNode)
   }
 
   runSeeder();
- 
 
   if (Verbosity() > 0)
   {
@@ -180,7 +181,7 @@ int PHActsSiliconSeeding::End(PHCompositeNode* /*topNode*/)
 
 void PHActsSiliconSeeding::runSeeder()
 {
-  Acts::SeedFinder<SpacePoint,Acts::CylindricalSpacePointGrid<SpacePoint>> seedFinder(m_seedFinderCfg);
+  Acts::SeedFinder<SpacePoint, Acts::CylindricalSpacePointGrid<SpacePoint>> seedFinder(m_seedFinderCfg);
 
   auto eventTimer = std::make_unique<PHTimer>("eventTimer");
   eventTimer->stop();
@@ -192,7 +193,7 @@ void PHActsSiliconSeeding::runSeeder()
     GridSeeds seedVector;
     /// Covariance converter functor needed by seed finder
     auto covConverter = [=](const SpacePoint& sp, float zAlign, float rAlign,
-                                       float sigmaError)
+                            float sigmaError)
     {
       Acts::Vector3 position{sp.x(), sp.y(), sp.z()};
       Acts::Vector2 cov;
@@ -225,13 +226,11 @@ void PHActsSiliconSeeding::runSeeder()
     auto spacePointsGrouping = Acts::CylindricalBinnedGroup<SpacePoint>(
         std::move(grid), *m_bottomBinFinder, *m_topBinFinder,
         std::move(navigation));
-   
+
     /// variable middle SP radial region of interest
     const Acts::Range1D<float> rMiddleSPRange(
         std::floor(rRangeSPExtent.min(Acts::binR) / 2) * 2 + 1.5,
         std::floor(rRangeSPExtent.max(Acts::binR) / 2) * 2 - 1.5);
-   
-
 
     eventTimer->restart();
     SeedContainer seeds;
@@ -327,7 +326,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(const GridSeeds& seedVector)
         {
           m_mvtxgx.push_back(globalPosition(0));
           m_mvtxgy.push_back(globalPosition(1));
-	  m_mvtxgz.push_back(globalPosition(2));
+          m_mvtxgz.push_back(globalPosition(2));
         }
         positions.insert(std::make_pair(cluskey, globalPosition));
         if (Verbosity() > 1)
@@ -497,39 +496,45 @@ short int PHActsSiliconSeeding::getCrossingIntt(TrackSeed& si_track)
     crossing_keep = intt_crossings[0];
     for (unsigned int ic = 1; ic < intt_crossings.size(); ++ic)
     {
-      if(intt_crossings[ic] != crossing_keep)
-	{
-	  if(abs(intt_crossings[ic] - crossing_keep) > 1)
-	    {
-	      keep_it = false;
-	      
-	      if (Verbosity() > 1)
-		{
-		  std::cout << " Warning: INTT crossings not all the same "
-			    << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " setting crossing to SHRT_MAX" << std::endl;
-		}
-	    }
-	  else
-	    {
-	      // we have INTT clusters with crossing values that differ by 1
-	      // This can be a readout issue, we take the lower value as the correct one
+      if (intt_crossings[ic] != crossing_keep)
+      {
+        if (abs(intt_crossings[ic] - crossing_keep) > 1)
+        {
+          keep_it = false;
 
-	      if(Verbosity() > 1) { std::cout << " ic " << ic << " crossing keep " << crossing_keep << " intt_crossings " << intt_crossings[ic] << std::endl; }
-	      if(intt_crossings[ic] < crossing_keep)
-		{
-		  crossing_keep = intt_crossings[ic];
-		  if(Verbosity() > 1) { std::cout << "         ----- crossing keep changed to " << crossing_keep << std::endl; }
-		}
-	    }
-	}
+          if (Verbosity() > 1)
+          {
+            std::cout << " Warning: INTT crossings not all the same "
+                      << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " setting crossing to SHRT_MAX" << std::endl;
+          }
+        }
+        else
+        {
+          // we have INTT clusters with crossing values that differ by 1
+          // This can be a readout issue, we take the lower value as the correct one
+
+          if (Verbosity() > 1)
+          {
+            std::cout << " ic " << ic << " crossing keep " << crossing_keep << " intt_crossings " << intt_crossings[ic] << std::endl;
+          }
+          if (intt_crossings[ic] < crossing_keep)
+          {
+            crossing_keep = intt_crossings[ic];
+            if (Verbosity() > 1)
+            {
+              std::cout << "         ----- crossing keep changed to " << crossing_keep << std::endl;
+            }
+          }
+        }
+      }
     }
   }
-  
+
   if (keep_it)
-    {
-      return crossing_keep;
-    }
-  
+  {
+    return crossing_keep;
+  }
+
   return SHRT_MAX;
 }
 
@@ -585,7 +590,7 @@ std::vector<short int> PHActsSiliconSeeding::getInttCrossings(TrackSeed& si_trac
       auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
       for (auto iter1 = crossings.first; iter1 != crossings.second; ++iter1)
       {
-	if (Verbosity() > 1)
+        if (Verbosity() > 1)
         {
           std::cout << "                si Track with cluster " << iter1->first << " layer " << layer << " crossing " << iter1->second << std::endl;
         }
@@ -1055,7 +1060,7 @@ int PHActsSiliconSeeding::getNodes(PHCompositeNode* topNode)
               << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-  
+
   m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   if (!m_tGeometry)
   {

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -317,7 +317,6 @@ class PHActsSiliconSeeding : public SubsysReco
   TrkrClusterIterationMapv1 *_iteration_map = nullptr;
   int m_nIteration = 0;
   std::string _track_map_name = "SiliconTrackSeedContainer";
-  ClusterErrorPara _ClusErrPara;
 
   bool m_seedAnalysis = false;
   TFile *m_file = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -235,7 +235,7 @@ class PHActsSiliconSeeding : public SubsysReco
   TrackSeedContainer *m_seedContainer = nullptr;
   TrkrClusterContainer *m_clusterMap = nullptr;
   PHG4CylinderGeomContainer *m_geomContainerIntt = nullptr;
-
+  PHG4CylinderGeomContainer *m_geomContainerMvtx = nullptr;
   int m_lowStrobeIndex = 0;
   int m_highStrobeIndex = 1;
   /// Configuration classes for Acts seeding

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -11,8 +11,8 @@
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Seeding/SeedFinder.hpp>
 
-#include <Acts/Utilities/GridBinFinder.hpp>
 #include <Acts/Seeding/SpacePointGrid.hpp>
+#include <Acts/Utilities/GridBinFinder.hpp>
 
 #include <trackbase/SpacePoint.h>
 
@@ -294,14 +294,13 @@ class PHActsSiliconSeeding : public SubsysReco
   std::vector<std::pair<int, int>> zBinNeighborsTop;
   std::vector<std::pair<int, int>> zBinNeighborsBottom;
   int nphineighbors = 1;
- std::unique_ptr<const Acts::GridBinFinder<2ul>> m_bottomBinFinder;
- std::unique_ptr<const Acts::GridBinFinder<2ul>> m_topBinFinder;
+  std::unique_ptr<const Acts::GridBinFinder<2ul>> m_bottomBinFinder;
+  std::unique_ptr<const Acts::GridBinFinder<2ul>> m_topBinFinder;
 
- int m_event = 0;
+  int m_event = 0;
 
- /// Maximum allowed transverse PCA for seed, cm
- double m_maxSeedPCA = 2.;
-
+  /// Maximum allowed transverse PCA for seed, cm
+  double m_maxSeedPCA = 2.;
 
   /// Search window for phi to match intt clusters in cm
   double m_inttrPhiSearchWin = 0.1;
@@ -311,33 +310,33 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
 
- bool m_cleanSeeds = false;
+  bool m_cleanSeeds = false;
 
- int m_nBadUpdates = 0;
- int m_nBadInitialFits = 0;
- TrkrClusterIterationMapv1 *_iteration_map = nullptr;
- int m_nIteration = 0;
- std::string _track_map_name = "SiliconTrackSeedContainer";
- ClusterErrorPara _ClusErrPara;
+  int m_nBadUpdates = 0;
+  int m_nBadInitialFits = 0;
+  TrkrClusterIterationMapv1 *_iteration_map = nullptr;
+  int m_nIteration = 0;
+  std::string _track_map_name = "SiliconTrackSeedContainer";
+  ClusterErrorPara _ClusErrPara;
 
- bool m_seedAnalysis = false;
- TFile *m_file = nullptr;
- TH2 *h_nInttProj = nullptr;
- TH1 *h_nMvtxHits = nullptr;
- TH1 *h_nInttHits = nullptr;
- TH1 *h_nMatchedClusters = nullptr;
- TH2 *h_nHits = nullptr;
- TH1 *h_nSeeds = nullptr;
- TH1 *h_nActsSeeds = nullptr;
- TH1 *h_nTotSeeds = nullptr;
- TH1 *h_nInputMeas = nullptr;
- TH1 *h_nInputMvtxMeas = nullptr;
- TH1 *h_nInputInttMeas = nullptr;
- TH2 *h_hits = nullptr;
- TH2 *h_zhits = nullptr;
- TH2 *h_projHits = nullptr;
- TH2 *h_zprojHits = nullptr;
- TH2 *h_resids = nullptr;
+  bool m_seedAnalysis = false;
+  TFile *m_file = nullptr;
+  TH2 *h_nInttProj = nullptr;
+  TH1 *h_nMvtxHits = nullptr;
+  TH1 *h_nInttHits = nullptr;
+  TH1 *h_nMatchedClusters = nullptr;
+  TH2 *h_nHits = nullptr;
+  TH1 *h_nSeeds = nullptr;
+  TH1 *h_nActsSeeds = nullptr;
+  TH1 *h_nTotSeeds = nullptr;
+  TH1 *h_nInputMeas = nullptr;
+  TH1 *h_nInputMvtxMeas = nullptr;
+  TH1 *h_nInputInttMeas = nullptr;
+  TH2 *h_hits = nullptr;
+  TH2 *h_zhits = nullptr;
+  TH2 *h_projHits = nullptr;
+  TH2 *h_zprojHits = nullptr;
+  TH2 *h_resids = nullptr;
 };
 
 #endif


### PR DESCRIPTION
This PR improves the matching of the INTT to the MVTX triplet by

1. Doing a "pre-projection" to the layer radius to determine an approximate phi for which to look up surface candidates
2. Refitting the track if a cluster is added to the track prior to doing the next projection

See these slides for more info
https://indico.bnl.gov/event/29457/contributions/113608/attachments/64738/111228/silicon_seeding.pdf
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

