### PR TITLE
MVTX streaming/triggered mode in PHG4MvtxHitReco

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -95,7 +95,7 @@ int PHG4MvtxHitReco::InitRun(PHCompositeNode* topNode)
 
   m_tmin = get_double_param("mvtx_tmin");
   m_tmax = get_double_param("mvtx_tmax");
-  // m_in_sphenix_srdo = (bool) get_int_param("mvtx_in_sphenix_srdo");
+  m_in_sphenix_srdo = (bool) get_int_param("mvtx_in_sphenix_srdo");
   m_strobe_width = (m_in_sphenix_srdo) ? get_double_param("mvtx_strobe_width_sro") : get_double_param("mvtx_strobe_width_trg");
   m_strobe_separation = (m_in_sphenix_srdo) ? get_double_param("mvtx_strobe_separation_sro") : get_double_param("mvtx_strobe_separation_trg");
   m_trigger_latency = get_double_param("mvtx_trigger_latency");

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -53,9 +53,6 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   //! parameters
   void SetDefaultParameters() override;
 
-  // set triggered or streaming mode for simulation
-  void set_triggered_mode(const bool val) { m_triggered_mode = val; }
-
  private:
   void makePixelMask(hitMask& aMask, const std::string& dbName, const std::string& totalPixelsToMask);
 
@@ -75,7 +72,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   double m_strobe_separation;
   double m_extended_readout_time = 0.0;
 
-  bool m_triggered_mode = false;
+  bool m_in_sphenix_srdo = false;
 
   class Deleter
   {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -53,6 +53,10 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   //! parameters
   void SetDefaultParameters() override;
 
+  void set_streaming_mode(bool val) { m_in_sphenix_srdo = val; }
+  void set_trigger_latency(double val) { m_trigger_latency = val; }
+  void set_strobe_width(double val) { m_strobe_width = val; }
+
  private:
   void makePixelMask(hitMask& aMask, const std::string& dbName, const std::string& totalPixelsToMask);
 
@@ -73,6 +77,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   double m_extended_readout_time = 0.0;
 
   bool m_in_sphenix_srdo = false;
+  double m_trigger_latency = 3.7;  // in us, same as in data
 
   class Deleter
   {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -53,10 +53,6 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   //! parameters
   void SetDefaultParameters() override;
 
-  void set_streaming_mode(bool val) { m_in_sphenix_srdo = val; }
-  void set_trigger_latency(double val) { m_trigger_latency = val; }
-  void set_strobe_width(double val) { m_strobe_width = val; }
-
  private:
   void makePixelMask(hitMask& aMask, const std::string& dbName, const std::string& totalPixelsToMask);
 
@@ -76,7 +72,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   double m_strobe_separation;
   double m_extended_readout_time = 0.0;
 
-  bool m_in_sphenix_srdo = false;
+  bool m_in_sphenix_srdo = true;
   double m_trigger_latency = 3.7;  // in us, same as in data
 
   class Deleter

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -53,6 +53,9 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   //! parameters
   void SetDefaultParameters() override;
 
+  // set triggered or streaming mode for simulation
+  void set_triggered_mode(const bool val) { m_triggered_mode = val; }
+
  private:
   void makePixelMask(hitMask& aMask, const std::string& dbName, const std::string& totalPixelsToMask);
 
@@ -72,7 +75,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   double m_strobe_separation;
   double m_extended_readout_time = 0.0;
 
-  bool m_in_sphenix_srdo = false;
+  bool m_triggered_mode = false;
 
   class Deleter
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Update PHG4MvtxHitReco for the triggered/streaming mode. Added and modified 
- The strobe width and separation will be set according to the parameter `mvtx_in_sphenix_srdo` (which is set in macro)
- Strobe width/separation for the streaming/triggered mode separately. These parameters could also be set in macro 
- The parameter for the trigger latency for the triggered mode. This parameter could be set in macro
- Pile-up rejection (for the triggered mode)
- The strobe assignment is now set based on the mode


[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)


