### PR TITLE
fix: clang tidy

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -79,17 +79,17 @@ namespace
   }
 
   // specify bins for which one will save histograms
-  static const std::vector<float> phi_rec = {get_sector_phi(9)};
-  static const std::vector<float> z_rec = {5.};
+  const std::vector<float> phi_rec = {get_sector_phi(9)};
+  const std::vector<float> z_rec = {5.};
 
   // phi range
-  static constexpr float m_phimin = 0;
-  static constexpr float m_phimax = 2. * M_PI;
+  constexpr float m_phimin = 0;
+  constexpr float m_phimax = 2. * M_PI;
 
   // TODO: could try to get the r and z range from TPC geometry
   // r range
-  static constexpr float m_rmin = 20;
-  static constexpr float m_rmax = 78;
+  constexpr float m_rmin = 20;
+  constexpr float m_rmax = 78;
 
   /// get cluster keys from a given track
   std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track)

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -756,7 +756,7 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
     PHG4TpcCylinderGeom* layergeom = _tpc_geom_container->GetLayerCellGeom(layer);
     
     double tpc_max_driftlength = layergeom->get_max_driftlength();
-    const auto params = _tpc_params->GetParameters(0);
+    const auto *const params = _tpc_params->GetParameters(0);
 
     double drift_velocity = params->get_double_param("drift_velocity");  // cm/ns
 


### PR DESCRIPTION
This should hopefully make jenkins mark the remaining clang-tidy errors as fixed and thus we get all green banners in the CI

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

