### PR TITLE
CaloTowerStatus: Prioritize Direct URL Overrides

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -133,7 +133,7 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
       m_cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
       if (Verbosity() > 1)
       {
-        std::cout << "CaloTowerStatus::Init " << m_detector << "  hot map found " << m_calibName_hotMap << " Ddoing isHot" << std::endl;
+        std::cout << "CaloTowerStatus::Init " << m_detector << "  hot map found " << m_calibName_hotMap << " Doing isHot" << std::endl;
       }
     }
     else

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -81,22 +81,23 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   m_calibName_chi2 = m_detector + "_hotTowers_fracBadChi2";
   m_fieldname_chi2 = "fraction";
 
-  std::string calibdir = CDBInterface::instance()->getUrl(m_calibName_chi2);
-  if (!calibdir.empty())
+  std::string calibdir_chi2;
+  if (use_directURL_chi2)
   {
-     m_cdbttree_chi2 = new CDBTTree(calibdir);
-    if (Verbosity() > 0)
-    {
-       std::cout << "CaloTowerStatus::InitRun Found " << m_calibName_chi2 << "  Doing isHot for frac bad chi2" << std::endl;
-    }
+    calibdir_chi2 = m_directURL_chi2;
+    std::cout << "CaloTowerStatus::InitRun: Using direct URL override for chi2: " << calibdir_chi2 << std::endl;
+    m_cdbttree_chi2 = new CDBTTree(calibdir_chi2);
   }
   else
   {
-    if (use_directURL_chi2)
+    calibdir_chi2 = CDBInterface::instance()->getUrl(m_calibName_chi2);
+    if (!calibdir_chi2.empty())
     {
-      calibdir = m_directURL_chi2;
-      std::cout << "CaloTowerStatus::InitRun: Using default hotBadChi2" << calibdir << std::endl;
-      m_cdbttree_chi2 = new CDBTTree(calibdir);
+      m_cdbttree_chi2 = new CDBTTree(calibdir_chi2);
+      if (Verbosity() > 0)
+      {
+        std::cout << "CaloTowerStatus::InitRun Found " << m_calibName_chi2 << "  Doing isHot for frac bad chi2" << std::endl;
+      }
     }
     else 
     {
@@ -117,30 +118,31 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   m_fieldname_hotMap = "status";
   m_fieldname_z_score = m_detector + "_sigma";
 
-  calibdir = CDBInterface::instance()->getUrl(m_calibName_hotMap);
-  if (!calibdir.empty())
+  std::string calibdir_hotMap;
+  if (use_directURL_hotMap)
   {
-    m_cdbttree_hotMap = new CDBTTree(calibdir);
-    if (Verbosity() > 1)
-    {
-      std::cout << "CaloTowerStatus::Init " << m_detector << "  hot map found " << m_calibName_hotMap << " Ddoing isHot" << std::endl;
-    }
+    calibdir_hotMap = m_directURL_hotMap;
+    std::cout << "CaloTowerStatus::InitRun: Using direct URL override for hot map: " << calibdir_hotMap << std::endl;
+    m_cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
   }
   else
   {
-    if (m_doAbortNoHotMap)
+    calibdir_hotMap = CDBInterface::instance()->getUrl(m_calibName_hotMap);
+    if (!calibdir_hotMap.empty())
     {
-      std::cout << "CaloTowerStatus::InitRun: No hot map found for " << m_calibName_hotMap << " and abort mode is set. Exiting." << std::endl;
-      gSystem->Exit(1);
-    }
-    if (use_directURL_hotMap)
-    {
-      calibdir = m_directURL_hotMap;
-      std::cout << "CaloTowerStatus::InitRun: Using default map " << calibdir << std::endl;
-      m_cdbttree_hotMap = new CDBTTree(calibdir);
+      m_cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
+      if (Verbosity() > 1)
+      {
+        std::cout << "CaloTowerStatus::Init " << m_detector << "  hot map found " << m_calibName_hotMap << " Ddoing isHot" << std::endl;
+      }
     }
     else
     {
+      if (m_doAbortNoHotMap)
+      {
+        std::cout << "CaloTowerStatus::InitRun: No hot map found for " << m_calibName_hotMap << " and abort mode is set. Exiting." << std::endl;
+        gSystem->Exit(1);
+      }
       m_doHotMap = false;
       if (Verbosity() > 1)
       {

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -82,7 +82,7 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   m_fieldname_chi2 = "fraction";
 
   std::string calibdir_chi2;
-  if (use_directURL_chi2)
+  if (!m_directURL_chi2.empty())
   {
     calibdir_chi2 = m_directURL_chi2;
     std::cout << "CaloTowerStatus::InitRun: Using direct URL override for chi2: " << calibdir_chi2 << std::endl;
@@ -119,7 +119,7 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   m_fieldname_z_score = m_detector + "_sigma";
 
   std::string calibdir_hotMap;
-  if (use_directURL_hotMap)
+  if (!m_directURL_hotMap.empty())
   {
     calibdir_hotMap = m_directURL_hotMap;
     std::cout << "CaloTowerStatus::InitRun: Using direct URL override for hot map: " << calibdir_hotMap << std::endl;

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -71,13 +71,11 @@ class CaloTowerStatus : public SubsysReco
   void set_directURL_hotMap(const std::string &str)
   {
     m_directURL_hotMap = str;
-    use_directURL_hotMap = true;
     return;
   }
   void set_directURL_chi2(const std::string &str)
   {
     m_directURL_chi2 = str;
-    use_directURL_chi2 = true;
     return;
   }
   void set_doAbortNoHotMap(bool status = true)
@@ -121,8 +119,6 @@ class CaloTowerStatus : public SubsysReco
 
   std::string m_directURL_hotMap;
   std::string m_directURL_chi2;
-  bool use_directURL_hotMap{false};
-  bool use_directURL_chi2{false};
 
   float badChi2_treshold_const = {1e4};
   float badChi2_treshold_quadratic = {1./100};


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Updated the logic in `InitRun` to ensure that URLs provided via `set_directURL_hotMap` and `set_directURL_chi2` take precedence over the default `CDBInterface` lookups. Previously, the code checked the CDB first, which caused user-specified URLs to act only as fallbacks rather than overrides.

The logic now:
1. Checks for a user-specified direct URL.
2. Falls back to the `CDBInterface` if no direct URL is provided.
3. Aborts or disables the masking if neither is found.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CaloTowerStatus: Prioritize Direct URL Overrides

### Motivation
CaloTowerStatus previously queried the CDB first and treated user-provided direct URLs as fallbacks. That made it awkward to run with local calibration files when a CDB entry existed. This PR fixes the lookup order so explicit direct URLs reliably override CDB entries, enabling straightforward local testing and intended override behavior.

### Key Changes
- Direct-URL precedence: InitRun now checks the direct URL string members (m_directURL_chi2, m_directURL_hotMap) first; non-empty strings are used directly.
- Removed boolean flags: Eliminated use_directURL_chi2 and use_directURL_hotMap; presence of a non-empty direct URL string is now the single signal to use an override.
- CDB fallback: If no direct URL is provided, the code queries CDBInterface for the appropriate entry and constructs CDBTTree only when a URL is returned.
- Abort/disable behavior preserved: If neither a direct URL nor a CDB entry is found, behavior remains — abort if m_doAbortNoChi2 / m_doAbortNoHotMap are set; otherwise disable the corresponding masking and log the outcome.
- Logging improved: Clearer messages distinguish direct-URL usage, CDB lookups, and the fallback/abort paths.

### Potential Risk Areas
- IO/data formats: None — no changes to calibration file formats or downstream reconstruction objects; only the lookup source selection changed.
- Reconstruction behavior: Low risk — the same CDBTTree objects are produced when a source is available; behavior differs only in which source is chosen.
- Thread-safety: No new shared mutable state introduced; risk is unchanged.
- Performance: Negligible — simple string emptiness checks replace the previous boolean-flag logic.
- Configuration pitfalls: Users who previously relied on the boolean flags must ensure they provide non-empty direct URL strings; otherwise CDB will be consulted.

### Possible Future Improvements
- Validate direct-URL/file existence at InitRun and emit actionable errors (instead of only logging) to avoid silent misconfiguration.
- Add unit/integration tests covering direct-URL overrides, CDB fallbacks, and abort vs disable behavior.
- Consolidate and simplify related configuration handling to a single helper that returns the resolved URL (direct or CDB) to reduce duplication.

Notes
- Reviewer feedback favored removing boolean flags (to avoid a true flag with no filename); this PR implements that suggestion.
- AI-generated summaries can be imperfect — please review the diff to confirm behavior and messaging details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4266)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->