### PR TITLE
feat: felix-by-felix hot maps for INTT in sim

### DIFF
--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
@@ -273,7 +273,31 @@ int PHG4InttHitReco::InitRun(PHCompositeNode *topNode)
       m_HotChannelSet.insert(rawHotChannel);
     }
   }
+  // if there are multiple hot map files from e.g. the InttCalib module, run
+  // on a felix by felix basis
+  if (!m_localHotStripFiles.empty())
+  {
+    m_HotChannelSet.clear();
+    for (const auto &localHotStripFile : m_localHotStripFiles)
+    {
+      if (std::filesystem::exists(localHotStripFile))
+      {
+        CDBTTree cdbttree(localHotStripFile);
+        cdbttree.LoadCalibrations();
 
+        uint64_t N = cdbttree.GetSingleIntValue("size");
+        for (uint64_t n = 0; n < N; ++n)
+        {
+          InttNameSpace::RawData_s rawHotChannel;
+          rawHotChannel.felix_server = cdbttree.GetIntValue(n, "felix_server");
+          rawHotChannel.felix_channel = cdbttree.GetIntValue(n, "felix_channel");
+          rawHotChannel.chip = cdbttree.GetIntValue(n, "chip");
+          rawHotChannel.channel = cdbttree.GetIntValue(n, "channel");
+          m_HotChannelSet.insert(rawHotChannel);
+        }
+      }
+    }
+  }
   if (Verbosity() > 0)
   {
     std::cout<<"INTT simulation BadChannelMap : size = "<<m_HotChannelSet.size()<<"  ";

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.h
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include <intt/InttMapping.h>
 
@@ -44,7 +45,7 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
   void setHotStripMaskFile(const std::string& name) { m_hotStripFileName = name; }
 
   void setLocalHotStripMaskFile(const std::string& name) { m_localHotStripFileName = name; }
-
+  void setLocalStripMaskFiles(const std::string& name) { m_localHotStripFiles.push_back(name); }
  protected:
   std::string m_Detector = "INTT";
   std::string m_HitNodeName;
@@ -72,7 +73,8 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
   std::map<TrkrDefs::hitsetkey, unsigned int> m_hitsetkey_cnt{};  // counter for making ckeys form hitsetkeys
 
   std::string m_hotStripFileName = "INTT_HotMap";
-  std::string m_localHotStripFileName = ""; // default to empty: only use local file for testing purpose; if empty, use CDB file
+  std::vector<std::string> m_localHotStripFiles;
+  std::string m_localHotStripFileName = "";  // default to empty: only use local file for testing purpose; if empty, use CDB file
   typedef std::set<InttNameSpace::RawData_s> Set_t;
   Set_t m_HotChannelSet;
 


### PR DESCRIPTION
This PR adds the ability to read in the felix-by-felix hot/dead maps that are created as a part of the production by the `InttCalib` module into the INTT digitization. These files need to go into the CDB but at the moment this at least gives us the ability to read them into simulation to study acceptance loss. The default behavior is not changed


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation
The InttCalib module produces FELIX-by-FELIX hot/dead maps as CDB files that characterize detector inefficiencies. This PR enables INTT digitization in simulation to read these calibration files, allowing studies of acceptance loss due to known hot/dead channels. The feature is optional and does not change default behavior.

## Key Changes
- **New setter method**: `setLocalStripMaskFiles(const std::string& name)` accumulates multiple local hot strip mask file paths into a `std::vector<std::string> m_localHotStripFiles`
- **Extended InitRun logic**: When `m_localHotStripFiles` is populated, the code:
  - Clears the existing hot channel set
  - Iterates through each file in the list
  - Loads CDBTTree calibrations from each file
  - Reads per-record `felix_server`, `felix_channel`, `chip`, and `channel` values
  - Populates `m_HotChannelSet` with the union of all loaded records
- **Backward compatible**: Existing single-file mechanism (`m_localHotStripFileName`) remains unchanged

## Potential Risk Areas
1. **Hot channel set overwriting**: When using multiple files, the code clears `m_HotChannelSet` before reloading from the multi-file list, effectively overwriting any hot channels loaded via the prior single-file path. This could be unexpected if both mechanisms are configured simultaneously.
2. **File format assumptions**: The code assumes CDBTTree files contain specific integer fields (`felix_server`, `felix_channel`, `chip`, `channel`) and a `size` metadata field. Misformatted files could cause silent failures or runtime errors.
3. **Limited error handling**: The code only checks file existence but does not validate file format or handle loading errors gracefully.
4. **No thread-safety analysis visible**: No obvious synchronization for concurrent access to `m_HotChannelSet`, though this may be acceptable depending on module initialization order.

## Possible Future Improvements
- Explicit validation or logging of file format/integrity
- Error messaging when files are missing or improperly formatted
- Option to merge hot channels from both single-file and multi-file sources rather than replacing
- Documentation of expected CDBTTree schema for hot/dead map files

---
*Note: AI-generated code analysis may contain errors. Please verify critical logic, especially the hot channel set clearing behavior and file format expectations, during review.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->