### PR TITLE
EventPlaneReco: Update sEPD channel selection and charge handling

### DIFF
--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -367,7 +367,7 @@ int EventPlaneReco::process_sEPD(PHCompositeNode* topNode)
     }
 
     // Clamp on high charge threshold
-    if (m_sEPD_charge_threshold && charge > m_sEPD_charge_threshold)
+    if (m_sEPD_charge_threshold > 0 && charge > m_sEPD_charge_threshold)
     {
       charge = m_sEPD_charge_threshold;
     }

--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -351,13 +351,25 @@ int EventPlaneReco::process_sEPD(PHCompositeNode* topNode)
     TowerInfo* tower = towerinfosEPD->get_tower_at_channel(channel);
 
     unsigned int key = TowerInfoDefs::encode_epd(channel);
+    int rbin = TowerInfoDefs::get_epd_rbin(key);
     double charge = tower->get_energy();
 
-    // skip bad channels
-    // skip channels with very low charge
-    if (tower->get_isHot() || charge < m_sepd_min_channel_charge)
+    // Skip Innermost Ring
+    if (m_skipRing0 && rbin == 0)
     {
       continue;
+    }
+
+    // Skip Noise
+    if (charge <= m_sepd_min_channel_charge)
+    {
+      continue;
+    }
+
+    // Clamp on high charge threshold
+    if (m_sEPD_charge_threshold && charge > m_sEPD_charge_threshold)
+    {
+      charge = m_sEPD_charge_threshold;
     }
 
     // arm = 0: South

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -65,6 +65,16 @@ class EventPlaneReco : public SubsysReco
     m_sepd_min_channel_charge = sepd_min_channel_charge;
   }
 
+  void set_charge_threshold(double threshold)
+  {
+    m_sEPD_charge_threshold = threshold;
+  }
+
+  void set_skipRing0(bool skip)
+  {
+    m_skipRing0 = skip;
+  }
+
   void set_EventPlaneInfoNodeName(const std::string &name)
   {
     m_EventPlaneInfoNodeName = name;
@@ -91,9 +101,12 @@ class EventPlaneReco : public SubsysReco
  bool m_doNotCalib{false};
  bool m_doNotCalibEvent{false};
 
+ bool m_skipRing0{true};
+
  double m_cent{0.0};
  double m_globalEvent{0};
- double m_sepd_min_channel_charge{0.2};
+ double m_sepd_min_channel_charge{0.5};
+ double m_sEPD_charge_threshold{50};
 
  std::string m_calibName{"SEPD_EventPlaneCalib"};
  std::string m_inputNode{"TOWERINFO_CALIB_SEPD"};

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -67,7 +67,7 @@ class EventPlaneReco : public SubsysReco
 
   void set_charge_threshold(double threshold)
   {
-    m_sEPD_charge_threshold = threshold;
+    m_sEPD_charge_threshold = std::max(0.0, threshold);
   }
 
   void set_skipRing0(bool skip)


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Updated the sEPD event plane reconstruction strategy based on recent QA findings. Major changes include:
- Removed isHot channel exclusion: QA determined no channels are consistently hot in sEPD; using all available channels instead.
- Implemented charge clamping: Added a configurable threshold (default 50) to cap the maximum charge per channel, mitigating the impact of non-linearities or outliers.
- Default Ring 0 exclusion: Added logic to skip the innermost ring (Ring 0) by default to avoid high-intensity beam background noise.
- Updated noise floor: Increased default minimum channel charge from 0.2 to 0.5.
- Added setters for the new charge threshold and ring-skipping toggle.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

sEPD Q Vector Calibration Generation: https://github.com/sPHENIX-Collaboration/coresoftware/pull/4245

## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## EventPlaneReco: Update sEPD channel selection and charge handling

### Motivation / Context
QA showed no consistently "hot" sEPD channels, so excluding channels by an isHot flag was unnecessary and could remove useful information. At the same time, high-intensity beam background from the innermost ring and occasional large per-channel signals/non-linearities can bias Q-vector sums. This PR adjusts selection and per-channel charge handling to reduce those effects while allowing configurable control.

### Key Changes
- Removed isHot-based channel exclusion; all available sEPD channels are considered.
- Implemented configurable per-channel charge clamping: charges above m_sEPD_charge_threshold are capped (default 50). The setter clamps negative inputs to 0 so threshold=0 disables clamping.
- Default behavior now skips the innermost ring (Ring 0) when m_skipRing0 is true (default true); skipping is governed by the ring index derived from the tower key.
- Increased the sEPD minimum channel charge (noise floor) from 0.2 → 0.5; channels with charge <= this value are suppressed.
- Added runtime configuration setters: set_charge_threshold(double) and set_skipRing0(bool).

### Potential Risk Areas
- Reconstruction changes: removing hot-channel exclusion and introducing Ring 0 skipping, a higher noise floor, and charge clamping will change event-plane Q-vectors and potentially event-plane resolution — validate against physics benchmarks.
- Bias from clamping: capping high charges (default 50) can bias harmonic sums for high-multiplicity or high-charge events; perform sensitivity studies across centrality/energy ranges.
- Default-parameter impact: new defaults (skipRing0=true, charge_threshold=50, min_channel_charge=0.5) affect all users; ensure analyses expecting prior defaults are revalidated.
- IO / API: new setters and default value changes are backward-compatible API additions, but behavior changes may affect reproducibility of prior results.
- Thread-safety / performance: no explicit thread-safety changes observed; slight per-channel branching for clamping is unlikely to materially affect performance but should be profiled in high-rate workflows.

### Possible Future Improvements
- Expose per-ring or per-channel charge thresholds and clamping policies for finer control.
- Add calibration-driven or run-dependent thresholds (e.g., per-run QA) instead of fixed defaults.
- Instrument QA metrics and monitoring to detect transient hot channels and toggle exclusions dynamically.
- Document recommended validation plots and benchmarks for physics groups to adopt after the change.

AI-generated summaries can be mistaken—please verify the technical details against the code diffs and tests during review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->