### PR TITLE
Fix nesting issue for skipped branches

### DIFF
--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -424,6 +424,11 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
     // Skip non-selected branches
     if (thisBranch->TestBit(kDoNotProcess))
     {
+      // Reset nodeIter to the parent branch
+      for (j = 1; j < splitvec.size() - 1; j++)
+      {
+        nodeIter.cd("..");
+      }
       continue;
     }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Without this fix, PHOOL DST nodes are badly nested when applying the `BranchSelect` method of `Fun4AllServer` (used to read only certain nodes of the DST file). An example is shown below for an input `DST_CALO` file:

```
  se->BranchSelect("*",0);
  se->BranchSelect("DST#Sync", 1);
  se->BranchSelect("DST#PacketsKeep#14001", 1);
  se->BranchSelect("DST#GLOBAL#GlobalVertexMap", 1);
  se->BranchSelect("DST#CEMC#TOWERINFO_CALIB_CEMC", 1);
  se->BranchSelect("DST#CEMC#CLUSTERINFO_CEMC", 1);
```

Before fix:

```
   DST (PHCompositeNode)/
      Sync (IO,SyncObjectv1)
      PacketsKeep (PHCompositeNode)/
         14001 (IO,Gl1Packetv3)
         PacketsKeep (PHCompositeNode)/
            ZDC (PHCompositeNode)/
               CEMC (PHCompositeNode)/
                  TOWERINFO_CALIB_CEMC (IO,TowerInfoContainerv4)
                  CLUSTERINFO_CEMC (IO,RawClusterContainer)
                  CLUSTER_SMALLINFO_CEMC (IO,ClusterSmallInfoContainer)
               HCALIN (PHCompositeNode)/
                  HCALOUT (PHCompositeNode)/
                     SEPD (PHCompositeNode)/
                        MBD (PHCompositeNode)/
                           MBD (PHCompositeNode)/
                              GLOBAL (PHCompositeNode)/
                                 GLOBAL (PHCompositeNode)/
                                    GlobalVertexMap (IO,GlobalVertexMapv1)
```

After fix:

```
   DST (PHCompositeNode)/
      Sync (IO,SyncObjectv1)
      PacketsKeep (PHCompositeNode)/
         14001 (IO,Gl1Packetv3)
      ZDC (PHCompositeNode)/
      CEMC (PHCompositeNode)/
         TOWERINFO_CALIB_CEMC (IO,TowerInfoContainerv4)
         CLUSTERINFO_CEMC (IO,RawClusterContainer)
         CLUSTER_SMALLINFO_CEMC (IO,ClusterSmallInfoContainer)
      HCALIN (PHCompositeNode)/
      HCALOUT (PHCompositeNode)/
      SEPD (PHCompositeNode)/
      MBD (PHCompositeNode)/
      GLOBAL (PHCompositeNode)/
         GlobalVertexMap (IO,GlobalVertexMapv1)
```

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

