### PR TITLE
Add optional QA Histograms to CaloStatusSkimmer

### DIFF
--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -16,7 +16,7 @@
 #include <cstdint>
 #include <iostream>
 
-#include <TH1F.h>
+#include <TH1.h>
 
 //____________________________________________________________________________..
 CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name)
@@ -36,44 +36,31 @@ int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
     auto* hm = QAHistManagerDef::getHistoManager();
     assert(hm);
 
-    h_EMC_nTowers_notinstr = new TH1F("h_EMC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in EMCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
+    h_EMC_nTowers_notinstr = new TH1("h_EMC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in EMCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
     h_EMC_nTowers_notinstr->SetDirectory(nullptr);
-    h_HCal_nTowers_notinstr = new TH1F("h_HCal_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in HCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
+    h_HCal_nTowers_notinstr = new TH1("h_HCal_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in HCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
     h_HCal_nTowers_notinstr->SetDirectory(nullptr);
-    h_sEPD_nTowers_notinstr = new TH1F("h_sEPD_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in sEPD; nNotInstrTowers; Counts", 17, -0.5, 16.5);
+    h_sEPD_nTowers_notinstr = new TH1("h_sEPD_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in sEPD; nNotInstrTowers; Counts", 17, -0.5, 16.5);
     h_sEPD_nTowers_notinstr->SetDirectory(nullptr);
-    h_ZDC_nTowers_notinstr = new TH1F("h_ZDC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in ZDC; nNotInstrTowers; Counts", 5, -0.5, 4.5);
+    h_ZDC_nTowers_notinstr = new TH1("h_ZDC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in ZDC; nNotInstrTowers; Counts", 5, -0.5, 4.5);
     h_ZDC_nTowers_notinstr->SetDirectory(nullptr);
 
-    h_EMC_nEvents = new TH1F("h_EMC_nEvents", "Number of events", 2, 0.5, 2.5);
-    h_EMC_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
-    h_EMC_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
-    h_EMC_nEvents->SetDirectory(nullptr); 
+    h_calo_nEvents = new TH1("h_calo_nEvents", "Number of events", 7, 0.5, 7.5);
+    h_calo_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
+    h_calo_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
+    h_calo_nEvents->GetXaxis()->SetBinLabel(3, "EMCal above not-instr threshold");
+    h_calo_nEvents->GetXaxis()->SetBinLabel(4, "HCal above not-instr threshold");
+    h_calo_nEvents->GetXaxis()->SetBinLabel(5, "sEPD above not-instr threshold");
+    h_calo_nEvents->GetXaxis()->SetBinLabel(6, "ZDC above not-instr threshold");
+    h_calo_nEvents->GetXaxis()->SetBinLabel(7, "No TowerInfo nodes found");
+    h_calo_nEvents->SetDirectory(nullptr);
 
-    h_HCal_nEvents = new TH1F("h_HCal_nEvents", "Number of events", 2, 0.5, 2.5);
-    h_HCal_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
-    h_HCal_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
-    h_HCal_nEvents->SetDirectory(nullptr);
-
-    h_sEPD_nEvents = new TH1F("h_sEPD_nEvents", "Number of events", 2, 0.5, 2.5);
-    h_sEPD_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
-    h_sEPD_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
-    h_sEPD_nEvents->SetDirectory(nullptr);
-
-    h_ZDC_nEvents = new TH1F("h_ZDC_nEvents", "Number of events", 2, 0.5, 2.5);
-    h_ZDC_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
-    h_ZDC_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
-    h_ZDC_nEvents->SetDirectory(nullptr);
+    hm->registerHisto(h_calo_nEvents);
 
     hm->registerHisto(h_EMC_nTowers_notinstr);
     hm->registerHisto(h_HCal_nTowers_notinstr);
     hm->registerHisto(h_sEPD_nTowers_notinstr);
     hm->registerHisto(h_ZDC_nTowers_notinstr);
-
-    hm->registerHisto(h_EMC_nEvents);
-    hm->registerHisto(h_HCal_nEvents);
-    hm->registerHisto(h_sEPD_nEvents);
-    hm->registerHisto(h_ZDC_nEvents);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -83,6 +70,12 @@ int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
 int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
 {
   n_eventcounter++;
+  uint16_t notinstr_EMC = 0;
+  uint16_t notinstr_HCalin = 0;
+  uint16_t notinstr_HCalout = 0;
+  uint16_t notinstr_sEPD = 0;
+  uint16_t notinstr_ZDC = 0;
+
   if (m_EMC_skim_threshold > 0)
   {
     TowerInfoContainer *towers =
@@ -97,29 +90,27 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
     const uint32_t ntowers = towers->size();
-    uint16_t notinstr_count = 0;
     for (uint32_t ch = 0; ch < ntowers; ++ch)
     {
       TowerInfo *tower = towers->get_tower_at_channel(ch);
       if (tower->get_isNotInstr())
       {
-        ++notinstr_count;
+        ++notinstr_EMC;
       }
     }
     if (Verbosity() > 9)
     {
-      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in EMCal = " << ntowers << ", not-instrumented(empty/missing pckt) towers in EMCal = " << notinstr_count << std::endl;
+      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in EMCal = " << ntowers << ", not-instrumented(empty/missing pckt) towers in EMCal = " << notinstr_EMC << std::endl;
     }
 
     if (b_produce_QA_histograms)
     {
-      h_EMC_nTowers_notinstr->Fill(notinstr_count);
+      h_EMC_nTowers_notinstr->Fill(notinstr_EMC);
     }
 
-    if (notinstr_count >= m_EMC_skim_threshold)
+    if (notinstr_EMC > m_EMC_skim_threshold)
     {
-      n_skimcounter++;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      EMC_skim_count++;
     }
   }
 
@@ -138,43 +129,40 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
     }
 
     const uint32_t ntowers_hcalin = hcalin_towers->size();
-    uint16_t notinstr_count_hcalin = 0;
     for (uint32_t ch = 0; ch < ntowers_hcalin; ++ch)
     {
       TowerInfo *tower_in = hcalin_towers->get_tower_at_channel(ch);
       if (tower_in->get_isNotInstr())
       {
-        ++notinstr_count_hcalin;
+        ++notinstr_HCalin;
       }
     }
 
     const uint32_t ntowers_hcalout = hcalout_towers->size();
-    uint16_t notinstr_count_hcalout = 0;
     for (uint32_t ch = 0; ch < ntowers_hcalout; ++ch)
     {
       TowerInfo *tower_out = hcalout_towers->get_tower_at_channel(ch);
       if (tower_out->get_isNotInstr())
       {
-        ++notinstr_count_hcalout;
+        ++notinstr_HCalout;
       }
     }
 
     if (Verbosity() > 9)
     {
-      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in HCalIn = " << ntowers_hcalin << ", not-instrumented(empty/missing pckt) towers in HCalIn = " << notinstr_count_hcalin << ", ntowers in HCalOut = " << ntowers_hcalout << ", not-instrumented(empty/missing pckt) towers in HCalOut = " << notinstr_count_hcalout << std::endl;
+      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in HCalIn = " << ntowers_hcalin << ", not-instrumented(empty/missing pckt) towers in HCalIn = " << notinstr_HCalin << ", ntowers in HCalOut = " << ntowers_hcalout << ", not-instrumented(empty/missing pckt) towers in HCalOut = " << notinstr_HCalout << std::endl;
     }
 
     if (b_produce_QA_histograms)
     {
-      h_HCal_nTowers_notinstr->Fill(notinstr_count_hcalin);
-      h_HCal_nTowers_notinstr->Fill(notinstr_count_hcalout);
+      h_HCal_nTowers_notinstr->Fill(notinstr_HCalin);
+      h_HCal_nTowers_notinstr->Fill(notinstr_HCalout);
     }
 
-    if (notinstr_count_hcalin >= m_HCal_skim_threshold ||
-        notinstr_count_hcalout >= m_HCal_skim_threshold)
+    if (notinstr_HCalin > m_HCal_skim_threshold ||
+        notinstr_HCalout > m_HCal_skim_threshold)
     {
-      n_skimcounter++;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      HCal_skim_count++;
     }
   }
 
@@ -192,30 +180,28 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
     const uint32_t ntowers = sepd_towers->size();
-    uint16_t notinstr_count = 0;
     for (uint32_t ch = 0; ch < ntowers; ++ch)
     {
       TowerInfo *tower = sepd_towers->get_tower_at_channel(ch);
       if (tower->get_isNotInstr())
       {
-        ++notinstr_count;
+        ++notinstr_sEPD;
       }
     }
 
     if (Verbosity() > 9)
     {
-      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in sEPD = " << ntowers << ", not-instrumented(empty/missing pckt) towers in sEPD = " << notinstr_count << std::endl;
+      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in sEPD = " << ntowers << ", not-instrumented(empty/missing pckt) towers in sEPD = " << notinstr_sEPD << std::endl;
     }
 
     if(b_produce_QA_histograms)
     {
-      h_sEPD_nTowers_notinstr->Fill(notinstr_count);
+      h_sEPD_nTowers_notinstr->Fill(notinstr_sEPD);
     }
 
-    if (notinstr_count >= m_sEPD_skim_threshold)
+    if (notinstr_sEPD > m_sEPD_skim_threshold)
     {
-      n_skimcounter++;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      sEPD_skim_count++;
     }
   }
 
@@ -233,31 +219,36 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
     const uint32_t ntowers = zdc_towers->size();
-    uint16_t notinstr_count = 0;
     for (uint32_t ch = 0; ch < ntowers; ++ch)
     {
       TowerInfo *tower = zdc_towers->get_tower_at_channel(ch);
       if (tower->get_isNotInstr())
       {
-        ++notinstr_count;
+        ++notinstr_ZDC;
       }
     }
 
     if (Verbosity() > 9)
     {
-      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in ZDC = " << ntowers << ", not-instrumented(empty/missing pckt) towers in ZDC = " << notinstr_count << std::endl;
+      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in ZDC = " << ntowers << ", not-instrumented(empty/missing pckt) towers in ZDC = " << notinstr_ZDC << std::endl;
     }
 
     if(b_produce_QA_histograms)
     {
-      h_ZDC_nTowers_notinstr->Fill(notinstr_count);
+      h_ZDC_nTowers_notinstr->Fill(notinstr_ZDC);
     }
 
-    if (notinstr_count >= m_ZDC_skim_threshold)
+    if (notinstr_ZDC > m_ZDC_skim_threshold)
     {
-      n_skimcounter++;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      ZDC_skim_count++;
     }
+  }
+
+  // If any of the enabled skimming conditions are met, then increment the skim counter and return ABORTEVENT to skip the event
+  if ((m_EMC_skim_threshold > 0 && notinstr_EMC > m_EMC_skim_threshold) || (m_HCal_skim_threshold > 0 && (notinstr_HCalin > m_HCal_skim_threshold || notinstr_HCalout > m_HCal_skim_threshold)) || (m_sEPD_skim_threshold > 0 && notinstr_sEPD > m_sEPD_skim_threshold) || (m_ZDC_skim_threshold > 0 && notinstr_ZDC > m_ZDC_skim_threshold))
+  {
+    n_skimcounter++;
+    return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -273,18 +264,13 @@ int CaloStatusSkimmer::End([[maybe_unused]] PHCompositeNode *topNode)
 
   if (b_produce_QA_histograms)
   {
-    h_EMC_nEvents->SetBinContent(1, n_eventcounter);
-    h_EMC_nEvents->SetBinContent(2, n_skimcounter);
-
-    h_HCal_nEvents->SetBinContent(1, n_eventcounter);
-    h_HCal_nEvents->SetBinContent(2, n_skimcounter);
-
-    h_sEPD_nEvents->SetBinContent(1, n_eventcounter);
-    h_sEPD_nEvents->SetBinContent(2, n_skimcounter);
-
-    h_ZDC_nEvents->SetBinContent(1, n_eventcounter);
-    h_ZDC_nEvents->SetBinContent(2, n_skimcounter);
-
+    h_calo_nEvents->SetBinContent(1, n_eventcounter);
+    h_calo_nEvents->SetBinContent(2, n_skimcounter);
+    h_calo_nEvents->SetBinContent(3, EMC_skim_count);
+    h_calo_nEvents->SetBinContent(4, HCal_skim_count);
+    h_calo_nEvents->SetBinContent(5, sEPD_skim_count);
+    h_calo_nEvents->SetBinContent(6, ZDC_skim_count);
+    h_calo_nEvents->SetBinContent(7, n_notowernodecounter);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -12,24 +12,24 @@
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
 
+#include <TH1.h>
+
 #include <cassert>
 #include <cstdint>
 #include <iostream>
-
-#include <TH1.h>
 
 //____________________________________________________________________________..
 CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name)
     : SubsysReco(name)
 {
-  std::cout << "CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name) ""Calling ctor" << std::endl;
+  //std::cout << "CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name) ""Calling ctor" << std::endl;
 }
 
 
 //____________________________________________________________________________..
 int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
 {
-  std::cout << "CaloStatusSkimmer::Init(PHCompositeNode *topNode) This is Init..." << std::endl;
+  // std::cout << "CaloStatusSkimmer::Init(PHCompositeNode *topNode) This is Init..." << std::endl;
 
   if (b_produce_QA_histograms)
   {

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -1,22 +1,82 @@
 #include "CaloStatusSkimmer.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#include <qautils/QAHistManagerDef.h>
+
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
 
+#include <cassert>
 #include <cstdint>
 #include <iostream>
+
+#include <TH1F.h>
 
 //____________________________________________________________________________..
 CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name)
     : SubsysReco(name)
 {
   std::cout << "CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name) ""Calling ctor" << std::endl;
+}
+
+
+//____________________________________________________________________________..
+int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
+{
+  std::cout << "CaloStatusSkimmer::Init(PHCompositeNode *topNode) This is Init..." << std::endl;
+
+  if (b_produce_QA_histograms)
+  {
+    auto* hm = QAHistManagerDef::getHistoManager();
+    assert(hm);
+
+    h_EMC_nTowers_notinstr = new TH1F("h_EMC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in EMCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
+    h_EMC_nTowers_notinstr->SetDirectory(nullptr);
+    h_HCal_nTowers_notinstr = new TH1F("h_HCal_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in HCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
+    h_HCal_nTowers_notinstr->SetDirectory(nullptr);
+    h_sEPD_nTowers_notinstr = new TH1F("h_sEPD_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in sEPD; nNotInstrTowers; Counts", 17, -0.5, 16.5);
+    h_sEPD_nTowers_notinstr->SetDirectory(nullptr);
+    h_ZDC_nTowers_notinstr = new TH1F("h_ZDC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in ZDC; nNotInstrTowers; Counts", 5, -0.5, 4.5);
+    h_ZDC_nTowers_notinstr->SetDirectory(nullptr);
+
+    h_EMC_nEvents = new TH1F("h_EMC_nEvents", "Number of events", 2, 0.5, 2.5);
+    h_EMC_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
+    h_EMC_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
+    h_EMC_nEvents->SetDirectory(nullptr); 
+
+    h_HCal_nEvents = new TH1F("h_HCal_nEvents", "Number of events", 2, 0.5, 2.5);
+    h_HCal_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
+    h_HCal_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
+    h_HCal_nEvents->SetDirectory(nullptr);
+
+    h_sEPD_nEvents = new TH1F("h_sEPD_nEvents", "Number of events", 2, 0.5, 2.5);
+    h_sEPD_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
+    h_sEPD_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
+    h_sEPD_nEvents->SetDirectory(nullptr);
+
+    h_ZDC_nEvents = new TH1F("h_ZDC_nEvents", "Number of events", 2, 0.5, 2.5);
+    h_ZDC_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
+    h_ZDC_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
+    h_ZDC_nEvents->SetDirectory(nullptr);
+
+    hm->registerHisto(h_EMC_nTowers_notinstr);
+    hm->registerHisto(h_HCal_nTowers_notinstr);
+    hm->registerHisto(h_sEPD_nTowers_notinstr);
+    hm->registerHisto(h_ZDC_nTowers_notinstr);
+
+    hm->registerHisto(h_EMC_nEvents);
+    hm->registerHisto(h_HCal_nEvents);
+    hm->registerHisto(h_sEPD_nEvents);
+    hm->registerHisto(h_ZDC_nEvents);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
@@ -32,7 +92,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       n_notowernodecounter++;
       if (Verbosity() > 0)
       {
-        std::cout << PHWHERE << "calostatuscheck::process_event: missing TOWERS_CEMC" << std::endl;
+        std::cout << PHWHERE << "CaloStatusSkimmer::process_event: missing TOWERS_CEMC" << std::endl;
       }
       return Fun4AllReturnCodes::ABORTEVENT;
     }
@@ -51,6 +111,11 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in EMCal = " << ntowers << ", not-instrumented(empty/missing pckt) towers in EMCal = " << notinstr_count << std::endl;
     }
 
+    if (b_produce_QA_histograms)
+    {
+      h_EMC_nTowers_notinstr->Fill(notinstr_count);
+    }
+
     if (notinstr_count >= m_EMC_skim_threshold)
     {
       n_skimcounter++;
@@ -67,7 +132,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       n_notowernodecounter++;
       if (Verbosity() > 0)
       {
-        std::cout << PHWHERE << "calostatuscheck::process_event: missing TOWERS_HCALIN or TOWERS_HCALOUT" << std::endl;
+        std::cout << PHWHERE << "CaloStatusSkimmer::process_event: missing TOWERS_HCALIN or TOWERS_HCALOUT" << std::endl;
       }
       return Fun4AllReturnCodes::ABORTEVENT;
     }
@@ -99,6 +164,12 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in HCalIn = " << ntowers_hcalin << ", not-instrumented(empty/missing pckt) towers in HCalIn = " << notinstr_count_hcalin << ", ntowers in HCalOut = " << ntowers_hcalout << ", not-instrumented(empty/missing pckt) towers in HCalOut = " << notinstr_count_hcalout << std::endl;
     }
 
+    if (b_produce_QA_histograms)
+    {
+      h_HCal_nTowers_notinstr->Fill(notinstr_count_hcalin);
+      h_HCal_nTowers_notinstr->Fill(notinstr_count_hcalout);
+    }
+
     if (notinstr_count_hcalin >= m_HCal_skim_threshold ||
         notinstr_count_hcalout >= m_HCal_skim_threshold)
     {
@@ -116,7 +187,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       n_notowernodecounter++;
       if (Verbosity() > 0)
       {
-        std::cout << PHWHERE << "calostatuscheck::process_event: missing TOWERS_SEPD" << std::endl;
+        std::cout << PHWHERE << "CaloStatusSkimmer::process_event: missing TOWERS_SEPD" << std::endl;
       }
       return Fun4AllReturnCodes::ABORTEVENT;
     }
@@ -136,6 +207,11 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in sEPD = " << ntowers << ", not-instrumented(empty/missing pckt) towers in sEPD = " << notinstr_count << std::endl;
     }
 
+    if(b_produce_QA_histograms)
+    {
+      h_sEPD_nTowers_notinstr->Fill(notinstr_count);
+    }
+
     if (notinstr_count >= m_sEPD_skim_threshold)
     {
       n_skimcounter++;
@@ -152,7 +228,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       n_notowernodecounter++;
       if (Verbosity() > 0)
       {
-        std::cout << PHWHERE << "calostatuscheck::process_event: missing TOWERS_ZDC" << std::endl;
+        std::cout << PHWHERE << "CaloStatusSkimmer::process_event: missing TOWERS_ZDC" << std::endl;
       }
       return Fun4AllReturnCodes::ABORTEVENT;
     }
@@ -172,6 +248,11 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in ZDC = " << ntowers << ", not-instrumented(empty/missing pckt) towers in ZDC = " << notinstr_count << std::endl;
     }
 
+    if(b_produce_QA_histograms)
+    {
+      h_ZDC_nTowers_notinstr->Fill(notinstr_count);
+    }
+
     if (notinstr_count >= m_ZDC_skim_threshold)
     {
       n_skimcounter++;
@@ -186,9 +267,25 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
 int CaloStatusSkimmer::End([[maybe_unused]] PHCompositeNode *topNode)
 {
   std::cout << "CaloStatusSkimmer::End(PHCompositeNode *topNode) This is the End..." << std::endl;
-  std::cout << "Total events processed: " << n_eventcounter << std::endl;
-  std::cout << "Total events skimmed: " << n_skimcounter << std::endl;
-  std::cout << "Total events with missing tower nodes: " << n_notowernodecounter << std::endl;
+  std::cout << "CaloStatusSkimmer::End Total events processed: " << n_eventcounter << std::endl;
+  std::cout << "CaloStatusSkimmer::End Total events skimmed: " << n_skimcounter << std::endl;
+  std::cout << "CaloStatusSkimmer::End Total events with missing tower nodes: " << n_notowernodecounter << std::endl;
+
+  if (b_produce_QA_histograms)
+  {
+    h_EMC_nEvents->SetBinContent(1, n_eventcounter);
+    h_EMC_nEvents->SetBinContent(2, n_skimcounter);
+
+    h_HCal_nEvents->SetBinContent(1, n_eventcounter);
+    h_HCal_nEvents->SetBinContent(2, n_skimcounter);
+
+    h_sEPD_nEvents->SetBinContent(1, n_eventcounter);
+    h_sEPD_nEvents->SetBinContent(2, n_skimcounter);
+
+    h_ZDC_nEvents->SetBinContent(1, n_eventcounter);
+    h_ZDC_nEvents->SetBinContent(2, n_skimcounter);
+
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -36,16 +36,16 @@ int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
     auto* hm = QAHistManagerDef::getHistoManager();
     assert(hm);
 
-    h_EMC_nTowers_notinstr = new TH1("h_EMC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in EMCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
+    h_EMC_nTowers_notinstr = new TH1F("h_EMC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in EMCal; nNotInstrTowers; Counts", 24577, -0.5, 24576.5);
     h_EMC_nTowers_notinstr->SetDirectory(nullptr);
-    h_HCal_nTowers_notinstr = new TH1("h_HCal_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in HCal; nNotInstrTowers; Counts", 193, -0.5, 192.5);
+    h_HCal_nTowers_notinstr = new TH1F("h_HCal_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in HCal; nNotInstrTowers; Counts", 1537, -0.5, 1536.5);
     h_HCal_nTowers_notinstr->SetDirectory(nullptr);
-    h_sEPD_nTowers_notinstr = new TH1("h_sEPD_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in sEPD; nNotInstrTowers; Counts", 17, -0.5, 16.5);
+    h_sEPD_nTowers_notinstr = new TH1F("h_sEPD_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in sEPD; nNotInstrTowers; Counts", 745, -0.5, 744.5);
     h_sEPD_nTowers_notinstr->SetDirectory(nullptr);
-    h_ZDC_nTowers_notinstr = new TH1("h_ZDC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in ZDC; nNotInstrTowers; Counts", 5, -0.5, 4.5);
+    h_ZDC_nTowers_notinstr = new TH1F("h_ZDC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in ZDC; nNotInstrTowers; Counts", 53, -0.5, 52.5);
     h_ZDC_nTowers_notinstr->SetDirectory(nullptr);
 
-    h_calo_nEvents = new TH1("h_calo_nEvents", "Number of events", 7, 0.5, 7.5);
+    h_calo_nEvents = new TH1F("h_calo_nEvents", "Number of events", 7, 0.5, 7.5);
     h_calo_nEvents->GetXaxis()->SetBinLabel(1, "Total events processed");
     h_calo_nEvents->GetXaxis()->SetBinLabel(2, "Total events skimmed");
     h_calo_nEvents->GetXaxis()->SetBinLabel(3, "EMCal above not-instr threshold");

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -108,7 +108,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       h_EMC_nTowers_notinstr->Fill(notinstr_EMC);
     }
 
-    if (notinstr_EMC > m_EMC_skim_threshold)
+    if (notinstr_EMC >= m_EMC_skim_threshold)
     {
       EMC_skim_count++;
     }
@@ -159,8 +159,8 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       h_HCal_nTowers_notinstr->Fill(notinstr_HCalout);
     }
 
-    if (notinstr_HCalin > m_HCal_skim_threshold ||
-        notinstr_HCalout > m_HCal_skim_threshold)
+    if (notinstr_HCalin >= m_HCal_skim_threshold ||
+        notinstr_HCalout >= m_HCal_skim_threshold)
     {
       HCal_skim_count++;
     }
@@ -199,7 +199,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       h_sEPD_nTowers_notinstr->Fill(notinstr_sEPD);
     }
 
-    if (notinstr_sEPD > m_sEPD_skim_threshold)
+    if (notinstr_sEPD >= m_sEPD_skim_threshold)
     {
       sEPD_skim_count++;
     }
@@ -238,14 +238,14 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       h_ZDC_nTowers_notinstr->Fill(notinstr_ZDC);
     }
 
-    if (notinstr_ZDC > m_ZDC_skim_threshold)
+    if (notinstr_ZDC >= m_ZDC_skim_threshold)
     {
       ZDC_skim_count++;
     }
   }
 
   // If any of the enabled skimming conditions are met, then increment the skim counter and return ABORTEVENT to skip the event
-  if ((m_EMC_skim_threshold > 0 && notinstr_EMC > m_EMC_skim_threshold) || (m_HCal_skim_threshold > 0 && (notinstr_HCalin > m_HCal_skim_threshold || notinstr_HCalout > m_HCal_skim_threshold)) || (m_sEPD_skim_threshold > 0 && notinstr_sEPD > m_sEPD_skim_threshold) || (m_ZDC_skim_threshold > 0 && notinstr_ZDC > m_ZDC_skim_threshold))
+  if ((m_EMC_skim_threshold > 0 && notinstr_EMC >= m_EMC_skim_threshold) || (m_HCal_skim_threshold > 0 && (notinstr_HCalin >= m_HCal_skim_threshold || notinstr_HCalout >= m_HCal_skim_threshold)) || (m_sEPD_skim_threshold > 0 && notinstr_sEPD >= m_sEPD_skim_threshold) || (m_ZDC_skim_threshold > 0 && notinstr_ZDC >= m_ZDC_skim_threshold))
   {
     n_skimcounter++;
     return Fun4AllReturnCodes::ABORTEVENT;

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
@@ -10,13 +10,18 @@
 #include <string>
 #include <utility>
 
+#include <TH1F.h>
+
 class PHCompositeNode;
+class TH1F;
 
 class CaloStatusSkimmer : public SubsysReco {
 public:
   CaloStatusSkimmer(const std::string &name = "CaloStatusSkimmer");
 
   ~CaloStatusSkimmer() override = default;
+
+  int Init(PHCompositeNode* topNode) override;
 
   /** Called for each event.
       This is where you do the real work.
@@ -26,26 +31,37 @@ public:
   /// Called at the end of all processing.
   int End(PHCompositeNode *topNode) override;
 
-  void do_skim_EMCal( uint16_t threshold) {
+  void do_skim_EMCal( uint16_t threshold) 
+  {
     m_EMC_skim_threshold = threshold;
   }
 
-  void do_skim_HCal( uint16_t threshold) {
+  void do_skim_HCal( uint16_t threshold) 
+  {
     m_HCal_skim_threshold = threshold;
   }
 
-  void do_skim_sEPD( uint16_t threshold) {
+  void do_skim_sEPD( uint16_t threshold) 
+  {
     m_sEPD_skim_threshold = threshold;
   }
 
-  void do_skim_ZDC( uint16_t threshold) {
+  void do_skim_ZDC( uint16_t threshold) 
+  {
     m_ZDC_skim_threshold = threshold;
+  }
+
+  void produce_QA_histograms(bool produce) 
+  {
+    b_produce_QA_histograms = produce;
   }
 
 private:
   uint32_t n_eventcounter{0};
   uint32_t n_skimcounter{0};
   uint32_t n_notowernodecounter{0};
+
+  bool b_produce_QA_histograms{false};
 
   // If the threshold is set to 0, then the skimming for that subsystem is disabled. If threshold is > 0, then the event is skimmed if nchannels >= threshold not-instrumented (empty/missing packet) channels in that subsystem.
   uint16_t m_EMC_skim_threshold{192}; 
@@ -59,6 +75,18 @@ private:
 
   uint16_t m_ZDC_skim_threshold{1}; 
   // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in ZDC
+
+  //histograms
+  TH1F* h_EMC_nTowers_notinstr = nullptr;
+  TH1F* h_HCal_nTowers_notinstr = nullptr;
+  TH1F* h_sEPD_nTowers_notinstr = nullptr;
+  TH1F* h_ZDC_nTowers_notinstr = nullptr;
+
+  TH1F* h_EMC_nEvents = nullptr;
+  TH1F* h_HCal_nEvents = nullptr;
+  TH1F* h_sEPD_nEvents = nullptr;
+  TH1F* h_ZDC_nEvents = nullptr;
+
 };
 
 #endif // CALOSTATUSSKIMMER_H

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
@@ -10,8 +10,6 @@
 #include <string>
 #include <utility>
 
-#include <TH1.h>
-
 class PHCompositeNode;
 class TH1;
 

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
@@ -64,17 +64,18 @@ private:
   bool b_produce_QA_histograms{false};
 
   // If the threshold is set to 0, then the skimming for that subsystem is disabled. If threshold is > 0, then the event is skimmed if nchannels >= threshold not-instrumented (empty/missing packet) channels in that subsystem.
-  uint16_t m_EMC_skim_threshold{192}; 
-  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in EMCal
+
+  uint16_t m_EMC_skim_threshold{193}; 
+  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in EMCal. For the EMCal in particular we want to skim if greater than 1 packet's worth of channels are not-instrumented, which corresponds to 193 channels (since each packet has 192 channels)
 
   uint16_t m_HCal_skim_threshold{192}; 
-  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in HCal
+  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in HCal. Corresponds to 1 packet's worth of channels in HCal, which has 192 channels per packet
 
   uint16_t m_sEPD_skim_threshold{1}; 
-  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in sEPD
+  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in sEPD. 
 
   uint16_t m_ZDC_skim_threshold{0}; 
-  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in ZDC
+  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in ZDC. Some issue in the ZDC right now so skimming is turned off by now by default.
 
   // Counters for number of events skimmed per subsystem
   uint32_t EMC_skim_count = 0;

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.h
@@ -10,10 +10,10 @@
 #include <string>
 #include <utility>
 
-#include <TH1F.h>
+#include <TH1.h>
 
 class PHCompositeNode;
-class TH1F;
+class TH1;
 
 class CaloStatusSkimmer : public SubsysReco {
 public:
@@ -65,27 +65,31 @@ private:
 
   // If the threshold is set to 0, then the skimming for that subsystem is disabled. If threshold is > 0, then the event is skimmed if nchannels >= threshold not-instrumented (empty/missing packet) channels in that subsystem.
   uint16_t m_EMC_skim_threshold{192}; 
-  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in EMCal
+  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in EMCal
 
   uint16_t m_HCal_skim_threshold{192}; 
-  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in HCal
+  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in HCal
 
   uint16_t m_sEPD_skim_threshold{1}; 
-  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in sEPD
+  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in sEPD
 
-  uint16_t m_ZDC_skim_threshold{1}; 
-  // skim if nchannels >= this many not-instrumented (empty/missing packet) channels in ZDC
+  uint16_t m_ZDC_skim_threshold{0}; 
+  // skim if nchannels > this many not-instrumented (empty/missing packet) channels in ZDC
 
-  //histograms
-  TH1F* h_EMC_nTowers_notinstr = nullptr;
-  TH1F* h_HCal_nTowers_notinstr = nullptr;
-  TH1F* h_sEPD_nTowers_notinstr = nullptr;
-  TH1F* h_ZDC_nTowers_notinstr = nullptr;
+  // Counters for number of events skimmed per subsystem
+  uint32_t EMC_skim_count = 0;
+  uint32_t HCal_skim_count = 0;
+  uint32_t sEPD_skim_count = 0; 
+  uint32_t ZDC_skim_count = 0;
 
-  TH1F* h_EMC_nEvents = nullptr;
-  TH1F* h_HCal_nEvents = nullptr;
-  TH1F* h_sEPD_nEvents = nullptr;
-  TH1F* h_ZDC_nEvents = nullptr;
+  //Per-calo tower counter histograms
+  TH1* h_EMC_nTowers_notinstr = nullptr;
+  TH1* h_HCal_nTowers_notinstr = nullptr;
+  TH1* h_sEPD_nTowers_notinstr = nullptr;
+  TH1* h_ZDC_nTowers_notinstr = nullptr;
+
+  //Event counter histograms
+  TH1* h_calo_nEvents = nullptr;
 
 };
 

--- a/offline/packages/Skimmers/CaloStatusSkimmer/Makefile.am
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/Makefile.am
@@ -22,7 +22,8 @@ libCaloStatusSkimmer_la_SOURCES = \
 libCaloStatusSkimmer_la_LIBADD = \
   -lphool \
   -lSubsysReco \
-  -lcalo_io
+  -lcalo_io \
+  -lqautils
 
 BUILT_SOURCES = testexternals.cc
 


### PR DESCRIPTION
[comment]: 
Addition of QA histograms to CaloStatusSkimmer. Off by default. 
Histograms attach to default Histogram output manager for QA. 
Macro still needs a line like: "QAHistManagerDef::saveQARootFile(OutFile_name);" to see that output.

Additionally cleaned up some of the cout lines so they are more obviously from the Skimmer module. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
New feature. 

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Optional QA histograms in the skimmer module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add Optional QA Histograms to CaloStatusSkimmer

### Motivation
This PR enhances the CaloStatusSkimmer module with optional QA histogram output for per-subsystem instrumentation diagnostics, allowing better monitoring of calorimeter data quality. The feature is disabled by default and can be activated through a new public method, with histogram output handled via the standard QA histogram manager infrastructure.

### Key Changes
- **New histogram output**: Added five per-subsystem QA histograms (EMCal, HCal-in/out, sEPD, ZDC) tracking counts of not-instrumented towers, plus an event-category histogram with labeled bins for processed/skipped/threshold events
- **Init method implementation**: New `Init(PHCompositeNode*)` override obtains the QA histogram manager and registers histograms when enabled via `produce_QA_histograms(bool)`
- **Refactored skim logic**: Changed from immediate per-subsystem abort-on-threshold to consolidated threshold checking after computing all subsystem counts; now increments per-subsystem skim counters then returns single `ABORTEVENT` if any condition is met
- **Threshold adjustments**: EMC threshold 192→193 (one less-permissive case), ZDC threshold 1→0 (effectively disables ZDC skimming via guard check `m_ZDC_skim_threshold > 0`)
- **Improved console output**: Normalized log message prefixes from `calostatuscheck::process_event` to `CaloStatusSkimmer::process_event` for clearer module identification
- **New dependency**: Added `-lqautils` library linking

### Potential Risk Areas

⚠️ **Important change in ZDC skimming behavior**: ZDC skimming is effectively disabled by setting the default threshold to 0 (checked via guard condition `if (m_ZDC_skim_threshold > 0)` before processing). This is a significant change from the previous threshold of 1.

**Reconstruction behavior changes**: Per-event subsystem counting now always occurs for enabled subsystems (previously was skipped on early return), potentially affecting performance minimally even when QA histograms are disabled.

**New library dependency**: Addition of qautilts library could impact build configurations in downstream packages.

### Recommendations
- Comprehensive test coverage comparing event skimming counts before/after this PR across representative data samples, particularly for ZDC behavior
- Verify the intent of disabling ZDC skimming by default
- Confirm EMC threshold adjustment (192→193) produces expected impact on event selection

**Note**: This summary includes AI-generated content that may contain inaccuracies; use best judgment and verify critical details through code review and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->