### PR TITLE
CaloTowerStatus: Refactor Hot Tower Identification

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -55,6 +55,8 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
     m_detector = "SEPD";
   }
 
+  CreateNodeTree(topNode);
+
   CDBTTree *cdbttree_chi2{nullptr};
 
   m_calibName_chi2 = m_detector + "_hotTowers_fracBadChi2";
@@ -139,8 +141,6 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
 
   delete cdbttree_chi2;
   delete cdbttree_hotMap;
-
-  CreateNodeTree(topNode);
 
   if (Verbosity() > 0)
   {

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -47,8 +47,6 @@ CaloTowerStatus::~CaloTowerStatus()
   {
     std::cout << "CaloTowerStatus::~CaloTowerStatus() Calling dtor" << std::endl;
   }
-  delete m_cdbttree_chi2;
-  delete m_cdbttree_hotMap;
 }
 
 //____________________________________________________________________________..
@@ -78,6 +76,8 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
     m_detector = "SEPD";
   }
 
+  CDBTTree *cdbttree_chi2 = nullptr;
+
   m_calibName_chi2 = m_detector + "_hotTowers_fracBadChi2";
   m_fieldname_chi2 = "fraction";
 
@@ -86,20 +86,20 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   {
     calibdir_chi2 = m_directURL_chi2;
     std::cout << "CaloTowerStatus::InitRun: Using direct URL override for chi2: " << calibdir_chi2 << std::endl;
-    m_cdbttree_chi2 = new CDBTTree(calibdir_chi2);
+    cdbttree_chi2 = new CDBTTree(calibdir_chi2);
   }
   else
   {
     calibdir_chi2 = CDBInterface::instance()->getUrl(m_calibName_chi2);
     if (!calibdir_chi2.empty())
     {
-      m_cdbttree_chi2 = new CDBTTree(calibdir_chi2);
+      cdbttree_chi2 = new CDBTTree(calibdir_chi2);
       if (Verbosity() > 0)
       {
         std::cout << "CaloTowerStatus::InitRun Found " << m_calibName_chi2 << "  Doing isHot for frac bad chi2" << std::endl;
       }
     }
-    else 
+    else
     {
       if (m_doAbortNoChi2)
       {
@@ -114,6 +114,8 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
     }
   }
 
+  CDBTTree *cdbttree_hotMap = nullptr;
+
   m_calibName_hotMap = m_detector + "_BadTowerMap";
   m_fieldname_hotMap = "status";
   m_fieldname_z_score = m_detector + "_sigma";
@@ -123,14 +125,14 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   {
     calibdir_hotMap = m_directURL_hotMap;
     std::cout << "CaloTowerStatus::InitRun: Using direct URL override for hot map: " << calibdir_hotMap << std::endl;
-    m_cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
+    cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
   }
   else
   {
     calibdir_hotMap = CDBInterface::instance()->getUrl(m_calibName_hotMap);
     if (!calibdir_hotMap.empty())
     {
-      m_cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
+      cdbttree_hotMap = new CDBTTree(calibdir_hotMap);
       if (Verbosity() > 1)
       {
         std::cout << "CaloTowerStatus::Init " << m_detector << "  hot map found " << m_calibName_hotMap << " Doing isHot" << std::endl;
@@ -148,7 +150,7 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
       {
         std::cout << "CaloTowerStatus::InitRun hot map info, " << m_calibName_hotMap << " not found, not doing isHot" << std::endl;
       }
-    }  
+    }
   }
 
   if (Verbosity() > 0)
@@ -170,7 +172,10 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   try
   {
     CreateNodeTree(topNode);
-    LoadCalib();
+    LoadCalib(cdbttree_chi2, cdbttree_hotMap);
+
+    delete cdbttree_chi2;
+    delete cdbttree_hotMap;
   }
   catch (std::exception &e)
   {
@@ -184,7 +189,7 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void CaloTowerStatus::LoadCalib()
+void CaloTowerStatus::LoadCalib(CDBTTree *cdbttree_chi2, CDBTTree *cdbttree_hotMap)
 {
   unsigned int ntowers = m_raw_towers->size();
   m_cdbInfo_vec.resize(ntowers);
@@ -193,14 +198,14 @@ void CaloTowerStatus::LoadCalib()
   {
     unsigned int key = m_raw_towers->encode_key(channel);
 
-    if (m_doHotChi2)
+    if (m_doHotChi2 && cdbttree_chi2)
     {
-      m_cdbInfo_vec[channel].fraction_badChi2 = m_cdbttree_chi2->GetFloatValue(key, m_fieldname_chi2);
+      m_cdbInfo_vec[channel].fraction_badChi2 = cdbttree_chi2->GetFloatValue(key, m_fieldname_chi2);
     }
-    if (m_doHotMap)
+    if (m_doHotMap && cdbttree_hotMap)
     {
-      m_cdbInfo_vec[channel].hotMap_val = m_cdbttree_hotMap->GetIntValue(key, m_fieldname_hotMap);
-      m_cdbInfo_vec[channel].z_score = m_cdbttree_hotMap->GetFloatValue(key, m_fieldname_z_score);
+      m_cdbInfo_vec[channel].hotMap_val = cdbttree_hotMap->GetIntValue(key, m_fieldname_hotMap);
+      m_cdbInfo_vec[channel].z_score = cdbttree_hotMap->GetFloatValue(key, m_fieldname_z_score);
     }
   }
 }

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -234,12 +234,30 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
     }
-    if (( hotMap_val == 1 || // dead
-          std::fabs(z_score) > z_score_threshold || // hot or cold
-          (hotMap_val == 3 && z_score >= -1 * z_score_threshold_default)) // cold part 2
-          && m_doHotMap)
+    if (m_doHotMap)
     {
-      m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
+      bool is_hot_tower = false;
+
+      // 1. Default behavior: simply rely on the hotMap value
+      if (z_score_threshold == z_score_threshold_default)
+      {
+        is_hot_tower = (hotMap_val != 0);
+      }
+      // 2. Custom behavior: evaluate based on the custom z_score threshold
+      else
+      {
+        bool is_dead = (hotMap_val == 1);
+        bool exceeds_zscore_limit = (std::abs(z_score) > z_score_threshold);                      // Captures both hot and cold by sigma
+        bool is_low_yield_cold = (hotMap_val == 3 && z_score >= -1 * z_score_threshold_default);  // Captures the mean-based cold towers
+
+        is_hot_tower = (is_dead || exceeds_zscore_limit || is_low_yield_cold);
+      }
+
+      // Apply the result
+      if (is_hot_tower)
+      {
+        m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
+      }
     }
     if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic),badChi2_treshold_max))
     {

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -8,27 +8,17 @@
 
 #include <ffamodules/CDBInterface.h>
 
-#include <ffaobjects/EventHeader.h>
-
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>    // for PHIODataNode
-#include <phool/PHNode.h>          // for PHNode
-#include <phool/PHNodeIterator.h>  // for PHNodeIterator
-#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>
-#include <phool/recoConsts.h>
 
 #include <TSystem.h>
 
+#include <algorithm>
 #include <cmath>
-#include <cstdlib>    // for exit
-#include <exception>  // for exception
-#include <iostream>   // for operator<<, basic_ostream
-#include <stdexcept>  // for runtime_error
+#include <iostream>  // for operator<<, basic_ostream
 
 //____________________________________________________________________________..
 CaloTowerStatus::CaloTowerStatus(const std::string &name)
@@ -41,19 +31,8 @@ CaloTowerStatus::CaloTowerStatus(const std::string &name)
 }
 
 //____________________________________________________________________________..
-CaloTowerStatus::~CaloTowerStatus()
-{
-  if (Verbosity() > 0)
-  {
-    std::cout << "CaloTowerStatus::~CaloTowerStatus() Calling dtor" << std::endl;
-  }
-}
-
-//____________________________________________________________________________..
 int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
 {
-  PHNodeIterator nodeIter(topNode);
-
   if (m_dettype == CaloTowerDefs::CEMC)
   {
     m_detector = "CEMC";
@@ -76,21 +55,19 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
     m_detector = "SEPD";
   }
 
-  CDBTTree *cdbttree_chi2 = nullptr;
+  CDBTTree *cdbttree_chi2{nullptr};
 
   m_calibName_chi2 = m_detector + "_hotTowers_fracBadChi2";
   m_fieldname_chi2 = "fraction";
 
-  std::string calibdir_chi2;
   if (!m_directURL_chi2.empty())
   {
-    calibdir_chi2 = m_directURL_chi2;
-    std::cout << "CaloTowerStatus::InitRun: Using direct URL override for chi2: " << calibdir_chi2 << std::endl;
-    cdbttree_chi2 = new CDBTTree(calibdir_chi2);
+    std::cout << "CaloTowerStatus::InitRun: Using direct URL override for chi2: " << m_directURL_chi2 << std::endl;
+    cdbttree_chi2 = new CDBTTree(m_directURL_chi2);
   }
   else
   {
-    calibdir_chi2 = CDBInterface::instance()->getUrl(m_calibName_chi2);
+    std::string calibdir_chi2 = CDBInterface::instance()->getUrl(m_calibName_chi2);
     if (!calibdir_chi2.empty())
     {
       cdbttree_chi2 = new CDBTTree(calibdir_chi2);
@@ -155,33 +132,16 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
 
   if (Verbosity() > 0)
   {
-    std::cout << "CaloTowerStatus::Init " << m_detector << "  doing hotBadChi2=" <<  std::boolalpha << m_doHotChi2 << " doing hot map=" << std::boolalpha << m_doHotMap << std::endl;
+    std::cout << "CaloTowerStatus::Init " << m_detector << "  doing hotBadChi2=" << std::boolalpha << m_doHotChi2 << " doing hot map=" << std::boolalpha << m_doHotMap << std::endl;
   }
 
-  PHNodeIterator iter(topNode);
+  LoadCalib(cdbttree_chi2, cdbttree_hotMap);
 
-  // Looking for the DST node
-  PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
-  if (!dstNode)
-  {
-    std::cout << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
-              << "DST Node missing, doing nothing." << std::endl;
-    exit(1);
-  }
-  try
-  {
-    CreateNodeTree(topNode);
-    LoadCalib(cdbttree_chi2, cdbttree_hotMap);
+  delete cdbttree_chi2;
+  delete cdbttree_hotMap;
 
-    delete cdbttree_chi2;
-    delete cdbttree_hotMap;
-  }
-  catch (std::exception &e)
-  {
-    std::cout << e.what() << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
+  CreateNodeTree(topNode);
+
   if (Verbosity() > 0)
   {
     topNode->print();
@@ -264,7 +224,7 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
         m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
       }
     }
-    if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic),badChi2_treshold_max))
+    if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
     }
@@ -283,10 +243,9 @@ void CaloTowerStatus::CreateNodeTree(PHCompositeNode *topNode)
   if (!m_raw_towers)
   {
     std::cout << Name() << "::" << m_detector.c_str() << "::" << __PRETTY_FUNCTION__
-              << " " << RawTowerNodeName << " Node missing, doing bail out!"
+              << " " << RawTowerNodeName << " Node missing, exiting!"
               << std::endl;
-    throw std::runtime_error(
-        "Failed to find " + RawTowerNodeName + " node in CaloTowerStatus::CreateNodes");
+    gSystem->Exit(1);
   }
 
   return;

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -238,10 +238,10 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
     {
       bool is_hot_tower = false;
 
-      // 1. Default behavior: simply rely on the hotMap value
+      // 1. Default behavior: rely on valid positive hotMap status codes only
       if (z_score_threshold == z_score_threshold_default)
       {
-        is_hot_tower = (hotMap_val != 0);
+        is_hot_tower = (hotMap_val > 0);
       }
       // 2. Custom behavior: evaluate based on the custom z_score threshold
       else

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -98,9 +98,6 @@ class CaloTowerStatus : public SubsysReco
  private:
   TowerInfoContainer *m_raw_towers{nullptr};
 
-  CDBTTree *m_cdbttree_chi2{nullptr};
-  CDBTTree *m_cdbttree_hotMap{nullptr};
-
   bool m_doHotChi2{true};
   bool m_doHotMap{true};
   bool m_doAbortNoHotMap{false};
@@ -127,7 +124,7 @@ class CaloTowerStatus : public SubsysReco
   float z_score_threshold = {5};
   float z_score_threshold_default = {5};
 
-  void LoadCalib();
+  void LoadCalib(CDBTTree *cdbttree_chi2, CDBTTree *cdbttree_hotMap);
 
   struct CDBInfo
   {

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -5,11 +5,8 @@
 
 #include "CaloTowerDefs.h"
 
-#include <calobase/TowerInfoContainer.h>  // for TowerInfoContainer, TowerIn...
-
 #include <fun4all/SubsysReco.h>
 
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -22,7 +19,7 @@ class CaloTowerStatus : public SubsysReco
  public:
   CaloTowerStatus(const std::string &name = "CaloTowerStatus");
 
-  ~CaloTowerStatus() override;
+  ~CaloTowerStatus() override = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -118,7 +115,7 @@ class CaloTowerStatus : public SubsysReco
   std::string m_directURL_chi2;
 
   float badChi2_treshold_const = {1e4};
-  float badChi2_treshold_quadratic = {1./100};
+  float badChi2_treshold_quadratic = {1. / 100};
   float badChi2_treshold_max = {1e8};
   float fraction_badChi2_threshold = {0.01};
   float z_score_threshold = {5};


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

- Added a logical split to handle the default behavior: if the z-score threshold is untouched, the code now relies strictly on the non-zero hotMap values.
- Refactored the complex if-statement for custom thresholds into an if/else block using descriptive boolean variables (`is_dead`,`exceeds_zscore_limit`, `is_low_yield_cold`) for better readability.
- Replaced the C-style `std::fabs` with the modern C++ standard `std::abs`.
- Guarded the entire evaluation block behind `m_doHotMap` to improve clarity.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# CaloTowerStatus: Refactor Hot Tower Identification

## Motivation / Context
Hot-tower identification previously used a dense conditional and kept CDBTTree objects as class members, which made the logic hard to read and increased memory lifetime of calibration trees. This change clarifies default vs. custom z-score handling, reduces memory usage by loading calibration into local caches, and improves readability and maintainability.

## Key changes
- Calibration loading and lifetime
  - Create CDBTTree objects locally in InitRun, pass them into LoadCalib(CDBTTree*, CDBTTree*), then delete them immediately after populating the in-memory m_cdbInfo_vec (reduces memory footprint).
  - Remove long-lived CDBTTree* members and default the destructor inline.
  - LoadCalib only reads chi2/hotMap fields when the corresponding m_doHot* flag is enabled and the provided CDBTTree* is non-null.

- Hot-map and hot-tower logic
  - Guard entire hot-map evaluation behind if (m_doHotMap).
  - Split behavior into explicit branches:
    - Default threshold path (z_score_threshold == z_score_threshold_default): mark tower hot only when hotMap_val > 0.
    - Custom threshold path: compute and use descriptive booleans:
      - is_dead = (hotMap_val == 1)
      - exceeds_zscore_limit = (std::abs(z_score) > z_score_threshold)
      - is_low_yield_cold = (hotMap_val == 3 && z_score >= -1 * z_score_threshold_default)
    - Mark tower hot if any boolean is true.
  - Replace std::fabs with std::abs.
  - Apply set_isHot(true) only when is_hot_tower is true.

- Minor control-flow change
  - InitRun now calls LoadCalib(...) and deletes local CDBTTree objects before CreateNodeTree(topNode).
  - CreateNodeTree now calls gSystem->Exit(1) when required tower node is missing (was previously throwing).

## Potential risk areas
- Reconstruction behavior
  - Hot-flagging semantics changed: previously any non-zero hotMap marked hot; now default path explicitly requires hotMap_val > 0 and custom path applies more selective rules. Downstream clustering, energy sums, and physics analyses may be affected — validate with regression plots.
- Threshold semantics
  - The custom low-yield/cold check references z_score_threshold_default in combination with a custom z_score_threshold. Confirm this mixed usage is intended.
- Calibration edge cases & IO
  - Missing or sentinel CDB entries are now interpreted differently (missing/misencoded values are less likely to be treated as hot). Ensure calibration authors expect this behavior.
  - No on-disk/format changes; interpretation at runtime changed only.
- Performance & memory
  - Memory usage during InitRun is reduced (good). No significant runtime perf regressions expected.
- API & tests
  - LoadCalib signature changed and CDBTTree members removed — update any internal tests or callers using the old signature.

## Possible future improvements
- Extract hotMap/z-score interpretation into a small helper / policy object for easier unit testing and per-detector policies.
- Add unit tests and validation plots comparing pre- and post-refactor classifications across detectors (CEMC, HCALIN, HCALOUT, ZDC, SEPD).
- Explicitly document hotMap value semantics and sentinel handling in code and calibration documentation; consider logging when calibration values are missing.
- Consider per-detector or per-run configurable thresholds.

Note: This summary was prepared with AI assistance — AI can make mistakes. Review the changes and validate classification behavior before deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4267)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->