### PR TITLE
update with RawClusterv2 for tower coord raw/corr access

### DIFF
--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -37,6 +37,7 @@ pkginclude_HEADERS = \
   RawClusterUtility.h \
   RawCluster.h \
   RawClusterv1.h \
+  RawClusterv2.h \
   RawClusterDefs.h \
   RawClusterContainer.h \
   RawTower.h \
@@ -77,6 +78,7 @@ ROOTDICTS = \
   PhotonClusterContainer_Dict.cc \
   RawCluster_Dict.cc \
   RawClusterv1_Dict.cc \
+  RawClusterv2_Dict.cc \
   RawClusterContainer_Dict.cc \
   RawTower_Dict.cc \
   RawTowerv1_Dict.cc \
@@ -119,6 +121,7 @@ libcalo_io_la_SOURCES = \
   PhotonClusterContainer.cc \
   RawCluster.cc \
   RawClusterv1.cc \
+  RawClusterv2.cc \
   RawClusterContainer.cc \
   RawTower.cc \
   RawTowerv1.cc \

--- a/offline/packages/CaloBase/RawClusterv2.cc
+++ b/offline/packages/CaloBase/RawClusterv2.cc
@@ -1,0 +1,3 @@
+#include "RawClusterv2.h"
+ClassImp(RawClusterv2)
+

--- a/offline/packages/CaloBase/RawClusterv2.h
+++ b/offline/packages/CaloBase/RawClusterv2.h
@@ -1,0 +1,48 @@
+#ifndef CALOBASE_RAWCLUSTERV2_H
+#define CALOBASE_RAWCLUSTERV2_H
+
+#include "RawClusterv1.h"
+#include <limits>
+
+class RawClusterv2 : public RawClusterv1
+{
+ public:
+  RawClusterv2() = default;
+  ~RawClusterv2() override = default;
+
+  // ---- new API: tower-space CoG, in TOWER UNITS ----
+  void set_tower_cog(float xr, float yr, float xc, float yc)
+  { _x_raw = xr; _y_raw = yr; _x_corr = xc; _y_corr = yc; }
+
+  float x_tower_raw()  const { return _x_raw;  }
+  float y_tower_raw()  const { return _y_raw;  }
+  float x_tower_corr() const { return _x_corr; }
+  float y_tower_corr() const { return _y_corr; }
+
+  // Optional: clone into the same dynamic type
+  RawCluster* CloneMe() const override { return new RawClusterv2(*this); }
+
+  void Reset() override
+  {
+    RawClusterv1::Reset();
+    _x_raw  = _y_raw  = _x_corr = _y_corr = std::numeric_limits<float>::quiet_NaN();
+  }
+
+  void identify(std::ostream& os = std::cout) const override
+  {
+    RawClusterv1::identify(os);
+    os << "  [towerCoG raw=(" << _x_raw << "," << _y_raw << ") corr=("
+       << _x_corr << "," << _y_corr << ")]\n";
+  }
+
+ private:
+  float _x_raw  = std::numeric_limits<float>::quiet_NaN();
+  float _y_raw  = std::numeric_limits<float>::quiet_NaN();
+  float _x_corr = std::numeric_limits<float>::quiet_NaN();
+  float _y_corr = std::numeric_limits<float>::quiet_NaN();
+
+  ClassDefOverride(RawClusterv2, 1)
+};
+
+#endif
+

--- a/offline/packages/CaloBase/RawClusterv2LinkDef.h
+++ b/offline/packages/CaloBase/RawClusterv2LinkDef.h
@@ -1,0 +1,3 @@
+#ifdef __CINT__
+#pragma link C++ class RawClusterv2+;
+#endif

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -9,6 +9,7 @@
 
 class PHCompositeNode;
 class RawClusterContainer;
+class RawClusterv2;
 class RawTowerGeomContainer;
 class BEmcRec;
 class TowerInfo;
@@ -30,7 +31,7 @@ class RawClusterBuilderTemplate : public SubsysReco
   void PrintCylGeom(RawTowerGeomContainer* towergeom, const std::string& fname) const;
   void SetProfileProb(bool pprob) { bProfProb = pprob; }
   void SetProbNoiseParam(float rn) { fProbNoiseParam = rn; }
-
+  void WriteClusterV2(bool b);
   void set_threshold_energy(const float e) { _min_tower_e = e; }
   void set_peakthreshold_energy(const float e) { _min_peak_e = e; }
   void setEnergyNorm(const float norm) { fEnergyNorm = norm; }
@@ -99,7 +100,9 @@ class RawClusterBuilderTemplate : public SubsysReco
   float _min_tower_e{0.020};
   float _min_peak_e{0.200};
   int chkenergyconservation{0};
-
+  bool m_write_cluster_v2 = false;
+  RawClusterContainer* m_cluster_container_v2 = nullptr; // second node
+    
   std::string detector;
   std::string ClusterNodeName;
 


### PR DESCRIPTION
[comment]: <Introduced RawClusterv2, a drop-in extension of RawClusterv1 that stores tower-space center of gravity in tower units. Extend RawClusterBuilderTemplate with an opt-in path to also write a v2 container under the node name: CLUSTERINFO_CEMC_V2, added WriteClusterV2(bool) setter; when enabled the builder mirrors each legacy cluster into a RawClusterv2, copies tower map & kinematics, and stamps tower-space CoG (raw/corr).> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <Adds RawClusterv2 to expose tower-space CoG (raw & corrected) and a new optional output node CLUSTERINFO_CEMC_V2. The builder remains backwards compatible; v2 output is produced only when enabled. Call ClusterBuilder->WriteClusterV2(true); in your Fun4All macro to enable> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

