### PR TITLE
sEPD Q Vector Calibration (Generation): Charge Clamping and Ring 0 Exclusion

### DIFF
--- a/calibrations/sepd/sepd_eventplanecalib/QVecCalib.cc
+++ b/calibrations/sepd/sepd_eventplanecalib/QVecCalib.cc
@@ -222,10 +222,13 @@ void QVecCalib::init_hists()
     m_hists2D[name_N] = new TH2F(name_N.c_str(), title_N.c_str(), m_cent_bins, m_cent_low, m_cent_high, bins_psi, psi_low, psi_high);
     m_hists2D[name_NS] = new TH2F(name_NS.c_str(), title_NS.c_str(), m_cent_bins, m_cent_low, m_cent_high, bins_psi, psi_low, psi_high);
 
-    std::string name_EP_res = std::format("hEP_res_{}", n);
-    std::string title_EP_res = std::format("; Centrality [%]; #LTRe(Q^{{S}}_{{{0}}} Q^{{N*}}_{{{0}}}) / (|Q^{{S}}_{{{0}}}||Q^{{N}}_{{{0}}}|)#GT", n);
+    if (m_pass == Pass::ApplyFlattening)
+    {
+      std::string name_EP_res = std::format("hEP_res_{}", n);
+      std::string title_EP_res = std::format("; Centrality [%]; #LTRe(Q^{{S}}_{{{0}}} Q^{{N*}}_{{{0}}}) / (|Q^{{S}}_{{{0}}}||Q^{{N}}_{{{0}}}|)#GT", n);
 
-    m_profiles[name_EP_res] = new TProfile(name_EP_res.c_str(), title_EP_res.c_str(), m_cent_bins, m_cent_low, m_cent_high);
+      m_profiles[name_EP_res] = new TProfile(name_EP_res.c_str(), title_EP_res.c_str(), m_cent_bins, m_cent_low, m_cent_high);
+    }
 
     // South, North
     for (auto det : m_subdetectors)

--- a/calibrations/sepd/sepd_eventplanecalib/QVecCalib.cc
+++ b/calibrations/sepd/sepd_eventplanecalib/QVecCalib.cc
@@ -111,13 +111,6 @@ int QVecCalib::process_QA_hist()
     return ret;
   }
 
-  // Get List of Bad Channels
-  ret = process_bad_channels(file);
-  if (ret)
-  {
-    return ret;
-  }
-
   // cleanup
   file->Close();
   delete file;
@@ -190,138 +183,6 @@ int QVecCalib::process_sEPD_event_thresholds(TFile* file)
     }
   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int QVecCalib::process_bad_channels(TFile* file)
-{
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  std::string sepd_charge_hist = "hSEPD_Charge";
-
-  TProfile *hSEPD_Charge{nullptr};
-  file->GetObject(sepd_charge_hist.c_str(), hSEPD_Charge);
-
-  // Check if the hist is stored in the file
-  if (hSEPD_Charge == nullptr)
-  {
-    std::cout << PHWHERE << "Error! Cannot find hist: " << sepd_charge_hist << ", in file: " << file->GetName() << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
-
-  int rbins = 16;
-  int bins_charge = 40;
-
-  h2SEPD_South_Charge_rbin = new TH2F("h2SEPD_South_Charge_rbin",
-                                      "sEPD South; r_{bin}; Avg Charge",
-                                      rbins, -0.5, rbins - 0.5,
-                                      bins_charge, 0, bins_charge);
-
-  h2SEPD_North_Charge_rbin = new TH2F("h2SEPD_North_Charge_rbin",
-                                      "sEPD North; r_{bin}; Avg Charge",
-                                      rbins, -0.5, rbins - 0.5,
-                                      bins_charge, 0, bins_charge);
-
-  h2SEPD_South_Charge_rbinv2 = new TH2F("h2SEPD_South_Charge_rbinv2",
-                                        "sEPD South; r_{bin}; Avg Charge",
-                                        rbins, -0.5, rbins - 0.5,
-                                        bins_charge, 0, bins_charge);
-
-  h2SEPD_North_Charge_rbinv2 = new TH2F("h2SEPD_North_Charge_rbinv2",
-                                        "sEPD North; r_{bin}; Avg Charge",
-                                        rbins, -0.5, rbins - 0.5,
-                                        bins_charge, 0, bins_charge);
-
-  hSEPD_Bad_Channels = new TProfile("h_sEPD_Bad_Channels", "sEPD Bad Channels; Channel; Status", QVecShared::SEPD_CHANNELS, -0.5, QVecShared::SEPD_CHANNELS-0.5);
-
-  se->registerHisto(h2SEPD_South_Charge_rbin);
-  se->registerHisto(h2SEPD_North_Charge_rbin);
-  se->registerHisto(h2SEPD_South_Charge_rbinv2);
-  se->registerHisto(h2SEPD_North_Charge_rbinv2);
-  se->registerHisto(hSEPD_Bad_Channels);
-
-  for (int channel = 0; channel < QVecShared::SEPD_CHANNELS; ++channel)
-  {
-    unsigned int key = TowerInfoDefs::encode_epd(channel);
-    int rbin = TowerInfoDefs::get_epd_rbin(key);
-    unsigned int arm = TowerInfoDefs::get_epd_arm(key);
-
-    double avg_charge = hSEPD_Charge->GetBinContent(channel + 1);
-
-    auto* h2 = (arm == 0) ? h2SEPD_South_Charge_rbin : h2SEPD_North_Charge_rbin;
-
-    h2->Fill(rbin, avg_charge);
-  }
-
-  auto* hSpx = h2SEPD_South_Charge_rbin->ProfileX("hSpx", 2, -1, "s");
-  auto* hNpx = h2SEPD_North_Charge_rbin->ProfileX("hNpx", 2, -1, "s");
-
-  int ctr_dead = 0;
-  int ctr_hot = 0;
-  int ctr_cold = 0;
-
-  for (int channel = 0; channel < QVecShared::SEPD_CHANNELS; ++channel)
-  {
-    unsigned int key = TowerInfoDefs::encode_epd(channel);
-    int rbin = TowerInfoDefs::get_epd_rbin(key);
-    unsigned int arm = TowerInfoDefs::get_epd_arm(key);
-
-    auto* h2 = (arm == 0) ? h2SEPD_South_Charge_rbinv2 : h2SEPD_North_Charge_rbinv2;
-    auto* hprof = (arm == 0) ? hSpx : hNpx;
-
-    double charge = hSEPD_Charge->GetBinContent(channel + 1);
-    double mean_charge = hprof->GetBinContent(rbin + 1);
-    double sigma = hprof->GetBinError(rbin + 1);
-    double zscore = 0.0;
-
-    if (sigma > 0)
-    {
-      zscore = (charge - mean_charge) / sigma;
-    }
-
-    if (charge < m_sEPD_min_avg_charge_threshold || std::abs(zscore) > m_sEPD_sigma_threshold)
-    {
-      m_bad_channels.insert(channel);
-
-      std::string type;
-      QVecShared::ChannelStatus status_fill;
-
-      // dead channel
-      if (charge == 0)
-      {
-        type = "Dead";
-        status_fill = QVecShared::ChannelStatus::Dead;
-        ++ctr_dead;
-      }
-      // hot channel
-      else if (zscore > m_sEPD_sigma_threshold)
-      {
-        type = "Hot";
-        status_fill = QVecShared::ChannelStatus::Hot;
-        ++ctr_hot;
-      }
-      // cold channel
-      else
-      {
-        type = "Cold";
-        status_fill = QVecShared::ChannelStatus::Cold;
-        ++ctr_cold;
-      }
-
-      hSEPD_Bad_Channels->Fill(channel, static_cast<int>(status_fill));
-      std::cout << std::format("{:4} Channel: {:3d}, arm: {}, rbin: {:2d}, Mean: {:5.2f}, Charge: {:5.2f}, Z-Score: {:5.2f}",
-                                type, channel, arm, rbin, mean_charge, charge, zscore) << std::endl;
-    }
-    else
-    {
-      h2->Fill(rbin, charge);
-    }
-  }
-
-  std::cout << "Total Bad Channels: " << m_bad_channels.size() << ", Dead: "
-	    << ctr_dead << ", Hot: " << ctr_hot << ", Cold: " << ctr_cold << std::endl;
-
-  std::cout << "Finished processing Hot sEPD channels" << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -957,14 +818,27 @@ bool QVecCalib::process_sEPD()
   {
     double charge = m_evtdata->get_sepd_charge(channel);
 
-    // Skip Bad Channels
-    if (m_bad_channels.contains(channel) || charge <= 0)
+    // Skip Noise
+    if (charge <= m_sEPD_noise_threshold)
     {
       continue;
     }
 
+    // Clamp on high charge threshold
+    if (m_sEPD_charge_threshold > 0 && charge > m_sEPD_charge_threshold)
+    {
+      charge = m_sEPD_charge_threshold;
+    }
+
     unsigned int key = TowerInfoDefs::encode_epd(channel);
     unsigned int arm = TowerInfoDefs::get_epd_arm(key);
+    int rbin = TowerInfoDefs::get_epd_rbin(key);
+
+    // Skip Innermost Ring
+    if (rbin == 0)
+    {
+      continue;
+    }
 
     // arm = 0: South
     // arm = 1: North
@@ -1291,48 +1165,7 @@ void QVecCalib::write_cdb()
     std::cout << "Info: Directory " << m_cdb_output_dir << " already exists." << std::endl;
   }
 
-  write_cdb_BadTowers();
   write_cdb_EventPlane();
-}
-
-void QVecCalib::write_cdb_BadTowers()
-{
-  std::cout << "Writing Bad Towers CDB" << std::endl;
-
-  std::string payload = "SEPD_HotMap";
-  std::string fieldname_status = "status";
-  std::string fieldname_sigma = "SEPD_sigma";
-  std::string output_file = std::format("{}/{}-{}-{}.root", m_cdb_output_dir, payload, m_dst_tag, m_runnumber);
-
-  CDBTTree cdbttree(output_file);
-
-  for (int channel = 0; channel < QVecShared::SEPD_CHANNELS; ++channel)
-  {
-    unsigned int key = TowerInfoDefs::encode_epd(channel);
-    int status = hSEPD_Bad_Channels->GetBinContent(channel+1);
-
-    float sigma = 0;
-
-    // Hot
-    if (status == static_cast<int>(QVecShared::ChannelStatus::Hot))
-    {
-      sigma = SIGMA_HOT;
-    }
-
-    // Cold
-    else if (status == static_cast<int>(QVecShared::ChannelStatus::Cold))
-    {
-      sigma = SIGMA_COLD;
-    }
-
-    cdbttree.SetIntValue(key, fieldname_status, status);
-    cdbttree.SetFloatValue(key, fieldname_sigma, sigma);
-  }
-
-  std::cout << "Saving CDB: " << payload << " to " << output_file << std::endl;
-
-  cdbttree.Commit();
-  cdbttree.WriteCDBTTree();
 }
 
 void QVecCalib::write_cdb_EventPlane()

--- a/calibrations/sepd/sepd_eventplanecalib/QVecCalib.cc
+++ b/calibrations/sepd/sepd_eventplanecalib/QVecCalib.cc
@@ -361,6 +361,11 @@ void QVecCalib::init_hists()
     m_hists2D[name_N] = new TH2F(name_N.c_str(), title_N.c_str(), m_cent_bins, m_cent_low, m_cent_high, bins_psi, psi_low, psi_high);
     m_hists2D[name_NS] = new TH2F(name_NS.c_str(), title_NS.c_str(), m_cent_bins, m_cent_low, m_cent_high, bins_psi, psi_low, psi_high);
 
+    std::string name_EP_res = std::format("hEP_res_{}", n);
+    std::string title_EP_res = std::format("; Centrality [%]; #LTRe(Q^{{S}}_{{{0}}} Q^{{N*}}_{{{0}}}) / (|Q^{{S}}_{{{0}}}||Q^{{N}}_{{{0}}}|)#GT", n);
+
+    m_profiles[name_EP_res] = new TProfile(name_EP_res.c_str(), title_EP_res.c_str(), m_cent_bins, m_cent_low, m_cent_high);
+
     // South, North
     for (auto det : m_subdetectors)
     {
@@ -723,6 +728,8 @@ void QVecCalib::prepare_flattening_hists()
     std::string psi_N_name = std::format("h2_sEPD_Psi_N_{}_corr2", n);
     std::string psi_NS_name = std::format("h2_sEPD_Psi_NS_{}_corr2", n);
 
+    std::string EP_res_name = std::format("hEP_res_{}", n);
+
     FlatteningHists h;
 
     h.S_x_corr2_avg = m_profiles.at(S_x_corr2_avg_name);
@@ -746,6 +753,8 @@ void QVecCalib::prepare_flattening_hists()
     h.Psi_N_corr2 = m_hists2D.at(psi_N_name);
     h.Psi_NS_corr2 = m_hists2D.at(psi_NS_name);
 
+    h.EP_res = m_profiles.at(EP_res_name);
+
     se->registerHisto(h.S_x_corr2_avg);
     se->registerHisto(h.S_y_corr2_avg);
     se->registerHisto(h.N_x_corr2_avg);
@@ -766,6 +775,8 @@ void QVecCalib::prepare_flattening_hists()
     se->registerHisto(h.Psi_S_corr2);
     se->registerHisto(h.Psi_N_corr2);
     se->registerHisto(h.Psi_NS_corr2);
+
+    se->registerHisto(h.EP_res);
 
     m_flattening_hists.push_back(h);
   }
@@ -908,6 +919,11 @@ void QVecCalib::process_flattening(double cent, size_t h_idx, const QVecShared::
   double psi_N = std::atan2(q_N_corr2.y, q_N_corr2.x);
   double psi_NS = std::atan2(q_NS_corr2.y, q_NS_corr2.x);
 
+  double SP_QS_QN = q_S_corr2.x * q_N_corr2.x + q_S_corr2.y * q_N_corr2.y;
+  double norm_S = std::sqrt(q_S_corr2.x * q_S_corr2.x + q_S_corr2.y * q_S_corr2.y);
+  double norm_N = std::sqrt(q_N_corr2.x * q_N_corr2.x + q_N_corr2.y * q_N_corr2.y);
+  double EP_res = (norm_S && norm_N) ? SP_QS_QN / (norm_S * norm_N) : 0;
+
   h.S_x_corr2_avg->Fill(cent, q_S_corr2.x);
   h.S_y_corr2_avg->Fill(cent, q_S_corr2.y);
   h.N_x_corr2_avg->Fill(cent, q_N_corr2.x);
@@ -927,6 +943,8 @@ void QVecCalib::process_flattening(double cent, size_t h_idx, const QVecShared::
   h.Psi_S_corr2->Fill(cent, psi_S);
   h.Psi_N_corr2->Fill(cent, psi_N);
   h.Psi_NS_corr2->Fill(cent, psi_NS);
+
+  h.EP_res->Fill(cent, EP_res);
 }
 
 bool QVecCalib::process_sEPD()

--- a/calibrations/sepd/sepd_eventplanecalib/QVecCalib.h
+++ b/calibrations/sepd/sepd_eventplanecalib/QVecCalib.h
@@ -96,6 +96,16 @@ class QVecCalib : public SubsysReco
     m_cdb_output_dir = cdb_dir;
   }
 
+  void set_charge_threshold(double threshold)
+  {
+    m_sEPD_charge_threshold = std::max(0.0, threshold);
+  }
+
+  void set_noise_threshold(double threshold)
+  {
+    m_sEPD_noise_threshold = threshold;
+  }
+
  private:
   static Pass validate_pass(int pass)
   {
@@ -229,11 +239,10 @@ class QVecCalib : public SubsysReco
     TH2* Psi_NS_corr2{nullptr};
   };
 
-  // sEPD Bad Channels
-  std::unordered_set<int> m_bad_channels;
-
-  double m_sEPD_min_avg_charge_threshold{1};
   double m_sEPD_sigma_threshold{3};
+
+  double m_sEPD_charge_threshold{50};
+  double m_sEPD_noise_threshold{0.5};
 
   // Hists
   TH1* hCentrality{nullptr};
@@ -241,16 +250,8 @@ class QVecCalib : public SubsysReco
   TH2* h2SEPD_Charge{nullptr};
   TH2* h2SEPD_Chargev2{nullptr};
 
-  TH2* h2SEPD_South_Charge_rbin{nullptr};
-  TH2* h2SEPD_North_Charge_rbin{nullptr};
-
-  TH2* h2SEPD_South_Charge_rbinv2{nullptr};
-  TH2* h2SEPD_North_Charge_rbinv2{nullptr};
-
   TProfile* hSEPD_Charge_Min{nullptr};
   TProfile* hSEPD_Charge_Max{nullptr};
-
-  TProfile* hSEPD_Bad_Channels{nullptr};
 
   std::map<std::string, TH2*> m_hists2D;
   std::map<std::string, TProfile*> m_profiles;
@@ -400,14 +401,6 @@ class QVecCalib : public SubsysReco
   int process_QA_hist();
 
   /**
-   * @brief Identifies and catalogs "Bad" (Hot, Cold, or Dead) sEPD channels.
-   * * Uses a reference charge histogram to compute Z-scores based on mean charge
-   * per radial bin. Channels exceeding the sigma threshold are added to the internal exclusion set.
-   * * @param file Pointer to the open TFile containing QA histograms.
-   */
-  int process_bad_channels(TFile* file);
-
-  /**
    * @brief Establishes sEPD charge-cut thresholds for event selection.
    * * Uses the 2D total charge vs. centrality distribution to derive mean and
    * sigma values, generating a 1D profile of the selection window.
@@ -424,14 +417,6 @@ class QVecCalib : public SubsysReco
    * * @param output_dir The filesystem directory where the .root payload will be saved.
    */
   void write_cdb_EventPlane();
-
-  /**
-   * @brief Writes the Hot/Cold tower status map to a CDB-formatted TTree.
-   * * Encodes sEPD channel indices into TowerInfo keys and maps status codes (1=Dead,
-   * 2=Hot, 3=Cold) to the final database payload.
-   * * @param output_dir The filesystem directory where the .root payload will be saved.
-   */
-  void write_cdb_BadTowers();
 };
 
 #endif  // SEPDEVENTPLANECALIB_QVECCALIB_H

--- a/calibrations/sepd/sepd_eventplanecalib/QVecCalib.h
+++ b/calibrations/sepd/sepd_eventplanecalib/QVecCalib.h
@@ -5,6 +5,7 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <algorithm>
 #include <array>
 #include <map>
 #include <stdexcept>

--- a/calibrations/sepd/sepd_eventplanecalib/QVecCalib.h
+++ b/calibrations/sepd/sepd_eventplanecalib/QVecCalib.h
@@ -222,6 +222,8 @@ class QVecCalib : public SubsysReco
     TProfile* NS_yy_corr_avg{nullptr};
     TProfile* NS_xy_corr_avg{nullptr};
 
+    TProfile* EP_res{nullptr};
+
     TH2* Psi_S_corr2{nullptr};
     TH2* Psi_N_corr2{nullptr};
     TH2* Psi_NS_corr2{nullptr};

--- a/calibrations/sepd/sepd_eventplanecalib/sEPD_TreeGen.cc
+++ b/calibrations/sepd/sepd_eventplanecalib/sEPD_TreeGen.cc
@@ -177,10 +177,10 @@ int sEPD_TreeGen::process_centrality(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int sEPD_TreeGen::process_sEPD(PHCompositeNode *topNode)
 {
-  TowerInfoContainer *towerinfosEPD = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SEPD");
+  TowerInfoContainer *towerinfosEPD = findNode::getClass<TowerInfoContainer>(topNode, m_inputNode);
   if (!towerinfosEPD)
   {
-    std::cout << PHWHERE << "TOWERINFO_CALIB_SEPD Node missing, doing nothing." << std::endl;
+    std::cout << PHWHERE << m_inputNode << " Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 

--- a/calibrations/sepd/sepd_eventplanecalib/sEPD_TreeGen.h
+++ b/calibrations/sepd/sepd_eventplanecalib/sEPD_TreeGen.h
@@ -85,6 +85,11 @@ class sEPD_TreeGen : public SubsysReco
     m_cuts.m_cent_max = cent_max;
   }
 
+  void set_inputNode(const std::string &inputNode)
+  {
+    m_inputNode = inputNode;
+  }
+
  private:
  /**
    * @brief Validates event-level conditions (GlobalVertex, Minimum Bias).
@@ -107,6 +112,8 @@ class sEPD_TreeGen : public SubsysReco
    * @return Fun4All return code.
    */
   int process_centrality(PHCompositeNode *topNode);
+
+  std::string m_inputNode{"TOWERINFO_CALIB_SEPD"};
 
   int m_event{0};
 


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

- **Removal of Status-Based Filtering**: The code no longer uses the isHot criteria or radial Z-score analysis to exclude individual "bad" channels.
- **Implemented Charge Clamping**: Introduced a saturation cap (defaulting to 50) to clamp high-charge channel signals rather than discarding them.
- **Mandatory Ring 0 Exclusion**: Explicitly skip Ring 0 to mitigate unreliable data from beam background.
- **Adjusted Noise Thresholds**: The default noise floor for sEPD channels has been increased to 0.5.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## sEPD Q-Vector Calibration Refactoring: Charge Clamping and Ring 0 Exclusion

### Motivation
This PR refactors the sEPD event-plane calibration strategy to replace status-based per-channel filtering with a simpler, more robust approach that better handles detector imperfections and beam-background effects in the innermost detector region.

### Key Changes

**QVecCalib.cc/h:**
- **Removed bad-channel identification workflow**: Deleted `process_bad_channels()` function, per-channel status mapping, and SEPD_HotMap CDB generation. Channels are no longer classified as Dead/Hot/Cold based on charge thresholds and radial z-scores.
- **Implemented charge clamping**: High-charge signals are now capped at a configurable threshold (default: 50) instead of being discarded, preserving the detector's response for saturated channels.
- **Mandatory Ring 0 exclusion**: Innermost ring channels (`rbin == 0`) are explicitly skipped unconditionally to mitigate unreliable beam-background-affected data.
- **Simplified noise filtering**: Replaced multi-criteria per-channel filtering with a single global noise floor threshold (default: 0.5). Channels with `charge ≤ m_sEPD_noise_threshold` are excluded.
- **Added event-plane resolution metric**: During the `ApplyFlattening` pass, a new `TProfile hEP_res_{n}` histogram is created to measure per-harmonic resolution via normalized dot product of corrected Q-vectors from South and North detectors.
- **New configuration setters**: `set_charge_threshold(double)` and `set_noise_threshold(double)` allow runtime customization of selection thresholds.
- **CDB output simplification**: Only `write_cdb_EventPlane()` is now called; bad-towers CDB is no longer produced.

**sEPD_TreeGen.cc/h:**
- Made the input node name configurable via `set_inputNode(const std::string&)` setter, replacing the hardcoded `"TOWERINFO_CALIB_SEPD"` string with a `m_inputNode` member (default: `"TOWERINFO_CALIB_SEPD"`).

### Potential Risk Areas

**IO Format Changes:**
- CDB output structure changes (bad-towers CDB removal). Downstream code relying on bad-towers CDB will fail; migration to the new workflow is required.

**Reconstruction Behavior:**
- Charge clamping at 50 may alter the response of high-energetic channels. This represents a trade-off: preserving detector information vs. robustness against saturation effects.
- Ring 0 exclusion reduces the active detector area (~5–10% depending on ring definition), potentially affecting coverage and requiring recalibration/validation studies.
- Noise threshold increase (0.5) may reject additional low-energy signals; impact depends on background conditions.

**Configuration Sensitivity:**
- Calibration results now depend critically on charge and noise thresholds. Incorrect threshold values could degrade or invalidate the event-plane reconstruction.

### Notes for Reviewers
- AI-generated summaries in the PR description may contain inaccuracies; use this summary in conjunction with direct code review.
- Validation against prior calibration results and comparison with alternate threshold choices is recommended before production deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->