### PR TITLE
add double interaction for pythia8 5GeV jets

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -995,6 +995,10 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet5";
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the selection of double interactions to the 5 GeV pythia8 jets, jenkins does not test this [skip-ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary: Add Double Interaction Support for Pythia8 5 GeV Jets

### Motivation / Context
Production type 36 (JS pythia8 Jet ptmin = 5 GeV) is being extended to support double interaction datasets. This brings the lower-threshold jet sample into line with other jet production types (ptmin = 10, 12, 20, 30, 40, 50 GeV, etc.) that already support double interaction configurations through the "Detroit" naming scheme.

### Key Changes
- **Modified:** `offline/framework/frog/CreateFileList.pl` (prodtype == 36 handling)
  - Unconditionally enables double interactions by setting `$doubleok = 1`
  - Unconditionally appends the `_pythia8_Detroit` suffix to dataset filenames for 5 GeV pythia8 jets
  - Uses a bare code block (rather than `if (defined $double)` conditional) to apply these settings

### Potential Risk Areas
- **Reconstruction behavior change:** Dataset filenames for 5 GeV pythia8 jets will now always include the `_pythia8_Detroit` suffix, affecting downstream file matching and dataset selection workflows regardless of explicit flag usage.
- **Flag behavior inconsistency:** This implementation departs from the standard conditional pattern used by all other jet production types (11, 12, 19, 20, 21, 27, 39, 48, etc.), which conditionally apply the Detroit suffix only when `-double` is explicitly specified. The unconditional application could cause unexpected behavior in scripts and workflows expecting the standard pattern.
- **Validation logic impact:** The script's double-interaction validation (line 1461) will no longer reject the `-double` flag for prodtype 36, potentially changing error handling and dataset selection behavior.

### Notes
- Jenkins does not test this change (marked with [skip-ci])
- **Caveat:** This summary is generated with AI assistance; carefully verify the unconditional flag setting and departure from established patterns in the codebase, particularly regarding whether the bare code block was intentional versus an `if (defined $double)` conditional that was intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->