### PR TITLE
add 8,80GeV pythia8 jets and update double interactions

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -49,35 +49,35 @@ my %proddesc = (
     "8" => "HF pythia8 Bottom",
     "9" => "HF pythia8 Charm D0",
     "10" => "HF pythia8 Bottom D0",
-    "11" => "JS pythia8 Jet ptmin = 30GeV",
-    "12" => "JS pythia8 Jet ptmin = 10GeV",
+    "11" => "JS pythia8 Jet ptmin = 30 GeV",
+    "12" => "JS pythia8 Jet ptmin = 10 GeV",
     "13" => "JS pythia8 Photon Jet",
     "14" => "Single Particles",
     "15" => "Special Productions",
     "16" => "HF pythia8 D0 Jets",
-    "17" => "HF pythia8 D0 pi-k Jets ptmin = 5GeV ",
-    "18" => "HF pythia8 D0 pi-k Jets ptmin = 12GeV",
-    "19" => "JS pythia8 Jet ptmin = 40GeV",
+    "17" => "HF pythia8 D0 pi-k Jets ptmin = 5 GeV ",
+    "18" => "HF pythia8 D0 pi-k Jets ptmin = 12 GeV",
+    "19" => "JS pythia8 Jet ptmin = 40 GeV",
     "20" => "hijing pAu (0-10fm) pileup 0-10fm",
-    "21" => "JS pythia8 Jet ptmin = 20GeV",
+    "21" => "JS pythia8 Jet ptmin = 20 GeV",
     "22" => "cosmic field on",
     "23" => "cosmic field off",
     "24" => "AMPT",
     "25" => "EPOS",
     "26" => "JS pythia8 Detroit (MB)",
-    "27" => "JS pythia8 Photonjet ptmin = 5GeV",
-    "28" => "JS pythia8 Photonjet ptmin = 10GeV",
-    "29" => "JS pythia8 Photonjet ptmin = 20GeV",
+    "27" => "JS pythia8 Photonjet ptmin = 5 GeV",
+    "28" => "JS pythia8 Photonjet ptmin = 10 GeV",
+    "29" => "JS pythia8 Photonjet ptmin = 20 GeV",
     "30" => "Herwig MB",
     "31" => "Herwig Jet ptmin = 10 GeV",
     "32" => "Herwig Jet ptmin = 30 GeV",
-    "33" => "JS pythia8 Jet ptmin = 15GeV",
-    "34" => "JS pythia8 Jet ptmin = 50GeV",
-    "35" => "JS pythia8 Jet ptmin = 70GeV",
-    "36" => "JS pythia8 Jet ptmin = 5GeV",
+    "33" => "JS pythia8 Jet ptmin = 15 GeV",
+    "34" => "JS pythia8 Jet ptmin = 50 GeV",
+    "35" => "JS pythia8 Jet ptmin = 70 GeV",
+    "36" => "JS pythia8 Jet ptmin = 5 GeV",
     "37" => "hijing O+O (0-15fm)",
-    "38" => "JS pythia8 Jet ptmin = 60GeV",
-    "39" => "JS pythia8 Jet ptmin = 12GeV",
+    "38" => "JS pythia8 Jet ptmin = 60 GeV",
+    "39" => "JS pythia8 Jet ptmin = 12 GeV",
     "40" => "Herwig Jet ptmin = 5 GeV",
     "41" => "Herwig Jet ptmin = 12 GeV",
     "42" => "Herwig Jet ptmin = 20 GeV",
@@ -85,7 +85,9 @@ my %proddesc = (
     "44" => "Herwig Jet ptmin = 50 GeV",
     "45" => "Herwig Photonjet ptmin = 5 GeV",
     "46" => "Herwig Photonjet ptmin = 10 GeV",
-    "47" => "Herwig Photonjet ptmin = 20 GeV"
+    "47" => "Herwig Photonjet ptmin = 20 GeV",
+    "48" => "JS pythia8 Jet ptmin = 8 GeV",
+    "49" => "JS pythia8 Jet ptmin = 80 GeV",
     );
 
 my %pileupdesc = (
@@ -319,6 +321,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet30";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -522,6 +529,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet40";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -569,6 +581,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet20";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -673,6 +690,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_PhotonJet5";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -744,6 +766,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_PhotonJet20";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -897,6 +924,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet50";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -1046,7 +1078,7 @@ if (defined $prodtype)
 	if (defined $double)
 	{
 	    $doubleok = 1;
-	    $filenamestring = "pythia8_Jet12_pythia8_Detroit";
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
 	}
 	if (! defined $nopileup)
 	{
@@ -1324,6 +1356,77 @@ if (defined $prodtype)
 		elsif ($embed eq "central")
 		{
 		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		else
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_20fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+	    }
+	    else
+	    {
+		$filenamestring = sprintf("%s%s",$filenamestring,$pp_pileupstring);
+	    }
+	}
+        $pileupstring = $pp_pileupstring;
+	&commonfiletypes();
+    }
+    elsif ($prodtype == 48)
+    {
+        $embedok = 1;
+	$filenamestring = "pythia8_Jet8";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
+	if (! defined $nopileup)
+	{
+	    if (defined $embed)
+	    {
+		if ($embed eq "pau")
+		{
+		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm%s",$filenamestring, $pAu_pileupstring);
+		}
+		elsif ($embed eq "central")
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		elsif ($embed eq "oo")
+		{
+		    $filenamestring = sprintf("%s_sHijing_OO_0_15fm%s",$filenamestring, $OO_pileupstring);
+		}
+		else
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_20fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+	    }
+	    else
+	    {
+		$filenamestring = sprintf("%s%s",$filenamestring,$pp_pileupstring);
+	    }
+	}
+        $pileupstring = $pp_pileupstring;
+	&commonfiletypes();
+    }
+        elsif ($prodtype == 49)
+    {
+        $embedok = 1;
+	$filenamestring = "pythia8_Jet80";
+	if (! defined $nopileup)
+	{
+	    if (defined $embed)
+	    {
+		if ($embed eq "pau")
+		{
+		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm%s",$filenamestring, $pAu_pileupstring);
+		}
+		elsif ($embed eq "central")
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		elsif ($embed eq "oo")
+		{
+		    $filenamestring = sprintf("%s_sHijing_OO_0_15fm%s",$filenamestring, $OO_pileupstring);
 		}
 		else
 		{

--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -87,7 +87,7 @@ my %proddesc = (
     "46" => "Herwig Photonjet ptmin = 10 GeV",
     "47" => "Herwig Photonjet ptmin = 20 GeV",
     "48" => "JS pythia8 Jet ptmin = 8 GeV",
-    "49" => "JS pythia8 Jet ptmin = 80 GeV",
+    "49" => "JS pythia8 Jet ptmin = 80 GeV"
     );
 
 my %pileupdesc = (


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds 8 and 80 GeV pythia8 jets. It also updates the available double interaction samples. No jenkins test: [skip-ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds new Pythia8 jet samples and expands double-interaction production support in the file catalog configuration script.

## Motivation

Support new lower and higher pT jet threshold measurements for sPHENIX analyses, and enable double-interaction studies (overlapping minimum-bias events) for a broader range of existing jet and photon-jet productions.

## Key Changes

- **New production types added:**
  - Type 48: Pythia8 jets with ptmin = 8 GeV (supports `--double` double-interaction mode)
  - Type 49: Pythia8 jets with ptmin = 80 GeV (standard production only)

- **Expanded double-interaction support:** Extended `--double` flag capability to production types 11, 19, 21, 27, 29, 34, and 39 using `sprintf`-based filename transformation to append `_pythia8_Detroit` suffix

- **Description metadata:** Added entries for types 48 and 49 in `%proddesc` dictionary with consistent GeV spacing formatting across all descriptions

- **Embedding and pileup:** Both new types support standard embedding modes (pau, central, oo) and pileup configuration options like existing jet samples

## Potential Risk Areas

- **File naming consistency:** Ensure downstream tools correctly parse the new `pythia8_Jet8` and `pythia8_Jet80` filenames and map them to appropriate reconstruction parameters
- **Double-interaction production:** Type 48 with `--double` flag generates `pythia8_Jet8_pythia8_Detroit` filenames; verify this naming matches physical data expectations and won't conflict with existing cataloging
- **Sample discovery:** Users must be aware of new production type IDs (48, 49) to request these samples

## Future Improvements

- Document the production type registry (mapping of type IDs to physics processes) in a human-readable reference
- Consider automation for consistent description formatting

**Note:** AI assistance was used to generate this summary. Please verify that the production type assignments and double-interaction capabilities align with experimental requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->