### PR TITLE
refactor: remove extra acts edm object from node tree

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -81,7 +81,6 @@ namespace
 
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
-  , m_trajectories(nullptr)
 {
 }
 
@@ -259,8 +258,6 @@ int PHActsTrkFitter::ResetEvent(PHCompositeNode* /*topNode*/)
   {
     std::cout << "Reset PHActsTrkFitter" << std::endl;
   }
-
-  m_trajectories->clear();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -915,8 +912,6 @@ bool PHActsTrkFitter::getTrackFitResult(FitResult& fitOutput,
 
     Trajectory trajectory(tracks.trackStateContainer(),
                           trackTips, indexedParams);
-
-    m_trajectories->insert(std::make_pair(track->get_id(), trajectory));
     
     if (m_actsEvaluator)
     {
@@ -1269,15 +1264,6 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
           new PHIODataNode<PHObject>(m_directedTrackMap, "SvtxSiliconMMTrackMap", "PHObject");
       svtxNode->addNode(trackNode);
     }
-  }
-
-  m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, m_trajectories_name);
-  if (!m_trajectories)
-  {
-    m_trajectories = new std::map<const unsigned int, Trajectory>;
-    auto node =
-        new PHDataNode<std::map<const unsigned int, Trajectory>>(m_trajectories, m_trajectories_name);
-    svtxNode->addNode(node);
   }
 
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, _track_map_name);

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -129,7 +129,6 @@ class PHActsTrkFitter : public SubsysReco
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_track_map_name(const std::string& map_name) { _track_map_name = map_name; }
   void set_svtx_seed_map_name(const std::string& map_name) { _svtx_seed_map_name = map_name; }
-  void set_trajctories_name(const std::string& map_name) {m_trajectories_name = map_name; }
 
   void set_svtx_alignment_state_map_name(const std::string& map_name) { 
       _svtx_alignment_state_map_name = map_name; 
@@ -251,10 +250,6 @@ class PHActsTrkFitter : public SubsysReco
       m_evaluator = nullptr;
   std::string m_evalname = "ActsEvaluator.root";
   //@}
-
-  //! acts trajectories
-  std::map<const unsigned int, Trajectory>* m_trajectories = nullptr;
-  std::string m_trajectories_name = "ActsTrajectories";
 
   //! tracks
 //  SvtxTrackMap* m_seedTracks = nullptr;

--- a/offline/packages/trackreco/PHActsVertexPropagator.cc
+++ b/offline/packages/trackreco/PHActsVertexPropagator.cc
@@ -1,4 +1,5 @@
 #include "PHActsVertexPropagator.h"
+#include "ActsPropagator.h"
 
 #include <trackbase_historic/ActsTransformations.h>
 
@@ -24,7 +25,6 @@
 
 PHActsVertexPropagator::PHActsVertexPropagator(const std::string& name)
   : SubsysReco(name)
-  , m_trajectories(nullptr)
 {
 }
 
@@ -40,15 +40,11 @@ int PHActsVertexPropagator::InitRun(PHCompositeNode* topNode)
 }
 int PHActsVertexPropagator::process_event(PHCompositeNode* /*unused*/)
 {
-  std::vector<unsigned int> deletedKeys;
-  for (const auto& [trackKey, trajectory] : *m_trajectories)
+  ActsPropagator propagator;
+  for (const auto& [trackKey, svtxTrack] : *m_trackMap)
   {
-    auto svtxTrack = m_trackMap->get(trackKey);
     if (!svtxTrack)
     {
-      /// Key was removed by the track cleaner, remove it from
-      /// the trajectory list too
-      deletedKeys.push_back(trackKey);
       continue;
     }
 
@@ -57,20 +53,13 @@ int PHActsVertexPropagator::process_event(PHCompositeNode* /*unused*/)
       svtxTrack->identify();
     }
 
-    const auto& trackTips = trajectory.tips();
-
-    if (trackTips.size() > 1 && Verbosity() > 0)
-    {
-      std::cout << PHWHERE
-                << "More than 1 track tip per track. Should never happen..."
-                << std::endl;
-    }
-
-    for (const auto& trackTip : trackTips)
-    {
-      const auto& boundParams = trajectory.trackParameters(trackTip);
-
-      auto result = propagateTrack(boundParams, svtxTrack->get_vertex_id());
+    Acts::Vector3 pos(svtxTrack->get_x(),
+                      svtxTrack->get_y(),
+                      svtxTrack->get_z());
+    auto surfptr = propagator.makeVertexSurface(pos);
+    auto vtxstate = svtxTrack->get_state(0);
+    auto boundParams = propagator.makeTrackParams(vtxstate, svtxTrack->get_charge(), surfptr).value();
+auto result = propagateTrack(boundParams, svtxTrack->get_vertex_id());
       if (result.ok())
       {
         updateSvtxTrack(svtxTrack, result.value().second);
@@ -82,7 +71,7 @@ int PHActsVertexPropagator::process_event(PHCompositeNode* /*unused*/)
           svtxTrack->identify();
         }
       }
-    }
+    
   }
 
   setVtxChi2();
@@ -90,11 +79,7 @@ int PHActsVertexPropagator::process_event(PHCompositeNode* /*unused*/)
   {
     std::cout << "Propagated tracks to PerigeeSurface at (0,0,0) as no track vertices were found" << std::endl;
   }
-  /// Erase the trajectories that were removed from the track cleaner
-  for (auto& key : deletedKeys)
-  {
-    m_trajectories->erase(key);
-  }
+
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -229,15 +214,6 @@ int PHActsVertexPropagator::getNodes(PHCompositeNode* topNode)
   if (!m_tGeometry)
   {
     std::cout << PHWHERE << "Acts tracking geometry not on node tree, exiting."
-              << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, m_trajectories_name);
-
-  if (!m_trajectories)
-  {
-    std::cout << PHWHERE << "No acts trajectories on node tree, exiting. "
               << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }

--- a/offline/packages/trackreco/PHActsVertexPropagator.h
+++ b/offline/packages/trackreco/PHActsVertexPropagator.h
@@ -35,7 +35,6 @@ class PHActsVertexPropagator : public SubsysReco
   int End(PHCompositeNode *topNode) override;
 
   void setTrackMapName(std::string const& track_map_name) { m_trackMapName = track_map_name; }
-  void setTrajectoriesName(std::string const& trajectories_name) { m_trajectories_name = trajectories_name; }
   void fieldMap(std::string &fieldmap) { m_fieldMap = fieldmap; }
 
  private:
@@ -51,9 +50,7 @@ class PHActsVertexPropagator : public SubsysReco
   ActsGeometry *m_tGeometry = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
   std::string m_trackMapName = "SvtxTrackMap";
-  std::string m_trajectories_name = "ActsTrajectories";
   SvtxTrackMap *m_trackMap = nullptr;
-  std::map<const unsigned int, Trajectory> *m_trajectories = nullptr;
   std::string m_fieldMap = "";
 };
 


### PR DESCRIPTION
The Acts fitter puts an SvtxTrackMap and a map containing Acts trajectories on the nodetree. This was historical before we had simple conversion code, which we do now. Having two output objects from a single reconstruction module is bad practice and makes the downstream reconstruction cumbersome - this PR removes the trajectory object from use and should simplify the downstream EDM handling. I checked that the constructed object in the vertex propagation is identical to that output from the track fitting, so this should result in no change to any performance

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

