### PR TITLE
Implement update runnode

### DIFF
--- a/offline/framework/ffamodules/CDBInterface.cc
+++ b/offline/framework/ffamodules/CDBInterface.cc
@@ -55,6 +55,13 @@ CDBInterface::~CDBInterface()
 //____________________________________________________________________________..
 int CDBInterface::End(PHCompositeNode *topNode)
 {
+  int iret = UpdateRunNode(topNode);PHNodeIterator iter(topNode);
+  return iret;
+}
+
+//____________________________________________________________________________..
+int CDBInterface::UpdateRunNode(PHCompositeNode *topNode)
+{
   PHNodeIterator iter(topNode);
   PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   CdbUrlSave *cdburls = findNode::getClass<CdbUrlSave>(runNode, "CdbUrl");

--- a/offline/framework/ffamodules/CDBInterface.h
+++ b/offline/framework/ffamodules/CDBInterface.h
@@ -25,6 +25,8 @@ class CDBInterface : public SubsysReco
 
   void Print(const std::string &what = "ALL") const override;
 
+  int UpdateRunNode(PHCompositeNode *topNode) override;
+
   void Disable() { disable = true; }
   void Enable() { disable = false; }
 

--- a/offline/framework/ffamodules/FlagHandler.cc
+++ b/offline/framework/ffamodules/FlagHandler.cc
@@ -43,12 +43,22 @@ int FlagHandler::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int FlagHandler::End(PHCompositeNode *topNode)
 {
+  UpdateRunNode(topNode);
+  FlagSave *flagsave = findNode::getClass<FlagSave>(topNode, "Flags");
+  if (flagsave)
+  {
+    flagsave->identify();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int FlagHandler::UpdateRunNode(PHCompositeNode *topNode)
+{
   FlagSave *flagsave = findNode::getClass<FlagSave>(topNode, "Flags");
   if (flagsave)
   {
     recoConsts *rc = recoConsts::instance();
     flagsave->FillFromPHFlag(rc, true);
-    flagsave->identify();
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/framework/ffamodules/FlagHandler.h
+++ b/offline/framework/ffamodules/FlagHandler.h
@@ -26,6 +26,8 @@ class FlagHandler : public SubsysReco
 
   void Print(const std::string &what = "ALL") const override;
 
+  int UpdateRunNode(PHCompositeNode *topNode) override;
+
  private:
 };
 

--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -137,7 +137,7 @@ void Fun4AllOutputManager::SetNEvents(const unsigned int nevt)
     gSystem->Exit(1);
     exit(1);
   }
-    
+
   m_MaxEvents = nevt;
   return;
 }
@@ -156,7 +156,7 @@ void Fun4AllOutputManager::SetEventNumberRollover(const int evtno)
     gSystem->Exit(1);
     exit(1);
   }
-  m_LastEventNumber = evtno-1; // for e.g. 100k we want first segment 0-99999, 100000-199999,...
+  m_LastEventNumber = evtno - 1;  // for e.g. 100k we want first segment 0-99999, 100000-199999,...
   m_EventRollover = evtno;
   return;
 }

--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -122,6 +122,7 @@ int Fun4AllOutputManager::RunAfterClosing()
   }
   return iret;
 }
+
 void Fun4AllOutputManager::SetNEvents(const unsigned int nevt)
 {
   if (nevt == 0)
@@ -130,6 +131,13 @@ void Fun4AllOutputManager::SetNEvents(const unsigned int nevt)
     gSystem->Exit(1);
     exit(1);
   }
+  if (m_EventRollover != 0)
+  {
+    std::cout << PHWHERE << " You cannot use SetNEvents() and SetEventNumberRollover() together" << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+    
   m_MaxEvents = nevt;
   return;
 }
@@ -139,6 +147,12 @@ void Fun4AllOutputManager::SetEventNumberRollover(const int evtno)
   if (evtno <= 0)
   {
     std::cout << PHWHERE << " Events number to roll over has to be > 0" << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+  if (m_MaxEvents < std::numeric_limits<unsigned int>::max())
+  {
+    std::cout << PHWHERE << " You cannot use SetEventNumberRollover() and SetNEvents() together" << std::endl;
     gSystem->Exit(1);
     exit(1);
   }

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -44,7 +44,7 @@ class Fun4AllOutputManager : public Fun4AllBase
     return 0;
   }
 
-  virtual int StripCompositeNode(const std::string & /*nodename*/) {return 0;}
+  virtual int StripCompositeNode(const std::string & /*nodename*/) { return 0; }
 
   virtual void SaveRunNode(const int) { return; }
   virtual void SaveDstNode(const int) { return; }
@@ -100,7 +100,7 @@ class Fun4AllOutputManager : public Fun4AllBase
   virtual void SetEventsWritten(const unsigned int i) { m_NEvents = i; }
   //! get number of Events
   virtual int LastEventNumber() const { return m_LastEventNumber; }
-  virtual void UpdateLastEvent() {m_LastEventNumber += m_EventRollover;}
+  virtual void UpdateLastEvent() { m_LastEventNumber += m_EventRollover; }
   //! set number of events
   virtual void SetEventNumberRollover(const int evtno);
   //! get output file name

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -725,7 +725,7 @@ int Fun4AllServer::process_event()
               std::cout << PHWHERE << (*iterOutMan)->Name() << " wrote " << (*iterOutMan)->EventsWritten()
                         << " events, closing " << (*iterOutMan)->OutFileName() << std::endl;
             }
-	    UpdateRunNode();
+            UpdateRunNode();
             PHNodeIterator nodeiter(TopNode);
             PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(nodeiter.findFirst("PHCompositeNode", "RUN"));
             MakeNodesTransient(runNode);  // make all nodes transient by default
@@ -748,7 +748,7 @@ int Fun4AllServer::process_event()
               std::cout << PHWHERE << (*iterOutMan)->Name() << " wrote " << (*iterOutMan)->EventsWritten()
                         << " events, closing " << (*iterOutMan)->OutFileName() << std::endl;
             }
-	    UpdateRunNode();
+            UpdateRunNode();
             PHNodeIterator nodeiter(TopNode);
             PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(nodeiter.findFirst("PHCompositeNode", "RUN"));
             MakeNodesTransient(runNode);  // make all nodes transient by default
@@ -1799,10 +1799,10 @@ void Fun4AllServer::PrintMemoryTracker(const std::string &name)
 
 int Fun4AllServer::UpdateRunNode()
 {
-  int iret {Fun4AllReturnCodes::EVENT_OK};
+  int iret{Fun4AllReturnCodes::EVENT_OK};
   for (auto &Subsystem : Subsystems)
   {
-   iret += Subsystem.first->UpdateRunNode(Subsystem.second);
+    iret += Subsystem.first->UpdateRunNode(Subsystem.second);
   }
   return iret;
 }

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -725,6 +725,7 @@ int Fun4AllServer::process_event()
               std::cout << PHWHERE << (*iterOutMan)->Name() << " wrote " << (*iterOutMan)->EventsWritten()
                         << " events, closing " << (*iterOutMan)->OutFileName() << std::endl;
             }
+	    UpdateRunNode();
             PHNodeIterator nodeiter(TopNode);
             PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(nodeiter.findFirst("PHCompositeNode", "RUN"));
             MakeNodesTransient(runNode);  // make all nodes transient by default
@@ -747,6 +748,7 @@ int Fun4AllServer::process_event()
               std::cout << PHWHERE << (*iterOutMan)->Name() << " wrote " << (*iterOutMan)->EventsWritten()
                         << " events, closing " << (*iterOutMan)->OutFileName() << std::endl;
             }
+	    UpdateRunNode();
             PHNodeIterator nodeiter(TopNode);
             PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(nodeiter.findFirst("PHCompositeNode", "RUN"));
             MakeNodesTransient(runNode);  // make all nodes transient by default
@@ -1793,4 +1795,14 @@ void Fun4AllServer::PrintMemoryTracker(const std::string &name)
   std::cout << "PrintMemoryTracker called with " << name << " is disabled" << std::endl;
 #endif
   return;
+}
+
+int Fun4AllServer::UpdateRunNode()
+{
+  int iret {Fun4AllReturnCodes::EVENT_OK};
+  for (auto &Subsystem : Subsystems)
+  {
+   iret += Subsystem.first->UpdateRunNode(Subsystem.second);
+  }
+  return iret;
 }

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -116,7 +116,8 @@ class Fun4AllServer : public Fun4AllBase
   int EventCounter() const { return eventcounter; }
   std::map<const std::string, PHTimer>::const_iterator timer_begin() { return timer_map.begin(); }
   std::map<const std::string, PHTimer>::const_iterator timer_end() { return timer_map.end(); }
-
+  int UpdateRunNode();
+  
  protected:
   Fun4AllServer(const std::string &name = "Fun4AllServer");
   static int InitNodeTree(PHCompositeNode *topNode);

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -117,7 +117,7 @@ class Fun4AllServer : public Fun4AllBase
   std::map<const std::string, PHTimer>::const_iterator timer_begin() { return timer_map.begin(); }
   std::map<const std::string, PHTimer>::const_iterator timer_end() { return timer_map.end(); }
   int UpdateRunNode();
-  
+
  protected:
   Fun4AllServer(const std::string &name = "Fun4AllServer");
   static int InitNodeTree(PHCompositeNode *topNode);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
For rollover outputs the flags and cdb content was only saved in the last DST since the update of the RUN node was called in the End() method. This PR adds an UpdateRunNode() method which can be implemented by the subsysreco modules which gets called whenever a rollover DST is closed. So far only the flags were affected in the event combining step which is the only place we use those rollovers so far. And in this case only the 64 bit timestamp was not saved. Once this is propagated through we might not have to set this timestamp anymore for further processing since it will be on all DSTs

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

