### PR TITLE
commit for associating the FPHXBCO and INTT_long_BCO information with TrkrHit

### DIFF
--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -502,6 +502,8 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
       hit = new TrkrHitv2;
       //--hit->setAdc(adc);
       hit->setAdc(dac);
+      hit->setFPHXBCO(intthit->get_FPHX_BCO());
+      hit->setBCO(intthit->get_bco());
       hit_set_container_itr->second->addHitSpecificKey(hit_key, hit);
     }
 

--- a/offline/packages/trackbase/TrkrHit.h
+++ b/offline/packages/trackbase/TrkrHit.h
@@ -11,6 +11,7 @@
 
 #include <phool/PHObject.h>
 
+#include <cstdint>
 #include <climits>
 #include <cmath>
 #include <iostream>
@@ -55,6 +56,13 @@ class TrkrHit : public PHObject
   // after digitization, these are the adc values
   virtual void setAdc(const unsigned int) {}
   virtual unsigned int getAdc() const { return 0; }
+
+  // optional per-hit timing payload used by detectors that need to retain
+  // the frontend bunch-counter value alongside the digitized hit.
+  virtual void setFPHXBCO(const uint16_t) {}
+  virtual uint16_t getFPHXBCO() const { return 0; }
+  virtual void setBCO(const uint64_t) {}
+  virtual uint64_t getBCO() const { return 0; }
   /*
   virtual void setCrossing(const short int) {}
   virtual short int getCrossing() { return 0;}

--- a/offline/packages/trackbase/TrkrHitv1.cc
+++ b/offline/packages/trackbase/TrkrHitv1.cc
@@ -13,6 +13,8 @@ void TrkrHitv1::CopyFrom(const TrkrHit& source)
 
   // copy adc
   setAdc(source.getAdc());
+  setFPHXBCO(source.getFPHXBCO());
+  setBCO(source.getBCO());
 }
 
 unsigned int TrkrHitv1::getAdc() const

--- a/offline/packages/trackbase/TrkrHitv1.h
+++ b/offline/packages/trackbase/TrkrHitv1.h
@@ -28,7 +28,9 @@ class TrkrHitv1 : public TrkrHit
   // PHObject virtual overloads
   void identify(std::ostream& os = std::cout) const override
   {
-    os << "TrkrHitV1 class with adc = " << m_adc << std::endl;
+    os << "TrkrHitV1 class with adc = " << m_adc
+       << " and FPHX_BCO = " << m_fphx_bco
+       << " and BCO = " << m_bco << std::endl;
   }
   void Reset() override {}
   int isValid() const override { return 0; }
@@ -49,11 +51,17 @@ class TrkrHitv1 : public TrkrHit
   double getEnergy() const override { return m_edep; }
   void setAdc(const unsigned int adc) override { m_adc = adc; }
   unsigned int getAdc() const override;
+  void setFPHXBCO(const uint16_t bco) override { m_fphx_bco = bco; }
+  uint16_t getFPHXBCO() const override { return m_fphx_bco; }
+  void setBCO(const uint64_t bco) override { m_bco = bco; }
+  uint64_t getBCO() const override { return m_bco; }
 
  protected:
   double m_edep = 0;
   unsigned int m_adc = 0;
-  ClassDefOverride(TrkrHitv1, 1);
+  uint16_t m_fphx_bco = 0;
+  uint64_t m_bco = 0;
+  ClassDefOverride(TrkrHitv1, 3);
 };
 
 #endif  // TRACKBASE_TRKRHITV1_H

--- a/offline/packages/trackbase/TrkrHitv2.cc
+++ b/offline/packages/trackbase/TrkrHitv2.cc
@@ -14,6 +14,8 @@ void TrkrHitv2::CopyFrom(const TrkrHit& source)
 
   // copy adc
   setAdc(source.getAdc());
+  setFPHXBCO(source.getFPHXBCO());
+  setBCO(source.getBCO());
 }
 
 // these set and get the energy before digitization

--- a/offline/packages/trackbase/TrkrHitv2.h
+++ b/offline/packages/trackbase/TrkrHitv2.h
@@ -33,7 +33,9 @@ class TrkrHitv2 : public TrkrHit
   // PHObject virtual overloads
   void identify(std::ostream& os = std::cout) const override
   {
-    os << "TrkrHitv2 class with adc = " << m_adc << std::endl;
+    os << "TrkrHitv2 class with adc = " << m_adc
+       << " and FPHX_BCO = " << m_fphx_bco
+       << " and BCO = " << m_bco << std::endl;
   }
   void Reset() override {}
   int isValid() const override { return 0; }
@@ -57,10 +59,16 @@ class TrkrHitv2 : public TrkrHit
   // after digitization, these are the adc values
   void setAdc(const unsigned int adc) override;
   unsigned int getAdc() const override;
+  void setFPHXBCO(const uint16_t bco) override { m_fphx_bco = bco; }
+  uint16_t getFPHXBCO() const override { return m_fphx_bco; }
+  void setBCO(const uint64_t bco) override { m_bco = bco; }
+  uint64_t getBCO() const override { return m_bco; }
 
  protected:
   unsigned short m_adc = 0;
-  ClassDefOverride(TrkrHitv2, 1);
+  uint16_t m_fphx_bco = 0;
+  uint64_t m_bco = 0;
+  ClassDefOverride(TrkrHitv2, 3);
 };
 
 #endif  // TRACKBASE_TRKRHITV2_H


### PR DESCRIPTION
[comment]: The commit is to associate the INTT timing information with the TrkrHit, which is very important for the study of the INTT carried-over-hit issue in streaming.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: 
The modification doesn't touch the `hit_set_key` structure. But change the `TrkrHit` data class. The following four are modified. 
trackbase/TrkrHit.h
trackbase/TrkrHitv1.cc
trackbase/TrkrHitv1.h
trackbase/TrkrHitv2.cc
trackbase/TrkrHitv2.h

And  `intt/InttCombinedRawDataDecoder.cc` is updated to assign the INTT_FPHX_BCO and INTT_long_BCO to Trkrhit.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

