### PR TITLE
PHSimpleVertexFinder INTT requirements

### DIFF
--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -404,8 +404,7 @@ bool HFTrackEfficiency::findTracks(PHCompositeNode *topNode, Decay decay)
             switch (id)
             {
             case TrkrDefs::mvtxId:
-              ++m_reco_track_silicon_seeds[index];
-              break;
+              [[fallthrough]];
             case TrkrDefs::inttId:
               ++m_reco_track_silicon_seeds[index];
               break;

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -401,6 +401,7 @@ bool HFTrackEfficiency::findTracks(PHCompositeNode *topNode, Decay decay)
           if (tstate->get_pathlength() != 0)  // The first track state is an extrapolation so has no cluster
           {
             auto stateckey = tstate->get_cluskey();
+            if (stateckey == TrkrDefs::CLUSKEYMAX) continue;
             uint8_t id = TrkrDefs::getTrkrId(stateckey);
 
             switch (id)

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -401,7 +401,10 @@ bool HFTrackEfficiency::findTracks(PHCompositeNode *topNode, Decay decay)
           if (tstate->get_pathlength() != 0)  // The first track state is an extrapolation so has no cluster
           {
             auto stateckey = tstate->get_cluskey();
-            if (stateckey == TrkrDefs::CLUSKEYMAX) continue;
+            if (stateckey == TrkrDefs::CLUSKEYMAX)
+            {
+              continue;
+            }
             uint8_t id = TrkrDefs::getTrkrId(stateckey);
 
             switch (id)

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -390,15 +390,34 @@ bool HFTrackEfficiency::findTracks(PHCompositeNode *topNode, Decay decay)
         m_reco_track_eta[index] = m_dst_track->get_eta();
         m_reco_track_phi[index] = m_dst_track->get_phi();
         m_reco_track_chi2nDoF[index] = m_dst_track->get_chisq() / m_dst_track->get_ndf();
-        if (m_dst_track->get_silicon_seed())
+
+        for (auto state_iter = m_dst_track->begin_states();
+        state_iter != m_dst_track->end_states();
+        ++state_iter)
         {
-          m_reco_track_silicon_seeds[index] = static_cast<int>(m_dst_track->get_silicon_seed()->size_cluster_keys());
+          SvtxTrackState *tstate = state_iter->second;
+          if (tstate->get_pathlength() != 0)  // The first track state is an extrapolation so has no cluster
+          {
+            auto stateckey = tstate->get_cluskey();
+            uint8_t id = TrkrDefs::getTrkrId(stateckey);
+
+            switch (id)
+            {
+            case TrkrDefs::mvtxId:
+              ++m_reco_track_silicon_seeds[index];
+              break;
+            case TrkrDefs::inttId:
+              ++m_reco_track_silicon_seeds[index];
+              break;
+            case TrkrDefs::tpcId:
+              ++m_reco_track_tpc_seeds[index];
+              break;
+            default:
+              break;
+            }
+          }
         }
-        else
-        {
-          m_reco_track_silicon_seeds[index] = 0;
-        }
-        m_reco_track_tpc_seeds[index] = static_cast<int>(m_dst_track->get_tpc_seed()->size_cluster_keys());
+
         m_min_reco_track_pT = std::min(m_reco_track_pT[index], m_min_reco_track_pT);
         m_max_reco_track_pT = std::max(m_reco_track_pT[index], m_max_reco_track_pT);
 
@@ -513,8 +532,8 @@ void HFTrackEfficiency::resetBranches()
     m_reco_track_phi[iTrack] = std::numeric_limits<float>::quiet_NaN();
     m_true_track_PID[iTrack] = std::numeric_limits<float>::quiet_NaN();
     m_reco_track_chi2nDoF[iTrack] = std::numeric_limits<float>::quiet_NaN();
-    m_reco_track_silicon_seeds[iTrack] = 0;
-    m_reco_track_tpc_seeds[iTrack] = 0;
+    m_reco_track_silicon_seeds[iTrack] = std::numeric_limits<int>::quiet_NaN();
+    m_reco_track_tpc_seeds[iTrack] = std::numeric_limits<int>::quiet_NaN();
   }
 
   m_primary_vtx_x = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -532,8 +532,8 @@ void HFTrackEfficiency::resetBranches()
     m_reco_track_phi[iTrack] = std::numeric_limits<float>::quiet_NaN();
     m_true_track_PID[iTrack] = std::numeric_limits<float>::quiet_NaN();
     m_reco_track_chi2nDoF[iTrack] = std::numeric_limits<float>::quiet_NaN();
-    m_reco_track_silicon_seeds[iTrack] = std::numeric_limits<int>::quiet_NaN();
-    m_reco_track_tpc_seeds[iTrack] = std::numeric_limits<int>::quiet_NaN();
+    m_reco_track_silicon_seeds[iTrack] = -1;
+    m_reco_track_tpc_seeds[iTrack] = -1;
   }
 
   m_primary_vtx_x = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -390,6 +390,8 @@ bool HFTrackEfficiency::findTracks(PHCompositeNode *topNode, Decay decay)
         m_reco_track_eta[index] = m_dst_track->get_eta();
         m_reco_track_phi[index] = m_dst_track->get_phi();
         m_reco_track_chi2nDoF[index] = m_dst_track->get_chisq() / m_dst_track->get_ndf();
+        m_reco_track_silicon_seeds[index] = 0;
+        m_reco_track_tpc_seeds[index] = 0;
 
         for (auto state_iter = m_dst_track->begin_states();
         state_iter != m_dst_track->end_states();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1423,7 +1423,7 @@ bool KFParticle_Tools::checkTrackAndVertexMatch(KFParticle vDaughters[], int nTr
   return vertexAndTrackMatch;
 }
 
-void KFParticle_Tools::printSelectionCheck(std::string parameter, float min, float val, float max)
+void KFParticle_Tools::printSelectionCheck(const std::string &parameter, float min, float val, float max)
 {
   std::string trailer = "the " + parameter + " requirement\033[0m";
   std::string passOrFail = isInRange(min, val, max) ? "\033[1;" + accept_colour + "mPassed " + trailer
@@ -1431,7 +1431,7 @@ void KFParticle_Tools::printSelectionCheck(std::string parameter, float min, flo
   std::cout << passOrFail << ". Lower bound = " << min << ", measured value =  " << val << ", upper bound = " << max << std::endl; 
 }
 
-void KFParticle_Tools::printSelectionCheck(std::string start, std::string accept, std::string reject, std::string end, bool equality)
+void KFParticle_Tools::printSelectionCheck(const std::string &start, const std::string &accept, const std::string &reject, const std::string &end, bool equality)
 {
   std::string decision = equality ? accept : reject;
   std::string colour = equality ? accept_colour : reject_colour;
@@ -1439,7 +1439,7 @@ void KFParticle_Tools::printSelectionCheck(std::string start, std::string accept
   std::cout << "\033[1;" << colour << "m" << start << spacing << decision << " " << end << "\033[0m" << std::endl;
 }
 
-void KFParticle_Tools::printSelectionCheck(std::string info, unsigned int value)
+void KFParticle_Tools::printSelectionCheck(const std::string &info, unsigned int value)
 {
   std::string colour = value > 0 ? accept_colour : reject_colour;
   std::cout << info << " = \033[1;" + colour + "m" + value + "\033[0m" << std::endl;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -472,9 +472,7 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFPart
   
   if (m_verbosity >= 10)
   {
-    std::string decision = goodTrack ? "\033[1;32mThis track passed the selection\033[0m"
-                                     : "\033[1;31mThis track failed the selection\033[0m";
-    std::cout << decision << std::endl;
+    printSelectionCheck("This track", "passed", "failed", "the selection", goodTrack);
     if (m_verbosity >= 11)
     {
       printSelectionCheck("Track pT", m_track_min_pt, pt, m_track_max_pt);
@@ -555,10 +553,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
 
         if (m_verbosity >= 10)
         {
-          std::string decision = (dca <= m_comb_DCA) && (dca_xy <= m_comb_DCA_xy) ? 
-                                 "\033[1;32mThis track pair passed the DCA selection\033[0m"
-                               : "\033[1;31mThis track pair failed the DCA selection\033[0m";
-          std::cout << decision << std::endl;
+          printSelectionCheck("This track pair", "passed", "failed", "the DCA selection", (dca <= m_comb_DCA) && (dca_xy <= m_comb_DCA_xy));
           if (m_verbosity >= 11)
           {
             printSelectionCheck("Pair DCA", 0., dca, m_comb_DCA);
@@ -577,10 +572,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
 
           if (nTracks == 2 && m_verbosity >= 10)
           {
-            std::string decision = (vertexchi2ndof <= m_vertex_chi2ndof) && (sv_radial_position >= m_min_radial_SV) ?
-                                   "\033[1;32mThis track pair passed the quality and radius selection\033[0m"
-                                 : "\033[1;31mThis track pair failed the quality and radius selection\033[0m";
-            std::cout << decision << std::endl;
+            printSelectionCheck("This track pair", "passed", "failed", "the quality and radius selection", (vertexchi2ndof <= m_vertex_chi2ndof) && (sv_radial_position >= m_min_radial_SV));
             if (m_verbosity >= 11)
             {
               printSelectionCheck("SV chi^2/nDoFA", 0., vertexchi2ndof, m_vertex_chi2ndof);
@@ -636,10 +628,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
 
          if (m_verbosity >= 10)
          {
-           std::string decision = (dca <= m_comb_DCA) && (dca_xy <= m_comb_DCA_xy) ? 
-                                  "\033[1;32mThis track combined with a SV set\033[0m"
-                                : "\033[1;31mThis track did not combine with a SV set\033[0m";
-           std::cout << decision << std::endl;
+           printSelectionCheck("This track", "combined", "did not combine", "with a SV set", (dca <= m_comb_DCA) && (dca_xy <= m_comb_DCA_xy));
            if (m_verbosity >= 11)
            {
              printSelectionCheck("Pair DCA", 0., dca, m_comb_DCA);
@@ -669,10 +658,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
 
           if ((unsigned int) nRequiredTracks == nProngs && m_verbosity >= 10)
           {
-            std::string decision = (vertexchi2ndof <= m_vertex_chi2ndof) && (sv_radial_position >= m_min_radial_SV) ?
-                                   "\033[1;32mThis SV combination passed the quality and radius selection\033[0m"
-                                 : "\033[1;31mThis SV combination failed the quality and radius selection\033[0m";
-            std::cout << decision << std::endl;
+            printSelectionCheck("This SV combination", "passed", "failed", "the quality and radius selection", (vertexchi2ndof <= m_vertex_chi2ndof) && (sv_radial_position >= m_min_radial_SV));
             if (m_verbosity >= 11)
             {
               printSelectionCheck("SV chi^2/nDoFA", 0., vertexchi2ndof, m_vertex_chi2ndof);
@@ -999,8 +985,8 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
 
     if (m_verbosity >= 11)
     {
-      std::string decision = crossings.size() == 1 ? "\033[1;32mAll tracks are from the same BC\033[0m" : "\033[1;31mTracks are from different BC\033[0m";
-      std::cout << decision << std::endl;
+      bool accept = crossings.size() == 1;
+      printSelectionCheck("", "All tracks are from the same BC", "Tracks are from different BC", "", accept);
     }
   }
 
@@ -1019,9 +1005,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
 
       if (m_verbosity >= 10)
       {
-        std::string decision = goodCandidate ? "\033[1;32mAccepted the intermediate selection\033[0m" : "\033[1;31mRejected the intermediate selection\033[0m";
-        std::cout << decision << std::endl;
-
+        printSelectionCheck("", "Accepted", "Rejected", "the intermediate selection", goodCandidate);
         if (m_verbosity >= 11)
         {
           printSelectionCheck("Intermediate DIRA", m_intermediate_min_dira[k], intermediate_DIRA, FLT_MAX);
@@ -1033,13 +1017,10 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
 
   if (m_verbosity >= 10)
   {
-    std::string decision = goodCandidate ? "\033[1;32mAccepted the mother selection\033[0m" : "\033[1;31mRejected the mother selection\033[0m";
-    std::cout << decision << std::endl;
-
+    printSelectionCheck("", "Accepted", "Rejected", "the mother selection", goodCandidate);
     if (m_verbosity >= 11)
     {
-      decision = chargeCheck ? "\033[1;32mVertex charge is right\033[0m" : "\033[1;31mVertex charge is wrong\033[0m";
-      std::cout << decision << std::endl;
+      printSelectionCheck("Vertex charge is", "right", "wrong", "", chargeCheck);
       printSelectionCheck("Invariant Mass", min_mass, calculated_mass, max_mass);
       printSelectionCheck("Mother pT", min_pt, calculated_pt, FLT_MAX);
       printSelectionCheck("Mother SV volume", 0., calculateEllipsoidVolume(mother), max_vertex_volume);
@@ -1093,9 +1074,7 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
 
   if (m_verbosity >= 10)
   {
-    std::string decision = goodCandidate ? "\033[1;32mPassed the PV constraint\033[0m" : "\033[1;31mFailed the PV constraint\033[0m";
-    std::cout << decision << std::endl;
-
+    printSelectionCheck("", "Passed", "Failed", "the PV constraint", goodCandidate);
     if (m_verbosity >= 11)
     {
       printSelectionCheck("Mother DIRA", m_dira_min, calculated_dira, m_dira_max);
@@ -1446,7 +1425,22 @@ bool KFParticle_Tools::checkTrackAndVertexMatch(KFParticle vDaughters[], int nTr
 
 void KFParticle_Tools::printSelectionCheck(std::string parameter, float min, float val, float max)
 {
-  std::string passOrFail = isInRange(min, val, max) ? "\033[1;32mPassed the " + parameter + " requirement\033[0m" 
-                                                    : "\033[1;31mFailed the " + parameter + " requirement\033[0m";
+  std::string trailer = "the " + parameter + " requirement\033[0m";
+  std::string passOrFail = isInRange(min, val, max) ? "\033[1;" + accept_colour + "mPassed " + trailer
+                                                    : "\033[1;" + reject_colour + "mFailed " + trailer;
   std::cout << passOrFail << ". Lower bound = " << min << ", measured value =  " << val << ", upper bound = " << max << std::endl; 
+}
+
+void KFParticle_Tools::printSelectionCheck(std::string start, std::string accept, std::string reject, std::string end, bool equality)
+{
+  std::string decision = equality ? accept : reject;
+  std::string colour = equality ? accept_colour : reject_colour;
+  std::string spacing = start.empty() ? "" : " ";
+  std::cout << "\033[1;" << colour << "m" << start << spacing << decision << " " << end << "\033[0m" << std::endl;
+}
+
+void KFParticle_Tools::printSelectionCheck(std::string info, unsigned int value)
+{
+  std::string colour = value > 0 ? accept_colour : reject_colour;
+  std::cout << info << " = \033[1;" + colour + "m" + value + "\033[0m" << std::endl;
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -327,6 +327,14 @@ std::vector<KFParticle> KFParticle_Tools::makeAllDaughterParticles(PHCompositeNo
       }
     }
 
+    if (m_verbosity > 100)
+    {
+      printSelectionCheck("MVTX states", m_nMVTXStates, MVTX_states, 5);
+      printSelectionCheck("INTT states", m_nINTTStates, INTT_states, 5);
+      printSelectionCheck("TPC states", m_nTPCStates, TPC_states, 100);
+      printSelectionCheck("TPOT states", m_nTPOTStates, TPOT_states, 5);
+    }
+
     if (MVTX_states < m_nMVTXStates)
     {
       continue;
@@ -460,6 +468,25 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFPart
   {
     goodTrack = true;
   }
+
+  
+  if (m_verbosity >= 10)
+  {
+    std::string decision = goodTrack ? "\033[1;32mThis track passed the selection\033[0m"
+                                     : "\033[1;31mThis track failed the selection\033[0m";
+    std::cout << decision << std::endl;
+    if (m_verbosity >= 11)
+    {
+      printSelectionCheck("Track pT", m_track_min_pt, pt, m_track_max_pt);
+      printSelectionCheck("Track pT chi^2", 0, ptchi2, m_track_ptchi2);
+      printSelectionCheck("IP", m_track_ip, min_ip, FLT_MAX);
+      printSelectionCheck("IP chi^2", m_track_ipchi2, min_ipchi2, FLT_MAX);
+      printSelectionCheck("IP xy", m_track_ip_xy, min_ip_xy, FLT_MAX);
+      printSelectionCheck("IP xy chi^2", m_track_ipchi2_xy, min_ipchi2_xy, FLT_MAX);
+      printSelectionCheck("Track chi^2/nDoF", 0, trackchi2ndof, m_track_chi2ndof);
+    }
+  }
+
   return goodTrack;
 }
 
@@ -513,7 +540,7 @@ std::vector<int> KFParticle_Tools::findAllGoodTracks(const std::vector<KFParticl
   return goodTrackIndex;
 }
 
-std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFParticle> daughterParticles, std::vector<int> goodTrackIndex, int nTracks) const
+std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFParticle> daughterParticles, std::vector<int> goodTrackIndex, int nTracks)
 {
   std::vector<std::vector<int>> goodTracksThatMeet;
 
@@ -526,6 +553,19 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
         float dca = daughterParticles[*i_it].GetDistanceFromParticle(daughterParticles[*j_it]);
         float dca_xy = abs(daughterParticles[*i_it].GetDistanceFromParticleXY(daughterParticles[*j_it]));
 
+        if (m_verbosity >= 10)
+        {
+          std::string decision = (dca <= m_comb_DCA) && (dca_xy <= m_comb_DCA_xy) ? 
+                                 "\033[1;32mThis track pair passed the DCA selection\033[0m"
+                               : "\033[1;31mThis track pair failed the DCA selection\033[0m";
+          std::cout << decision << std::endl;
+          if (m_verbosity >= 11)
+          {
+            printSelectionCheck("Pair DCA", 0., dca, m_comb_DCA);
+            printSelectionCheck("Pair DCA xy", 0., dca_xy, m_comb_DCA_xy);
+          }
+        }
+
         if (dca <= m_comb_DCA && dca_xy <= m_comb_DCA_xy)
         {
           KFVertex twoParticleVertex;
@@ -534,6 +574,19 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
           float vertexchi2ndof = twoParticleVertex.GetChi2() / twoParticleVertex.GetNDF();
           float sv_radial_position = sqrt(pow(twoParticleVertex.GetX(), 2) + pow(twoParticleVertex.GetY(), 2));
           std::vector<int> combination = {*i_it, *j_it};
+
+          if (nTracks == 2 && m_verbosity >= 10)
+          {
+            std::string decision = (vertexchi2ndof <= m_vertex_chi2ndof) && (sv_radial_position >= m_min_radial_SV) ?
+                                   "\033[1;32mThis track pair passed the quality and radius selection\033[0m"
+                                 : "\033[1;31mThis track pair failed the quality and radius selection\033[0m";
+            std::cout << decision << std::endl;
+            if (m_verbosity >= 11)
+            {
+              printSelectionCheck("SV chi^2/nDoFA", 0., vertexchi2ndof, m_vertex_chi2ndof);
+              printSelectionCheck("SV radius", m_min_radial_SV, sv_radial_position, FLT_MAX);
+            }
+          }
 
           if (nTracks == 2 && vertexchi2ndof > m_vertex_chi2ndof)
           {
@@ -581,6 +634,19 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
           float dca = daughterParticles[i_it].GetDistanceFromParticle(daughterParticles[goodTracksThatMeet[i_prongs][i]]);
           float dca_xy = abs(daughterParticles[i_it].GetDistanceFromParticleXY(daughterParticles[goodTracksThatMeet[i_prongs][i]]));
 
+         if (m_verbosity >= 10)
+         {
+           std::string decision = (dca <= m_comb_DCA) && (dca_xy <= m_comb_DCA_xy) ? 
+                                  "\033[1;32mThis track combined with a SV set\033[0m"
+                                : "\033[1;31mThis track did not combine with a SV set\033[0m";
+           std::cout << decision << std::endl;
+           if (m_verbosity >= 11)
+           {
+             printSelectionCheck("Pair DCA", 0., dca, m_comb_DCA);
+             printSelectionCheck("Pair DCA xy", 0., dca_xy, m_comb_DCA_xy);
+           }
+         }
+
           if (dca > m_comb_DCA || dca_xy > m_comb_DCA_xy)
           {
             dcaMet = false;
@@ -600,6 +666,19 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
           }
           float vertexchi2ndof = particleVertex.GetChi2() / particleVertex.GetNDF();
           float sv_radial_position = sqrt(pow(particleVertex.GetX(), 2) + pow(particleVertex.GetY(), 2));
+
+          if ((unsigned int) nRequiredTracks == nProngs && m_verbosity >= 10)
+          {
+            std::string decision = (vertexchi2ndof <= m_vertex_chi2ndof) && (sv_radial_position >= m_min_radial_SV) ?
+                                   "\033[1;32mThis SV combination passed the quality and radius selection\033[0m"
+                                 : "\033[1;31mThis SV combination failed the quality and radius selection\033[0m";
+            std::cout << decision << std::endl;
+            if (m_verbosity >= 11)
+            {
+              printSelectionCheck("SV chi^2/nDoFA", 0., vertexchi2ndof, m_vertex_chi2ndof);
+              printSelectionCheck("SV radius", m_min_radial_SV, sv_radial_position, FLT_MAX);
+            }
+          }
 
           if ((unsigned int) nRequiredTracks == nProngs && vertexchi2ndof > m_vertex_chi2ndof)
           {
@@ -825,6 +904,12 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
         float calculated_dEdx_value = get_dEdx(topNode, vDaughters[i]);
         double expected_dEdx_value = get_dEdx_fitValue((Int_t) vDaughters[i].GetQ() * vDaughters[i].GetP(), track_PDG_ID);
         bool accept_dEdx = isInRange((1 - m_dEdx_band_width) * expected_dEdx_value, calculated_dEdx_value, (1 + m_dEdx_band_width) * expected_dEdx_value);
+
+        if (m_verbosity >= 11)
+        {
+          printSelectionCheck("dE/dx check", (1 - m_dEdx_band_width) * expected_dEdx_value, calculated_dEdx_value, (1 + m_dEdx_band_width) * expected_dEdx_value);
+        }
+
         if (!accept_dEdx)
         {
           delete[] inputTracks;
@@ -875,7 +960,9 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
   float calculated_mass;
   float calculated_mass_err;
   mother.GetMass(calculated_mass, calculated_mass_err);
-  float calculated_pt = mother.GetPt();
+  float calculated_pt;
+  float calculated_pt_err;
+  mother.GetPt(calculated_pt, calculated_pt_err);
 
   float min_mass = isIntermediate ? m_intermediate_mass_range[intermediateNumber].first : m_min_mass;
   float max_mass = isIntermediate ? m_intermediate_mass_range[intermediateNumber].second : m_max_mass;
@@ -909,6 +996,12 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     {
       goodCandidate = false;
     }
+
+    if (m_verbosity >= 11)
+    {
+      std::string decision = crossings.size() == 1 ? "\033[1;32mAll tracks are from the same BC\033[0m" : "\033[1;31mTracks are from different BC\033[0m";
+      std::cout << decision << std::endl;
+    }
   }
 
   // Check the requirements of an intermediate states against this mother and re-do goodCandidate
@@ -923,6 +1016,33 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
       {
         goodCandidate = false;
       }
+
+      if (m_verbosity >= 10)
+      {
+        std::string decision = goodCandidate ? "\033[1;32mAccepted the intermediate selection\033[0m" : "\033[1;31mRejected the intermediate selection\033[0m";
+        std::cout << decision << std::endl;
+
+        if (m_verbosity >= 11)
+        {
+          printSelectionCheck("Intermediate DIRA", m_intermediate_min_dira[k], intermediate_DIRA, FLT_MAX);
+          printSelectionCheck("Intermediate FD chi^2", m_intermediate_min_fdchi2[k], intermediate_FDchi2, FLT_MAX);
+        }
+      }
+    }
+  }
+
+  if (m_verbosity >= 10)
+  {
+    std::string decision = goodCandidate ? "\033[1;32mAccepted the mother selection\033[0m" : "\033[1;31mRejected the mother selection\033[0m";
+    std::cout << decision << std::endl;
+
+    if (m_verbosity >= 11)
+    {
+      decision = chargeCheck ? "\033[1;32mVertex charge is right\033[0m" : "\033[1;31mVertex charge is wrong\033[0m";
+      std::cout << decision << std::endl;
+      printSelectionCheck("Invariant Mass", min_mass, calculated_mass, max_mass);
+      printSelectionCheck("Mother pT", min_pt, calculated_pt, FLT_MAX);
+      printSelectionCheck("Mother SV volume", 0., calculateEllipsoidVolume(mother), max_vertex_volume);
     }
   }
   delete[] inputTracks;
@@ -969,6 +1089,30 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
   if (calculated_fdchi2 >= m_fdchi2 && calculated_ip <= m_mother_ip && calculated_ipchi2 <= m_mother_ipchi2 && calculated_ip_xy <= m_mother_ip_xy && calculated_ipchi2_xy <= m_mother_ipchi2_xy && calculated_decay_time_significance >= m_mother_min_decay_time_significance && calculated_decay_length_significance >= m_mother_min_decay_length_significance && calculated_decay_length_xy_significance >= m_mother_min_decay_length_xy_significance && isInRange(m_dira_min, calculated_dira, m_dira_max) && isInRange(m_dira_xy_min, calculated_dira_xy, m_dira_xy_max) && isInRange(m_min_decayTime, calculated_decayTime, m_max_decayTime) && isInRange(m_min_decayTime_xy, calculated_decayTime_xy, m_max_decayTime_xy) && isInRange(m_min_decayLength, calculated_decayLength, m_max_decayLength) && isInRange(m_min_decayLength_xy, calculated_decayLength_xy, m_max_decayLength_xy))
   {
     goodCandidate = true;
+  }
+
+  if (m_verbosity >= 10)
+  {
+    std::string decision = goodCandidate ? "\033[1;32mPassed the PV constraint\033[0m" : "\033[1;31mFailed the PV constraint\033[0m";
+    std::cout << decision << std::endl;
+
+    if (m_verbosity >= 11)
+    {
+      printSelectionCheck("Mother DIRA", m_dira_min, calculated_dira, m_dira_max);
+      printSelectionCheck("Mother DIRA xy", m_dira_xy_min, calculated_dira_xy, m_dira_xy_max);
+      printSelectionCheck("Mother FD chi^2", m_fdchi2, calculated_fdchi2, FLT_MAX);
+      printSelectionCheck("Mother IP", 0, calculated_ip, m_mother_ip);
+      printSelectionCheck("Mother IP chi^2", 0., calculated_ipchi2, m_mother_ipchi2);
+      printSelectionCheck("Mother IP xy", 0., calculated_ip_xy, m_mother_ip_xy);
+      printSelectionCheck("Mother IP xy chi^2", 0., calculated_ipchi2_xy, m_mother_ipchi2_xy);
+      printSelectionCheck("Mother Decay Time", m_min_decayTime, calculated_decayTime, m_max_decayTime);
+      printSelectionCheck("Mother Decay Time Significance", m_mother_min_decay_time_significance, calculated_decay_time_significance, FLT_MAX);
+      printSelectionCheck("Mother Decay Time xy", m_min_decayTime_xy, calculated_decayTime_xy, m_max_decayTime_xy);
+      printSelectionCheck("Mother Decay Length", m_min_decayLength, calculated_decayLength, m_max_decayLength);
+      printSelectionCheck("Mother Decay Length Significance", m_mother_min_decay_length_significance, calculated_decay_length_significance, FLT_MAX);
+      printSelectionCheck("Mother Decay Length xy", m_min_decayLength_xy, calculated_decayLength_xy, m_max_decayLength_xy);
+      printSelectionCheck("Mother Decay Length xy Significance", m_mother_min_decay_length_xy_significance, calculated_decay_length_xy_significance, FLT_MAX);
+    }
   }
 }
 
@@ -1210,7 +1354,7 @@ void KFParticle_Tools::init_dEdx_fits()
 
   if (m_use_local_PID_file)
   {
-    std::cout << PHWHERE << " using local file " << m_local_PID_filename << std::endl;
+    if (m_verbosity > 4) std::cout << PHWHERE << " using local file " << m_local_PID_filename << std::endl;
     // new method is independent of charge
     filefit->GetObject("pi_band",f_pion_plus);
     filefit->GetObject("K_band",f_kaon_plus);
@@ -1298,4 +1442,11 @@ bool KFParticle_Tools::checkTrackAndVertexMatch(KFParticle vDaughters[], int nTr
   }
 
   return vertexAndTrackMatch;
+}
+
+void KFParticle_Tools::printSelectionCheck(std::string parameter, float min, float val, float max)
+{
+  std::string passOrFail = isInRange(min, val, max) ? "\033[1;32mPassed the " + parameter + " requirement\033[0m" 
+                                                    : "\033[1;31mFailed the " + parameter + " requirement\033[0m";
+  std::cout << passOrFail << ". Lower bound = " << min << ", measured value =  " << val << ", upper bound = " << max << std::endl; 
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1333,7 +1333,10 @@ void KFParticle_Tools::init_dEdx_fits()
 
   if (m_use_local_PID_file)
   {
-    if (m_verbosity > 4) std::cout << PHWHERE << " using local file " << m_local_PID_filename << std::endl;
+    if (m_verbosity > 4)
+    {
+      std::cout << PHWHERE << " using local file " << m_local_PID_filename << std::endl;
+    }
     // new method is independent of charge
     filefit->GetObject("pi_band",f_pion_plus);
     filefit->GetObject("K_band",f_kaon_plus);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1445,5 +1445,5 @@ void KFParticle_Tools::printSelectionCheck(const std::string &start, const std::
 void KFParticle_Tools::printSelectionCheck(const std::string &info, unsigned int value)
 {
   std::string colour = value > 0 ? accept_colour : reject_colour;
-  std::cout << info << " = \033[1;" + colour + "m" + value + "\033[0m" << std::endl;
+  std::cout << info << " = \033[1;" << colour << "m" << value << "\033[0m" << std::endl;
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -285,6 +285,10 @@ class KFParticle_Tools : protected KFParticle_MVA
   void removeDuplicates(std::vector<std::vector<std::string>> &v);
 
   void printSelectionCheck(std::string parameter, float min, float val, float max);
+  void printSelectionCheck(std::string start, std::string accept, std::string reject, std::string end, bool equality);
+  void printSelectionCheck(std::string info, unsigned int value);
+  std::string accept_colour = "32";
+  std::string reject_colour = "31";
 };
 
 #endif  // KFPARTICLESPHENIX_KFPARTICLETOOLS_H

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -284,9 +284,9 @@ class KFParticle_Tools : protected KFParticle_MVA
   void removeDuplicates(std::vector<std::vector<int>> &v);
   void removeDuplicates(std::vector<std::vector<std::string>> &v);
 
-  void printSelectionCheck(std::string parameter, float min, float val, float max);
-  void printSelectionCheck(std::string start, std::string accept, std::string reject, std::string end, bool equality);
-  void printSelectionCheck(std::string info, unsigned int value);
+  void printSelectionCheck(const std::string &parameter, float min, float val, float max);
+  void printSelectionCheck(const std::string &start, const std::string a&ccept, const std::string &reject, const std::string &end, bool equality);
+  void printSelectionCheck(const std::string &info, unsigned int value);
   std::string accept_colour = "32";
   std::string reject_colour = "31";
 };

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -75,7 +75,7 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   std::vector<int> findAllGoodTracks(const std::vector<KFParticle> &daughterParticles, const std::vector<KFParticle> &primaryVertices);
 
-  std::vector<std::vector<int>> findTwoProngs(std::vector<KFParticle> daughterParticles, std::vector<int> goodTrackIndex, int nTracks) const;
+  std::vector<std::vector<int>> findTwoProngs(std::vector<KFParticle> daughterParticles, std::vector<int> goodTrackIndex, int nTracks);
 
   std::vector<std::vector<int>> findNProngs(std::vector<KFParticle> daughterParticles,
                                             const std::vector<int> &goodTrackIndex,
@@ -126,6 +126,8 @@ class KFParticle_Tools : protected KFParticle_MVA
   void set_dont_use_global_vertex(bool set_variable) { m_dont_use_global_vertex = set_variable; }
 
  protected:
+  int m_verbosity = 0;
+
   std::string m_mother_name_Tools;
   int m_num_intermediate_states{-1};
   std::vector<int> m_num_tracks_from_intermediate;
@@ -281,6 +283,8 @@ class KFParticle_Tools : protected KFParticle_MVA
   void removeDuplicates(std::vector<int> &v);
   void removeDuplicates(std::vector<std::vector<int>> &v);
   void removeDuplicates(std::vector<std::vector<std::string>> &v);
+
+  void printSelectionCheck(std::string parameter, float min, float val, float max);
 };
 
 #endif  // KFPARTICLESPHENIX_KFPARTICLETOOLS_H

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -285,7 +285,7 @@ class KFParticle_Tools : protected KFParticle_MVA
   void removeDuplicates(std::vector<std::vector<std::string>> &v);
 
   void printSelectionCheck(const std::string &parameter, float min, float val, float max);
-  void printSelectionCheck(const std::string &start, const std::string a&ccept, const std::string &reject, const std::string &end, bool equality);
+  void printSelectionCheck(const std::string &start, const std::string &accept, const std::string &reject, const std::string &end, bool equality);
   void printSelectionCheck(const std::string &info, unsigned int value);
   std::string accept_colour = "32";
   std::string reject_colour = "31";

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -78,20 +78,9 @@ void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::
 
   if (m_verbosity >= 10)
   {
-    unsigned int i_number = daughterParticles.size();
-    std::string s_number = i_number > 0 ? "\033[1;32m" + std::to_string(i_number) + "\033[0m"
-                                        : "\033[1;31m" + std::to_string(i_number) + "\033[0m";
-    std::cout << "Number of daughters passing state selection = " << s_number << std::endl;
-
-    i_number = goodTrackIndex.size();
-    s_number = i_number > 0 ? "\033[1;32m" + std::to_string(i_number) + "\033[0m"
-                            : "\033[1;31m" + std::to_string(i_number) + "\033[0m";
-    std::cout << "Number of daughters passing track selection = " <<  s_number<< std::endl;
-
-    i_number = primaryVertices.size();
-    s_number = i_number > 0 ? "\033[1;32m" + std::to_string(i_number) + "\033[0m"
-                            : "\033[1;31m" + std::to_string(i_number) + "\033[0m";
-    std::cout << "Number of PVs passing selection =  " << s_number << std::endl;
+    printSelectionCheck("Number of daughters passing state selection", daughterParticles.size());
+    printSelectionCheck("Number of daughters passing track selection", goodTrackIndex.size());
+    printSelectionCheck("Number of PVs passing selection", primaryVertices.size());
   }
 
   if (!m_has_intermediates)
@@ -122,9 +111,7 @@ void KFParticle_eventReconstruction::buildBasicChain(std::vector<KFParticle>& se
 
   if (m_verbosity >= 10)
   { 
-    std::string number = goodTracksThatMeet.size() > 0 ? "\033[1;32m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m"
-                                                       : "\033[1;31m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m";
-    std::cout << "Number of SVs passing selection = " << number << std::endl;
+    printSelectionCheck("Number of SVs passing selection", goodTracksThatMeet.size());
   }
 
   getCandidateDecay(selectedMotherBasic, selectedVertexBasic, selectedDaughtersBasic, daughterParticlesBasic,
@@ -164,9 +151,7 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
 
     if (m_verbosity >= 10)
     { 
-      std::string number = goodTracksThatMeet.size() > 0 ? "\033[1;32m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m"
-                                                         : "\033[1;31m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m";
-      std::cout << "Number of SVs passing selection = " << number << std::endl;
+      printSelectionCheck("Number of SVs passing selection", goodTracksThatMeet.size());
     }
 
     getCandidateDecay(potentialIntermediates[i], vertices, potentialDaughters[i], daughterParticlesAdv,

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -76,6 +76,24 @@ void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::
 
   std::vector<int> goodTrackIndex = findAllGoodTracks(daughterParticles, primaryVertices);
 
+  if (m_verbosity >= 10)
+  {
+    unsigned int i_number = daughterParticles.size();
+    std::string s_number = i_number > 0 ? "\033[1;32m" + std::to_string(i_number) + "\033[0m"
+                                        : "\033[1;31m" + std::to_string(i_number) + "\033[0m";
+    std::cout << "Number of daughters passing state selection = " << s_number << std::endl;
+
+    i_number = goodTrackIndex.size();
+    s_number = i_number > 0 ? "\033[1;32m" + std::to_string(i_number) + "\033[0m"
+                            : "\033[1;31m" + std::to_string(i_number) + "\033[0m";
+    std::cout << "Number of daughters passing track selection = " <<  s_number<< std::endl;
+
+    i_number = primaryVertices.size();
+    s_number = i_number > 0 ? "\033[1;32m" + std::to_string(i_number) + "\033[0m"
+                            : "\033[1;31m" + std::to_string(i_number) + "\033[0m";
+    std::cout << "Number of PVs passing selection =  " << s_number << std::endl;
+  }
+
   if (!m_has_intermediates)
   {
     buildBasicChain(selectedMother, selectedVertex, selectedDaughters, daughterParticles, goodTrackIndex, primaryVertices, topNode);
@@ -100,6 +118,13 @@ void KFParticle_eventReconstruction::buildBasicChain(std::vector<KFParticle>& se
   for (int p = 3; p < m_num_tracks + 1; ++p)
   {
     goodTracksThatMeet = findNProngs(daughterParticlesBasic, goodTrackIndexBasic, goodTracksThatMeet, m_num_tracks, p);
+  }
+
+  if (m_verbosity >= 10)
+  { 
+    std::string number = goodTracksThatMeet.size() > 0 ? "\033[1;32m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m"
+                                                       : "\033[1;31m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m";
+    std::cout << "Number of SVs passing selection = " << number << std::endl;
   }
 
   getCandidateDecay(selectedMotherBasic, selectedVertexBasic, selectedDaughtersBasic, daughterParticlesBasic,
@@ -136,6 +161,14 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                                        goodTracksThatMeet,
                                        m_num_tracks_from_intermediate[i], p);
     }
+
+    if (m_verbosity >= 10)
+    { 
+      std::string number = goodTracksThatMeet.size() > 0 ? "\033[1;32m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m"
+                                                         : "\033[1;31m" + std::to_string(goodTracksThatMeet.size()) + "\033[0m";
+      std::cout << "Number of SVs passing selection = " << number << std::endl;
+    }
+
     getCandidateDecay(potentialIntermediates[i], vertices, potentialDaughters[i], daughterParticlesAdv,
                       goodTracksThatMeet, primaryVerticesAdv, track_start, track_stop, true, i, m_constrain_int_mass, topNode);
     track_start += track_stop;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -303,9 +303,9 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
 
   m_tree->Branch("runNumber", &m_runNumber, "runNumber/I");
   m_tree->Branch("eventNumber", &m_evtNumber, "eventNumber/I");
-  m_tree->Branch("event_bco", &m_event_bco, "event_bco/L"); //adding for the current event BCO, not shifted
-  m_tree->Branch("BCO", &m_bco, "BCO/L"); //already there, this is shifted BCO
-  m_tree->Branch("last_event_bco", &m_last_event_bco, "last_event_bco/L"); //BCO for the last event 
+  m_tree->Branch("Collision_BCO", &m_bco, "Collision_BCO/L"); //already there, this is shifted BCO
+  m_tree->Branch("GL1_BCO", &m_event_bco, "GL1_BCO/L"); //adding for the current event BCO, not shifted
+  m_tree->Branch("last_GL1_BCO", &m_last_event_bco, "last_GL1_BCO/L"); //BCO for the last event 
 
   if (m_get_trigger_info)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -194,18 +194,17 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
     {
       std::cout << "KFParticle: EventHeader or GL1 packet not found" << std::endl;
     }
-    m_this_event_bco = -1;
-    m_last_event_bco = -1;
-    m_prev_event_bco = -1;
-    m_prev_runNumber = -1;
-    m_prev_eventNumber = -1;
+    m_this_event_bco = 0;
+    m_last_event_bco = 0;
+    m_prev_event_bco = 0;
+    m_prev_runNumber = 0;
+    m_prev_eventNumber = 0;
   }
   // End BCO matching here
 
   SvtxTrackMap *check_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name);
-  multiplicity = check_trackmap->size();
 
-  if (check_trackmap->empty())
+  if (!check_trackmap || check_trackmap->empty())
   {
     if (Verbosity() >= VERBOSITY_SOME)
     {
@@ -213,6 +212,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
     }
     return Fun4AllReturnCodes::EVENT_OK;
   }
+  multiplicity = check_trackmap->size();
 
   if (!m_use_fake_pv)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -88,6 +88,7 @@ KFParticle_sPHENIX::KFParticle_sPHENIX(const std::string &name)
 
 int KFParticle_sPHENIX::Init(PHCompositeNode *topNode)
 {
+  m_verbosity = Verbosity();
   
   if (m_save_output && Verbosity() >= VERBOSITY_SOME)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -155,64 +155,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
     }
     return Fun4AllReturnCodes::EVENT_OK;
   }
- 
-  // Adding BCO Matching  
-  auto* evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader"); // event header node
-  auto* gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");     // gl1 packet node
 
-  if (!gl1packet)
-  {
-  gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
-  }
-
-  if (evtHeader && gl1packet)
-  {
-  const int64_t run = evtHeader->get_RunNumber();
-  const int64_t evn = evtHeader->get_EvtSequence();
-  m_this_event_bco = static_cast<uint64_t>(gl1packet->lValue(0, "BCO"));
-
-    if (Verbosity() >= VERBOSITY_SOME)
-  	{
-	std::cout << "Event start | run: " << run << " event: " << evn << " this_event_bco: " << m_this_event_bco << std::endl;
-	}
-
-  if (run != m_prev_runNumber || evn != m_prev_eventNumber)
-  {
-
-    if (Verbosity() >= VERBOSITY_SOME)
-    {
-	std::cout << "New event detected" << std::endl;
-    	std::cout << "Previous event BCO: " << m_prev_event_bco << std::endl;
-	}
-    //m_last_event_bco = m_prev_event_bco;
-     m_last_event_bco = (run == m_prev_runNumber) ? m_prev_event_bco : -1;
-	m_prev_event_bco = m_this_event_bco;
-
-    m_prev_runNumber = run;
-    m_prev_eventNumber = evn;
-
-    if (Verbosity() >= VERBOSITY_SOME)
-    {
-	std::cout << "Updated values | last_event_bco: " << m_last_event_bco
-              << " stored_prev_event_bco: " << m_prev_event_bco
-              << std::endl;
-	}
-  }
- }
-  else
-  {
-	
-    if (Verbosity() >= VERBOSITY_SOME)
-  {
-	std::cout << "EventHeader or GL1 packet not found" << std::endl;
-	}
-  m_this_event_bco = -1;
-  m_last_event_bco = -1;
-  m_prev_event_bco = -1;
-  m_prev_runNumber = -1;
-  m_prev_eventNumber = -1;
-  }
-// End BCO matching here
   if (!m_use_fake_pv)
   {
     if (m_use_mbd_vertex)
@@ -241,6 +184,65 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
     }
   }
   
+ 
+  // Adding BCO Matching  
+  auto* evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader"); // event header node
+  auto* gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");     // gl1 packet node
+
+  if (!gl1packet)
+  {
+    gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+  }
+
+  if (evtHeader && gl1packet)
+  {
+    const int64_t run = evtHeader->get_RunNumber();
+    const int64_t evn = evtHeader->get_EvtSequence();
+    m_this_event_bco = static_cast<uint64_t>(gl1packet->lValue(0, "BCO"));
+
+    if (Verbosity() >= VERBOSITY_A_LOT)
+    {
+      std::cout << "Event start | run: " << run << " event: " << evn << " this_event_bco: " << m_this_event_bco << std::endl;
+    }
+
+    if (run != m_prev_runNumber || evn != m_prev_eventNumber)
+    {
+
+      if (Verbosity() >= VERBOSITY_A_LOT)
+      {
+        std::cout << "New event detected" << std::endl;
+      	std::cout << "Previous event BCO: " << m_prev_event_bco << std::endl;
+      }
+ 
+      m_last_event_bco = (run == m_prev_runNumber) ? m_prev_event_bco : -1;
+      m_prev_event_bco = m_this_event_bco;
+
+      m_prev_runNumber = run;
+      m_prev_eventNumber = evn;
+
+      if (Verbosity() >= VERBOSITY_A_LOT)
+      {
+        std::cout << "Updated values | last_event_bco: " << m_last_event_bco
+                  << " stored_prev_event_bco: " << m_prev_event_bco
+                  << std::endl;
+      }
+    }
+  }
+  else
+  {
+	
+    if (Verbosity() >= VERBOSITY_MORE)
+    {
+      std::cout << "KFParticle: EventHeader or GL1 packet not found" << std::endl;
+    }
+    m_this_event_bco = -1;
+    m_last_event_bco = -1;
+    m_prev_event_bco = -1;
+    m_prev_runNumber = -1;
+    m_prev_eventNumber = -1;
+  }
+  // End BCO matching here
+
   createDecay(topNode, mother, vertex_kfparticle, daughters, intermediates, nPVs);
   if (!m_has_intermediates_sPHENIX)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -136,55 +136,13 @@ int KFParticle_sPHENIX::InitRun(PHCompositeNode *topNode)
 }
 
 int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
-{
-  
+{ 
   std::vector<KFParticle> mother;
   std::vector<KFParticle> vertex_kfparticle;
   std::vector<std::vector<KFParticle>> daughters;
   std::vector<std::vector<KFParticle>> intermediates;
   int nPVs;
   int multiplicity;
-
-  SvtxTrackMap *check_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name);
-  multiplicity = check_trackmap->size();
-
-  if (check_trackmap->empty())
-  {
-    if (Verbosity() >= VERBOSITY_SOME)
-    {
-      std::cout << "KFParticle: Event skipped as there are no tracks" << std::endl;
-    }
-    return Fun4AllReturnCodes::EVENT_OK;
-  }
-
-  if (!m_use_fake_pv)
-  {
-    if (m_use_mbd_vertex)
-    {
-      MbdVertexMap* check_vertexmap = findNode::getClass<MbdVertexMap>(topNode, "MbdVertexMap");
-      if (check_vertexmap->empty())
-      {
-        if (Verbosity() >= VERBOSITY_SOME)
-        {
-          std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
-        }
-        return Fun4AllReturnCodes::EVENT_OK;
-      }
-    }
-    else
-    {
-      SvtxVertexMap* check_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, m_vtx_map_node_name);
-      if (check_vertexmap->empty())
-      {
-        if (Verbosity() >= VERBOSITY_SOME)
-        {
-          std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
-        }
-        return Fun4AllReturnCodes::EVENT_OK;
-      }
-    }
-  }
-  
  
   // Adding BCO Matching  
   auto* evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader"); // event header node
@@ -243,6 +201,47 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
     m_prev_eventNumber = -1;
   }
   // End BCO matching here
+
+  SvtxTrackMap *check_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name);
+  multiplicity = check_trackmap->size();
+
+  if (check_trackmap->empty())
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+    {
+      std::cout << "KFParticle: Event skipped as there are no tracks" << std::endl;
+    }
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  if (!m_use_fake_pv)
+  {
+    if (m_use_mbd_vertex)
+    {
+      MbdVertexMap* check_vertexmap = findNode::getClass<MbdVertexMap>(topNode, "MbdVertexMap");
+      if (check_vertexmap->empty())
+      {
+        if (Verbosity() >= VERBOSITY_SOME)
+        {
+          std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
+        }
+        return Fun4AllReturnCodes::EVENT_OK;
+      }
+    }
+    else
+    {
+      SvtxVertexMap* check_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, m_vtx_map_node_name);
+      if (check_vertexmap->empty())
+      {
+        if (Verbosity() >= VERBOSITY_SOME)
+        {
+          std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
+        }
+        return Fun4AllReturnCodes::EVENT_OK;
+      }
+    }
+  }
+  
 
   createDecay(topNode, mother, vertex_kfparticle, daughters, intermediates, nPVs);
   if (!m_has_intermediates_sPHENIX)

--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -93,14 +93,14 @@ int DecayFinder::Init(PHCompositeNode* topNode)
 
 int DecayFinder::process_event(PHCompositeNode* topNode)
 {
-  bool decayFound = findDecay(topNode);
+  int decayFound = findDecay(topNode);
 
-  if (decayFound && m_save_dst && Verbosity() >= VERBOSITY_MORE)
+  if (decayFound > 0 && m_save_dst && Verbosity() >= VERBOSITY_MORE)
   {
     printNode(topNode);
   }
 
-  if (m_triggerOnDecay && !decayFound)
+  if (m_triggerOnDecay && decayFound < 1)
   {
     if (Verbosity() >= VERBOSITY_MORE)
     {
@@ -317,10 +317,10 @@ int DecayFinder::parseDecayDescriptor()
  * as decays wont enter the HepMC record
  * need a switch to go to Geant4 record
  */
-bool DecayFinder::findDecay(PHCompositeNode* topNode)
+int DecayFinder::findDecay(PHCompositeNode* topNode)
 {
   bool decayWasFound = false;
-  bool reconstructableDecayWasFound = false;
+  int reconstructableDecayWasFound = 0;
   bool aTrackFailedPT = false;
   bool aTrackFailedETA = false;
   bool aMotherHasPhoton = false;
@@ -384,6 +384,11 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
           std::cout << "parent->pdg_id(): " << g4particle->get_pid() << std::endl;
         }
 
+        aTrackFailedPT = false;
+        aTrackFailedETA = false;
+        aMotherHasPhoton = false;
+        aMotherHasPi0 = false;
+
         bool breakOut = false;
         correctMotherProducts.clear();
         decayChain.clear();
@@ -416,7 +421,7 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
           else
           {
             m_nCandReconstructable += 1;
-            reconstructableDecayWasFound = true;
+            ++reconstructableDecayWasFound;
             if (m_save_dst)
             {
               fillDecayNode(topNode, decayChain);
@@ -465,6 +470,11 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
           std::cout << "parent->pdg_id(): " << (*p)->pdg_id() << std::endl;
         }
 
+        aTrackFailedPT = false;
+        aTrackFailedETA = false;
+        aMotherHasPhoton = false;
+        aMotherHasPi0 = false;
+
         bool breakOut = false;
         correctMotherProducts.clear();
         decayChain.clear();
@@ -505,7 +515,7 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
           else
           {
             m_nCandReconstructable += 1;
-            reconstructableDecayWasFound = true;
+            ++reconstructableDecayWasFound;
             if (m_save_dst)
             {
               fillDecayNode(topNode, decayChain);

--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -455,7 +455,7 @@ int DecayFinder::findDecay(PHCompositeNode* topNode)
     if (!m_genevt)
     {
       std::cout << "DecayFinder: Missing node PHHepMCGenEvent" << std::endl;
-      return false;
+      continue;
     }
 
     HepMC::GenEvent* theEvent = m_genevt->getEvent();

--- a/offline/packages/decayfinder/DecayFinder.h
+++ b/offline/packages/decayfinder/DecayFinder.h
@@ -42,7 +42,7 @@ class DecayFinder : public SubsysReco
 
   int parseDecayDescriptor();
 
-  bool findDecay(PHCompositeNode *topNode);
+  int findDecay(PHCompositeNode *topNode);
 
   bool findParticle(const std::string &particle);
 

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -515,7 +515,7 @@ void PHSimpleVertexFinder::checkDCAs(SvtxTrackMap *track_map)
     {
       continue;
     }
-    if (_require_mvtx && !passClusterRequirement(tr1))
+    if (_require_mvtx && !passClusterRequirement(tr1, "MVTX"))
     {
       continue;
     }
@@ -533,7 +533,7 @@ void PHSimpleVertexFinder::checkDCAs(SvtxTrackMap *track_map)
       {
         continue;
       }
-      if (_require_mvtx && !passClusterRequirement(tr2))
+      if (_require_mvtx && !passClusterRequirement(tr2, "MVTX"))
       {
         continue;
       }
@@ -574,7 +574,9 @@ void PHSimpleVertexFinder::checkDCAsZF(SvtxTrackMap *track_map)
     //    tr1->identify();
  
     TrackSeed *siliconseed = tr1->get_silicon_seed();
-    if ((_require_mvtx || _require_intt) && !siliconseed)
+    const bool needs_mvtx_seed = _require_mvtx && _nmvtx_required > 0;
+    const bool needs_intt_seed = _require_intt && _nintt_required > 0;
+    if ((needs_mvtx_seed || needs_intt_seed) && !siliconseed)
     {
       continue;
     }
@@ -760,7 +762,7 @@ void PHSimpleVertexFinder::checkDCAs()
     {
       continue;
     }
-    if (_require_mvtx && !passClusterRequirement(tr1))
+    if (_require_mvtx && !passClusterRequirement(tr1, "MVTX"))
     {
       continue;
     }
@@ -778,7 +780,7 @@ void PHSimpleVertexFinder::checkDCAs()
       {
         continue;
       }
-      if (_require_mvtx && !passClusterRequirement(tr2))
+      if (_require_mvtx && !passClusterRequirement(tr2, "MVTX"))
       {
         continue;
       }
@@ -1265,7 +1267,8 @@ bool PHSimpleVertexFinder::passClusterRequirement(SvtxTrack *track, const std::s
   unsigned int _nclus_required = type == "MVTX" ? _nmvtx_required : _nintt_required;
 
   TrackSeed *siliconseed = track->get_silicon_seed();
-  if (!siliconseed)
+  bool needs_clus = _nclus_required > 0;
+  if (needs_clus && !siliconseed)
   {
     return pass;
   }

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -515,21 +515,13 @@ void PHSimpleVertexFinder::checkDCAs(SvtxTrackMap *track_map)
     {
       continue;
     }
-    if (_require_mvtx)
+    if (_require_mvtx && !passClusterRequirement(tr1))
     {
-      bool passed = passClusterRequirement(tr1);
-      if (!passed)
-      {
-        continue;
-      }
+      continue;
     }
-    if (_require_intt)
+    if (_require_intt && !passClusterRequirement(tr1, "INTT"))
     {
-      bool passed = passClusterRequirement(tr1, "INTT");
-      if (!passed)
-      {
-        continue;
-      }
+      continue;
     }
 
     // look for close DCA matches with all other such tracks
@@ -541,21 +533,13 @@ void PHSimpleVertexFinder::checkDCAs(SvtxTrackMap *track_map)
       {
         continue;
       }
-      if (_require_mvtx)
+      if (_require_mvtx && !passClusterRequirement(tr2))
       {
-        bool passed = passClusterRequirement(tr2);
-        if (!passed)
-        {
-          continue;
-        }
+        continue;
       }
-      if (_require_intt)
+      if (_require_intt && !passClusterRequirement(tr2, "INTT"))
       {
-        bool passed = passClusterRequirement(tr2, "INTT");
-        if (!passed)
-        {
-          continue;
-        }
+        continue;
       }
 
       // find DCA of these two tracks
@@ -771,21 +755,13 @@ void PHSimpleVertexFinder::checkDCAs()
     {
       continue;
     }
-    if (_require_mvtx)
+    if (_require_mvtx && !passClusterRequirement(tr1))
     {
-      bool passed = passClusterRequirement(tr1);
-      if (!passed)
-      {
-        continue;
-      }
+      continue;
     }
-    if (_require_intt)
+    if (_require_intt && !passClusterRequirement(tr1, "INTT"))
     {
-      bool passed = passClusterRequirement(tr1, "INTT");
-      if (!passed)
-      {
-        continue;
-      }
+      continue;
     }
 
     // look for close DCA matches with all other such tracks
@@ -797,21 +773,13 @@ void PHSimpleVertexFinder::checkDCAs()
       {
         continue;
       }
-      if (_require_mvtx)
+      if (_require_mvtx && !passClusterRequirement(tr2))
       {
-        bool passed = passClusterRequirement(tr2);
-        if (!passed)
-        {
-          continue;
-        }
+        continue;
       }
-      if (_require_intt)
+      if (_require_intt && !passClusterRequirement(tr2, "INTT"))
       {
-        bool passed = passClusterRequirement(tr2, "INTT");
-        if (!passed)
-        {
-          continue;
-        }
+        continue;
       }
       // find DCA of these two tracks
       if (Verbosity() > 3)
@@ -1272,7 +1240,7 @@ double PHSimpleVertexFinder::getAverage(std::vector<double> &v)
   return avge;
 }
 
-bool PHSimpleVertexFinder::passClusterRequirement(SvtxTrack *track, std::string type)
+bool PHSimpleVertexFinder::passClusterRequirement(SvtxTrack *track, const std::string &type)
 {
   bool pass = false;
 

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -517,31 +517,18 @@ void PHSimpleVertexFinder::checkDCAs(SvtxTrackMap *track_map)
     }
     if (_require_mvtx)
     {
-      unsigned int nmvtx = 0;
-      TrackSeed *siliconseed = tr1->get_silicon_seed();
-      if (!siliconseed)
+      bool passed = passClusterRequirement(tr1);
+      if (!passed)
       {
         continue;
       }
-
-      for (auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
-      {
-        if (TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId)
-        {
-          nmvtx++;
-        }
-        if (nmvtx >= _nmvtx_required)
-        {
-          break;
-        }
-      }
-      if (nmvtx < _nmvtx_required)
+    }
+    if (_require_intt)
+    {
+      bool passed = passClusterRequirement(tr1, "INTT");
+      if (!passed)
       {
         continue;
-      }
-      if (Verbosity() > 3)
-      {
-        std::cout << " tr1 id " << id1 << " has nmvtx at least " << nmvtx << std::endl;
       }
     }
 
@@ -556,31 +543,18 @@ void PHSimpleVertexFinder::checkDCAs(SvtxTrackMap *track_map)
       }
       if (_require_mvtx)
       {
-        unsigned int nmvtx = 0;
-        TrackSeed *siliconseed = tr2->get_silicon_seed();
-        if (!siliconseed)
+        bool passed = passClusterRequirement(tr2);
+        if (!passed)
         {
           continue;
         }
-
-        for (auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
-        {
-          if (TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId)
-          {
-            nmvtx++;
-          }
-          if (nmvtx >= _nmvtx_required)
-          {
-            break;
-          }
-        }
-        if (nmvtx < _nmvtx_required)
+      }
+      if (_require_intt)
+      {
+        bool passed = passClusterRequirement(tr2, "INTT");
+        if (!passed)
         {
           continue;
-        }
-        if (Verbosity() > 3)
-        {
-          std::cout << " tr2 id " << id2 << " has nmvtx at least " << nmvtx << std::endl;
         }
       }
 
@@ -799,31 +773,18 @@ void PHSimpleVertexFinder::checkDCAs()
     }
     if (_require_mvtx)
     {
-      unsigned int nmvtx = 0;
-      TrackSeed *siliconseed = tr1->get_silicon_seed();
-      if (!siliconseed)
+      bool passed = passClusterRequirement(tr1);
+      if (!passed)
       {
         continue;
       }
-
-      for (auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
-      {
-        if (TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId)
-        {
-          nmvtx++;
-        }
-        if (nmvtx >= _nmvtx_required)
-        {
-          break;
-        }
-      }
-      if (nmvtx < _nmvtx_required)
+    }
+    if (_require_intt)
+    {
+      bool passed = passClusterRequirement(tr1, "INTT");
+      if (!passed)
       {
         continue;
-      }
-      if (Verbosity() > 3)
-      {
-        std::cout << " tr1 id " << id1 << " has nmvtx at least " << nmvtx << std::endl;
       }
     }
 
@@ -838,34 +799,20 @@ void PHSimpleVertexFinder::checkDCAs()
       }
       if (_require_mvtx)
       {
-        unsigned int nmvtx = 0;
-        TrackSeed *siliconseed = tr2->get_silicon_seed();
-        if (!siliconseed)
+        bool passed = passClusterRequirement(tr2);
+        if (!passed)
         {
           continue;
-        }
-
-        for (auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
-        {
-          if (TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId)
-          {
-            nmvtx++;
-          }
-          if (nmvtx >= _nmvtx_required)
-          {
-            break;
-          }
-        }
-        if (nmvtx < _nmvtx_required)
-        {
-          continue;
-        }
-        if (Verbosity() > 3)
-        {
-          std::cout << " tr2 id " << id2 << " has nmvtx at least " << nmvtx << std::endl;
         }
       }
-
+      if (_require_intt)
+      {
+        bool passed = passClusterRequirement(tr2, "INTT");
+        if (!passed)
+        {
+          continue;
+        }
+      }
       // find DCA of these two tracks
       if (Verbosity() > 3)
       {
@@ -1323,4 +1270,50 @@ double PHSimpleVertexFinder::getAverage(std::vector<double> &v)
   }
 
   return avge;
+}
+
+bool PHSimpleVertexFinder::passClusterRequirement(SvtxTrack *track, std::string type)
+{
+  bool pass = false;
+
+  std::vector<std::string> acceptable_types = {"MVTX", "INTT"};
+  bool accept_this_type = std::find(acceptable_types.begin(), acceptable_types.end(), type) != acceptable_types.end();
+
+  if (!accept_this_type)
+  {
+    if (Verbosity() > 3)
+    {
+      std::cout << "type " << type << " was not recognised" << std::endl;
+    }
+    return pass;
+  }
+
+  unsigned int nclus = 0;
+  unsigned int _nclus_required = type == "MVTX" ? _nmvtx_required : _nintt_required;
+
+  TrackSeed *siliconseed = track->get_silicon_seed();
+  if (!siliconseed)
+  {
+    return pass;
+  }
+
+  for (auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
+  {
+    uint8_t trkrId = type == "MVTX" ? TrkrDefs::mvtxId : TrkrDefs::inttId;
+    if (TrkrDefs::getTrkrId(*clusit) == trkrId)
+    {
+      nclus++;
+    }
+    if (nclus >= _nclus_required)
+    {
+      pass = true;
+    }
+  }
+
+  if (Verbosity() > 3)
+  {
+    std::cout << " track id " << track->get_id() << " has " << nclus << " clusters for " << type << std::endl;
+  }
+
+  return pass;
 }

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -574,13 +574,18 @@ void PHSimpleVertexFinder::checkDCAsZF(SvtxTrackMap *track_map)
     //    tr1->identify();
  
     TrackSeed *siliconseed = tr1->get_silicon_seed();
-    if (_require_mvtx)
-      {
-	if (!siliconseed)
-	  {
-	    continue;
-	  }
-      }
+    if ((_require_mvtx || _require_intt) && !siliconseed)
+    {
+      continue;
+    }
+    if (_require_mvtx && !passClusterRequirement(tr1, "MVTX"))
+    {
+      continue;
+    }
+    if (_require_intt && !passClusterRequirement(tr1, "INTT"))
+    {
+      continue;
+    }
     TrackSeed *tpcseed = tr1->get_tpc_seed();
 
     std::vector<Acts::Vector3> global_vec;

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -1260,19 +1260,22 @@ bool PHSimpleVertexFinder::passClusterRequirement(SvtxTrack *track, const std::s
     {
       std::cout << "type " << type << " was not recognised" << std::endl;
     }
-    return pass;
+    return false;
+  }
+
+  unsigned int _nclus_required = type == "MVTX" ? _nmvtx_required : _nintt_required;
+  if (_nclus_required == 0)
+  {
+    return true;
+  }
+
+  TrackSeed *siliconseed = track->get_silicon_seed();
+  if (!siliconseed)
+  {
+    return false;
   }
 
   unsigned int nclus = 0;
-  unsigned int _nclus_required = type == "MVTX" ? _nmvtx_required : _nintt_required;
-
-  TrackSeed *siliconseed = track->get_silicon_seed();
-  bool needs_clus = _nclus_required > 0;
-  if (needs_clus && !siliconseed)
-  {
-    return pass;
-  }
-
   for (auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
   {
     uint8_t trkrId = type == "MVTX" ? TrkrDefs::mvtxId : TrkrDefs::inttId;

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -46,18 +46,18 @@ class PHSimpleVertexFinder : public SubsysReco
   void setBeamSpotCutY(const double cutlo, const double cuthi) { _beamline_y_cut_lo = cutlo; _beamline_y_cut_hi = cuthi; }
   void setDcaCut(const double cut) { _base_dcacut = cut; }
   void setTrackQualityCut(double cut) { _qual_cut = cut; }
-  void setRequireMVTX(bool set) { _require_mvtx = set; }
+  void setRequireMVTX(bool set = true) { _require_mvtx = set; }
   void setNmvtxRequired(unsigned int n) { _nmvtx_required = n; }
-  void setRequireINTT(bool set) { _require_intt = set; }
+  void setRequireINTT(bool set = true) { _require_intt = set; }
   void setNinttRequired(unsigned int n) { _nintt_required = n; }
   void setTrackPtCut(const double cut) { _track_pt_cut = cut; }
   // void setUseTrackCovariance(bool set) {_use_track_covariance = set;}
   void setOutlierPairCut(const double cut) { _outlier_cut = cut; }
   void setTrackMapName(const std::string &name) { _track_map_name = name; }
   void setVertexMapName(const std::string &name) { _vertex_map_name = name; }
-  void zeroField(const bool flag) { _zero_field = flag; }
+  void zeroField(const bool flag = true) { _zero_field = flag; }
   void setTrkrClusterContainerName(const std::string &name){ m_clusterContainerName = name; }
-  void set_pp_mode(bool mode) { _pp_mode = mode; }
+  void set_pp_mode(bool mode = true) { _pp_mode = mode; }
 
  private:
   int GetNodes(PHCompositeNode *topNode);

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -48,6 +48,8 @@ class PHSimpleVertexFinder : public SubsysReco
   void setTrackQualityCut(double cut) { _qual_cut = cut; }
   void setRequireMVTX(bool set) { _require_mvtx = set; }
   void setNmvtxRequired(unsigned int n) { _nmvtx_required = n; }
+  void setRequireINTT(bool set) { _require_intt = set; }
+  void setNinttRequired(unsigned int n) { _nintt_required = n; }
   void setTrackPtCut(const double cut) { _track_pt_cut = cut; }
   // void setUseTrackCovariance(bool set) {_use_track_covariance = set;}
   void setOutlierPairCut(const double cut) { _outlier_cut = cut; }
@@ -75,6 +77,7 @@ class PHSimpleVertexFinder : public SubsysReco
   void removeOutlierTrackPairs();
   double getMedian(std::vector<double> &v);
   double getAverage(std::vector<double> &v);
+  bool passClusterRequirement(SvtxTrack *track, std::string type = "MVTX");
 
   SvtxTrackMap *_track_map{nullptr};
   TrkrClusterContainer* _cluster_map{nullptr};
@@ -91,7 +94,9 @@ class PHSimpleVertexFinder : public SubsysReco
   double _beamline_y_cut_hi = 0.2; 
   double _qual_cut = 10.0;
   bool _require_mvtx = true;
+  bool _require_intt = false;
   unsigned int _nmvtx_required = 2;
+  unsigned int _nintt_required = 1;
   double _track_pt_cut = 0.0;
   double _outlier_cut = 0.015;
 

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -77,7 +77,7 @@ class PHSimpleVertexFinder : public SubsysReco
   void removeOutlierTrackPairs();
   double getMedian(std::vector<double> &v);
   double getAverage(std::vector<double> &v);
-  bool passClusterRequirement(SvtxTrack *track, std::string type = "MVTX");
+  bool passClusterRequirement(SvtxTrack *track, const std::string &type = "MVTX");
 
   SvtxTrackMap *_track_map{nullptr};
   TrkrClusterContainer* _cluster_map{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I added the ability to require INTT clusters on a track when making primary vertices. The code defaults to not requiring this, and when enabled the default is a single cluster

```c++
  void setRequireINTT(bool set) { _require_intt = set; }
  void setNinttRequired(unsigned int n) { _nintt_required = n; }
```
and
```c++
  bool _require_mvtx = true;
  bool _require_intt = false;
  unsigned int _nmvtx_required = 2;
  unsigned int _nintt_required = 1;
```

I also patched a small bug in DecayFinder which would veto events if one candidate passed the trigger but another failed

Lastly, I cleaned up some KFParticle code. Its only cosmetic

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Motivation / Context
Add optional INTT-cluster requirements to the primary-vertex finder so vertexing can require both MVTX and INTT silicon clusters on tracks. Preserve default behavior (backwards compatible) while enabling tighter track/vertex selection when INTT information is desired. Also fix a DecayFinder logic bug that could incorrectly veto events, adjust HFTrackEfficiency seed counting, and add verbosity/diagnostic cleanups in KFParticle code.

Key changes
- PHSimpleVertexFinder
  - New public API: setRequireINTT(bool set = true), setNinttRequired(unsigned int n)
  - New config/state: _require_intt (default false), _nintt_required (default 1)
  - Centralized cluster gating via passClusterRequirement(SvtxTrack*, const std::string& type = "MVTX")
  - Default arguments added for setRequireMVTX, zeroField, set_pp_mode
  - Behavior: when _require_intt enabled, tracks must meet the configured INTT cluster count (default 1) to be used for vertexing
- DecayFinder
  - findDecay() return type changed bool → int (returns count of reconstructable candidates)
  - Fix: per-candidate flags are reset each loop and HepMC-missing events continue to next candidate; event trigger/abort logic uses candidate count to avoid vetoing when at least one candidate is valid
- HFTrackEfficiency
  - Seed-counting now iterates SvtxTrackState entries instead of using TrackSeed::size_cluster_keys(); m_reco_track_silicon_seeds and m_reco_track_tpc_seeds default/unfilled values changed from 0 to -1
- KFParticle modules
  - Added verbosity-gated diagnostic printing and helper printSelectionCheck()
  - Minor API change: removed const from findTwoProngs()
  - TTree branch renames for BCO timing: Collision_BCO, GL1_BCO, last_GL1_BCO
  - Minor reordering and logging adjustments in event processing

Potential risk areas
- Reconstruction behavior: Enabling _require_intt changes track acceptance and vertexing results — validate physics and efficiency impacts before enabling in production.
- HFTrackEfficiency outputs: New seed-counting logic and defaulting to -1 can change QA/NTuple values and downstream analyses; verify ROOT outputs and comparisons to previous baseline.
- API/ABI: DecayFinder findDecay() return-type change requires that all callers be updated; missing updates could cause build/runtime issues.
- IO/NTuple compatibility: Branch renames (BCO → Collision_BCO/GL1_BCO/last_GL1_BCO) will break scripts expecting old names.
- Performance & thread-safety: Iterating SvtxTrackState for seed counts and added diagnostic logging may affect hot paths or multi-threaded contexts; profile and audit for contention/regressions.
- Logging/verbosity: Added verbose diagnostics are gated but may still produce heavy output at high verbosity—ensure not enabled in production workflows.

Possible future improvements
- Surface MVTX/INTT cluster requirements in central reconstruction configuration and documentation for consistent workflows.
- Add unit/integration tests for vertexing with/without INTT requirements, DecayFinder candidate-counting, and HFTrackEfficiency seed-count consistency.
- Provide an optimized seed-counting path (or cache) if profiling shows regressions from state iteration.
- Consolidate verbosity/diagnostic controls across KFParticle modules into a common logger or configuration.

Caveat
AI-generated summaries can be mistaken. Review the diffs and run targeted tests to confirm behavior before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->