### PR TITLE
fix: remove hard coded dv

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -8,14 +8,14 @@
 
 #include <g4main/PHG4Particle.h>
 
+#include <micromegas/MicromegasDefs.h>
+
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrClusterv1.h>
 #include <trackbase/TrkrDefs.h>
-
-#include <micromegas/MicromegasDefs.h>
 
 #include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
@@ -28,8 +28,12 @@
 #include <intt/CylinderGeomIntt.h>
 #include <intt/CylinderGeomInttHelper.h>
 
+#include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
+
+#include <phparameter/PHParameters.h>
+#include <phparameter/PHParametersContainer.h>
 
 #include <TVector3.h>
 
@@ -752,7 +756,9 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
     PHG4TpcCylinderGeom* layergeom = _tpc_geom_container->GetLayerCellGeom(layer);
     
     double tpc_max_driftlength = layergeom->get_max_driftlength();
-    double drift_velocity = 8.0 / 1000.0;  // cm/ns
+    const auto params = _tpc_params->GetParameters(0);
+
+    double drift_velocity = params->get_double_param("drift_velocity");  // cm/ns
 
     // Phi size
     //======
@@ -1157,6 +1163,11 @@ void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode)
   _intt_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
   _mvtx_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
 
+  PHNodeIterator iter(topNode);
+  auto* parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR"));
+  PHNodeIterator parIter(parNode);
+  auto* ParDetNode = dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode", "TPC"));
+  _tpc_params = findNode::getClass<PHParametersContainer>(ParDetNode, "G4GEO_TPC");
   return;
 }
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -16,6 +16,7 @@ class PHG4TpcCylinderGeomContainer;
 class PHG4VtxPoint;
 class TrkrCluster;
 class ActsGeometry;
+class PHParametersContainer;
 
 #include <map>
 #include <memory>
@@ -84,6 +85,7 @@ class SvtxTruthEval
   PHG4HitContainer* _g4hits_mms = nullptr;
   PHG4HitContainer* _g4hits_tracker = nullptr;
   PHG4HitContainer* _g4hits_maps = nullptr;
+  PHParametersContainer* _tpc_params = nullptr;
 
   PHG4TpcCylinderGeomContainer* _tpc_geom_container{};
   PHG4CylinderGeomContainer* _intt_geom_container{};


### PR DESCRIPTION
This alters a hard coded drift velocity in the truth eval to read from the tpc geometry object, which is where the simulated drift velocity is actually set in simulation jobs. Local test showed it improved the cluster residuals dependence on radius slightly, curious to see the jenkins report and in any case this is now more robust.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

