### PR TITLE
return hardcoded vars and remove new data members

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
@@ -35,11 +35,11 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   double get_etastep() const;
   double get_etamin() const;
 
-  double get_max_driftlength() const { return max_driftlength; }
-  double get_CM_halfwidth() const  { return CM_halfwidth; }
-  double get_adc_clock() const  { return adc_clock; }
-  double get_extended_readout_time() const  { return extended_readout_time; }
-  double get_drift_velocity_sim() const  { return drift_velocity_sim; }
+  double get_max_driftlength() const { return 102.325; }
+  double get_CM_halfwidth() const  { return 0.28; }
+  double get_adc_clock() const  { return 50.037280; } // 20MHz
+  double get_extended_readout_time() const  { return 0.; }
+  double get_drift_velocity_sim() const  { return 0.007550; }
   
   virtual std::pair<double, double> get_zbounds(const int ibin) const;
   virtual std::pair<double, double> get_phibounds(const int ibin) const;
@@ -73,11 +73,11 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   void set_etamin(const double z);
   void set_etastep(const double z);
   // capture the z geometry related setup parameters
-  void set_max_driftlength(const double val) { max_driftlength = val; }
-  void set_CM_halfwidth(const double val) { CM_halfwidth = val; }
-  void set_adc_clock(const double val) { adc_clock = val; }
-  void set_extended_readout_time(const double val) { extended_readout_time = val; }
-  void set_drift_velocity_sim(const double val) { drift_velocity_sim = val; }
+  void set_max_driftlength(const double /*val*/) { return; }
+  void set_CM_halfwidth(const double /*val*/) { return; }
+  void set_adc_clock(const double /*val*/) { return; }
+  void set_extended_readout_time(const double /*val*/) { return; }
+  void set_drift_velocity_sim(const double /*val*/) { return; }
   
   static const int NSides = 2;
 
@@ -107,11 +107,11 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   double phistep{std::numeric_limits<double>::quiet_NaN()};
   double thickness{std::numeric_limits<double>::quiet_NaN()};
 
-  double max_driftlength{std::numeric_limits<double>::quiet_NaN()};
-  double CM_halfwidth{std::numeric_limits<double>::quiet_NaN()};
-  double adc_clock{std::numeric_limits<double>::quiet_NaN()};
-  double extended_readout_time{std::numeric_limits<double>::quiet_NaN()};
-  double drift_velocity_sim{std::numeric_limits<double>::quiet_NaN()};
+  // double max_driftlength{std::numeric_limits<double>::quiet_NaN()};
+  // double CM_halfwidth{std::numeric_limits<double>::quiet_NaN()};
+  // double adc_clock{std::numeric_limits<double>::quiet_NaN()};
+  // double extended_readout_time{std::numeric_limits<double>::quiet_NaN()};
+  // double drift_velocity_sim{std::numeric_limits<double>::quiet_NaN()};
   
   std::array<std::vector<double>, NSides> sector_R_bias;
   std::array<std::vector<double>, NSides> sector_Phi_bias;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR rolls back the data members of PHG4TpcCylinderGeom.h which broke the readback. The accessors for the removed data members were replaced by returning hardcoded values which should keep our new reconstruction somewhat functional (those values need to be checked)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

