### PR TITLE
fix: set adc clock automatically based on runnumber

### DIFF
--- a/offline/framework/phool/RunnumberRange.h
+++ b/offline/framework/phool/RunnumberRange.h
@@ -8,6 +8,7 @@ namespace RunnumberRange
   static const int RUN2PP_LAST = 53880;
   static const int RUN2AUAU_FIRST = 54128;
   static const int RUN2AUAU_LAST = 54974;
+  static const int RUN3_TPCFW_CLOCK_CHANGE = 59852;
   static const int RUN3AUAU_FIRST = 66457;
   static const int RUN3AUAU_LAST = 20000000;
 }

--- a/offline/framework/phool/RunnumberRange.h
+++ b/offline/framework/phool/RunnumberRange.h
@@ -8,7 +8,7 @@ namespace RunnumberRange
   static const int RUN2PP_LAST = 53880;
   static const int RUN2AUAU_FIRST = 54128;
   static const int RUN2AUAU_LAST = 54974;
-  static const int RUN3_TPCFW_CLOCK_CHANGE = 59852;
+  static const int RUN3_TPCFW_CLOCK_CHANGE = 58667;
   static const int RUN3AUAU_FIRST = 66457;
   static const int RUN3AUAU_LAST = 20000000;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -230,10 +230,18 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   else if ( runnumber < RunnumberRange::RUN3_TPCFW_CLOCK_CHANGE)
   {
     set_default_double_param("tpc_adc_clock", 50.037280);  // ns, for 20 MHz clock
+    // with drift length of 102cm and clock of 50 ns we get 542 time bins
+    // to get to 1024 samples (time bins0) we therefore need 1024-542=482 additional time bins
+    // and 482*50ns = 24100 ns. Add one some extra samples as they can always 
+    // be cut out later in the reconstruction
+    set_default_double_param("extended_readout_time", 24800); //ns, to account for 1024 samples
   }
   else
   {
     set_default_double_param("tpc_adc_clock", 56.881262);  // ns, for 17.5 MHz clock
+    // with drift length of 102cm and clock of 56 ns we get 477 time bins
+    // this already exceeds the 450 samples in the data
+    set_default_double_param("extended_readout_time", 0);  // ns, to account for 1024 samples
   }
   set_default_double_param("tpc_sector_phi_inner", 0.5024);  // 2 * M_PI / 12 );//sector size in phi for R1 sector
   set_default_double_param("tpc_sector_phi_mid", 0.5087);    // 2 * M_PI / 12 );//sector size in phi for R2 sector

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -227,13 +227,9 @@ void PHG4TpcSubsystem::SetDefaultParameters()
     // and ensure that the electron drift uses the same value
     set_default_double_param("tpc_adc_clock", 53.326184);  // ns, for 18.83 MHz clock
   }
-  else if ( runnumber < RunnumberRange::RUN2AUAU_LAST)
-  {
-    set_default_double_param("tpc_adc_clock", 50.037280);  // ns, for 20 MHz clock
-  }
   else if ( runnumber < RunnumberRange::RUN3_TPCFW_CLOCK_CHANGE)
   {
-    set_default_double_param("tpc_adc_clock", 53.326184);  // ns, for 18.83 MHz clock
+    set_default_double_param("tpc_adc_clock", 50.037280);  // ns, for 20 MHz clock
   }
   else
   {

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -230,19 +230,27 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   else if ( runnumber < RunnumberRange::RUN3_TPCFW_CLOCK_CHANGE)
   {
     set_default_double_param("tpc_adc_clock", 50.037280);  // ns, for 20 MHz clock
-    // with drift length of 102cm and clock of 50 ns we get 542 time bins
-    // to get to 1024 samples (time bins0) we therefore need 1024-542=482 additional time bins
-    // and 482*50ns = 24100 ns. Add one some extra samples as they can always 
-    // be cut out later in the reconstruction
-    set_default_double_param("extended_readout_time", 24800); //ns, to account for 1024 samples
   }
   else
   {
     set_default_double_param("tpc_adc_clock", 56.881262);  // ns, for 17.5 MHz clock
+  }
+  if(runnumber < RunnumberRange::RUN2AUAU_FIRST)
+  {
+    // with drift length of 102cm and clock of 50 ns we get 542 time bins
+    // to get to 1024 samples (time bins0) we therefore need 1024-542=482 additional time bins
+    // and 482*50ns = 24100 ns. Add one some extra samples as they can always
+    // be cut out later in the reconstruction
+    set_default_double_param("extended_readout_time", 24800);  // ns, to account for 1024 samples
+  }
+  else 
+  {
     // with drift length of 102cm and clock of 56 ns we get 477 time bins
     // this already exceeds the 450 samples in the data
-    set_default_double_param("extended_readout_time", 0);  // ns, to account for 1024 samples
+    set_default_double_param("extended_readout_time", 0);  // ns, to account for 450 samples
+
   }
+
   set_default_double_param("tpc_sector_phi_inner", 0.5024);  // 2 * M_PI / 12 );//sector size in phi for R1 sector
   set_default_double_param("tpc_sector_phi_mid", 0.5087);    // 2 * M_PI / 12 );//sector size in phi for R2 sector
   set_default_double_param("tpc_sector_phi_outer", 0.5097);  // 2 * M_PI / 12 );//sector size in phi for R3 sector

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -218,7 +218,6 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_double_param("tpc_maxradius_outer", 75.911);  // 77.0);  // from Tom
 
   set_default_double_param("maxdriftlength", 105.5);       // cm
-  set_default_double_param("extended_readout_time", 0.0);  // ns
   recoConsts *rc = recoConsts::instance();
   int runnumber = rc->get_IntFlag("RUNNUMBER");
   if (runnumber < RunnumberRange::RUN2PP_FIRST)
@@ -235,7 +234,7 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   {
     set_default_double_param("tpc_adc_clock", 56.881262);  // ns, for 17.5 MHz clock
   }
-  if(runnumber < RunnumberRange::RUN2AUAU_FIRST)
+  if(runnumber <= RunnumberRange::RUN2AUAU_FIRST && runnumber >= RunnumberRange::RUN2PP_FIRST)
   {
     // with drift length of 102cm and clock of 50 ns we get 542 time bins
     // to get to 1024 samples (time bins0) we therefore need 1024-542=482 additional time bins

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -17,6 +17,8 @@
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
+#include <phool/RunnumberRange.h>
+#include <phool/recoConsts.h>
 
 #include <iostream>  // for operator<<, basic_ost...
 #include <set>
@@ -217,8 +219,26 @@ void PHG4TpcSubsystem::SetDefaultParameters()
 
   set_default_double_param("maxdriftlength", 105.5);       // cm
   set_default_double_param("extended_readout_time", 0.0);  // ns
-  set_default_double_param("tpc_adc_clock", 53.326184);    // ns, for 18.8 MHz clock
-
+  recoConsts *rc = recoConsts::instance();
+  int runnumber = rc->get_IntFlag("RUNNUMBER");
+  if (runnumber < RunnumberRange::RUN2PP_FIRST)
+  {
+    // current default clock used in simulation. Need to decide how to handle long term
+    // and ensure that the electron drift uses the same value
+    set_default_double_param("tpc_adc_clock", 53.326184);  // ns, for 18.83 MHz clock
+  }
+  else if ( runnumber < RunnumberRange::RUN2AUAU_LAST)
+  {
+    set_default_double_param("tpc_adc_clock", 50.037280);  // ns, for 20 MHz clock
+  }
+  else if ( runnumber < RunnumberRange::RUN3_TPCFW_CLOCK_CHANGE)
+  {
+    set_default_double_param("tpc_adc_clock", 53.326184);  // ns, for 18.83 MHz clock
+  }
+  else
+  {
+    set_default_double_param("tpc_adc_clock", 56.881262);  // ns, for 17.5 MHz clock
+  }
   set_default_double_param("tpc_sector_phi_inner", 0.5024);  // 2 * M_PI / 12 );//sector size in phi for R1 sector
   set_default_double_param("tpc_sector_phi_mid", 0.5087);    // 2 * M_PI / 12 );//sector size in phi for R2 sector
   set_default_double_param("tpc_sector_phi_outer", 0.5097);  // 2 * M_PI / 12 );//sector size in phi for R3 sector


### PR DESCRIPTION
This PR sets the TPC ADC clock value to be the correct value by default based on the runnumber range being processed. This way the correct sample bin width is obtained automatically based on the runnumber in `recoConsts`

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

