### PR TITLE
handle missing gl1 packet

### DIFF
--- a/offline/packages/bcolumicount/BcoLumiReco.cc
+++ b/offline/packages/bcolumicount/BcoLumiReco.cc
@@ -77,6 +77,15 @@ int BcoLumiReco::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
     Packet *packet = evt->getPacket(14001);
+    if (!packet)
+    {
+      if (Verbosity() > 0)
+      {
+	std::cout << "no gl1 packet 14001" << std::endl;
+	evt->identify();
+      }
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
     uint64_t gtm_bco = packet->lValue(0, "BCO");
     if (Verbosity() > 1)
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
For some runs, the last GL1 event does not contain packet 14001 (or any other packet). This PR now checks the packet pointer for null and aborts if the 14001 packet is missing

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

The GL1 (Global Level 1) trigger packet (ID 14001) contains critical beam crossing order (BCO) information used for luminosity reconstruction. In some runs, the last GL1 event may not contain packet 14001, previously causing a null pointer dereference and crash during reconstruction.

## Key Changes

- **Added null pointer check** for GL1 packet 14001 in `BcoLumiReco::process_event()`
- **Diagnostic logging** when packet is missing (printed when Verbosity > 0):
  - Message: "no gl1 packet 14001"
  - Event identification details via `evt->identify()`
- **Graceful event abortion** via `Fun4AllReturnCodes::ABORTEVENT` to prevent segmentation fault

## Potential Risk Areas

- **Reconstruction behavior change**: Events missing the GL1 packet will now be skipped rather than causing a crash. This could affect the count of processed events and potentially luminosity calculations if missing packets occur frequently.
- **Silent data loss**: Events with missing packets are aborted; monitor logs to quantify impact on data quality.

## Possible Future Improvements

- Add metrics/counters to track frequency of missing GL1 packets across runs
- Implement fallback logic or alternative packet sources if applicable
- Distinguish between packet-missing and other abort conditions for better diagnostics

---
*Note: AI-generated analysis; please verify against actual code behavior and confirm reconstruction impact.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->