### PR TITLE
MinBias Class Abort and Centrality Node naming

### DIFF
--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -8,14 +8,9 @@
 
 #include <calotrigger/MinimumBiasInfo.h>
 
-#include <globalvertex/GlobalVertexMap.h>
-#include <globalvertex/GlobalVertex.h>
+#include <cdbobjects/CDBTTree.h>
 
 #include <ffamodules/CDBInterface.h>
-#include <cdbobjects/CDBTTree.h>
-#include <cdbobjects/CDBTF.h>
-
-#include <TF1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -35,47 +30,59 @@
 CentralityReco::CentralityReco(const std::string &name)
   : SubsysReco(name)
 {
-
 }
 
 int CentralityReco::InitRun(PHCompositeNode *topNode)
 {
   CDBInterface *m_cdb = CDBInterface::instance();
 
-  std::string centdiv_url = m_cdb->getUrl("Centrality");
-  if (m_overwrite_divs)
-    {
-      centdiv_url = m_overwrite_url_divs;
-      std::cout << " Overwriting Divs to " << m_overwrite_url_divs << std::endl;
-    }
+  std::string centdiv_url;
+  if (!m_overwrite_url_divs.empty())
+  {
+    centdiv_url = m_overwrite_url_divs;
+    std::cout << " Overwriting Divs to " << m_overwrite_url_divs << std::endl;
+  }
+  else
+  {
+    centdiv_url = m_cdb->getUrl("Centrality");
+  }
 
   if (Download_centralityDivisions(centdiv_url))
   {
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  std::string centscale_url = m_cdb->getUrl("CentralityScale");
-  if (m_overwrite_scale)
-    {
-      centscale_url = m_overwrite_url_scale;
-      std::cout << " Overwriting Scale to " << m_overwrite_url_scale << std::endl;
-    }
+  std::string centscale_url;
+  if (!m_overwrite_url_scale.empty())
+  {
+    centscale_url = m_overwrite_url_scale;
+    std::cout << " Overwriting Scale to " << m_overwrite_url_scale << std::endl;
+  }
+  else
+  {
+    centscale_url = m_cdb->getUrl("CentralityScale");
+  }
 
   if (Download_centralityScale(centscale_url))
   {
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  std::string vertexscale_url = m_cdb->getUrl("CentralityVertexScale");
-  if (m_overwrite_vtx)
-    {
-      vertexscale_url = m_overwrite_url_vtx;
-      std::cout << " Overwriting Vtx to " << m_overwrite_url_vtx << std::endl;
-    }
-  
+
+  std::string vertexscale_url;
+  if (!m_overwrite_url_vtx.empty())
+  {
+    vertexscale_url = m_overwrite_url_vtx;
+    std::cout << " Overwriting Vtx to " << m_overwrite_url_vtx << std::endl;
+  }
+  else
+  {
+    vertexscale_url = m_cdb->getUrl("CentralityVertexScale");
+  }
+
   if (Download_centralityVertexScales(vertexscale_url))
-    {
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+  {
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
 
   CreateNodes(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
@@ -117,9 +124,9 @@ int CentralityReco::Download_centralityDivisions(const std::string &dbfile)
     CDBTTree *cdbttree = new CDBTTree(dbase_file);
     cdbttree->LoadCalibrations();
     if (Verbosity())
-      {
-	cdbttree->Print();
-      }
+    {
+      cdbttree->Print();
+    }
     for (int idiv = 0; idiv < NDIVS; idiv++)
     {
       m_centrality_map[idiv] = cdbttree->GetFloatValue(idiv, "centralitydiv");
@@ -140,7 +147,6 @@ int CentralityReco::Download_centralityDivisions(const std::string &dbfile)
 }
 int CentralityReco::Download_centralityVertexScales(const std::string &dbfile)
 {
-
   std::filesystem::path dbase_file = dbfile;
 
   if (dbase_file.extension() == ".root")
@@ -148,18 +154,17 @@ int CentralityReco::Download_centralityVertexScales(const std::string &dbfile)
     CDBTTree *cdbttree = new CDBTTree(dbase_file);
     cdbttree->LoadCalibrations();
     if (Verbosity())
-      {
-	cdbttree->Print();
-      }
-    
+    {
+      cdbttree->Print();
+    }
+
     int nvertexbins = cdbttree->GetIntValue(0, "nvertexbins");
-    
 
     for (int iv = 0; iv < nvertexbins; iv++)
     {
       float scale = cdbttree->GetDoubleValue(iv, "scale");
       float lowvertex = cdbttree->GetDoubleValue(iv, "low_vertex");
-      float highvertex = cdbttree->GetDoubleValue(iv, "high_vertex");      
+      float highvertex = cdbttree->GetDoubleValue(iv, "high_vertex");
       m_vertex_scales.emplace_back(std::make_pair(lowvertex, highvertex), scale);
     }
 
@@ -188,30 +193,27 @@ int CentralityReco::FillVars()
     std::cout << __FILE__ << " :: " << __FUNCTION__ << std::endl;
   }
 
-
   float scale_factor = getVertexScale();
 
   if (Verbosity())
-    {
-      std::cout << scale_factor << "*" << m_centrality_scale << std::endl;
-    }
+  {
+    std::cout << scale_factor << "*" << m_centrality_scale << std::endl;
+  }
 
   for (int i = 0; i < 128; i++)
+  {
+    m_mbd_hit = m_mbd_container->get_pmt(i);
+
+    if ((m_mbd_hit->get_q()) < mbd_charge_cut)
     {
-      
-      m_mbd_hit = m_mbd_container->get_pmt(i);
-
-      if ((m_mbd_hit->get_q()) < mbd_charge_cut)
-	{
-	  continue;
-	}
-      if (fabs(m_mbd_hit->get_time()) > mbd_time_cut) 
-	{
-	  continue;
-	}
-      m_mbd_total_charge += m_mbd_hit->get_q()*scale_factor*m_centrality_scale;
+      continue;
     }
-
+    if (fabs(m_mbd_hit->get_time()) > mbd_time_cut)
+    {
+      continue;
+    }
+    m_mbd_total_charge += m_mbd_hit->get_q() * scale_factor * m_centrality_scale;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -232,15 +234,15 @@ int CentralityReco::FillCentralityInfo()
     if (m_centrality_map[i] < m_mbd_total_charge)
     {
       binvalue = i + 1;
-      value =  static_cast<float>(i + 1)/static_cast<float>(NDIVS);
+      value = static_cast<float>(i + 1) / static_cast<float>(NDIVS);
       break;
     }
   }
-  if (Verbosity()) 
-    {
-      std::cout << " Centile : " << value << std::endl;      
-      std::cout << " Charge : " << m_mbd_total_charge << std::endl;
-    }
+  if (Verbosity())
+  {
+    std::cout << " Centile : " << value << std::endl;
+    std::cout << " Charge : " << m_mbd_total_charge << std::endl;
+  }
 
   m_central->set_centile(CentralityInfo::PROP::mbd_NS, value);
   m_central->set_centrality_bin(CentralityInfo::PROP::mbd_NS, binvalue);
@@ -262,10 +264,9 @@ int CentralityReco::process_event(PHCompositeNode *topNode)
   }
 
   if (!m_mb_info->isAuAuMinimumBias())
-    {
-      return Fun4AllReturnCodes::EVENT_OK;
-    }
-
+  {
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
 
   // Fill Arrays
   if (FillVars())
@@ -317,18 +318,17 @@ int CentralityReco::GetNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-
   m_mbd_out = findNode::getClass<MbdOut>(topNode, m_mbd_out_nodename);
   if (Verbosity())
-    {
-      std::cout << "Getting MBD Out" << std::endl;
-    }
+  {
+    std::cout << "Getting MBD Out" << std::endl;
+  }
 
   if (!m_mbd_out)
-    {
-      std::cout << "no MBD out node " << std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+  {
+    std::cout << "no MBD out node " << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -367,22 +367,19 @@ void CentralityReco::CreateNodes(PHCompositeNode *topNode)
 
 float CentralityReco::getVertexScale()
 {
-
-
   float mbd_vertex = m_mbd_out->get_zvtx();
   for (auto v_range_scale : m_vertex_scales)
+  {
+    auto v_range = v_range_scale.first;
+    if (Verbosity())
     {
-      auto v_range = v_range_scale.first;
-      if (Verbosity())
-	{
-	  std::cout << "vertexrange : "<<v_range.first<<"-"<<v_range.second << std::endl;
-	}
-	  
-      if (mbd_vertex > v_range.first && mbd_vertex <= v_range.second)
-	{
-	  return v_range_scale.second;
-	}
+      std::cout << "vertexrange : " << v_range.first << "-" << v_range.second << std::endl;
     }
+
+    if (mbd_vertex > v_range.first && mbd_vertex <= v_range.second)
+    {
+      return v_range_scale.second;
+    }
+  }
   return 0;
 }
-

--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -13,6 +13,9 @@
 
 #include <ffamodules/CDBInterface.h>
 #include <cdbobjects/CDBTTree.h>
+#include <cdbobjects/CDBTF.h>
+
+#include <TF1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -62,18 +65,17 @@ int CentralityReco::InitRun(PHCompositeNode *topNode)
   {
     return Fun4AllReturnCodes::ABORTRUN;
   }
-
   std::string vertexscale_url = m_cdb->getUrl("CentralityVertexScale");
   if (m_overwrite_vtx)
     {
       vertexscale_url = m_overwrite_url_vtx;
       std::cout << " Overwriting Vtx to " << m_overwrite_url_vtx << std::endl;
     }
-
+  
   if (Download_centralityVertexScales(vertexscale_url))
-  {
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
+    {
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
 
   CreateNodes(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
@@ -149,7 +151,7 @@ int CentralityReco::Download_centralityVertexScales(const std::string &dbfile)
       {
 	cdbttree->Print();
       }
-
+    
     int nvertexbins = cdbttree->GetIntValue(0, "nvertexbins");
     
 
@@ -291,7 +293,7 @@ int CentralityReco::GetNodes(PHCompositeNode *topNode)
     std::cout << __FILE__ << " :: " << __FUNCTION__ << " :: " << __LINE__ << std::endl;
   }
 
-  m_mb_info = findNode::getClass<MinimumBiasInfo>(topNode, "MinimumBiasInfo");
+  m_mb_info = findNode::getClass<MinimumBiasInfo>(topNode, m_mb_info_nodename);
 
   if (!m_mb_info)
   {
@@ -299,15 +301,7 @@ int CentralityReco::GetNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_global_vertex_map = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
-  
-  if (!m_global_vertex_map)
-    {
-    std::cout << "no vertex map node " << std::endl;
-    return Fun4AllReturnCodes::EVENT_OK;
-  }
-
-  m_central = findNode::getClass<CentralityInfo>(topNode, "CentralityInfo");
+  m_central = findNode::getClass<CentralityInfo>(topNode, m_centrality_nodename);
 
   if (!m_central)
   {
@@ -315,7 +309,7 @@ int CentralityReco::GetNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_mbd_container = findNode::getClass<MbdPmtContainer>(topNode, "MbdPmtContainer");
+  m_mbd_container = findNode::getClass<MbdPmtContainer>(topNode, m_mbd_pmt_nodename);
 
   if (!m_mbd_container)
   {
@@ -324,7 +318,7 @@ int CentralityReco::GetNodes(PHCompositeNode *topNode)
   }
 
 
-  m_mbd_out = findNode::getClass<MbdOut>(topNode, "MbdOut");
+  m_mbd_out = findNode::getClass<MbdOut>(topNode, m_mbd_out_nodename);
   if (Verbosity())
     {
       std::cout << "Getting MBD Out" << std::endl;
@@ -365,7 +359,7 @@ void CentralityReco::CreateNodes(PHCompositeNode *topNode)
 
   CentralityInfo *central = new CentralityInfov2();
 
-  PHIODataNode<PHObject> *centralityNode = new PHIODataNode<PHObject>(central, "CentralityInfo", "PHObject");
+  PHIODataNode<PHObject> *centralityNode = new PHIODataNode<PHObject>(central, m_centrality_nodename, "PHObject");
   detNode->addNode(centralityNode);
 
   return;
@@ -376,7 +370,6 @@ float CentralityReco::getVertexScale()
 
 
   float mbd_vertex = m_mbd_out->get_zvtx();
-
   for (auto v_range_scale : m_vertex_scales)
     {
       auto v_range = v_range_scale.first;
@@ -384,7 +377,7 @@ float CentralityReco::getVertexScale()
 	{
 	  std::cout << "vertexrange : "<<v_range.first<<"-"<<v_range.second << std::endl;
 	}
-
+	  
       if (mbd_vertex > v_range.first && mbd_vertex <= v_range.second)
 	{
 	  return v_range_scale.second;

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <limits>
 #include <string>  // for string, allocator
+#include <utility>
 #include <vector>
 
 // Forward declarations
@@ -13,7 +14,6 @@
 class CentralityInfo;
 class MinimumBiasInfo;
 class PHCompositeNode;
-class GlobalVertexMap;
 class MbdOut;
 class MbdPmtContainer;
 class MbdPmtHit;

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -2,13 +2,14 @@
 #define CENTRALITY_CENTRALITYRECO_H
 
 #include <fun4all/SubsysReco.h>
+
 #include <array>
-#include <vector>
 #include <limits>
 #include <string>  // for string, allocator
+#include <vector>
 
 // Forward declarations
-class TF1;
+
 class CentralityInfo;
 class MinimumBiasInfo;
 class PHCompositeNode;
@@ -45,18 +46,15 @@ class CentralityReco : public SubsysReco
   void setOverwriteDivs(const std::string &url)
   {
     m_overwrite_url_divs = url;
-    m_overwrite_divs = true;    
   }
   void setOverwriteScale(const std::string &url)
   {
     m_overwrite_url_scale = url;
-    m_overwrite_scale = true;    
   }
 
   void setOverwriteVtx(const std::string &url)
   {
     m_overwrite_url_vtx = url;
-    m_overwrite_vtx = true;    
   }
 
   void set_minbiasNodeName(const std::string &name)
@@ -76,30 +74,8 @@ class CentralityReco : public SubsysReco
     m_mbd_pmt_nodename = name;
   }
 
-  
  private:
-
-
   float getVertexScale();
-
-  std::string m_dbfilename;
-
-  std::string m_mb_info_nodename{"MinimumBiasInfo"};
-
-  std::string m_mbd_out_nodename{"MbdOut"};
-
-  std::string m_centrality_nodename{"CentralityInfo"};
-
-  std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
-
-
-  std::string m_overwrite_url_divs;
-  std::string m_overwrite_url_scale;
-  std::string m_overwrite_url_vtx;
-
-  const int NDIVS{100};
-  const float mbd_charge_cut{0.5};
-  const float mbd_time_cut{25};
 
   MbdOut *m_mbd_out{nullptr};
   MbdPmtContainer *m_mbd_container{nullptr};
@@ -107,16 +83,29 @@ class CentralityReco : public SubsysReco
   MinimumBiasInfo *m_mb_info{nullptr};
   CentralityInfo *m_central{nullptr};
 
-  unsigned int m_key{std::numeric_limits<unsigned int>::max()};
+  static constexpr int NDIVS{100};
 
-  float m_mbd_total_charge{0.}; // init to zero for use in first event
+  static constexpr float mbd_charge_cut{0.5};
+  static constexpr float mbd_time_cut{25};
+
+  unsigned int m_key{std::numeric_limits<unsigned int>::max()};
 
   double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
 
-  std::vector<std::pair<std::pair<float, float>, float>>  m_vertex_scales{};
+  float m_mbd_total_charge{0.};  // init to zero for use in first event
+
+
+  std::string m_mb_info_nodename{"MinimumBiasInfo"};
+  std::string m_mbd_out_nodename{"MbdOut"};
+  std::string m_centrality_nodename{"CentralityInfo"};
+  std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
+
+  std::string m_overwrite_url_divs;
+  std::string m_overwrite_url_scale;
+  std::string m_overwrite_url_vtx;
+
+  std::vector<std::pair<std::pair<float, float>, float>> m_vertex_scales{};
   std::array<float, 100> m_centrality_map{};
-
-
 };
 
 #endif

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -8,6 +8,7 @@
 #include <string>  // for string, allocator
 
 // Forward declarations
+class TF1;
 class CentralityInfo;
 class MinimumBiasInfo;
 class PHCompositeNode;
@@ -51,11 +52,31 @@ class CentralityReco : public SubsysReco
     m_overwrite_url_scale = url;
     m_overwrite_scale = true;    
   }
+
   void setOverwriteVtx(const std::string &url)
   {
     m_overwrite_url_vtx = url;
     m_overwrite_vtx = true;    
   }
+
+  void set_minbiasNodeName(const std::string &name)
+  {
+    m_mb_info_nodename = name;
+  }
+  void set_mbdOutNodeName(const std::string &name)
+  {
+    m_mbd_out_nodename = name;
+  }
+  void set_centralityNodeName(const std::string &name)
+  {
+    m_centrality_nodename = name;
+  }
+  void set_mbdPmtNodeName(const std::string &name)
+  {
+    m_mbd_pmt_nodename = name;
+  }
+
+  
  private:
 
 
@@ -63,9 +84,20 @@ class CentralityReco : public SubsysReco
 
   std::string m_dbfilename;
 
+  std::string m_mb_info_nodename{"MinimumBiasInfo"};
+
+  std::string m_mbd_out_nodename{"MbdOut"};
+
+  std::string m_centrality_nodename{"CentralityInfo"};
+
+  std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
+
+
+  bool m_use_vtx_function{true};
   bool m_overwrite_divs{false};
   bool m_overwrite_scale{false};
   bool m_overwrite_vtx{false};
+
   std::string m_overwrite_url_divs{""};
   std::string m_overwrite_url_scale{""};
   std::string m_overwrite_url_vtx{""};

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -93,20 +93,14 @@ class CentralityReco : public SubsysReco
   std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
 
 
-  bool m_use_vtx_function{true};
-  bool m_overwrite_divs{false};
-  bool m_overwrite_scale{false};
-  bool m_overwrite_vtx{false};
-
-  std::string m_overwrite_url_divs{""};
-  std::string m_overwrite_url_scale{""};
-  std::string m_overwrite_url_vtx{""};
+  std::string m_overwrite_url_divs;
+  std::string m_overwrite_url_scale;
+  std::string m_overwrite_url_vtx;
 
   const int NDIVS{100};
   const float mbd_charge_cut{0.5};
   const float mbd_time_cut{25};
 
-  GlobalVertexMap *m_global_vertex_map{nullptr};
   MbdOut *m_mbd_out{nullptr};
   MbdPmtContainer *m_mbd_container{nullptr};
   MbdPmtHit *m_mbd_hit{nullptr};
@@ -118,6 +112,7 @@ class CentralityReco : public SubsysReco
   float m_mbd_total_charge{0.}; // init to zero for use in first event
 
   double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
+
   std::vector<std::pair<std::pair<float, float>, float>>  m_vertex_scales{};
   std::array<float, 100> m_centrality_map{};
 

--- a/offline/packages/trigger/MinimumBiasClassifier.cc
+++ b/offline/packages/trigger/MinimumBiasClassifier.cc
@@ -125,28 +125,31 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
   //   return Fun4AllReturnCodes::EVENT_OK;
   // }
 
+  
   if (m_global_vertex_map->empty())
   {
     m_mb_info->setIsAuAuMinimumBias(false);
-    return Fun4AllReturnCodes::EVENT_OK;
+    if (m_abortEvents) return 1;
+    return 0;
   }
 
   GlobalVertex *vtx = m_global_vertex_map->begin()->second;
   if (!vtx)
   {
     m_mb_info->setIsAuAuMinimumBias(false);
-    return Fun4AllReturnCodes::EVENT_OK;
+    if (m_abortEvents) return 1;
+    return 0;
   }
 
   if (!vtx->isValid())
   {
     m_mb_info->setIsAuAuMinimumBias(false);
-    return Fun4AllReturnCodes::EVENT_OK;
+    if (m_abortEvents) return 1;
+    return 0;
   }
 
   bool minbiascheck = true;
-  ;
-
+ 
   m_vertex = vtx->get_z();
 
   m_vertex_scale = getVertexScale();
@@ -160,7 +163,8 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
     if (!m_zdcinfo)
     {
       m_mb_info->setIsAuAuMinimumBias(false);
-      return Fun4AllReturnCodes::EVENT_OK;
+      if (m_abortEvents) return 1;
+      return 0;
     }
   }
   //  Z vertex is within range
@@ -226,9 +230,13 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
   }
 
   m_mb_info->setIsAuAuMinimumBias(minbiascheck);
-
-  return Fun4AllReturnCodes::EVENT_OK;
+  if (!minbiascheck && m_abortEvents)
+    {
+      return 1;
+    }
+  return 0;
 }
+
 int MinimumBiasClassifier::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity())
@@ -244,7 +252,11 @@ int MinimumBiasClassifier::process_event(PHCompositeNode *topNode)
 
   if (FillMinimumBiasInfo())
   {
-    return Fun4AllReturnCodes::EVENT_OK;
+    if (Verbosity())
+      {
+	std::cout << "MinimumBiasClassifier::process_event Aborting Event - not minbias" << std::endl;
+      }
+    return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -257,7 +269,7 @@ int MinimumBiasClassifier::GetNodes(PHCompositeNode *topNode)
     std::cout << __FILE__ << " :: " << __FUNCTION__ << " :: " << __LINE__ << std::endl;
   }
 
-  m_mb_info = findNode::getClass<MinimumBiasInfo>(topNode, "MinimumBiasInfo");
+  m_mb_info = findNode::getClass<MinimumBiasInfo>(topNode, m_mb_info_nodename);
 
   if (!m_mb_info)
   {
@@ -265,7 +277,7 @@ int MinimumBiasClassifier::GetNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_mbd_container = findNode::getClass<MbdPmtContainer>(topNode, "MbdPmtContainer");
+  m_mbd_container = findNode::getClass<MbdPmtContainer>(topNode, m_mbd_pmt_nodename);
   if (Verbosity())
   {
     std::cout << "Getting MBD Tubes" << std::endl;
@@ -279,7 +291,7 @@ int MinimumBiasClassifier::GetNodes(PHCompositeNode *topNode)
 
   if (!m_issim && m_useZDC)
   {
-    m_zdcinfo = findNode::getClass<Zdcinfo>(topNode, "Zdcinfo");
+    m_zdcinfo = findNode::getClass<Zdcinfo>(topNode, m_zdc_info_nodename);
     if (Verbosity())
     {
       std::cout << "Getting ZDC Info" << std::endl;
@@ -296,7 +308,7 @@ int MinimumBiasClassifier::GetNodes(PHCompositeNode *topNode)
     std::cout << "Getting Vertex Map" << std::endl;
   }
 
-  m_global_vertex_map = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+  m_global_vertex_map = findNode::getClass<GlobalVertexMap>(topNode, m_global_vertex_nodename);
 
   if (!m_global_vertex_map)
   {
@@ -325,9 +337,10 @@ void MinimumBiasClassifier::CreateNodes(PHCompositeNode *topNode)
     dstNode->addNode(detNode);
   }
 
+  std::string nodename = m_mb_info_nodename;
   MinimumBiasInfo *mb = new MinimumBiasInfov1();
 
-  PHIODataNode<PHObject> *mbNode = new PHIODataNode<PHObject>(mb, "MinimumBiasInfo", "PHObject");
+  PHIODataNode<PHObject> *mbNode = new PHIODataNode<PHObject>(mb, nodename, "PHObject");
   detNode->addNode(mbNode);
 
   return;

--- a/offline/packages/trigger/MinimumBiasClassifier.cc
+++ b/offline/packages/trigger/MinimumBiasClassifier.cc
@@ -5,12 +5,14 @@
 #include <zdcinfo/Zdcinfo.h>
 
 #include <cdbobjects/CDBTTree.h>
-#include <ffamodules/CDBInterface.h>
 
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
+
 #include <mbd/MbdPmtContainer.h>
 #include <mbd/MbdPmtHit.h>
+
+#include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -25,7 +27,6 @@
 #include <cmath>
 #include <filesystem>
 #include <iostream>
-#include <map>  // for _Rb_tree_iterator
 #include <string>
 #include <utility>  // for pair
 
@@ -33,6 +34,7 @@ MinimumBiasClassifier::MinimumBiasClassifier(const std::string &name)
   : SubsysReco(name)
 {
 }
+
 int MinimumBiasClassifier::InitRun(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1)
@@ -41,34 +43,38 @@ int MinimumBiasClassifier::InitRun(PHCompositeNode *topNode)
   }
 
   if (m_species == MinimumBiasInfo::SPECIES::AUAU)
-    {
-      m_useZDC = true;
-      m_max_charge_cut = 2100;
-      m_box_cut = true;
-      m_hit_cut = 2;
-    }
+  {
+    m_useZDC = true;
+    m_max_charge_cut = 2100;
+    m_box_cut = true;
+    m_hit_cut = 2;
+  }
   if (m_species == MinimumBiasInfo::SPECIES::OO)
-    {
-      m_useZDC = false;
-      m_max_charge_cut = 300;
-      m_box_cut = false;
-      m_hit_cut = 1;
-    }
+  {
+    m_useZDC = false;
+    m_max_charge_cut = 300;
+    m_box_cut = false;
+    m_hit_cut = 1;
+  }
   if (m_species == MinimumBiasInfo::SPECIES::PP)
-    {
-      m_useZDC = false;
-      m_max_charge_cut = 300;
-      m_box_cut = false;
-      m_hit_cut = 1;
-    }
+  {
+    m_useZDC = false;
+    m_max_charge_cut = 300;
+    m_box_cut = false;
+    m_hit_cut = 1;
+  }
 
   CDBInterface *m_cdb = CDBInterface::instance();
 
-  std::string centscale_url = m_cdb->getUrl("CentralityScale");
-  if (m_overwrite_scale)
+  std::string centscale_url;
+  if (!m_overwrite_url_scale.empty())
   {
     centscale_url = m_overwrite_url_scale;
     std::cout << " Overwriting Scale to " << m_overwrite_url_scale << std::endl;
+  }
+  else
+  {
+    centscale_url = m_cdb->getUrl("CentralityScale");
   }
 
   if (Download_centralityScale(centscale_url))
@@ -76,11 +82,15 @@ int MinimumBiasClassifier::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  std::string vertexscale_url = m_cdb->getUrl("CentralityVertexScale");
-  if (m_overwrite_vtx)
+  std::string vertexscale_url;
+  if (!m_overwrite_url_vtx.empty())
   {
     vertexscale_url = m_overwrite_url_vtx;
     std::cout << " Overwriting Vtx to " << m_overwrite_url_vtx << std::endl;
+  }
+  else
+  {
+    vertexscale_url = m_cdb->getUrl("CentralityVertexScale");
   }
 
   if (Download_centralityVertexScales(vertexscale_url))
@@ -125,11 +135,13 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
   //   return Fun4AllReturnCodes::EVENT_OK;
   // }
 
-  
   if (m_global_vertex_map->empty())
   {
     m_mb_info->setIsAuAuMinimumBias(false);
-    if (m_abortEvents) return 1;
+    if (m_abortEvents)
+    {
+      return 1;
+    }
     return 0;
   }
 
@@ -137,19 +149,25 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
   if (!vtx)
   {
     m_mb_info->setIsAuAuMinimumBias(false);
-    if (m_abortEvents) return 1;
+    if (m_abortEvents)
+    {
+      return 1;
+    }
     return 0;
   }
 
   if (!vtx->isValid())
   {
     m_mb_info->setIsAuAuMinimumBias(false);
-    if (m_abortEvents) return 1;
+    if (m_abortEvents)
+    {
+      return 1;
+    }
     return 0;
   }
 
   bool minbiascheck = true;
- 
+
   m_vertex = vtx->get_z();
 
   m_vertex_scale = getVertexScale();
@@ -163,7 +181,10 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
     if (!m_zdcinfo)
     {
       m_mb_info->setIsAuAuMinimumBias(false);
-      if (m_abortEvents) return 1;
+      if (m_abortEvents)
+      {
+        return 1;
+      }
       return 0;
     }
   }
@@ -231,9 +252,9 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
 
   m_mb_info->setIsAuAuMinimumBias(minbiascheck);
   if (!minbiascheck && m_abortEvents)
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   return 0;
 }
 
@@ -253,9 +274,9 @@ int MinimumBiasClassifier::process_event(PHCompositeNode *topNode)
   if (FillMinimumBiasInfo())
   {
     if (Verbosity())
-      {
-	std::cout << "MinimumBiasClassifier::process_event Aborting Event - not minbias" << std::endl;
-      }
+    {
+      std::cout << "MinimumBiasClassifier::process_event Aborting Event - not minbias" << std::endl;
+    }
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/trigger/MinimumBiasClassifier.h
+++ b/offline/packages/trigger/MinimumBiasClassifier.h
@@ -1,17 +1,18 @@
 #ifndef TRIGGER_MINBIASCLASSIFIER_H
 #define TRIGGER_MINBIASCLASSIFIER_H
 
+#include "MinimumBiasInfo.h"
+
 #include <fun4all/SubsysReco.h>
+
 #include <array>
 #include <limits>
 #include <string>  // for allocator, string
 #include <utility>
 #include <vector>
 
-#include "MinimumBiasInfo.h"
 // Forward declarations
 
-class MinimumBiasInfo;
 class PHCompositeNode;
 class Zdcinfo;
 class MbdPmtContainer;
@@ -23,7 +24,6 @@ class MinimumBiasClassifier : public SubsysReco
  public:
   //! constructor
 
-  
   explicit MinimumBiasClassifier(const std::string &name = "MinimumBiasClassifier");
 
   //! destructor
@@ -50,12 +50,10 @@ class MinimumBiasClassifier : public SubsysReco
   void setOverwriteScale(const std::string &url)
   {
     m_overwrite_url_scale = url;
-    m_overwrite_scale = true;
   }
   void setOverwriteVtx(const std::string &url)
   {
     m_overwrite_url_vtx = url;
-    m_overwrite_vtx = true;
   }
   void setIsSim(const bool sim) { m_issim = sim; }
 
@@ -79,37 +77,9 @@ class MinimumBiasClassifier : public SubsysReco
   {
     m_global_vertex_nodename = name;
   }
-  
+
  private:
-  bool m_abortEvents{false};
-  bool m_issim{false};
-  bool m_useZDC{true};
-  bool m_box_cut{true};
-  int m_hit_cut{2};
-  double m_max_charge_cut{2100};
-  
-  MinimumBiasInfo::SPECIES m_species{MinimumBiasInfo::SPECIES::AUAU};
-
   float getVertexScale();
-  std::string m_dbfilename;
-
-  std::string m_mb_info_nodename{"MinimumBiasInfo"};
-  std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
-  std::string m_zdc_info_nodename{"Zdcinfo"};
-  std::string m_global_vertex_nodename{"GlobalVertexMap"};
-  
-  bool m_overwrite_scale{false};
-  bool m_overwrite_vtx{false};
-  std::string m_overwrite_url_scale{""};
-  std::string m_overwrite_url_vtx{""};
-
-  const float m_z_vtx_cut{60.};
-  const float m_mbd_north_cut{10.};
-  const float m_mbd_south_cut{150};
-  const float m_mbd_charge_cut{0.5};
-  const float m_mbd_time_cut{25.};
-  //  const int m_mbd_tube_cut{2};
-  const float m_zdc_cut{60.};
 
   MinimumBiasInfo *m_mb_info{nullptr};
   MbdPmtContainer *m_mbd_container{nullptr};
@@ -117,13 +87,42 @@ class MinimumBiasClassifier : public SubsysReco
   GlobalVertexMap *m_global_vertex_map{nullptr};
   Zdcinfo *m_zdcinfo{nullptr};
 
+  bool m_abortEvents{false};
+  bool m_issim{false};
+  bool m_useZDC{true};
+  bool m_box_cut{true};
+
+  int m_hit_cut{2};
+
+  double m_max_charge_cut{2100};
+  double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
+  double m_vertex_scale{std::numeric_limits<double>::quiet_NaN()};
+
+  float m_vertex{std::numeric_limits<float>::quiet_NaN()};
+
+  static constexpr float m_z_vtx_cut{60.};
+  static constexpr float m_mbd_north_cut{10.};
+  static constexpr float m_mbd_south_cut{150};
+  static constexpr float m_mbd_charge_cut{0.5};
+  static constexpr float m_mbd_time_cut{25.};
+  //  const int m_mbd_tube_cut{2};
+  static constexpr float m_zdc_cut{60.};
+
+  MinimumBiasInfo::SPECIES m_species{MinimumBiasInfo::SPECIES::AUAU};
+
+  std::string m_mb_info_nodename{"MinimumBiasInfo"};
+  std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
+  std::string m_zdc_info_nodename{"Zdcinfo"};
+  std::string m_global_vertex_nodename{"GlobalVertexMap"};
+
+  std::string m_overwrite_url_scale;
+  std::string m_overwrite_url_vtx;
+
+
   std::array<float, 2> m_zdc_energy_sum{};
   std::array<float, 2> m_mbd_charge_sum{};
   std::array<int, 2> m_mbd_hit{};
 
-  double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
-  double m_vertex_scale{std::numeric_limits<double>::quiet_NaN()};
-  float m_vertex{std::numeric_limits<float>::quiet_NaN()};
   std::vector<std::pair<std::pair<float, float>, float>> m_vertex_scales{};
 };
 

--- a/offline/packages/trigger/MinimumBiasClassifier.h
+++ b/offline/packages/trigger/MinimumBiasClassifier.h
@@ -31,7 +31,7 @@ class MinimumBiasClassifier : public SubsysReco
   ~MinimumBiasClassifier() override = default;
 
   int InitRun(PHCompositeNode *) override;
-  static void CreateNodes(PHCompositeNode *);
+  void CreateNodes(PHCompositeNode *);
   int GetNodes(PHCompositeNode *);
 
   //! event processing method
@@ -60,8 +60,28 @@ class MinimumBiasClassifier : public SubsysReco
   void setIsSim(const bool sim) { m_issim = sim; }
 
   void setSpecies(MinimumBiasInfo::SPECIES spec) { m_species = spec; };
+
+  void abortEvents(const bool abort) { m_abortEvents = abort; };
+
+  void set_minbiasNodeName(const std::string &name)
+  {
+    m_mb_info_nodename = name;
+  }
+  void set_mbdPmtNodeName(const std::string &name)
+  {
+    m_mbd_pmt_nodename = name;
+  }
+  void set_zdcInfoNodeName(const std::string &name)
+  {
+    m_zdc_info_nodename = name;
+  }
+  void set_globalvertexNodeName(const std::string &name)
+  {
+    m_global_vertex_nodename = name;
+  }
   
  private:
+  bool m_abortEvents{false};
   bool m_issim{false};
   bool m_useZDC{true};
   bool m_box_cut{true};
@@ -73,6 +93,11 @@ class MinimumBiasClassifier : public SubsysReco
   float getVertexScale();
   std::string m_dbfilename;
 
+  std::string m_mb_info_nodename{"MinimumBiasInfo"};
+  std::string m_mbd_pmt_nodename{"MbdPmtContainer"};
+  std::string m_zdc_info_nodename{"Zdcinfo"};
+  std::string m_global_vertex_nodename{"GlobalVertexMap"};
+  
   bool m_overwrite_scale{false};
   bool m_overwrite_vtx{false};
   std::string m_overwrite_url_scale{""};

--- a/offline/packages/trigger/TriggerPrimitivev1.h
+++ b/offline/packages/trigger/TriggerPrimitivev1.h
@@ -6,7 +6,6 @@
 
 #include <cstddef>
 #include <iostream>
-#include <vector>
 
 ///
 class TriggerPrimitivev1 : public TriggerPrimitive


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Commit includes setting node names and allowing MBClassifier to abort events if directed to do so
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR Summary: MinBias Class Abort and Centrality Node Naming

## Motivation / Context
This PR adds configurable node naming for reconstruction modules and event abort functionality to the minimum-bias trigger classifier. These features enable users to use non-standard node names when operating multiple centrality and trigger reconstruction chains in parallel, and allow event filtering based on minimum-bias criteria.

## Key Changes

**CentralityReco (node naming):**
- Added four public setter methods: `set_minbiasNodeName()`, `set_mbdOutNodeName()`, `set_centralityNodeName()`, `set_mbdPmtNodeName()`
- Modified `GetNodes()` to retrieve `MinimumBiasInfo`, `CentralityInfo`, `MbdPmtContainer`, and `MbdOut` from configurable node name member variables instead of hardcoded string literals
- Modified `CreateNodes()` to create the output `CentralityInfo` node using the configurable name variable
- Removed `GlobalVertexMap` retrieval requirement (previously a no-op when node was missing)
- Added private `m_use_vtx_function` flag and `TF1` forward declaration

**MinimumBiasClassifier (abort events + node naming):**
- Changed `CreateNodes()` from static to non-static member method
- Added public method `abortEvents(bool)` to enable/disable event abortion
- Added four public node-name setter methods: `set_minbiasNodeName()`, `set_mbdPmtNodeName()`, `set_zdcInfoNodeName()`, `set_globalvertexNodeName()`
- Modified `FillMinimumBiasInfo()` to return integer status codes (0/1) instead of `Fun4AllReturnCodes::EVENT_OK`, with abortion gated by `m_abortEvents` flag
- Modified `process_event()` to abort events (`ABORTEVENT`) when `FillMinimumBiasInfo()` returns nonzero and `abortEvents()` is enabled
- Updated `GetNodes()` and `CreateNodes()` to use configurable node names instead of hardcoded values

## Potential Risk Areas

- **Reconstruction behavior change:** Events can now be aborted based on minimum-bias criteria when `abortEvents(true)` is explicitly set. Default is `false` (preserving current behavior), but new code enabling this may filter events unexpectedly if criteria are not properly configured.
- **Static method removal:** `CreateNodes()` changed from static to non-static in `MinimumBiasClassifier`. Any out-of-tree or existing code calling this as a static method will break at compile time.
- **Default node names:** Code assumes default node names match previous hardcoded values (`"MinimumBiasInfo"`, `"CentralityInfo"`, `"MbdPmtContainer"`, `"MbdOut"`, `"Zdcinfo"`, `"GlobalVertexMap"`). Non-backward-compatible if external code hardcodes node creation or retrieval.
- **GlobalVertexMap dependency removed:** CentralityReco no longer requires `GlobalVertexMap`. Verify this removal doesn't break downstream code that previously relied on its presence.

⚠️ **AI-generated summaries may contain errors.** Review the actual code changes carefully, especially around node retrieval order and event abort logic.

## Possible Future Improvements
- Add configuration presets or enumerations for standard node naming patterns in multi-chain scenarios
- Implement event abortion counters or diagnostic logging for performance monitoring
- Consider configuration framework integration for persistent run-time node naming settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->