### PR TITLE
add 60,80 and Detroit to double

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -91,7 +91,7 @@ my %proddesc = (
     );
 
 my %pileupdesc = (
-    "1" => "50kHz for Au+Au, 3MHz for p+p (default)",
+    "1" => "50kHz for Au+Au, 3MHz for p+p, 220kHz for O+O (default)",
     "2" => "25kHz for Au+Au",
     "3" => "10kHz for Au+Au",
     "4" => "1MHz for pp 100us streaming",
@@ -188,6 +188,7 @@ if ($pileup == 1)
     $AuAu_pileupstring = sprintf("_50kHz%s",$AuAu_bkgpileup);
     $pp_pileupstring = sprintf("_3MHz");
     $pAu_pileupstring = sprintf("_500kHz%s",$pAu_bkgpileup);
+    $OO_pileupstring = sprintf("_220kHz%s",$OO_bkgpileup);
 }
 elsif ($pileup == 2)
 {
@@ -661,6 +662,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Detroit";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -1046,6 +1052,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet60";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)
@@ -1416,6 +1427,11 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet80";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the latest double jet sims. Also sets the default pileup for OO to 220kHz (previously it returned no pileup files
 even without the -nop flag) [skip-ci]
## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request extends the file list creation script to support double-jet simulations with the "Detroit" configuration and improves O+O (Oxygen-Oxygen) collision support.

## Key Changes

- **Double-jet simulation support**: The `-double` flag now works with three additional production types:
  - Type 26: JS pythia8 Detroit (MB)
  - Type 38: JS pythia8 Jet ptmin = 60 GeV
  - Type 49: JS pythia8 Jet ptmin = 80 GeV
  
  When `-double` is specified for these types, the filename is appended with `_pythia8_Detroit`.

- **O+O pileup integration**: O+O collisions (Oxygen-Oxygen) are now explicitly included in the default pileup configuration (pileup=1) with a 220 kHz rate and 0-15 fm background pileup. This addresses an issue where O+O files were not being returned unless the `-nop` flag was used.

- **Updated pileup description**: The pileup selector "1" now displays: "50kHz for Au+Au, 3MHz for p+p, 220kHz for O+O (default)" to reflect the new O+O support.

## Potential Risk Areas

- **File catalog dependency**: The changes assume that files with the `_pythia8_Detroit` suffix exist in the file catalog for production types 26, 38, and 49. If these files are not yet available, users may encounter missing file errors.

- **Default behavior change**: O+O is now part of the default pileup configuration. Existing workflows expecting the old pileup defaults should be verified to ensure compatibility.

- **Filename collision risk**: The appended `_pythia8_Detroit` suffix could potentially conflict with other naming conventions if similar patterns are used elsewhere in the file catalog.

## Notes

**Please note**: AI-generated summaries can contain errors. Use your best judgment when reviewing the actual file changes to confirm the implementation details and assess potential impacts on file retrieval and reconstruction workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->