### PR TITLE
QAKFParticle update 2

### DIFF
--- a/offline/QA/KFParticle/QAKFParticle.cc
+++ b/offline/QA/KFParticle/QAKFParticle.cc
@@ -50,6 +50,37 @@
 
 KFParticle_Tools kfpTools;
 
+namespace
+{
+  inline void fillBunchCrossingRanges(std::vector<std::pair<double, double>> &ranges)
+  {
+    ranges.clear();
+
+    int start = -100;
+    int stop = 800;
+    int step = 100;
+
+    for (int lower = start; lower < stop;)
+    {
+      int upper = lower + step;
+
+      if (lower == 0)
+      {
+        lower += 1;
+      }
+
+      ranges.emplace_back(static_cast<double>(lower), static_cast<double>(upper));
+
+      if (lower == 1)
+      {
+        lower = 0;
+      }
+
+      lower = upper;
+    }
+  }
+}  // namespace
+
 QAKFParticle::QAKFParticle(const std::string &name, const std::string &mother_name, double min_m, double max_m)
   : SubsysReco(name)
   , m_mother_id(kfpTools.getParticleID(mother_name))
@@ -74,6 +105,18 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
+
+  fillBunchCrossingRanges(bunchCrossingRanges);
+
+  std::cout << "Bunch crossing ranges for mass histograms: " << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "Total number of ranges: " << bunchCrossingRanges.size() << std::endl;
+    for (const auto &range : bunchCrossingRanges)
+    {
+      std::cout << "  [" << range.first << ", " << range.second << ")" << std::endl;
+    }
+  }
 
   TH1 *h(nullptr);
 
@@ -103,8 +146,8 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
   hm->registerHisto(h2);
 
   // mass v.s bunch crossing
-  h2 = new TH2F(TString(get_histo_prefix()) + "BunchCrossing_InvMass_KFP",  //
-                ";Beam crossing (106 ns/crossing);mass [GeV];", 899, -149.5, 749.5, 100, m_min_mass, m_max_mass); // the axis title is the same as the approved plot https://www.sphenix.bnl.gov/sites/default/files/2025-04/sphenix-perf-4-25-Kscrossingcut.pdf
+  h2 = new TH2F(TString(get_histo_prefix()) + "BunchCrossing_InvMass_KFP",                                         //
+                ";Beam crossing (106 ns/crossing);mass [GeV];", 899, -149.5, 749.5, 100, m_min_mass, m_max_mass);  // the axis title is the same as the approved plot https://www.sphenix.bnl.gov/sites/default/files/2025-04/sphenix-perf-4-25-Kscrossingcut.pdf
   hm->registerHisto(h2);
 
   h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_crossing0",  //
@@ -126,6 +169,14 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
   h = new TH1F(TString(get_histo_prefix()) + "InvMass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm",  //
                ";mass [GeV];Entries", 100, m_min_mass, m_max_mass);
   hm->registerHisto(h);
+
+  // create the histograms for different bunch crossing ranges
+  for (const auto &range : bunchCrossingRanges)
+  {
+    std::string histname = get_histo_prefix() + "InvMass_KFP_crossing_" + std::to_string(static_cast<int>(range.first)) + "_to_" + std::to_string(static_cast<int>(range.second));
+    h = new TH1F(histname.c_str(), ";mass [GeV];Entries", 100, m_min_mass, m_max_mass);
+    hm->registerHisto(h);
+  }
 
   h_mass_KFP = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP"));
   assert(h_mass_KFP);
@@ -156,6 +207,13 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
 
   h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm"));
   assert(h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm);
+
+  // histograms for different bunch crossing ranges
+  for (size_t i = 0; i < bunchCrossingRanges.size(); ++i)
+  {
+    h_mass_KFP_crossingrange.push_back(dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_crossing_" + std::to_string(static_cast<int>(bunchCrossingRanges[i].first)) + "_to_" + std::to_string(static_cast<int>(bunchCrossingRanges[i].second)))));
+    assert(h_mass_KFP_crossingrange.back());
+  }
 
   // pt asymmetry analyzer
   if (m_doTrackPtAsymmetry)
@@ -236,6 +294,16 @@ int QAKFParticle::process_event(PHCompositeNode *topNode)
         }
 
         h_bunchcrossing_mass_KFP->Fill(kfpTrack->get_crossing(), iter.second->GetMass());
+
+        // fill the appropriate crossing range histogram
+        for (size_t i = 0; i < bunchCrossingRanges.size(); ++i)
+        {
+          if (kfpTrack->get_crossing() >= bunchCrossingRanges[i].first && kfpTrack->get_crossing() < bunchCrossingRanges[i].second)
+          {
+            h_mass_KFP_crossingrange[i]->Fill(iter.second->GetMass());
+            break;
+          }
+        }
       }
 
       if (hasTriggerInfo)

--- a/offline/QA/KFParticle/QAKFParticle.cc
+++ b/offline/QA/KFParticle/QAKFParticle.cc
@@ -209,9 +209,9 @@ int QAKFParticle::Init(PHCompositeNode * /*topNode*/)
   assert(h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm);
 
   // histograms for different bunch crossing ranges
-  for (size_t i = 0; i < bunchCrossingRanges.size(); ++i)
+for (const auto &range : bunchCrossingRanges)
   {
-    h_mass_KFP_crossingrange.push_back(dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_crossing_" + std::to_string(static_cast<int>(bunchCrossingRanges[i].first)) + "_to_" + std::to_string(static_cast<int>(bunchCrossingRanges[i].second)))));
+    h_mass_KFP_crossingrange.push_back(dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "InvMass_KFP_crossing_" + std::to_string(static_cast<int>(range.first)) + "_to_" + std::to_string(static_cast<int>(range.second)))));
     assert(h_mass_KFP_crossingrange.back());
   }
 
@@ -296,13 +296,15 @@ int QAKFParticle::process_event(PHCompositeNode *topNode)
         h_bunchcrossing_mass_KFP->Fill(kfpTrack->get_crossing(), iter.second->GetMass());
 
         // fill the appropriate crossing range histogram
-        for (size_t i = 0; i < bunchCrossingRanges.size(); ++i)
+        size_t range_index = 0;
+        for (const auto &range : bunchCrossingRanges)
         {
-          if (kfpTrack->get_crossing() >= bunchCrossingRanges[i].first && kfpTrack->get_crossing() < bunchCrossingRanges[i].second)
+          if (kfpTrack->get_crossing() >= range.first && kfpTrack->get_crossing() < range.second)
           {
-            h_mass_KFP_crossingrange[i]->Fill(iter.second->GetMass());
+            h_mass_KFP_crossingrange[range_index]->Fill(iter.second->GetMass());
             break;
           }
+          ++range_index;
         }
       }
 

--- a/offline/QA/KFParticle/QAKFParticle.h
+++ b/offline/QA/KFParticle/QAKFParticle.h
@@ -78,12 +78,16 @@ class QAKFParticle : public SubsysReco
   TH2 *h_mass_KFP_eta{nullptr};
   TH2 *h_mass_KFP_phi{nullptr};
   TH2 *h_mass_KFP_pt{nullptr};
-  TH2 *h_bunchcrossing_mass_KFP{nullptr}; // mass v.s bunch crossing
+  TH2 *h_bunchcrossing_mass_KFP{nullptr};  // mass v.s bunch crossing
   TH1 *h_mass_KFP_crossing0{nullptr};
   TH1 *h_mass_KFP_non_crossing0{nullptr};
   TH1 *h_mass_KFP_ZDC_Coincidence{nullptr};
   TH1 *h_mass_KFP_MBD_NandS_geq_1_vtx_l_10_cm{nullptr};
   TH1 *h_mass_KFP_Jet_6_GeV_MBD_NandS_geq_1_vtx_l_10_cm{nullptr};
+
+  // 1D histogram of mass in different crossing ranges
+  std::vector<std::pair<double, double>> bunchCrossingRanges;
+  std::vector<TH1 *> h_mass_KFP_crossingrange;
 
   TriggerAnalyzer *triggeranalyzer{nullptr};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Per suggestions from today's tracking meeting, new histograms of the candidate mass in different bunch crossing ranges are added. The default ranges of the crossing are [−100,0), [1,100), [100,200), [200,300), [300,400), [400,500), [500,600), [600,700), and [700,800).
Histograms for the candidate mass at crossing =0 and for all non-zero crossings already exist. These new histograms are intended to be an exclusive set beyond the existing ones.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

