### PR TITLE
Truth association lookup for MVTX hitsetkeys

### DIFF
--- a/offline/packages/trackbase/TrkrHitTruthAssocv1.cc
+++ b/offline/packages/trackbase/TrkrHitTruthAssocv1.cc
@@ -5,8 +5,8 @@
  * @brief Implementation of TrkrHitTruthAssocv1
  */
 
-#include "TrkrHitTruthAssocv1.h"
-#include "TrkrDefs.h"
+#include <TrkrHitTruthAssocv1.h>
+#include <TrkrDefs.h>
 
 #include <MvtxDefs.h>
 
@@ -29,8 +29,7 @@ void TrkrHitTruthAssocv1::identify(std::ostream& os) const
   for (const auto& entry : m_map)
   {
     int layer = TrkrDefs::getLayer(entry.first);
-    int strobeID = (static_cast<unsigned>(TrkrDefs::getLayer(entry.first)) < 3) ? MvtxDefs::getStrobeId(entry.first) : std::numeric_limits<int>::min();
-    os << "   hitset key: " << entry.first << " layer " << layer << " strobe ID " << strobeID
+    os << "   hitset key: " << entry.first << " layer " << layer
        << " hit key: " << entry.second.first
        << " g4hit key: " << entry.second.second
        << std::endl;
@@ -86,14 +85,32 @@ void TrkrHitTruthAssocv1::removeAssoc(const TrkrDefs::hitsetkey hitsetkey, const
 void TrkrHitTruthAssocv1::getG4Hits(const TrkrDefs::hitsetkey hitsetkey, const unsigned int hidx, MMap& temp_map) const
 {
   const auto hitsetrange = m_map.equal_range(hitsetkey);
-  // print out for debug
-  for(auto iter=hitsetrange.first;iter!=hitsetrange.second;++iter)
+
+  bool found = false;
+  for (auto it = hitsetrange.first; it != hitsetrange.second; ++it)
   {
-    int strobeID = (static_cast<unsigned>(TrkrDefs::getLayer(iter->first)) < 3) ? MvtxDefs::getStrobeId(iter->first) : std::numeric_limits<int>::min();
-    std::cout << __FILE__ << ":" << __PRETTY_FUNCTION__ << " hitsetkey " << iter->first << " strobe ID " << strobeID << " hitkey " << iter->second.first << " g4hitkey " << iter->second.second << std::endl;
+    if (it->second.first == hidx)
+    {
+      temp_map.emplace_hint(temp_map.end(), it->first, it->second);
+      found = true;
+    }
   }
 
-  std::copy_if(hitsetrange.first, hitsetrange.second, std::inserter(temp_map, temp_map.end()),
-               [hidx](MMap::const_reference pair)
-               { return pair.second.first == hidx; });
+  // mvtx special case: if no hits were found, look for the bare hitsetkey
+  const auto layer = TrkrDefs::getLayer(hitsetkey);
+  if (!found && layer < 3)
+  {
+    const auto stave = MvtxDefs::getStaveId(hitsetkey);
+    const auto chip = MvtxDefs::getChipId(hitsetkey);
+    const TrkrDefs::hitsetkey bare_hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, /*strobe_in=*/0);
+
+    const auto bare_hitsetrange = m_map.equal_range(bare_hitsetkey);
+    for (auto it = bare_hitsetrange.first; it != bare_hitsetrange.second; ++it)
+    {
+      if (it->second.first == hidx)
+      {
+        temp_map.emplace_hint(temp_map.end(), it->first, it->second);
+      }
+    }
+  }
 }

--- a/offline/packages/trackbase/TrkrHitTruthAssocv1.cc
+++ b/offline/packages/trackbase/TrkrHitTruthAssocv1.cc
@@ -8,10 +8,13 @@
 #include "TrkrHitTruthAssocv1.h"
 #include "TrkrDefs.h"
 
+#include <MvtxDefs.h>
+
 #include <g4main/PHG4HitDefs.h>
 
 #include <algorithm>
 #include <ostream>  // for operator<<, endl, basic_ostream, bas...
+#include <limits>
 
 void TrkrHitTruthAssocv1::Reset()
 {
@@ -26,7 +29,8 @@ void TrkrHitTruthAssocv1::identify(std::ostream& os) const
   for (const auto& entry : m_map)
   {
     int layer = TrkrDefs::getLayer(entry.first);
-    os << "   hitset key: " << entry.first << " layer " << layer
+    int strobeID = (static_cast<unsigned>(TrkrDefs::getLayer(entry.first)) < 3) ? MvtxDefs::getStrobeId(entry.first) : std::numeric_limits<int>::min();
+    os << "   hitset key: " << entry.first << " layer " << layer << " strobe ID " << strobeID
        << " hit key: " << entry.second.first
        << " g4hit key: " << entry.second.second
        << std::endl;
@@ -82,6 +86,13 @@ void TrkrHitTruthAssocv1::removeAssoc(const TrkrDefs::hitsetkey hitsetkey, const
 void TrkrHitTruthAssocv1::getG4Hits(const TrkrDefs::hitsetkey hitsetkey, const unsigned int hidx, MMap& temp_map) const
 {
   const auto hitsetrange = m_map.equal_range(hitsetkey);
+  // print out for debug
+  for(auto iter=hitsetrange.first;iter!=hitsetrange.second;++iter)
+  {
+    int strobeID = (static_cast<unsigned>(TrkrDefs::getLayer(iter->first)) < 3) ? MvtxDefs::getStrobeId(iter->first) : std::numeric_limits<int>::min();
+    std::cout << __FILE__ << ":" << __PRETTY_FUNCTION__ << " hitsetkey " << iter->first << " strobe ID " << strobeID << " hitkey " << iter->second.first << " g4hitkey " << iter->second.second << std::endl;
+  }
+
   std::copy_if(hitsetrange.first, hitsetrange.second, std::inserter(temp_map, temp_map.end()),
                [hidx](MMap::const_reference pair)
                { return pair.second.first == hidx; });

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -3,8 +3,6 @@
 #include "SvtxHitEval.h"
 #include "SvtxTruthEval.h"
 
-#include <trackbase/MvtxDefs.h>
-
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
@@ -357,12 +355,8 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
 
   std::set<PHG4Hit*> truth_hits;
 
-  std::cout << __FILE__ << ":" << __PRETTY_FUNCTION__ << " line " << __LINE__ << std::endl;
-
   // get all truth hits for this cluster
-  // _cluster_hit_map->identify();
-  _hit_truth_map->identify();
-
+  //_cluster_hit_map->identify();
   std::pair<std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey>::const_iterator, std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey>::const_iterator>
       hitrange = _cluster_hit_map->getHits(cluster_key);  // returns range of pairs {cluster key, hit key} for this cluskey
 
@@ -374,24 +368,17 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
     // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
     TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
 
-    int strobeID = (static_cast<unsigned>(TrkrDefs::getLayer(hitsetkey)) < 3) ? MvtxDefs::getStrobeId(hitsetkey) : std::numeric_limits<int>::min();
-
-    std::cout << __LINE__ << " cluster key " << cluster_key << " hitsetkey " << hitsetkey << " layer " << static_cast<unsigned>(TrkrDefs::getLayer(hitsetkey)) << " strobe ID " << strobeID << " hitkey " << hitkey << std::endl;
-
     // get all of the g4hits for this hitkey
     std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype>> temp_map;
     _hit_truth_map->getG4Hits(hitsetkey, hitkey, temp_map);
     // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
 
-    std::cout << __LINE__ << " size of temp_map " << temp_map.size() << std::endl;
-    
     for (auto& htiter : temp_map)
     {
       // extract the g4 hit key here and add the hits to the set
       PHG4HitDefs::keytype g4hitkey = htiter.second.second;
       PHG4Hit* g4hit = nullptr;
       unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
-      std::cout << __LINE__ << " cluster key " << cluster_key << " trkrid " << trkrid << std::endl;
       switch (trkrid)
       {
       case TrkrDefs::tpcId:
@@ -401,7 +388,6 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
         g4hit = _g4hits_intt->findHit(g4hitkey);
         break;
       case TrkrDefs::mvtxId:
-        std::cout << __LINE__ << " cluster key " << cluster_key << " hitsetkey " << hitsetkey << " layer " << TrkrDefs::getLayer(hitsetkey) << " g4hitkey " << g4hitkey << std::endl;
         g4hit = _g4hits_mvtx->findHit(g4hitkey);
         break;
       case TrkrDefs::micromegasId:

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -3,6 +3,8 @@
 #include "SvtxHitEval.h"
 #include "SvtxTruthEval.h"
 
+#include <trackbase/MvtxDefs.h>
+
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
@@ -355,8 +357,12 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
 
   std::set<PHG4Hit*> truth_hits;
 
+  std::cout << __FILE__ << ":" << __PRETTY_FUNCTION__ << " line " << __LINE__ << std::endl;
+
   // get all truth hits for this cluster
-  //_cluster_hit_map->identify();
+  // _cluster_hit_map->identify();
+  _hit_truth_map->identify();
+
   std::pair<std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey>::const_iterator, std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey>::const_iterator>
       hitrange = _cluster_hit_map->getHits(cluster_key);  // returns range of pairs {cluster key, hit key} for this cluskey
 
@@ -368,17 +374,24 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
     // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
     TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
 
+    int strobeID = (static_cast<unsigned>(TrkrDefs::getLayer(hitsetkey)) < 3) ? MvtxDefs::getStrobeId(hitsetkey) : std::numeric_limits<int>::min();
+
+    std::cout << __LINE__ << " cluster key " << cluster_key << " hitsetkey " << hitsetkey << " layer " << static_cast<unsigned>(TrkrDefs::getLayer(hitsetkey)) << " strobe ID " << strobeID << " hitkey " << hitkey << std::endl;
+
     // get all of the g4hits for this hitkey
     std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype>> temp_map;
     _hit_truth_map->getG4Hits(hitsetkey, hitkey, temp_map);
     // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
 
+    std::cout << __LINE__ << " size of temp_map " << temp_map.size() << std::endl;
+    
     for (auto& htiter : temp_map)
     {
       // extract the g4 hit key here and add the hits to the set
       PHG4HitDefs::keytype g4hitkey = htiter.second.second;
       PHG4Hit* g4hit = nullptr;
       unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
+      std::cout << __LINE__ << " cluster key " << cluster_key << " trkrid " << trkrid << std::endl;
       switch (trkrid)
       {
       case TrkrDefs::tpcId:
@@ -388,6 +401,7 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
         g4hit = _g4hits_intt->findHit(g4hitkey);
         break;
       case TrkrDefs::mvtxId:
+        std::cout << __LINE__ << " cluster key " << cluster_key << " hitsetkey " << hitsetkey << " layer " << TrkrDefs::getLayer(hitsetkey) << " g4hitkey " << g4hitkey << std::endl;
         g4hit = _g4hits_mvtx->findHit(g4hitkey);
         break;
       case TrkrDefs::micromegasId:


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

In the original truth association, there are cases where there is an offset of 1 between the mvtx hitsetkeys and the hitsetkey in the TrkrHitTruthAssoc container. The change keeps the original lookup, but if no match is found for mvtx hitsetkeys, it tries again with the bare hitsetkey (which assumes the strobe ID = 0)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

