### PR TITLE
Feat(JetBackgroundCut): Improve input flexibility and readability

### DIFF
--- a/offline/packages/jetbackground/JetBackgroundCut.cc
+++ b/offline/packages/jetbackground/JetBackgroundCut.cc
@@ -63,8 +63,8 @@ void JetBackgroundCut::CreateNodeTree(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int JetBackgroundCut::process_event(PHCompositeNode *topNode)
 {
-  TowerInfoContainer *towersEM = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-  TowerInfoContainer *towersOH = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
+  TowerInfoContainer *towersEM = findNode::getClass<TowerInfoContainer>(topNode, m_input_cemc_tower_node);
+  TowerInfoContainer *towersOH = findNode::getClass<TowerInfoContainer>(topNode, m_input_ohcal_tower_node);
   JetContainer *jets = findNode::getClass<JetContainer>(topNode, _jetNodeName);
   GlobalVertexMap *gvtxmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
 
@@ -216,7 +216,7 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
       {
         unsigned int channel = comp.second;
         TowerInfo *tower;
-        if (comp.first == 13 || comp.first == 28 || comp.first == 25)
+        if (comp.first == Jet::CEMC_TOWER_RETOWER || comp.first == Jet::CEMC_TOWERINFO_RETOWER || comp.first == Jet::CEMC_TOWERINFO || comp.first == Jet::CEMC_TOWERINFO_SUB1)
         {
           tower = towersEM->get_tower_at_channel(channel);
           int key = towersEM->encode_key(channel);
@@ -230,7 +230,7 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
           float towerEta = -log(std::tan(0.5 * newTheta));
           frcem += tower->get_energy() / std::cosh(towerEta);
         }
-        if (comp.first == 7 || comp.first == 27)
+        if (comp.first == Jet::HCALOUT_TOWER|| comp.first == Jet::HCALOUT_TOWERINFO || comp.first == Jet::HCALOUT_TOWERINFO_SUB1)
         {
           tower = towersOH->get_tower_at_channel(channel);
           int key = towersOH->encode_key(channel);

--- a/offline/packages/jetbackground/JetBackgroundCut.h
+++ b/offline/packages/jetbackground/JetBackgroundCut.h
@@ -90,14 +90,14 @@ class JetBackgroundCut : public SubsysReco
     _cutParams.set_int_param("failsAnyJetCut", 0);
   }
 
-  void set_input_cemc_tower_node(std::string input_cemc_tower_node)
+  void set_input_cemc_tower_node(const std::string &input_cemc_tower_node)
   {
-    m_input_cemc_tower_node = std::move(input_cemc_tower_node);
+    m_input_cemc_tower_node = input_cemc_tower_node;
   }
 
-  void set_input_ohcal_tower_node(std::string input_ohcal_tower_node)
+  void set_input_ohcal_tower_node(const std::string &input_ohcal_tower_node)
   {
-    m_input_ohcal_tower_node = std::move(input_ohcal_tower_node);
+    m_input_ohcal_tower_node = input_ohcal_tower_node;
   }
 
  private:

--- a/offline/packages/jetbackground/JetBackgroundCut.h
+++ b/offline/packages/jetbackground/JetBackgroundCut.h
@@ -90,6 +90,16 @@ class JetBackgroundCut : public SubsysReco
     _cutParams.set_int_param("failsAnyJetCut", 0);
   }
 
+  void set_input_cemc_tower_node(std::string input_cemc_tower_node)
+  {
+    m_input_cemc_tower_node = std::move(input_cemc_tower_node);
+  }
+
+  void set_input_ohcal_tower_node(std::string input_ohcal_tower_node)
+  {
+    m_input_ohcal_tower_node = std::move(input_ohcal_tower_node);
+  }
+
  private:
   bool _doAbort;
   std::string _name;
@@ -99,6 +109,9 @@ class JetBackgroundCut : public SubsysReco
   GlobalVertex::VTXTYPE _vtxtype;
   int _sysvar;
   PHParameters _cutParams;
+
+  std::string m_input_cemc_tower_node{"TOWERINFO_CALIB_CEMC_RETOWER"};
+  std::string m_input_ohcal_tower_node{"TOWERINFO_CALIB_HCALOUT"};
 };
 
 #endif


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This commit refactors the `JetBackgroundCut` module to enhance its flexibility and code clarity without altering the default behavior.

Key changes include:

- Configurable Inputs: Introduced setter methods (`set_input_cemc_tower_node` and `set_input_ohcal_tower_node`) to allow users to specify the input tower node names. The module now retrieves tower containers using these configurable names instead of hardcoded strings. The default node names remain the same, ensuring backward compatibility.

- Improved Readability: Replaced hardcoded integer values for jet component sources with their respective `Jet::SRC` enum members (e.g., `Jet::CEMC_TOWERINFO_RETOWER`, `Jet::HCALOUT_TOWERINFO`). This makes the source checking logic more explicit and maintainable.

- Support for Subtracted Jets: Added checks for the `Jet::CEMC_TOWERINFO_SUB1` and `Jet::HCALOUT_TOWERINFO_SUB1` enums. This enables the module to correctly process jets that have undergone underlying event subtraction and use the "SUB1" tower representation.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

