### PR TITLE
Update TrkrNtuplizer: refine ntuple filling and fix variable handling

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -1386,53 +1386,8 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
   }
 
   //-----------------------
-  // fill the Vertex NTuple
+  // fill the Vertex NTuple and fixed NaN placeholders 
   //-----------------------
- /* bool doit = true;
-  if (_ntp_vertex && doit)
-  {
-    if (Verbosity() > 1)
-    {
-      std::cout << "Filling ntp_vertex " << std::endl;
-      std::cout << "start vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << std::endl;
-      _timer->restart();
-    }
-    float fx_vertex[n_vertex::vtxsize];
-    for (float& i : fx_vertex)
-    {
-      i = 0;
-    }
-    //    SvtxVertexMap* vertexmap = nullptr;
-    //    vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
-    float vx = std::numeric_limits<float>::quiet_NaN();
-    float vy = std::numeric_limits<float>::quiet_NaN();
-    float vz = std::numeric_limits<float>::quiet_NaN();
-    float ntracks = std::numeric_limits<float>::quiet_NaN();
-    fx_vertex[vtxnvx] = vx;
-    fx_vertex[vtxnvy] = vy;
-    fx_vertex[vtxnvz] = vz;
-    fx_vertex[vtxnntracks] = ntracks;
-    if (Verbosity() > 1)
-    {
-      std::cout << " adding vertex data " << std::endl;
-    }
-    float* vertex_data = new float[((int) (n_info::infosize)) + n_event::evsize + n_vertex::vtxsize];
-    std::copy(fx_event, fx_event + n_event::evsize, vertex_data);
-    std::copy(fx_vertex, fx_vertex + n_vertex::vtxsize, vertex_data + n_event::evsize);
-    std::copy(fx_info, fx_info + ((int) (n_info::infosize)), vertex_data + n_event::evsize + n_vertex::vtxsize);
-    _ntp_vertex->Fill(vertex_data);
-    delete[] vertex_data;
-
-  }
-  if (Verbosity() > 1)
-  {
-    _timer->stop();
-    std::cout << "vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << std::endl;
-  }*/
-
-  //-----------------------
-  // Fix Nan placeholders for vertex variables
-  // //-----------------------
   bool doit = true;
   if (_ntp_vertex && doit)
   {

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -1388,7 +1388,7 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
   //-----------------------
   // fill the Vertex NTuple
   //-----------------------
-  bool doit = true;
+ /* bool doit = true;
   if (_ntp_vertex && doit)
   {
     if (Verbosity() > 1)
@@ -1402,11 +1402,8 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
     {
       i = 0;
     }
-
     //    SvtxVertexMap* vertexmap = nullptr;
-
     //    vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
-
     float vx = std::numeric_limits<float>::quiet_NaN();
     float vy = std::numeric_limits<float>::quiet_NaN();
     float vz = std::numeric_limits<float>::quiet_NaN();
@@ -1425,12 +1422,84 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
     std::copy(fx_info, fx_info + ((int) (n_info::infosize)), vertex_data + n_event::evsize + n_vertex::vtxsize);
     _ntp_vertex->Fill(vertex_data);
     delete[] vertex_data;
+
   }
   if (Verbosity() > 1)
   {
     _timer->stop();
     std::cout << "vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << std::endl;
+  }*/
+
+  //-----------------------
+  // Fix Nan placeholders for vertex variables
+  // //-----------------------
+  bool doit = true;
+  if (_ntp_vertex && doit)
+  {
+    if (Verbosity() > 1)
+    {
+      std::cout << "Filling ntp_vertex " << std::endl;
+      std::cout << "start vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << std::endl;
+      _timer->restart();
+    }
+
+    SvtxVertexMap* vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");
+
+    if (!vertexmap)
+    {
+      std::cout << PHWHERE << " WARNING: SvtxVertexMapActs not found. Writing no vertex entries for this event." << std::endl;
+    }
+    else
+    {
+      for (auto & iter : *vertexmap)
+      {
+        SvtxVertex* vertex = iter.second;
+        if (!vertex) { continue;
+}
+
+        float fx_vertex[n_vertex::vtxsize];
+        for (float& i : fx_vertex)
+        {
+          i = std::numeric_limits<float>::quiet_NaN();
+        }
+
+        fx_vertex[vtxnvertexID] = static_cast<float>(vertex->get_id());
+        fx_vertex[vtxnvx]       = vertex->get_x();
+        fx_vertex[vtxnvy]       = vertex->get_y();
+        fx_vertex[vtxnvz]       = vertex->get_z();
+        fx_vertex[vtxnntracks]  = static_cast<float>(vertex->size_tracks());
+        fx_vertex[vtxnchi2]     = vertex->get_chisq();
+        fx_vertex[vtxnndof]     = vertex->get_ndof();
+
+        if (Verbosity() > 1)
+        {
+          std::cout << " adding vertex data "
+                    << " id = " << vertex->get_id()
+                    << " vx = " << vertex->get_x()
+                    << " vy = " << vertex->get_y()
+                    << " vz = " << vertex->get_z()
+                    << " ntracks = " << vertex->size_tracks()
+                    << std::endl;
+        }
+
+        float* vertex_data = new float[((int) (n_info::infosize)) + n_event::evsize + n_vertex::vtxsize];
+        std::copy(fx_event, fx_event + n_event::evsize, vertex_data);
+        std::copy(fx_vertex, fx_vertex + n_vertex::vtxsize, vertex_data + n_event::evsize);
+        std::copy(fx_info, fx_info + ((int) (n_info::infosize)), vertex_data + n_event::evsize + n_vertex::vtxsize);
+
+        _ntp_vertex->Fill(vertex_data);
+        delete[] vertex_data;
+      }
+    }
   }
+
+  if (Verbosity() > 1)
+  {
+    _timer->stop();
+    std::cout << "vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << std::endl;
+  }
+
+
   //--------------------
   // fill the Hit NTuple
   //--------------------


### PR DESCRIPTION
[comment]: <> Fixed NaN placeholders for vertex variables

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? Bug Fix

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
PR Summary: TrkrNtuplizer — refine vertex ntuple filling and fix variable handling

Motivation / context
- Vertex ntuple output previously produced a single per-event entry filled with NaN placeholders for vertex observables, making vertex ntuples unusable for downstream analysis. This PR restores correct retrieval of reconstructed vertices and writes one ntuple entry per vertex so analyses receive actual vertex parameters.

Key changes
- Replace placeholder single-entry vertex fill with per-vertex filling from SvtxVertexMapActs.
- Retrieve SvtxVertexMap from node "SvtxVertexMapActs"; emit a warning and write zero vertex entries if the node is missing.
- For each non-null SvtxVertex: reset vertex buffer to quiet_NaN(), populate vertexID, vx/vy/vz, ntracks (size_tracks), chisq and ndof, then fill the NTuple once per vertex.
- Keep event/vertex/info buffers combined into the vertex ntuple row; allocate/deallocate vertex_data per vertex.
- Add verbose debugging output (Verbosity()>1) showing populated vertex parameters.
- Minor control/timing adjustments around the vertex processing block.

Potential risk areas
- Ntuple format/semantics: downstream analysis expecting one vertex row per event (possibly NaN when absent) must be updated to handle zero or multiple vertex entries per event.
- Event counting and normalization: events with no reconstructed vertices now produce zero rows (previously one NaN row), which can change normalization or event-based bookkeeping.
- Data volume and performance: writing one entry per vertex increases ntuple size and CPU cost; impact depends on typical vertex multiplicities.
- Thread-safety: no explicit thread-safety changes were introduced, but per-event per-vertex heap allocation/deallocation in a multi-threaded environment should be reviewed.
- Backward compatibility: existing analysis scripts and ntuple consumers may need schema/expectation updates.

Possible future improvements
- Add configurable vertex selection (e.g., minimum track count, quality cuts) before ntuple filling to reduce volume and improve analysis relevance.
- Reuse or pre-allocate vertex_data buffer to avoid per-vertex heap allocations and reduce overhead.
- Add validation checks (reasonable vertex position ranges, chi2/ndof sanity checks) and unit tests covering the absent-node and multi-vertex cases.
- Document the ntuple schema change in collaboration analysis notes and update downstream scripts.

Caveat
- This summary was generated with AI assistance. AI can make mistakes; please verify the code changes and their impacts against the actual diffs and run tests where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->