### PR TITLE
Original calo geom

### DIFF
--- a/offline/packages/CaloReco/CaloGeomMapping.cc
+++ b/offline/packages/CaloReco/CaloGeomMapping.cc
@@ -182,6 +182,12 @@ void CaloGeomMapping::BuildFormerGeometry()
           RawTowerDefs::encode_towerid(m_caloid, ieta, iphi);
 
       double r = m_RawTowerGeomContainer->get_radius();
+
+      if (m_Detector == "HCALIN" || m_Detector == "HCALOUT")
+      {
+        r += m_RawTowerGeomContainer->get_radius() / 2.;
+      }
+      
       const double x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
       const double y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
       const double z(r / tan(2 * atan(exp(-1 * m_RawTowerGeomContainer->get_etacenter(ieta)))));


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This change fixes a mismatch in CaloGeomMapping. Before that change, CaloGeomMapping reproduces the HCALIN/HCALOUT geometry at the inner radius, whereas it is given at the middle radius under `calo_geo`.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

