### PR TITLE
pi0EtaByEta.cc: Apply ptClusMax cut, both clusters

### DIFF
--- a/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.cc
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.cc
@@ -410,7 +410,8 @@ int pi0EtaByEta::process_towers(PHCompositeNode* topNode)
       float clus2_pt = E_vec_cluster2.perp();
       float clus2_chisq = recoCluster2->get_prob();
 
-      if (clus2_pt < pt2ClusCut || clus_pt > ptClusMax)
+      // Apply pt cuts to second cluster in the pair
+      if (clus2_pt < pt2ClusCut || clus2_pt > ptClusMax)
       {
         continue;
       }


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Previously, the `ptClusMax` cut was only applied to the first cluster (`clus_pt`) in the pair selection logic, while the second cluster (`clus2_pt`) only had a lower cut (`pt2ClusCut`) applied. This fix ensures both clusters are subject to the upper `ptClusMax` cut, improving selection consistency.

Updated the condition:
  `if (clus2_pt < pt2ClusCut || clus2_pt > ptClusMax)`

This removes a redundant check on `clus_pt` and properly applies the upper cut to `clus2_pt` as intended.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

