### PR TITLE
Migrating the coderabbit setting from webUI to code

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,142 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+tone_instructions: >-
+  Be respectful, concise, and educational. Assume physicist contributors. Prioritize correctness and
+  safety. Ignore purely stylistic issues and Minor/Trivial/Info items.
+reviews:
+  high_level_summary_instructions: >-
+    Write a concise PR summary for a scientific collaboration.
+
+    Include:
+
+    - Motivation / context
+
+    - Key changes (bullets)
+
+    - Potential risk areas (IO format changes, reconstruction behavior changes, thread-safety,
+    performance)
+
+    - Possible future improvements 
+
+
+    Add an emphasis that AI can make mistakes and use best judgment when reading 
+  estimate_code_review_effort: false
+  suggested_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: false
+  path_filters:
+    - '!**/build/**'
+    - '!**/install/**'
+    - '!**/*.root'
+    - '!**/*.pdf'
+    - '!**/*.png'
+    - '!**/*.jpg'
+    - '!**/*.gif'
+    - '!**/*.zip'
+    - '!**/*.tar.gz'
+    - '!**/*.so'
+    - '!**/*.dylib'
+    - '!**/*.a'
+    - '!**/*.o'
+  path_instructions:
+    - path: '**/*.{h,hpp,hxx,hh}'
+      instructions: >-
+        Focus on API clarity/stability, ownership semantics (RAII), and avoiding raw new/delete.
+
+        If interfaces change, ask for compatibility notes and any needed downstream updates.
+
+
+        Only raise Critical or Major findings.  Do not post minor style, formatting, naming, or
+        “nice-to-have” refactors.
+    - path: '**/*.{cc,cpp,cxx,c}'
+      instructions: >-
+        Prioritize correctness, memory safety, error handling, and thread-safety.
+
+        Flag hidden global state, non-const singletons, and unclear lifetime assumptions.
+
+
+        Only raise Critical or Major findings.  Do not post minor style, formatting, naming, or
+        “nice-to-have” refactors.
+    - path: '**/*.C'
+      instructions: Do NOT review these files
+    - path: '**/CMakeLists.txt'
+      instructions: |
+        Check for modern CMake target usage, correct scoping, and avoiding global flags.
+  auto_review:
+    ignore_title_keywords:
+      - WIP
+      - DRAFT
+      - DO NOT MERGE
+      - RFC
+  finishing_touches:
+    unit_tests:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: 'off'
+    title:
+      mode: 'off'
+    description:
+      mode: 'off'
+    issue_assessment:
+      mode: 'off'
+    custom_checks:
+      - mode: 'off'
+        name: Test plan present
+        instructions: >
+          Check that the PR description includes a "Testing" or "Test Plan" section with at least
+          one bullet.
+
+          Accept: unit test, integration test, or example macro/validation command.
+      - mode: 'off'
+        name: Physics/reco impact noted (if applicable)
+        instructions: >
+          If the PR changes reconstruction outputs, calibration constants, or simulation behavior,
+
+          ensure the description states expected analysis impact and whether reprocessing is
+          required.
+  tools:
+    swiftlint:
+      enabled: false
+    phpstan:
+      enabled: false
+    phpmd:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    detekt:
+      enabled: false
+    pmd:
+      enabled: false
+chat:
+  art: false
+  integrations:
+    jira:
+      usage: disabled
+    linear:
+      usage: disabled
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - CONTRIBUTING.md
+      - docs/**
+      - .github/*.md
+  learnings:
+    scope: global
+  jira:
+    usage: disabled
+code_generation:
+  docstrings:
+    path_instructions:
+      - path: '**/*.{h,hpp,hh,hxx,cc,cpp,cxx,C}'
+        instructions: >-
+          Use Doxygen-style documentation, Link to example caller function if available. ONLY add
+          docstrings where none exist. Do NOT modify, rewrite, or reformat any existing
+          docstrings/comments. If a function already has a docstring (even if incomplete), leave it
+          unchanged.
+issue_enrichment:
+  planning:
+    enabled: false
+    auto_planning:
+      enabled: false


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

As we passed the initial evaluation stage, we are moving the AI coder reviewer configuration for coderabbit.ai from their webUI to be managed as code at `/.coderabbit.yaml`.

The goal is that everyone _can_ propose changes to it via our nominal pull request process. And we can use our repo to track the change history to coderabbit configuration. 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context
This PR moves CodeRabbit AI code reviewer configuration from the coderabbit.ai web UI into a repository-managed `.coderabbit.yaml` file. This enables configuration changes to be proposed, reviewed, and tracked through normal pull request workflows rather than through the web interface, improving transparency and maintainability for the collaboration.

## Key Changes
- **Tone & Review Guidance**: Sets review instructions emphasizing respectful, concise, educational feedback tailored to physicist contributors, with focus on correctness and safety over stylistic issues
- **File-Type-Specific Review Rules**: 
  - Headers (`.h`, `.hpp`): Focus on API clarity, RAII patterns, and memory safety; report only Critical/Major findings
  - C/C++ sources (`.cc`, `.cpp`): Emphasize correctness, memory safety, thread-safety, and global state issues; report only Critical/Major findings
  - ROOT macros (`.C`): Disabled from review entirely
  - CMake: Checks for modern target usage and proper scoping
- **Build Artifacts Exclusion**: Excludes binary files, compiled objects, build directories, and large media files (PDF, images, archives) from review
- **Automated Checks**: Disables unit test validation, docstring/title/description auto-checks, and most lint integrations; requires custom checks for "Testing/Test Plan" sections and physics/reconstruction impact notes (currently set to `mode: 'off'`)
- **Reduced Integration Noise**: Disables chat features, Jira/Linear integration, and most knowledge-base enrichment to focus on core code review

## Potential Risk Areas
- **Disabled Custom Checks**: Test plan and physics impact detection are currently set to `mode: 'off'`, meaning they won't automatically be enforced. These should be monitored manually or re-enabled if adoption issues arise.
- **High Strictness on Source Files**: Filtering to only Critical/Major findings may miss important but non-critical issues (memory leaks, subtle thread-safety problems) in the complex reconstruction codebase.
- **AI Limitations**: CodeRabbit, like all AI tools, can misunderstand domain-specific physics constraints and may miss subtle errors in calibration logic or reconstruction algorithms. Human reviewers should exercise judgment.

## Possible Future Improvements
- Monitor CodeRabbit review quality and gradually lower thresholds to Major/Minor if coverage seems insufficient for a scientific codebase
- Re-enable custom checks for test plans and physics impact once tooling maturity is assessed
- Consider path-specific rules for critical physics modules (reconstruction, calibration) with lower severity thresholds
- Periodically review and refine path filters and file-type instructions based on contributor feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->