### PR TITLE
Apply TPC alignment to laser clusters

### DIFF
--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -859,6 +859,7 @@ namespace
       {
         // clean up
         alignmentTransformationContainer::use_alignment = alignmentflag;
+        delete clus;
         delete fit3D;
         if (my_data.hitHist)
         {
@@ -881,7 +882,7 @@ namespace
     clus->setX(global(0));
     clus->setY(global(1));
     clus->setZ(global(2));
-    
+
     alignmentTransformationContainer::use_alignment = alignmentflag;
     pthread_mutex_unlock(&mythreadlock);
 

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -444,6 +444,7 @@ namespace
 
     double maxAdc = 0.0;
     TrkrDefs::hitsetkey maxKey = 0;
+    double secondmaxAdc = 0.0;
     TrkrDefs::hitsetkey secondmaxKey = 0;
 
     unsigned int nHits = clusHits.size();
@@ -556,10 +557,18 @@ namespace
 
       if (adc > maxAdc)
       {
-        maxAdc = adc;
+        secondmaxAdc = maxAdc;
         secondmaxKey = maxKey;
+        maxAdc = adc;
         maxKey = spechitkey.second;
       }
+      else if (adc > secondmaxAdc)
+      {
+        secondmaxAdc = adc;
+        secondmaxKey = spechitkey.second;
+      }
+
+
     }
 
     if (nHits == 0)
@@ -824,6 +833,7 @@ namespace
 
     pthread_mutex_lock(&mythreadlock);
     // Get surface of max ADC hit
+    bool alignmentflag = alignmentTransformationContainer::use_alignment;
     alignmentTransformationContainer::use_alignment = false;
     Acts::Vector3 ideal(clus->getX(), clus->getY(), clus->getZ());
     TrkrDefs::subsurfkey subsurfkey = 0;
@@ -848,7 +858,7 @@ namespace
       if (!surface)
       {
         // clean up
-        alignmentTransformationContainer::use_alignment = true;
+        alignmentTransformationContainer::use_alignment = alignmentflag;
         delete fit3D;
         if (my_data.hitHist)
         {
@@ -871,6 +881,8 @@ namespace
     clus->setX(global(0));
     clus->setY(global(1));
     clus->setZ(global(2));
+    
+    alignmentTransformationContainer::use_alignment = alignmentflag;
     pthread_mutex_unlock(&mythreadlock);
 
 
@@ -878,6 +890,7 @@ namespace
     my_data.cluster_vector.push_back(clus);
     my_data.cluster_key_vector.push_back(ckey);
 
+    
     delete fit3D;
 
     if (my_data.hitHist)

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -11,6 +11,7 @@
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/alignmentTransformationContainer.h>
 
 #include <ffaobjects/EventHeader.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -818,6 +819,35 @@ namespace
       clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
     }
 
+
+    // Get surface of max ADC hit
+    alignmentTransformationContainer::use_alignment = false;
+    Acts::Vector3 ideal(clusX, clusY, clusZ);
+    TrkrDefs::subsurfkey subsurfkey = 0;
+
+    Surface surface = my_data.tGeometry->get_tpc_surface_from_coords(
+        maxKey,
+        ideal,
+        subsurfkey);
+
+    if (!surface)
+    {
+      return;
+    }
+
+    // Convert from ideal TPC coordinates to surface coordinates 
+    Acts::Vector3 local = surface->transform(my_data.tGeometry->geometry().getGeoContext()).inverse() * (ideal * Acts::UnitConstants::cm);
+    local /= Acts::UnitConstants::cm;
+
+    // Convert back to TPC coordinates with alignment applied 
+    alignmentTransformationContainer::use_alignment = true;
+    Acts::Vector3 global = surface->transform(my_data.tGeometry->geometry().getGeoContext()) * (local * Acts::UnitConstants::cm);
+    global /= Acts::UnitConstants::cm;
+    clus->setX(global(0));
+    clus->setY(global(1));
+    clus->setZ(global(2));
+
+
     const auto ckey = TrkrDefs::genClusKey(maxKey, my_data.cluster_vector.size());
     my_data.cluster_vector.push_back(clus);
     my_data.cluster_key_vector.push_back(ckey);
@@ -995,6 +1025,7 @@ int LaserClusterizer::InitRun(PHCompositeNode *topNode)
   // get the first layer to get the clock freq
   AdcClockPeriod = m_geom_container->GetFirstLayerCellGeom()->get_zstep();
   m_tdriftmax = AdcClockPeriod * NZBinsSide;
+  
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1146,6 +1177,9 @@ int LaserClusterizer::process_event(PHCompositeNode *topNode)
         thread_pair.data.peakTimeBin = m_laserEventInfo->getPeakSample(s);
         thread_pair.data.layerMin = 3;
         thread_pair.data.layerMax = 3;
+        // ******************** //
+        // m_tdriftmax = m_tGeometry->get_max_driftlength() / m_tGeometry->get_drift_velocity(); 
+        // ******************** //
         thread_pair.data.tdriftmax = m_tdriftmax;
         thread_pair.data.eventNum = m_event;
         thread_pair.data.Verbosity = Verbosity();

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -444,6 +444,7 @@ namespace
 
     double maxAdc = 0.0;
     TrkrDefs::hitsetkey maxKey = 0;
+    TrkrDefs::hitsetkey secondmaxKey = 0;
 
     unsigned int nHits = clusHits.size();
 
@@ -556,6 +557,7 @@ namespace
       if (adc > maxAdc)
       {
         maxAdc = adc;
+        secondmaxKey = maxKey;
         maxKey = spechitkey.second;
       }
     }
@@ -820,9 +822,10 @@ namespace
     }
 
 
+    pthread_mutex_lock(&mythreadlock);
     // Get surface of max ADC hit
     alignmentTransformationContainer::use_alignment = false;
-    Acts::Vector3 ideal(clusX, clusY, clusZ);
+    Acts::Vector3 ideal(clus->getX(), clus->getY(), clus->getZ());
     TrkrDefs::subsurfkey subsurfkey = 0;
 
     Surface surface = my_data.tGeometry->get_tpc_surface_from_coords(
@@ -832,7 +835,29 @@ namespace
 
     if (!surface)
     {
-      return;
+      // try second maximum ADC hit
+      if (secondmaxKey != 0)
+      {
+        surface = my_data.tGeometry->get_tpc_surface_from_coords(
+            secondmaxKey,
+            ideal,
+            subsurfkey);
+      }
+
+      // if still no surface, skip this cluster
+      if (!surface)
+      {
+        // clean up
+        alignmentTransformationContainer::use_alignment = true;
+        delete fit3D;
+        if (my_data.hitHist)
+        {
+          delete my_data.hitHist;
+          my_data.hitHist = nullptr;
+        }
+        pthread_mutex_unlock(&mythreadlock);
+        return;
+      }
     }
 
     // Convert from ideal TPC coordinates to surface coordinates 
@@ -846,6 +871,7 @@ namespace
     clus->setX(global(0));
     clus->setY(global(1));
     clus->setZ(global(2));
+    pthread_mutex_unlock(&mythreadlock);
 
 
     const auto ckey = TrkrDefs::genClusKey(maxKey, my_data.cluster_vector.size());

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -1177,9 +1177,6 @@ int LaserClusterizer::process_event(PHCompositeNode *topNode)
         thread_pair.data.peakTimeBin = m_laserEventInfo->getPeakSample(s);
         thread_pair.data.layerMin = 3;
         thread_pair.data.layerMax = 3;
-        // ******************** //
-        // m_tdriftmax = m_tGeometry->get_max_driftlength() / m_tGeometry->get_drift_velocity(); 
-        // ******************** //
         thread_pair.data.tdriftmax = m_tdriftmax;
         thread_pair.data.eventNum = m_event;
         thread_pair.data.Verbosity = Verbosity();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR applies the alignment of the TPC to the laser clusters on the central membrane.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

Laser events on the TPC central membrane are used as alignment/calibration references. This PR applies the TPC alignment corrections to reconstructed laser clusters so their stored global positions reflect detector misalignments, improving the fidelity of alignment and downstream calibration studies.

## Key Changes

- Apply alignment-aware coordinate transforms to laser clusters:
  - Record primary max-ADC hit and a second-max ADC hit as a fallback.
  - Lookup detector surface for the chosen hit; fall back to second-max if primary surface is unavailable.
  - Convert cluster from ideal TPC coordinates to surface-local frame with alignment temporarily disabled, then re-enable alignment and transform back to global coordinates to write corrected cluster X/Y/Z.
- Add include for trackbase/alignmentTransformationContainer to access alignment utilities.
- Minor formatting change in InitRun (blank line after AdcClockPeriod).
- Added error/cleanup paths to restore alignment state and free temporary objects when surface lookup fails.

## Potential Risk Areas

- Thread-safety: The code toggles the global alignmentTransformationContainer::use_alignment flag around transforms. That global toggle can race between threads in multi-threaded clustering and produce inconsistent alignment application.
- Reconstruction behavior: Cluster global coordinates change; downstream algorithms, calibrations, and analyses may be affected and need revalidation.
- Silent fallbacks / observability: Surface-lookup fallbacks and early returns could hide unaligned clusters without explicit counters or logging.
- Performance: Per-cluster surface lookups and extra coordinate transforms add CPU overhead during clustering; throughput impact should be measured.
- IO/backwards compatibility: Stored cluster coordinates differ from previous unaligned outputs; workflows that assume the old coordinates may break.

## Possible Future Improvements

- Replace global alignment toggle with a thread-local or per-call alignment API to avoid races.
- Add diagnostic counters/logging for surface-lookup failures and fallback usage to aid validation.
- Optionally perform alignment in a separate, single-threaded post-processing step to simplify threading and reduce per-cluster overhead.
- Benchmark and optimize surface-lookup / transform hot paths if clustering latency is impacted.

Note: AI-generated summaries may omit subtle details or misinterpret code—please review the diff and test runtime behavior (threading, logging, and alignment semantics) before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->