### PR TITLE
enable cosmic momentum setting

### DIFF
--- a/simulation/g4simulation/g4main/CosmicSpray.h
+++ b/simulation/g4simulation/g4main/CosmicSpray.h
@@ -21,6 +21,9 @@ class CosmicSpray : public SubsysReco
   ~CosmicSpray() override {}
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
+  void set_gen_min_momentum(const double p) { gen.SetMinimumMomentum(p); }  
+  void set_gen_max_momentum(const double p) { gen.SetMaximumMomentum(p); }
+
 
  private:
   EcoMug gen;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add setter for the muon momentum range, to study the response from large energy cosmic muons.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

