### PR TITLE
fix 5GeV selection

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -1001,6 +1001,7 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet5";
+	if (defined $double)
 	{
 	    $doubleok = 1;
 	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
@@ -1423,7 +1424,7 @@ if (defined $prodtype)
         $pileupstring = $pp_pileupstring;
 	&commonfiletypes();
     }
-        elsif ($prodtype == 49)
+    elsif ($prodtype == 49)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Jet80";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
cut and paste error for the pythia8 5 GeV jet selection (it stopped to work, no bad files were selected)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation/Context
This PR fixes critical bugs in the `CreateFileList.pl` script that were preventing proper file selection for specific pythia8 jet production types. The script is responsible for identifying and cataloging production files in the sPHENIX file catalog database. Production type 36 corresponds to pythia8 Jet samples with ptmin = 5 GeV threshold.

## Key Changes
- **Production type 36 (pythia8 Jet ptmin = 5 GeV)**: Fixed incomplete `if (defined $double)` block. The original code was missing the body of the conditional—it lacked the `$doubleok = 1` flag setting and the critical `_pythia8_Detroit` suffix appending logic, and also bypassed all pileup handling by immediately calling `&commonfiletypes()`. The corrected version now properly handles double-interaction overlay selection and pileup configuration.

- **Production type 49 (pythia8 Jet ptmin = 80 GeV)**: Fixed `elsif` statement indentation/positioning within the main production-type dispatch if/elsif ladder to ensure the branch is correctly recognized during control flow.

## Potential Risk Areas
- **Reconstruction behavior**: These fixes restore critical file selection logic. Production types 36 and 49 would have been non-functional with no files selected when requested, especially with the `--double` flag for Detroit overlay simulations. Users running analyses on 5 GeV and 80 GeV jet samples may need to re-run file list generation.
- **File catalog dependencies**: The script relies on correct database query results; any malformed production names would cascade through downstream file identification.

## Possible Future Improvements
- Add validation/testing of production type file selection to catch similar cut-and-paste errors
- Consider refactoring the long if/elsif chain into a data-driven structure (e.g., hash-based configuration) to reduce maintenance burden

**Note**: AI-assisted analysis was used in this summary. Please verify the technical details against the actual code review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->