### PR TITLE
Add method to subsys reco

### DIFF
--- a/offline/framework/fun4all/SubsysReco.h
+++ b/offline/framework/fun4all/SubsysReco.h
@@ -26,7 +26,7 @@ class SubsysReco : public Fun4AllBase
   /** dtor.
       Does nothing as this is a base class only.
   */
-  ~SubsysReco() override {}
+  ~SubsysReco() override = default;
 
   /// Called at the end of all processing.
   virtual int End(PHCompositeNode * /*topNode*/) { return 0; }

--- a/offline/framework/fun4all/SubsysReco.h
+++ b/offline/framework/fun4all/SubsysReco.h
@@ -60,7 +60,10 @@ class SubsysReco : public Fun4AllBase
 
   void Print(const std::string & /*what*/ = "ALL") const override {}
 
- protected:
+  /// For new rollover DSTs - we need to be able to update the Run Node before the End()
+  virtual int UpdateRunNode(PHCompositeNode * /*topNode*/) { return 0; }
+
+protected:
   /** ctor.
       @param name is the reference used inside the Fun4AllServer
   */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the 
virtual int UpdateRunNode(PHCompositeNode * /*topNode*/)
to the SubsysReco base class. I need a hook to be able to let modules update the RUN Node before the End() in cases where we save DSTs in a rollover fashion (e.g. the event combining). Currently only the last segment (where End() is called) contains all rc flags and calibrations which were used since they are saved only during End(). So far this didn't cause problems (the only flag affected during the event combining is the timestamp which is then overridden anyway during the DST production) but better solve this before we get problems 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

