### PR TITLE
add type 51: ets meson pt > 8GeV

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -88,7 +88,8 @@ my %proddesc = (
     "47" => "Herwig Photonjet ptmin = 20 GeV",
     "48" => "JS pythia8 Jet ptmin = 8 GeV",
     "49" => "JS pythia8 Jet ptmin = 80 GeV",
-    "50" => "JS pythia8 Detroit eta ptmin = 3 GeV"
+    "50" => "JS pythia8 Detroit eta ptmin = 3 GeV",
+    "51" => "JS pythia8 Detroit eta ptmin = 8 GeV"
     );
 
 my %pileupdesc = (
@@ -1467,6 +1468,39 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Eta3";
+	if (! defined $nopileup)
+	{
+	    if (defined $embed)
+	    {
+		if ($embed eq "pau")
+		{
+		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm%s",$filenamestring, $pAu_pileupstring);
+		}
+		elsif ($embed eq "central")
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		elsif ($embed eq "oo")
+		{
+		    $filenamestring = sprintf("%s_sHijing_OO_0_15fm%s",$filenamestring, $OO_pileupstring);
+		}
+		else
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_20fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+	    }
+	    else
+	    {
+		$filenamestring = sprintf("%s%s",$filenamestring,$pp_pileupstring);
+	    }
+	}
+        $pileupstring = $pp_pileupstring;
+	&commonfiletypes();
+    }
+    elsif ($prodtype == 51)
+    {
+        $embedok = 1;
+	$filenamestring = "pythia8_Eta8";
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the pythia8 Detroit with eta meson pt >= 8GeV sample as type 51, no jenkins testing: [skip-ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

This PR adds support for a new physics production type to the sPHENIX simulation framework: pythia8-generated events with eta meson particles having transverse momentum ≥ 8 GeV. This complements the existing type 50 (eta ptmin = 3 GeV) and enables higher-pT eta meson studies.

## Key Changes

- **Added production type 51** to `CreateFileList.pl`:
  - Registered as "JS pythia8 Detroit eta ptmin = 8 GeV" in the production description hash
  - Base filename set to `pythia8_Eta8` for file cataloging
  - Supports pileup configuration with multiple embedding options (p+Au, Au+Au central, O+O collisions)
  - Follows established pattern used by type 50 (eta ptmin = 3 GeV)

## Risk Assessment

- **Low risk**: This is a straightforward addition of a new enumeration value following proven code patterns
- **No IO format changes**: Uses standard naming convention and file type handling
- **No reconstruction behavior changes**: Purely adds a new production type selection without altering analysis logic
- **No thread-safety issues**: Perl script executes sequentially for file list generation
- **Minimal performance impact**: Only affects file catalog lookups when type 51 is explicitly requested

## Notes

*AI-assisted analysis: Please review the actual physics parameters (eta ptmin = 8 GeV threshold, Detroit sample configuration) and verify they match intended physics goals. Confirm the filename conventions align with your collaboration's data organization standards.*

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4265)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->