### PR TITLE
Tpc distortion correction

### DIFF
--- a/offline/packages/tpc/Makefile.am
+++ b/offline/packages/tpc/Makefile.am
@@ -86,6 +86,7 @@ libtpc_la_SOURCES = \
   TpcClusterizer.cc \
   TpcCombinedRawDataUnpacker.cc \
   TpcCombinedRawDataUnpackerDebug.cc \
+  TpcDistortionCorrectionContainer.cc \
   TpcGlobalPositionWrapper.cc \
   TpcLoadDistortionCorrection.cc \
   TpcMap.cc \

--- a/offline/packages/tpc/TpcDistortionCorrectionContainer.cc
+++ b/offline/packages/tpc/TpcDistortionCorrectionContainer.cc
@@ -1,0 +1,61 @@
+
+/*!
+ * \file TpcDistortionCorrectionContainer.cc
+ * \brief stores distortion correction histograms on the node tree
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "TpcDistortionCorrectionContainer.h"
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TObject.h>
+
+#include <iostream>
+#include <memory>
+
+//_______________________________________________________________
+void TpcDistortionCorrectionContainer::load_histograms( const std::string& source )
+{
+  std::cout << "TpcDistortionCorrectionContainer::load_histograms - reading corrections from " << source << std::endl;
+  auto *distortion_tfile = TFile::Open(source.c_str());
+  if (!distortion_tfile)
+  {
+    std::cout << "TpcDistortionCorrectionContainer::load_histograms - cannot open " << source << std::endl;
+    exit(1);
+  }
+
+  const std::array<const std::string, 2> extension = {{"_negz", "_posz"}};
+  for (int j = 0; j < 2; ++j)
+  {
+    m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP")+extension[j]).c_str()));
+    assert(m_hDPint[j]);
+    m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR")+extension[j]).c_str()));
+    assert(m_hDRint[j]);
+    m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ")+extension[j]).c_str()));
+    assert(m_hDZint[j]);
+  }
+}
+
+//_______________________________________________________________
+void TpcDistortionCorrectionContainer::save_histograms( const std::string& destination ) const
+{
+  // save everything to root file
+  std::cout << "TpcDistortionCorrectionContainer::save_histograms - writing histograms to " << destination << std::endl;
+  std::unique_ptr<TFile> outputfile(TFile::Open(destination.c_str(), "RECREATE"));
+  outputfile->cd();
+
+  for (const auto& h_list : {m_hentries, m_hDRint, m_hDPint, m_hDZint})
+  {
+    for (const auto& h : h_list)
+    {
+      if (h)
+      {
+        h->Write(h->GetName());
+      }
+    }
+  }
+
+  // close TFile
+  outputfile->Close();
+}

--- a/offline/packages/tpc/TpcDistortionCorrectionContainer.h
+++ b/offline/packages/tpc/TpcDistortionCorrectionContainer.h
@@ -8,6 +8,7 @@
  */
 
 #include <array>
+#include <string>
 
 class TH1;
 
@@ -16,6 +17,12 @@ class TpcDistortionCorrectionContainer
  public:
   //! constructor
   TpcDistortionCorrectionContainer() = default;
+
+  //! load histograms from input file
+  void load_histograms( const std::string& /*source*/ );
+
+  //! save histograms to out file
+  void save_histograms( const std::string& /*destination*/ ) const;
 
   //! flag to tell us whether to read z data or just 2d data
   int m_dimensions = 3;

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -56,7 +56,7 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
   {
     std::cout << "("<< i <<", "<<m_correction_in_use[i] << ", " << m_phi_hist_in_radians[i] << ", " << m_interpolate_z[i] << ")"<< std::endl;
   }
-  
+
   /// Get the RUN node and check
   auto *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
@@ -83,24 +83,8 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
       runNode->addNode(node);
     }
 
-    std::cout << "TpcLoadDistortionCorrection::InitRun - reading corrections from " << m_correction_filename[i] << std::endl;
-    auto *distortion_tfile = TFile::Open(m_correction_filename[i].c_str());
-    if (!distortion_tfile)
-    {
-      std::cout << "TpcLoadDistortionCorrection::InitRun - cannot open " << m_correction_filename[i] << std::endl;
-      exit(1);
-    }
-
-    const std::array<const std::string, 2> extension = {{"_negz", "_posz"}};
-    for (int j = 0; j < 2; ++j)
-    {
-      distortion_correction_object->m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP")+extension[j]).c_str()));
-      assert(distortion_correction_object->m_hDPint[j]);
-      distortion_correction_object->m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR")+extension[j]).c_str()));
-      assert(distortion_correction_object->m_hDRint[j]);
-      distortion_correction_object->m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ")+extension[j]).c_str()));
-      assert(distortion_correction_object->m_hDZint[j]);
-    }
+    // load histograms from file
+    distortion_correction_object->load_histograms(m_correction_filename[i]);
 
     // assign correction object dimension from histograms dimention, assuming all histograms have the same
     distortion_correction_object->m_dimensions = distortion_correction_object->m_hDPint[0]->GetDimension();

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -457,22 +457,6 @@ void TpcSpaceChargeMatrixInversion::save_distortion_corrections(const std::strin
     return;
   }
 
-  // save everything to root file
-  std::cout << "TpcSpaceChargeMatrixInversion::save_distortions - writing histograms to " << filename << std::endl;
-  std::unique_ptr<TFile> outputfile(TFile::Open(filename.c_str(), "RECREATE"));
-  outputfile->cd();
+  m_dcc_average->save_histograms(filename);
 
-  for (const auto& h_list : {m_dcc_average->m_hentries, m_dcc_average->m_hDRint, m_dcc_average->m_hDPint, m_dcc_average->m_hDZint})
-  {
-    for (const auto& h : h_list)
-    {
-      if (h)
-      {
-        h->Write(h->GetName());
-      }
-    }
-  }
-
-  // close TFile
-  outputfile->Close();
 }

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -603,52 +603,63 @@ TH3* TpcSpaceChargeReconstructionHelper::add_guarding_bins(const TH3* source, co
   }
 
   // fill guarding phi bins
+  fill_guarding_bins( hout );
+
+  return hout;
+}
+
+//_____________________________________________________________________________________________________________________-
+void TpcSpaceChargeReconstructionHelper::fill_guarding_bins(TH3* source )
+{
+  const auto nbinsx = source->GetNbinsX();
+  const auto nbinsy = source->GetNbinsY();
+  const auto nbinsz = source->GetNbinsZ();
+
+  // fill guarding phi bins
   /*
    * we use 2pi periodicity to do that:
    * - last valid bin is copied to first guarding bin;
    * - first valid bin is copied to last guarding bin
    */
-  for (int ir = 0; ir < rbins + 2; ++ir)
+  for (int ir = 0; ir < nbinsy; ++ir)
   {
-    for (int iz = 0; iz < zbins + 2; ++iz)
+    for (int iz = 0; iz < nbinsz; ++iz)
     {
       // copy last bin to first guarding bin
-      hout->SetBinContent(1, ir + 1, iz + 1, hout->GetBinContent(phibins + 1, ir + 1, iz + 1));
-      hout->SetBinError(1, ir + 1, iz + 1, hout->GetBinError(phibins + 1, ir + 1, iz + 1));
+      source ->SetBinContent(1, ir + 1, iz + 1, source ->GetBinContent(nbinsx-1, ir + 1, iz + 1));
+      source ->SetBinError(1, ir + 1, iz + 1, source ->GetBinError(nbinsx-1, ir + 1, iz + 1));
 
       // copy first bin to last guarding bin
-      hout->SetBinContent(phibins + 2, ir + 1, iz + 1, hout->GetBinContent(2, ir + 1, iz + 1));
-      hout->SetBinError(phibins + 2, ir + 1, iz + 1, hout->GetBinError(2, ir + 1, iz + 1));
+      source ->SetBinContent(nbinsx, ir + 1, iz + 1, source ->GetBinContent(2, ir + 1, iz + 1));
+      source ->SetBinError(nbinsx, ir + 1, iz + 1, source ->GetBinError(2, ir + 1, iz + 1));
     }
   }
 
   // fill guarding r bins
-  for (int iphi = 0; iphi < phibins + 2; ++iphi)
+  for (int iphi = 0; iphi < nbinsx; ++iphi)
   {
-    for (int iz = 0; iz < zbins + 2; ++iz)
+    for (int iz = 0; iz < nbinsz; ++iz)
     {
-      hout->SetBinContent(iphi + 1, 1, iz + 1, hout->GetBinContent(iphi + 1, 2, iz + 1));
-      hout->SetBinError(iphi + 1, 1, iz + 1, hout->GetBinError(iphi + 1, 2, iz + 1));
+      source ->SetBinContent(iphi + 1, 1, iz + 1, source ->GetBinContent(iphi + 1, 2, iz + 1));
+      source ->SetBinError(iphi + 1, 1, iz + 1, source ->GetBinError(iphi + 1, 2, iz + 1));
 
-      hout->SetBinContent(iphi + 1, rbins + 2, iz + 1, hout->GetBinContent(iphi + 1, rbins + 1, iz + 1));
-      hout->SetBinError(iphi + 1, rbins + 2, iz + 1, hout->GetBinError(iphi + 1, rbins + 1, iz + 1));
+      source ->SetBinContent(iphi + 1, nbinsy, iz + 1, source ->GetBinContent(iphi + 1, nbinsy-1, iz + 1));
+      source ->SetBinError(iphi + 1, nbinsy, iz + 1, source ->GetBinError(iphi + 1, nbinsy-1, iz + 1));
     }
   }
 
   // fill guarding z bins
-  for (int iphi = 0; iphi < phibins + 2; ++iphi)
+  for (int iphi = 0; iphi < nbinsx; ++iphi)
   {
-    for (int ir = 0; ir < rbins + 2; ++ir)
+    for (int ir = 0; ir < nbinsy; ++ir)
     {
-      hout->SetBinContent(iphi + 1, ir + 1, 1, hout->GetBinContent(iphi + 1, ir + 1, 2));
-      hout->SetBinError(iphi + 1, ir + 1, 1, hout->GetBinError(iphi + 1, ir + 1, 2));
+      source ->SetBinContent(iphi + 1, ir + 1, 1, source ->GetBinContent(iphi + 1, ir + 1, 2));
+      source ->SetBinError(iphi + 1, ir + 1, 1, source ->GetBinError(iphi + 1, ir + 1, 2));
 
-      hout->SetBinContent(iphi + 1, ir + 1, zbins + 2, hout->GetBinContent(iphi + 1, ir + 1, zbins + 1));
-      hout->SetBinError(iphi + 1, ir + 1, zbins + 2, hout->GetBinError(iphi + 1, ir + 1, zbins + 1));
+      source ->SetBinContent(iphi + 1, ir + 1, nbinsz, source ->GetBinContent(iphi + 1, ir + 1, nbinsz-1));
+      source ->SetBinError(iphi + 1, ir + 1, nbinsz, source ->GetBinError(iphi + 1, ir + 1, nbinsz-1));
     }
   }
-
-  return hout;
 }
 
 //___________________________________________________________________________________________________

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -611,6 +611,12 @@ TH3* TpcSpaceChargeReconstructionHelper::add_guarding_bins(const TH3* source, co
 //_____________________________________________________________________________________________________________________-
 void TpcSpaceChargeReconstructionHelper::fill_guarding_bins(TH3* source )
 {
+  if (!source)
+  {
+    std::cout << "TpcSpaceChargeReconstructionHelper::fill_guarding_bins - invalid source histogram" << std::endl;
+    return;
+  }
+
   const auto nbinsx = source->GetNbinsX();
   const auto nbinsy = source->GetNbinsY();
   const auto nbinsz = source->GetNbinsZ();

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -71,11 +71,16 @@ class TpcSpaceChargeReconstructionHelper
 
   /**
    * copy input histogram into output, with new name, while adding two "guarding bins" on
-   * each axis, with identical content and error as the first and last bin of the original histogram
-   * this is necessary for being able to call TH3->Interpolate() when using these histograms
-   * to correct for the space charge distortions.
+   * each axis. Uses fill_guarding_bins to set guarding bin content
    */
   static TH3* add_guarding_bins(const TH3* /*source*/, const TString& /*name*/);
+
+  /**
+   * fill first and last bins (along all axis) of provided histogram with
+   * either copy of the previous/next (physical) bin, (for r and z)
+   * or using 2pi invariance for the phi axis.
+   */
+  static void fill_guarding_bins(TH3* /*source*/);
 
   /// shortcut to angular window, needed to define TPOT acceptance
   using range_t = std::pair<double, double>;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR
- moves loading distortion correction histograms from TFile and saving to TFile to TpcDistortionCorrectionContainer, to avoid code duplication
- puts filling guarding bins in distortion correction histogram to a dedicated method from TpcSpaceChargeReconstructionHelper so that it can be reused in distortion corrections generation macros without duplicating the code

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## TPC Distortion Correction: Consolidate Histogram I/O and Extract Guarding Bin Logic

### Motivation / Context
Refactor TPC distortion-correction code to remove duplicated ROOT file I/O and to centralize guarding-bin filling logic so macros and reconstruction code reuse the same behavior. This improves maintainability and reduces risk of divergent implementations of histogram loading/saving and guard-bin population.

### Key changes
- Added TpcDistortionCorrectionContainer::load_histograms(const std::string&) and ::save_histograms(const std::string&) to encapsulate ROOT file I/O for the distortion-correction histograms (m_hDRint, m_hDPint, m_hDZint, m_hentries) for both +z and -z sectors.
- Updated TpcLoadDistortionCorrection::InitRun to delegate histogram loading to TpcDistortionCorrectionContainer::load_histograms(...) instead of performing ad-hoc TFile opening and per-histogram Get/assert logic.
- Updated TpcSpaceChargeMatrixInversion::save_distortion_corrections(...) to delegate persistence to TpcDistortionCorrectionContainer::save_histograms(...) rather than manually creating a TFile and writing histograms.
- Extracted guarding-bin population into TpcSpaceChargeReconstructionHelper::fill_guarding_bins(TH3*), and updated add_guarding_bins(...) to call it. The new method derives bin counts from the provided TH3 and implements 2π periodicity in phi and nearest-neighbor replication for r and z.
- Build: registered TpcDistortionCorrectionContainer.cc in offline/packages/tpc/Makefile.am.

### Potential risk areas
- IO/format expectations: The new load/save methods centralize assumptions about histogram names, types and ROOT file layout. If naming conventions or file layouts differ in existing files, loads may fail or assert; verify compatibility with existing calibration/production files.
- Error handling: load_histograms currently aborts on missing files/histograms (uses assert/exit in the implemented changes). Ensure callers and CI handle these failure modes appropriately and consider more graceful error propagation/logging.
- Behavioral equivalence: The guarding-bin logic was refactored to compute bin counts from the TH3 object; verify that the produced guard-bin contents match previous behavior for all existing distortion-correction histograms.
- Thread-safety & performance: Centralizing I/O and modifying when files are opened/written may change concurrency characteristics; review usage in multi-threaded workflows and any performance implications when writing/reading large histograms.

### Possible future improvements
- Add unit/integration tests that validate round-trip load/save and verify guarding-bin results against known-good histograms.
- Replace abrupt aborts/asserts with error-return or exception-based diagnostics and clearer logging to aid CI and offline debugging.
- Document the expected ROOT histogram names, types and dimensionality that load_histograms()/save_histograms() rely on, and provide an API for alternative naming/layouts or versioning.
- Consider providing a small utility or header-only helper to expose fill_guarding_bins to external calibration macros and scripts (if not already intended) and add thread-safe I/O helpers if needed.

---
Note: AI-assisted summary — AI can make mistakes; please validate file-format, error-handling and numeric equivalence of guarding-bin logic when reviewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->