### PR TITLE
Add drift_velocity_sim to TPC layergeom

### DIFF
--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -105,6 +105,18 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
 
   auto surface = m_surfMaps.getSurface(key, cluster);
 
+  /*
+  std::cout << " getGlobalPositionTpc transform is: " << std::endl
+	    <<  surface->transform(m_tGeometry.getGeoContext()).matrix()
+	    << std::endl;
+  alignmentTransformationContainer::use_alignment = false;
+  Acts::Vector3 ideal_center = surface->center(m_tGeometry.getGeoContext()) * 0.1;
+  alignmentTransformationContainer::use_alignment = true;  
+  Acts::Vector3 sensorCenter = surface->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
+  std::cout << "  ideal surface center: " << ideal_center << std::endl;
+  std::cout << "  aligned surface center: " << sensorCenter << std::endl;
+  */
+  
   if (!surface)
   {
     std::cerr << "Couldn't identify cluster surface. Returning NAN"
@@ -122,6 +134,11 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
                                 Acts::Vector3(1, 1, 1));
   glob /= Acts::UnitConstants::cm;
 
+  /*
+  std::cout << "  local " << local << std::endl;
+  std::cout << "  glob " << glob << std::endl;
+  */  
+  
   return glob;
 }
 
@@ -253,6 +270,10 @@ Acts::Vector2 ActsGeometry::getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* c
     }
     local(0) = cluster->getLocalX();
     local(1) = zloc;
+    /*
+    std::cout << " clust " << cluster->getLocalY() << " tpc tzero " << _tpc_tzero << " sampa tbias " << _sampa_tzero_bias
+	      << " crossing tzero correction " << crossing_tzero_correction << " drift vel " << _drift_velocity << " zdriftlength " << zdriftlength << " zloc " << zloc << std::endl;
+    */
   }
   else
   {

--- a/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
@@ -39,7 +39,7 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   double get_CM_halfwidth() const  { return CM_halfwidth; }
   double get_adc_clock() const  { return adc_clock; }
   double get_extended_readout_time() const  { return extended_readout_time; }
-
+  double get_drift_velocity_sim() const  { return drift_velocity_sim; }
   
   virtual std::pair<double, double> get_zbounds(const int ibin) const;
   virtual std::pair<double, double> get_phibounds(const int ibin) const;
@@ -77,6 +77,7 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   void set_CM_halfwidth(const double val) { CM_halfwidth = val; }
   void set_adc_clock(const double val) { adc_clock = val; }
   void set_extended_readout_time(const double val) { extended_readout_time = val; }
+  void set_drift_velocity_sim(const double val) { drift_velocity_sim = val; }
   
   static const int NSides = 2;
 
@@ -110,6 +111,7 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   double CM_halfwidth{std::numeric_limits<double>::quiet_NaN()};
   double adc_clock{std::numeric_limits<double>::quiet_NaN()};
   double extended_readout_time{std::numeric_limits<double>::quiet_NaN()};
+  double drift_velocity_sim{std::numeric_limits<double>::quiet_NaN()};
   
   std::array<std::vector<double>, NSides> sector_R_bias;
   std::array<std::vector<double>, NSides> sector_Phi_bias;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -884,10 +884,14 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
   }
   else  // MVTX
   {
-    unsigned int stave, stave_outer;
-    unsigned int chip, chip_outer;
-    int row, row_outer;
-    int column, column_outer;
+    unsigned int stave;
+    unsigned int stave_outer;
+    unsigned int chip;
+    unsigned int chip_outer;
+    int row;
+    int row_outer;
+    int column;
+    int column_outer;
 
     // add diffusion to entry and exit locations
     double max_diffusion_radius = 25.0e-4;  // 25 microns

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -756,10 +756,8 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, co
     PHG4TpcCylinderGeom* layergeom = _tpc_geom_container->GetLayerCellGeom(layer);
     
     double tpc_max_driftlength = layergeom->get_max_driftlength();
-    const auto params = _tpc_params->GetParameters(0);
-
-    double drift_velocity = params->get_double_param("drift_velocity");  // cm/ns
-
+    double drift_velocity = layergeom->get_drift_velocity_sim();
+ 
     // Phi size
     //======
     double diffusion_trans = 0.006;  // cm/SQRT(cm)

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -565,17 +565,17 @@ void PHG4TpcDetector::add_geometry_node()
           0.56891770257002054,
       }};
 
-  const double drift_velocity = m_Params->get_double_param("drift_velocity");
+  const double drift_velocity_sim = m_Params->get_double_param("drift_velocity_sim");
   const double tpc_adc_clock = m_Params->get_double_param("tpc_adc_clock");
   const double maxdriftlength = m_Params->get_double_param("maxdriftlength");
   const double TBinWidth = tpc_adc_clock;
   const double extended_readout_time = m_Params->get_double_param("extended_readout_time");
-  const double MaxT = extended_readout_time + 2. * maxdriftlength / drift_velocity;  // allows for extended time readout
+  const double MaxT = extended_readout_time + 2. * maxdriftlength / drift_velocity_sim;  // allows for extended time readout
   const double MinT = 0;
   const int NTBins = (int) ((MaxT - MinT) / TBinWidth) + 1;
 
   std::cout << PHWHERE << "MaxT " << MaxT << " TBinWidth " << TBinWidth << " extended readout time "
-            << extended_readout_time << " NTBins = " << NTBins << " drift velocity " << drift_velocity << std::endl;
+            << extended_readout_time << " NTBins = " << NTBins << " drift velocity sim " << drift_velocity_sim << std::endl;
 
   const std::array<int, 3> NPhiBins =
       {{m_Params->get_int_param("ntpc_phibins_inner"),
@@ -722,7 +722,8 @@ void PHG4TpcDetector::add_geometry_node()
 	layerseggeo->set_max_driftlength(m_Params->get_double_param("maxdriftlength"));
 	layerseggeo->set_CM_halfwidth(m_Params->get_double_param("CM_halfwidth"));
 	layerseggeo->set_adc_clock(m_Params->get_double_param("tpc_adc_clock"));
-	layerseggeo->set_extended_readout_time(m_Params->get_double_param("extended_readout_time"));	
+	layerseggeo->set_extended_readout_time(m_Params->get_double_param("extended_readout_time"));
+	layerseggeo->set_drift_velocity_sim(m_Params->get_double_param("drift_velocity_sim"));	
       }
 
       // Chris Pinkenburg: greater causes huge memory growth which causes problems

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
@@ -134,7 +134,7 @@ void PHG4TpcDigitizer::CalculateCylinderCellADCScale(PHCompositeNode *topNode)
     int layer = layeriter->second->get_layer();
     float thickness = (layeriter->second)->get_thickness();
     float pitch = (layeriter->second)->get_phistep() * (layeriter->second)->get_radius();
-    float length = (layeriter->second)->get_zstep() * _drift_velocity;
+    float length = (layeriter->second)->get_zstep() * (layeriter->second)->get_drift_velocity_sim();
 
     float minpath = pitch;
     minpath = std::min(length, minpath);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -44,7 +44,6 @@ class PHG4TpcDigitizer : public SubsysReco
   void SetTpcMinLayer(const int minlayer) { TpcMinLayer = minlayer; };
   void SetADCThreshold(const float thresh) { ADCThreshold = thresh; };
   void SetENC(const float enc) { TpcEnc = enc; };
-  void set_drift_velocity(float vd) { _drift_velocity = vd; }
   void set_skip_noise_flag(const bool skip) { skip_noise = skip; }
 
  private:
@@ -60,8 +59,6 @@ class PHG4TpcDigitizer : public SubsysReco
   float TpcEnc;
   float Pedestal;
   float ChargeToPeakVolts;
-  float _drift_velocity = 8.0e-3;  // override from macro with simulation drift velocity
-
   float ADCSignalConversionGain;
   float ADCNoiseConversionGain;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -129,7 +129,6 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   double added_smear_sigma_trans = std::numeric_limits<double>::quiet_NaN();
   double diffusion_long = std::numeric_limits<double>::quiet_NaN();
   double added_smear_sigma_long = std::numeric_limits<double>::quiet_NaN();
-  double drift_velocity = std::numeric_limits<double>::quiet_NaN();
   double tpc_length = std::numeric_limits<double>::quiet_NaN();
   double electrons_per_gev = std::numeric_limits<double>::quiet_NaN();
   double min_active_radius = std::numeric_limits<double>::quiet_NaN();

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -368,7 +368,8 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
         phi_center += 2 * pi;
       }
       _hit_phi = phi_center;
-      _hit_z = AdcClockPeriod * MaxTBins * _drift_velocity / 2.0 - layergeom->get_zcenter(tbin) * _drift_velocity;
+      _hit_z = AdcClockPeriod * MaxTBins * layergeom->get_drift_velocity_sim() / 2.0 -
+	layergeom->get_zcenter(tbin) * layergeom->get_drift_velocity_sim();
       if (side == 0)
       {
         _hit_z *= -1.0;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
@@ -37,7 +37,6 @@ class PHG4TpcPadBaselineShift : public SubsysReco
   void setScale(float CScale);
   void setFileName(const std::string &filename);
   void writeTree(int f_writeTree);
-  void set_drift_velocity(float vd) { _drift_velocity = vd; }
 
  private:
   bool is_in_sector_boundary(int phibin, int sector, PHG4TpcCylinderGeom *layergeom) const;
@@ -69,7 +68,6 @@ class PHG4TpcPadBaselineShift : public SubsysReco
   float _hit_phi{std::numeric_limits<float>::quiet_NaN()};
   float _hit_e{std::numeric_limits<float>::quiet_NaN()};
   float _CScale{1.};
-  float _drift_velocity{8.0e-03};
 
   //   bool do_hit_assoc {true};
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -112,8 +112,9 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
   double tpc_adc_clock = layergeom->get_adc_clock();
   double extended_readout_time = layergeom->get_extended_readout_time();
   double maxdriftlength = layergeom->get_max_driftlength();
+  double drift_velocity_sim = layergeom->get_drift_velocity_sim();
   const double TBinWidth = tpc_adc_clock;
-  const double MaxT = extended_readout_time + 2.0 * maxdriftlength / drift_velocity;  // allows for extended time readout
+  const double MaxT = extended_readout_time + 2.0 * maxdriftlength / drift_velocity_sim;  // allows for extended time readout
   const double MinT = 0;
   NTBins = (int) ((MaxT - MinT) / TBinWidth) + 1;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -43,8 +43,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   void SetUseLangauGEMGain(const int flagLangau) { m_useLangau = flagLangau; }
   void SetLangauParsFileName(const std::string &name) { m_tpc_langau_pars_file = name; }
 
-  void SetDriftVelocity(double vd) override { drift_velocity = vd; }
-
   // otherwise warning of inconsistent overload since only one MapToPadPlane methow is overridden
   using PHG4TpcPadPlane::MapToPadPlane;
 
@@ -88,7 +86,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   double sigmaT = std::numeric_limits<double>::quiet_NaN();
   std::array<double, 2> sigmaL{};
   double phi_bin_width{};
-  double drift_velocity = 8.0e-03;  // default value, override from macro
+
   int NTBins = std::numeric_limits<int>::max();
   int m_NHits = 0;
   // Using Gain maps is turned off by default

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -202,7 +202,7 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_double_param("window_surface2_thickness", 0.0127);  // 127  um 2nd shell thickness be default
 
   // for geonode initialization
-  set_default_double_param("drift_velocity", 0.008);
+  set_default_double_param("drift_velocity_sim", 0.008);
 
   set_default_int_param("ntpc_layers_inner", 16);
   set_default_int_param("ntpc_layers_mid", 16);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Adds the simulation drift velocity to PHG4TpcCylinderGeom, making it accessible throughout the simulation process. The value is set only once, in PHG4TpcSubsystem, now.

This requires some changes to macros because the setters for drift_velocity_sim have been removed from some modules.

## TODOs (if applicable)

Needs a corresponding macros update.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

