### PR TITLE
check if Sumw2() has been called already for histo registration

### DIFF
--- a/offline/framework/fun4all/Fun4AllHistoManager.cc
+++ b/offline/framework/fun4all/Fun4AllHistoManager.cc
@@ -237,7 +237,11 @@ bool Fun4AllHistoManager::registerHisto(const std::string &hname, TNamed *h1d, c
   // For histograms, enforce error calculation and propagation
   if (h1d->InheritsFrom("TH1"))
   {
-    static_cast<TH1 *>(h1d)->Sumw2();// NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+    TH1 *h = static_cast<TH1 *>(h1d); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+    if (h->GetSumw2N() == 0)
+    {
+      h->Sumw2();
+    }
   }
 
   return true;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The HistoManager calls TH1->Sumw2() for each histogram during registration. If that had already been done for a histogram it resulted in a warning: Warning in <TH1F::Sumw2>: Sum of squares of weights structure already created
Now it checks if Sumw2() had been executed for that histogram 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## sPHENIX Collaboration - Pull Request Summary

### Motivation / Context
The HistoManager module previously called `TH1::Sumw2()` unconditionally for every histogram during registration. When histograms had already initialized their sum-of-squares error storage through prior `Sumw2()` calls, this produced the ROOT warning: "Warning in <TH1F::Sumw2>: Sum of squares of weights structure already created". While benign, this warning clutters output and creates unnecessary noise in logs, especially in production analysis environments.

### Key Changes
- **Modified `Fun4AllHistoManager::registerHisto()` method**: Now conditionally initializes histogram error bookkeeping
- **Guard check added**: Before calling `Sumw2()`, the code checks `GetSumw2N() == 0` to verify that sum-of-squares storage has not already been initialized
- **Scope**: Applied to `TH1` objects and their derived classes

### Potential Risk Areas
- **Minimal**: This is a purely defensive check with no functional behavior change—histograms obtain proper error bookkeeping either way, via existing initialization or this call
- **Edge cases**: Should work transparently with histogram subclasses; behavior depends on correct ROOT implementation of `GetSumw2N()`

### Possible Future Improvements
- Consider applying similar guard checks to other unconditional ROOT histogram initialization calls
- Document expected histogram initialization state in registration API documentation

---
**Note**: AI-generated summaries can contain errors. Please verify key technical details against the actual code changes when reviewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->