### PR TITLE
47287 was the first run2pp physics run passing our 5minute cut

### DIFF
--- a/offline/framework/phool/RunnumberRange.h
+++ b/offline/framework/phool/RunnumberRange.h
@@ -6,7 +6,7 @@
  *
  * Each constant names the first or last run number (or a special marker) for a given data-taking period.
  *
- * @var RUN2PP_FIRST First Run 2 proton-proton physics run.
+ * @var RUN2PP_FIRST First Run 2 proton-proton physics run passing >=5m, >=100k evts.
  * @var RUN2PP_LAST  Last Run 2 proton-proton physics run.
  * @var RUN2AUAU_FIRST First Run 2 Au+Au (heavy-ion) physics run.
  * @var RUN2AUAU_LAST  Last Run 2 Au+Au (heavy-ion) physics run.
@@ -20,7 +20,7 @@
  */
 namespace RunnumberRange
 {
-  constexpr int RUN2PP_FIRST = 47286;
+  constexpr int RUN2PP_FIRST = 47287;
   constexpr int RUN2PP_LAST = 53880;
   constexpr int RUN2AUAU_FIRST = 54128;
   constexpr int RUN2AUAU_LAST = 54974;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR changes the first run2pp physics run from 47286 to 47287. Run 47286 is just 30 seconds long and is therefore not among the reconstructed run2pp runs

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Run 47286 was initially identified as the first Run 2 proton-proton physics run but was only 30 seconds in duration, failing to meet the established reconstruction criteria for Run 2 datasets. sPHENIX requires Run 2 proton-proton physics runs to satisfy a minimum 5-minute duration threshold and accumulate at least 100k events. Run 47287 is the first run that meets these quality standards.

## Key Changes

- Updated `RUN2PP_FIRST` constant in `RunnumberRange.h` from `47286` to `47287`
- This adjusts the run-number boundary definition for identifying Run 2 proton-proton physics data in downstream reconstruction and analysis code
- File: `offline/framework/phool/RunnumberRange.h` (+2/-2 lines)

## Potential Risk Areas

- **Reconstruction behavior**: Any code that filters or selects Run 2 proton-proton data using `RUN2PP_FIRST` will now exclude run 47286, potentially affecting:
  - Existing datasets indexed by run number ranges
  - Analysis workflows that explicitly include early runs in this period
  - Calibration procedures tied to specific run ranges
- **Data consistency**: Validation of run-selection logic across the collaboration's analysis framework should ensure consistency with this new boundary

## Possible Future Improvements

- Document run 47286's exclusion in data quality notes to ensure analysis teams are aware of the gap
- Consider automated validation checks in reconstruction that verify runs meet the stated quality criteria (≥5 minutes, ≥100k events)

---
**Note**: This summary is AI-generated and should be cross-checked against the actual code changes. Use your best judgment when reviewing critical data selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->