### PR TITLE
add eta pt>3GeV

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -87,7 +87,8 @@ my %proddesc = (
     "46" => "Herwig Photonjet ptmin = 10 GeV",
     "47" => "Herwig Photonjet ptmin = 20 GeV",
     "48" => "JS pythia8 Jet ptmin = 8 GeV",
-    "49" => "JS pythia8 Jet ptmin = 80 GeV"
+    "49" => "JS pythia8 Jet ptmin = 80 GeV",
+    "50" => "JS pythia8 Detroit eta ptmin = 3 GeV"
     );
 
 my %pileupdesc = (
@@ -1433,6 +1434,39 @@ if (defined $prodtype)
 	    $doubleok = 1;
 	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
 	}
+	if (! defined $nopileup)
+	{
+	    if (defined $embed)
+	    {
+		if ($embed eq "pau")
+		{
+		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm%s",$filenamestring, $pAu_pileupstring);
+		}
+		elsif ($embed eq "central")
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		elsif ($embed eq "oo")
+		{
+		    $filenamestring = sprintf("%s_sHijing_OO_0_15fm%s",$filenamestring, $OO_pileupstring);
+		}
+		else
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_20fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+	    }
+	    else
+	    {
+		$filenamestring = sprintf("%s%s",$filenamestring,$pp_pileupstring);
+	    }
+	}
+        $pileupstring = $pp_pileupstring;
+	&commonfiletypes();
+    }
+    elsif ($prodtype == 50)
+    {
+        $embedok = 1;
+	$filenamestring = "pythia8_Eta3";
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the new pythia8 Detroit with eta's > 3GeV as type 50, jenkins does not test this anyway: skipping jenkins run [skip-ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary: Add Eta > 3 GeV Pythia8 Production Type

**Motivation/Context:**  
This PR extends the sPHENIX file catalog production type system to support a new Pythia8 Detroit event generation with an eta pseudorapidity cutoff of ptmin = 3 GeV. This complements existing high-pT jet production types and enables exploration of forward/backward detector regions.

**Key Changes:**
- **Production type 50 registration**: Added new descriptor "JS pythia8 Detroit eta ptmin = 3 GeV" to the production description mapping (line 91)
- **Type 49 addition**: Simultaneously added "JS pythia8 Jet ptmin = 80 GeV" as type 49 (line 90)
- **Dispatch logic implementation**: Added handler for type 50 (lines 1466+) with:
  - Base dataset name `pythia8_Eta3`
  - Embedding support enabled (`$embedok = 1`)
  - Configurable pileup background: supports pAu (0-10 fm), central (0-488 fm), O+O (0-15 fm), and default Au+Au (0-20 fm) collision backgrounds
  - Fallback to pp pileup when embedding is not specified
  - Integration with existing file-type selection workflow via `commonfiletypes()` call

**Implementation Pattern:**  
Type 50 mirrors the structure of type 49 (80 GeV jets), inheriting the same embedding and pileup configuration logic. This ensures consistency with established production workflows.

**Potential Risk Areas:**
- **Dataset naming collision**: Verify that "pythia8_Eta3" does not conflict with existing dataset names in the file catalog
- **Embedding behavior**: Confirm the pileup background selections (pAu, central, oo) are appropriate for eta-biased events with different collision systems
- **Backward compatibility**: Type 50 assignment is sequential; confirm no existing productions are already registered as type 50

**Note on Summary Accuracy:**  
AI-generated summaries may contain errors. Please verify production type definitions, pileup string configurations, and embedding behavior align with intended physics specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->