### PR TITLE
set classdef version back to 1 for PHG4TpcCylinderGeom

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4TpcCylinderGeom.h
@@ -121,7 +121,7 @@ class PHG4TpcCylinderGeom : public PHG4CylinderGeom
   // streamer
   friend std::ostream& operator<<(std::ostream&, const PHG4TpcCylinderGeom&);
 
-  ClassDefOverride(PHG4TpcCylinderGeom, 2)
+  ClassDefOverride(PHG4TpcCylinderGeom, 1)
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This restores the previous ClassDef version for PHG4TpcCylinderGeom. I had forgotten to set it back to 1

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

