### PR TITLE
Add delta_phi and pT masking cut before and after helix–plane intersection for field-on

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -39,6 +39,8 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   void set_test_windows_printout(const bool test) { _test_windows = test; }
   void set_pp_mode(const bool mode) { _pp_mode = mode; }
   void set_use_silicon( const bool value ) { _use_silicon = value; }
+  void set_pt_cut( const float pt) { _pt_cut = pt; }
+  void set_dphi_cut( const float dphi) { _dphi_cut = dphi; }
   void SetIteration(int iter) { _n_iteration = iter; }
 
   void zeroField(const bool flag) { _zero_field = flag; }
@@ -73,6 +75,12 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   // range of TPC layers to use in projection to micromegas
   unsigned int _max_tpc_layer = 55;
+
+  // pt cut for field-on data
+  float _pt_cut = 0.5;
+
+  // delta_phi window between the last cluster in the tracklet and the projection
+  float _dphi_cut = 0.9;
 
   TrkrClusterContainer* _cluster_map{nullptr};
   TrkrClusterContainer* _corrected_cluster_map{nullptr};


### PR DESCRIPTION
…onfigurable delta_phi, pT cuts

Implements a configurable delta_phi and pT mask in PHMicromegasTpcTrackMatching for field-on

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <https://indico.bnl.gov/event/29460/> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

