### PR TITLE
use event number to close output file

### DIFF
--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -133,3 +133,16 @@ void Fun4AllOutputManager::SetNEvents(const unsigned int nevt)
   m_MaxEvents = nevt;
   return;
 }
+
+void Fun4AllOutputManager::SetEventNumberRollover(const int evtno)
+{
+  if (evtno <= 0)
+  {
+    std::cout << PHWHERE << " Events number to roll over has to be > 0" << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+  m_LastEventNumber = evtno-1; // for e.g. 100k we want first segment 0-99999, 100000-199999,...
+  m_EventRollover = evtno;
+  return;
+}

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -98,6 +98,11 @@ class Fun4AllOutputManager : public Fun4AllBase
   virtual void IncrementEvents(const unsigned int i) { m_NEvents += i; }
   //! set number of events
   virtual void SetEventsWritten(const unsigned int i) { m_NEvents = i; }
+  //! get number of Events
+  virtual int LastEventNumber() const { return m_LastEventNumber; }
+  virtual void UpdateLastEvent() {m_LastEventNumber += m_EventRollover;}
+  //! set number of events
+  virtual void SetEventNumberRollover(const int evtno);
   //! get output file name
   virtual std::string OutFileName() const { return m_OutFileName; }
   //! set compression level (if implemented)
@@ -139,6 +144,12 @@ class Fun4AllOutputManager : public Fun4AllBase
 
   //! Split level of TBranches
   int splitlevel{std::numeric_limits<int>::min()};
+
+  //! Last Event Number in output file
+  int m_LastEventNumber{std::numeric_limits<int>::max()};
+
+  //! Event number for rollover
+  int m_EventRollover{0};
 
   //! Number of Events
   unsigned int m_NEvents{0};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This adds the capability to roll over at event numbers, not only event counts. Basically we can now create output files with a deterministic first and  last event

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

