### PR TITLE
Cppcheck 2.20

### DIFF
--- a/calibrations/calorimeter/calo_tower_slope/LiteCaloEval.cc
+++ b/calibrations/calorimeter/calo_tower_slope/LiteCaloEval.cc
@@ -14,7 +14,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <RtypesCore.h>  // for Double_t
+#include <Rtypes.h>  // for Double_t
 #include <TCanvas.h>
 #include <TF1.h>
 #include <TFile.h>
@@ -548,7 +548,7 @@ void LiteCaloEval::Get_Histos(const std::string &infile, const std::string &outf
 
       if (!heta_tempp && i == 0)
       {
-        std::cout << " warning hist " << hist_name_p.c_str() << " not found" << std::endl;
+        std::cout << " warning hist " << hist_name_p << " not found" << std::endl;
       }
 
       /// assign heta_tempp to array of tower histos

--- a/calibrations/framework/fun4cal/Fun4CalServer.cc
+++ b/calibrations/framework/fun4cal/Fun4CalServer.cc
@@ -660,7 +660,7 @@ bool Fun4CalServer::connectDB()
     }
     catch (odbc::SQLException &e)
     {
-      std::cout << "Cannot connect to " << database.c_str() << std::endl;
+      std::cout << "Cannot connect to " << database << std::endl;
       std::cout << e.getMessage() << std::endl;
       std::cout << "countdown: " << countdown << std::endl;
       countdown--;
@@ -673,7 +673,7 @@ bool Fun4CalServer::connectDB()
     std::cout << "could not connect to DB after 10 tries in 1000 secs, giving up" << std::endl;
     exit(-1);
   }
-  std::cout << "connected to " << database.c_str() << " database." << std::endl;
+  std::cout << "connected to " << database << " database." << std::endl;
   return true;
 }
 //---------------------------------------------------------------------
@@ -1349,7 +1349,7 @@ int Fun4CalServer::SyncCalibTimeStampsToOnCal(const CalReco *calibrator, const s
   }
   catch (odbc::SQLException &e)
   {
-    std::cout << "Cannot connect to " << database.c_str() << std::endl;
+    std::cout << "Cannot connect to " << database << std::endl;
     std::cout << e.getMessage() << std::endl;
     return -1;
   }
@@ -1511,7 +1511,7 @@ int Fun4CalServer::SyncOncalTimeStampsToRunDB(const int commit)
   }
   catch (odbc::SQLException &e)
   {
-    std::cout << "Cannot connect to " << database.c_str() << std::endl;
+    std::cout << "Cannot connect to " << database << std::endl;
     std::cout << e.getMessage() << std::endl;
     return -1;
   }
@@ -2322,7 +2322,7 @@ int Fun4CalServer::AdjustRichTimeStampForMultipleRuns()
     }
     catch (odbc::SQLException& e)
     {
-    std::cout << "Cannot connect to " << database.c_str() << std::endl;
+    std::cout << "Cannot connect to " << database << std::endl;
     std::cout << e.getMessage() << std::endl;
     return -1;
     }

--- a/calibrations/framework/fun4cal/Fun4CalServer.cc
+++ b/calibrations/framework/fun4cal/Fun4CalServer.cc
@@ -17,7 +17,7 @@
 
 #include <pdbcalbase/RunToTime.h>
 
-#include <RtypesCore.h>  // for Stat_t
+#include <Rtypes.h>  // for Stat_t
 #include <TDirectory.h>  // for TDirectoryAtomicAdapter
 #include <TFile.h>
 #include <TH1.h>

--- a/offline/QA/SimulationModules/QAG4SimulationKFParticle.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationKFParticle.cc
@@ -417,7 +417,7 @@ int QAG4SimulationKFParticle::load_nodes(PHCompositeNode *topNode)
   m_kfpContainer = findNode::getClass<KFParticle_Container>(topNode, m_mother_name + "_KFParticle_Container");
   if (!m_kfpContainer)
   {
-    std::cout << m_mother_name.c_str() << "_KFParticle_Container - Fatal Error - "
+    std::cout << m_mother_name << "_KFParticle_Container - Fatal Error - "
               << "unable to find DST node "
               << "G4_QA" << std::endl;
     assert(m_kfpContainer);

--- a/offline/framework/fun4all/Fun4AllHistoManager.cc
+++ b/offline/framework/fun4all/Fun4AllHistoManager.cc
@@ -126,7 +126,7 @@ int Fun4AllHistoManager::dumpHistos(const std::string &filename, const std::stri
   TFile hfile(theoutfile.c_str(), openmode.c_str(), creator.c_str());
   if (!hfile.IsOpen())
   {
-    std::cout << PHWHERE << " Could not open output file" << theoutfile.c_str() << std::endl;
+    std::cout << PHWHERE << " Could not open output file" << theoutfile << std::endl;
     return -1;
   }
   hfile.SetCompressionSettings(compress);

--- a/offline/framework/fun4allraw/mvtx_decoder/GBTLink.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/GBTLink.h
@@ -330,7 +330,7 @@ inline GBTLink::CollectedDataStatus GBTLink::collectROFCableData(/*const Mapping
                  ((gbtWord.activeLanes >> 6) & 0x7) == 0x7) )
           {
             log_error << "Expected all active lanes for links, but " << gbtWord.activeLanes << "found in HBF " << hbfEntry << ", " \
-              << gbtWord.asString().data() << std::endl;
+              << gbtWord.asString() << std::endl;
           }
         }
         else if (gbtWord.isTDH()) // TRIGGER DATA HEADER (TDH)

--- a/offline/framework/fun4allraw/mvtx_decoder/GBTWord.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/GBTWord.h
@@ -107,7 +107,7 @@ struct GBTWord {
     uint8_t data8[GBTWordLength]; // 80 bits GBT word
   };
 #pragma GCC diagnostic pop
-
+// cppcheck-suppress uninitMemberVar
   GBTWord() = default;
 
   /// check if the GBT Header corresponds to GBT payload header

--- a/offline/framework/fun4allraw/mvtx_decoder/GBTWord.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/GBTWord.h
@@ -104,10 +104,9 @@ struct GBTWord {
     }; // DIAGNOSTIC IB LANE
 
 
-    uint8_t data8[GBTWordLength]; // 80 bits GBT word
+    uint8_t data8[GBTWordLength]{}; // 80 bits GBT word
   };
 #pragma GCC diagnostic pop
-// cppcheck-suppress uninitMemberVar
   GBTWord() = default;
 
   /// check if the GBT Header corresponds to GBT payload header

--- a/offline/framework/fun4allraw/mvtx_decoder/PixelData.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/PixelData.h
@@ -40,7 +40,7 @@ class ChipPixelData
   ~ChipPixelData() = default;
   uint16_t getChipID() const { return mChipID; }
   const std::vector<PixelData>& getData() const { return mPixels; }
-  std::vector<PixelData>& getData() { return static_cast<std::vector<PixelData>&> (mPixels); }
+  std::vector<PixelData>& getData() { return mPixels; }
 
 //  void setROFlags(uint8_t f = 0) { mROFlags = f; }
   void setChipID(uint16_t id) { mChipID = id; }

--- a/offline/framework/fun4allraw/mvtx_decoder/PixelData.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/PixelData.h
@@ -40,7 +40,7 @@ class ChipPixelData
   ~ChipPixelData() = default;
   uint16_t getChipID() const { return mChipID; }
   const std::vector<PixelData>& getData() const { return mPixels; }
-  std::vector<PixelData>& getData() { return (std::vector<PixelData>&)mPixels; }
+  std::vector<PixelData>& getData() { return static_cast<std::vector<PixelData>&> (mPixels); }
 
 //  void setROFlags(uint8_t f = 0) { mROFlags = f; }
   void setChipID(uint16_t id) { mChipID = id; }

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -242,7 +242,7 @@ void CaloTowerStatus::CreateNodeTree(PHCompositeNode *topNode)
   m_raw_towers = findNode::getClass<TowerInfoContainer>(topNode, RawTowerNodeName);
   if (!m_raw_towers)
   {
-    std::cout << Name() << "::" << m_detector.c_str() << "::" << __PRETTY_FUNCTION__
+    std::cout << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
               << " " << RawTowerNodeName << " Node missing, exiting!"
               << std::endl;
     gSystem->Exit(1);

--- a/offline/packages/CaloReco/ClusterCDFCalculator.cc
+++ b/offline/packages/CaloReco/ClusterCDFCalculator.cc
@@ -5,9 +5,8 @@
 #include <TMatrixD.h>
 #include <TVectorD.h>
 
-#include <boost/format.hpp>
-
 #include <iostream>
+#include <format>
 
 ClusterCDFCalculator::~ClusterCDFCalculator()
 {
@@ -94,9 +93,9 @@ void ClusterCDFCalculator::LoadHistogramsAndMatrices()
   for (int binidx = 0; binidx < nBins; ++binidx)
   {
     // photon hist
-    std::string hD2_3x3_name_photon = (boost::format("h_photon_hD2_3x3_en%d") % binidx).str();
-    std::string hD2_5x5_name_photon = (boost::format("h_photon_hD2_5x5_en%d") % binidx).str();
-    std::string hD2_7x7_name_photon = (boost::format("h_photon_hD2_7x7_en%d") % binidx).str();
+    std::string hD2_3x3_name_photon = std::format("h_photon_hD2_3x3_en{}", binidx);
+    std::string hD2_5x5_name_photon = std::format("h_photon_hD2_5x5_en{}", binidx);
+    std::string hD2_7x7_name_photon = std::format("h_photon_hD2_7x7_en{}", binidx);
 
     file->GetObject(hD2_3x3_name_photon.c_str(), hD2_3x3_photon[binidx]);
     file->GetObject(hD2_5x5_name_photon.c_str(), hD2_5x5_photon[binidx]);
@@ -109,11 +108,11 @@ void ClusterCDFCalculator::LoadHistogramsAndMatrices()
     }
 
     TH1 *hD2mean3_photon{nullptr};
-    file->GetObject((boost::format("h_photon_hD2mean3_en%d") % binidx).str().c_str(), hD2mean3_photon);
+    file->GetObject(std::format("h_photon_hD2mean3_en{}", binidx).c_str(), hD2mean3_photon);
     TH1 *hD2mean5_photon{nullptr};
-    file->GetObject((boost::format("h_photon_hD2mean5_en%d") % binidx).str().c_str(), hD2mean5_photon);
+    file->GetObject(std::format("h_photon_hD2mean5_en{}", binidx).c_str(), hD2mean5_photon);
     TH1 *hD2mean7_photon{nullptr};
-    file->GetObject((boost::format("h_photon_hD2mean7_en%d") % binidx).str().c_str(), hD2mean7_photon);
+    file->GetObject(std::format("h_photon_hD2mean7_en{}", binidx).c_str(), hD2mean7_photon);
 
     if (!hD2mean3_photon || !hD2mean5_photon || !hD2mean7_photon)
     {
@@ -126,40 +125,40 @@ void ClusterCDFCalculator::LoadHistogramsAndMatrices()
 
     for (int i = 0; i < NMATRIX_3x3; ++i)
     {
-      std::string histName = (boost::format("h_photon_heratio_3x3_en%d_%d") % binidx % i).str();
+      std::string histName = std::format("h_photon_heratio_3x3_en{}_{}", binidx, i);
       file->GetObject(histName.c_str(), ratioHistograms_3x3_photon[binidx][i]);
       if (!ratioHistograms_3x3_photon[binidx][i])
       {
-        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: photon hist " << histName.c_str() << " is missing." << std::endl;
+        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: photon hist " << histName << " is missing." << std::endl;
         return;
       }
     }
     for (int i = 0; i < NMATRIX_5x5; ++i)
     {
-      std::string histName = (boost::format("h_photon_heratio_5x5_en%d_%d") % binidx % i).str();
+      std::string histName = std::format("h_photon_heratio_5x5_en{}_{}", binidx, i);
       file->GetObject(histName.c_str(), ratioHistograms_5x5_photon[binidx][i]);
       if (!ratioHistograms_5x5_photon[binidx][i])
       {
-        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: photon hist " << histName.c_str() << " is missing." << std::endl;
+        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: photon hist " << histName << " is missing." << std::endl;
         return;
       }
     }
     for (int i = 0; i < NMATRIX_7x7; ++i)
     {
-      std::string histName = (boost::format("h_photon_heratio_7x7_en%d_%d") % binidx % i).str();
+      std::string histName = std::format("h_photon_heratio_7x7_en{}_{}", binidx, i);
       file->GetObject(histName.c_str(), ratioHistograms_7x7_photon[binidx][i]);
       if (!ratioHistograms_7x7_photon[binidx][i])
       {
-        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: photon hist " << histName.c_str() << " is missing." << std::endl;
+        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: photon hist " << histName << " is missing." << std::endl;
         return;
       }
     }
     TH2 *hCovMatrix3x3_photon{nullptr};
-    file->GetObject((boost::format("h_photon_hCovMatrix3_en%d") % binidx).str().c_str(), hCovMatrix3x3_photon);
+    file->GetObject(std::format("h_photon_hCovMatrix3_en{}", binidx).c_str(), hCovMatrix3x3_photon);
     TH2 *hCovMatrix5x5_photon{nullptr};
-    file->GetObject((boost::format("h_photon_hCovMatrix5_en%d") % binidx).str().c_str(), hCovMatrix5x5_photon);
+    file->GetObject(std::format("h_photon_hCovMatrix5_en{}", binidx).c_str(), hCovMatrix5x5_photon);
     TH2 *hCovMatrix7x7_photon{nullptr};
-    file->GetObject((boost::format("h_photon_hCovMatrix7_en%d") % binidx).str().c_str(), hCovMatrix7x7_photon);
+    file->GetObject(std::format("h_photon_hCovMatrix7_en{}", binidx).c_str(), hCovMatrix7x7_photon);
 
     if (!hCovMatrix3x3_photon || !hCovMatrix5x5_photon || !hCovMatrix7x7_photon)
     {
@@ -200,9 +199,9 @@ void ClusterCDFCalculator::LoadHistogramsAndMatrices()
     }
 
     // pi0 hist
-    std::string hD2_3x3_name_pi0 = (boost::format("h_pi0_hD2_3x3_en%d") % binidx).str();
-    std::string hD2_5x5_name_pi0 = (boost::format("h_pi0_hD2_5x5_en%d") % binidx).str();
-    std::string hD2_7x7_name_pi0 = (boost::format("h_pi0_hD2_7x7_en%d") % binidx).str();
+    std::string hD2_3x3_name_pi0 = std::format("h_pi0_hD2_3x3_en{}", binidx);
+    std::string hD2_5x5_name_pi0 = std::format("h_pi0_hD2_5x5_en{}", binidx);
+    std::string hD2_7x7_name_pi0 = std::format("h_pi0_hD2_7x7_en{}", binidx);
 
     file->GetObject(hD2_3x3_name_pi0.c_str(), hD2_3x3_pi0[binidx]);
     file->GetObject(hD2_5x5_name_pi0.c_str(), hD2_5x5_pi0[binidx]);
@@ -215,11 +214,11 @@ void ClusterCDFCalculator::LoadHistogramsAndMatrices()
     }
 
     TH1 *hD2mean3_pi0{nullptr};
-    file->GetObject((boost::format("h_pi0_hD2mean3_en%d") % binidx).str().c_str(), hD2mean3_pi0);
+    file->GetObject(std::format("h_pi0_hD2mean3_en{}", binidx).c_str(), hD2mean3_pi0);
     TH1 *hD2mean5_pi0{nullptr};
-    file->GetObject((boost::format("h_pi0_hD2mean5_en%d") % binidx).str().c_str(), hD2mean5_pi0);
+    file->GetObject(std::format("h_pi0_hD2mean5_en{}", binidx).c_str(), hD2mean5_pi0);
     TH1 *hD2mean7_pi0{nullptr};
-    file->GetObject((boost::format("h_pi0_hD2mean7_en%d") % binidx).str().c_str(), hD2mean7_pi0);
+    file->GetObject(std::format("h_pi0_hD2mean7_en{}", binidx).c_str(), hD2mean7_pi0);
 
     if (!hD2mean3_pi0 || !hD2mean5_pi0 || !hD2mean7_pi0)
     {
@@ -232,40 +231,40 @@ void ClusterCDFCalculator::LoadHistogramsAndMatrices()
 
     for (int i = 0; i < NMATRIX_3x3; ++i)
     {
-      std::string histName = (boost::format("h_pi0_heratio_3x3_en%d_%d") % binidx % i).str();
+      std::string histName = std::format("h_pi0_heratio_3x3_en{}_{}", binidx, i);
       file->GetObject(histName.c_str(), ratioHistograms_3x3_pi0[binidx][i]);
       if (!ratioHistograms_3x3_pi0[binidx][i])
       {
-        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: pi0 hist " << histName.c_str() << " is missing." << std::endl;
+        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: pi0 hist " << histName << " is missing." << std::endl;
         return;
       }
     }
     for (int i = 0; i < NMATRIX_5x5; ++i)
     {
-      std::string histName = (boost::format("h_pi0_heratio_5x5_en%d_%d") % binidx % i).str();
+      std::string histName = std::format("h_pi0_heratio_5x5_en{}_{}", binidx, i);
       file->GetObject(histName.c_str(), ratioHistograms_5x5_pi0[binidx][i]);
       if (!ratioHistograms_5x5_pi0[binidx][i])
       {
-        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: pi0 hist " << histName.c_str() << " is missing." << std::endl;
+        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: pi0 hist " << histName << " is missing." << std::endl;
         return;
       }
     }
     for (int i = 0; i < NMATRIX_7x7; ++i)
     {
-      std::string histName = (boost::format("h_pi0_heratio_7x7_en%d_%d") % binidx % i).str();
+      std::string histName = std::format("h_pi0_heratio_7x7_en{}_{}", binidx, i);
       file->GetObject(histName.c_str(), ratioHistograms_7x7_pi0[binidx][i]);
       if (!ratioHistograms_7x7_pi0[binidx][i])
       {
-        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: pi0 hist " << histName.c_str() << " is missing." << std::endl;
+        std::cout << "ClusterCDFCalculator::LoadHistogramsAndMatrices() error: pi0 hist " << histName << " is missing." << std::endl;
         return;
       }
     }
     TH2 *hCovMatrix3x3_pi0{nullptr};
-    file->GetObject((boost::format("h_pi0_hCovMatrix3_en%d") % binidx).str().c_str(), hCovMatrix3x3_pi0);
+    file->GetObject(std::format("h_pi0_hCovMatrix3_en{}", binidx).c_str(), hCovMatrix3x3_pi0);
     TH2 *hCovMatrix5x5_pi0{nullptr};
-    file->GetObject((boost::format("h_pi0_hCovMatrix5_en%d") % binidx).str().c_str(), hCovMatrix5x5_pi0);
+    file->GetObject(std::format("h_pi0_hCovMatrix5_en{}", binidx).c_str(), hCovMatrix5x5_pi0);
     TH2 *hCovMatrix7x7_pi0{nullptr};
-    file->GetObject((boost::format("h_pi0_hCovMatrix7_en%d") % binidx).str().c_str(), hCovMatrix7x7_pi0);
+    file->GetObject(std::format("h_pi0_hCovMatrix7_en{}", binidx).c_str(), hCovMatrix7x7_pi0);
 
     if (!hCovMatrix3x3_pi0 || !hCovMatrix5x5_pi0 || !hCovMatrix7x7_pi0)
     {

--- a/offline/packages/jetbase/JetProbeMaker.cc
+++ b/offline/packages/jetbase/JetProbeMaker.cc
@@ -5,6 +5,7 @@
 #include "Jetv2.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNode.h>  // for PHNode
@@ -15,6 +16,7 @@
 #include <phool/phool.h>  // for PHWHERE
 
 #include <TRandom3.h>
+
 #include <fastjet/PseudoJet.hh>
 
 int JetProbeMaker::process_event(PHCompositeNode * /*topNode*/)
@@ -29,7 +31,7 @@ int JetProbeMaker::process_event(PHCompositeNode * /*topNode*/)
   fastjet::PseudoJet fjet{};
   fjet.reset_PtYPhiM(pt, eta, phi);
 
-  Jetv2 *jet = (Jetv2 *) _jets->add_jet();
+  Jetv2 *jet = static_cast<Jetv2 *> (_jets->add_jet());
   jet->set_px(fjet.px());
   jet->set_py(fjet.py());
   jet->set_pz(fjet.pz());

--- a/offline/packages/jetbase/JetProbeMaker.h
+++ b/offline/packages/jetbase/JetProbeMaker.h
@@ -19,7 +19,7 @@ class JetProbeMaker : public SubsysReco
 {
  public:
   JetProbeMaker(const std::string &name = "JetProbeMaker");
-  ~JetProbeMaker() override{};
+  ~JetProbeMaker() override = default;
 
   int process_event(PHCompositeNode * /*topNode*/) override;
   int InitRun(PHCompositeNode *topNode) override;

--- a/offline/packages/trackbase/MvtxEventInfov2.cc
+++ b/offline/packages/trackbase/MvtxEventInfov2.cc
@@ -140,12 +140,6 @@ unsigned int MvtxEventInfov2::get_number_L1s() const
   return mySet.size();
 }
 
-std::set<uint64_t> MvtxEventInfov2::get_strobe_BCOs() const
-{
-  std::set<uint64_t> mySet = m_strobe_BCOs;
-  return mySet;
-}
-
 std::set<uint64_t> MvtxEventInfov2::get_L1_BCOs() const
 {
   std::set<uint64_t> mySet;

--- a/offline/packages/trackbase/MvtxEventInfov2.h
+++ b/offline/packages/trackbase/MvtxEventInfov2.h
@@ -51,7 +51,7 @@ class MvtxEventInfov2 : public MvtxEventInfo
   unsigned int get_number_L1s() const override;
 
   // std::set<uint64_t> get_strobe_BCOs() const;
-  std::set<uint64_t> get_strobe_BCOs() const override;
+  std::set<uint64_t> get_strobe_BCOs() const override {return m_strobe_BCOs;}
   std::set<uint64_t> get_L1_BCOs() const override;
 
   std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t ival) const override;

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -49,6 +49,7 @@
 
 #include <omp.h>
 
+#include <bit>
 #include <cmath>
 #include <filesystem>
 #include <iostream>
@@ -60,7 +61,7 @@ namespace
 {
   // square
   template <class T>
-  inline constexpr T square(const T& x)
+  constexpr T square(const T& x)
   {
     return x * x;
   }
@@ -73,12 +74,6 @@ PHSimpleKFProp::PHSimpleKFProp(const std::string& name)
 {}
 
 //______________________________________________________
-int PHSimpleKFProp::End(PHCompositeNode* /*unused*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-//______________________________________________________
 int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
 {
   int ret = get_nodes(topNode);
@@ -89,7 +84,7 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
 
   // load magnetic field from node tree
   /* note: if field is not found it is created with default configuration, as defined in PHFieldUtility */
-  const auto field_map = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
+  auto *const field_map = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
   // alice kalman filter
   fitter = std::make_unique<ALICEKF>(_cluster_map, field_map, _min_clusters_per_track, _max_sin_phi, Verbosity());
@@ -104,7 +99,7 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
   fitter->setFixedClusterError(2, _fixed_clus_err.at(2));
 
   // properly set constField in ALICEKF, based on PHFieldConfig
-  const auto field_config = PHFieldUtility::GetFieldConfigNode(nullptr, topNode);
+  auto *const field_config = PHFieldUtility::GetFieldConfigNode(nullptr, topNode);
   if( field_config->get_field_config() == PHFieldConfig::kFieldUniform )
   { fitter->setConstBField(field_config->get_field_mag_z()); }
 
@@ -154,7 +149,7 @@ int PHSimpleKFProp::get_nodes(PHCompositeNode* topNode)
   }
 
   // tpc grometry
-  auto geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  auto *geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
   if (!geom_container)
   {
     std::cerr << PHWHERE << "ERROR: Can't find node TPCGEOMCONTAINER" << std::endl;
@@ -230,7 +225,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       }
 
       // if not a TPC track, ignore
-      auto track = _track_map->get(track_it);
+      auto *track = _track_map->get(track_it);
       const bool is_tpc = std::any_of(
         track->begin_cluster_keys(),
         track->end_cluster_keys(),
@@ -335,7 +330,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 
         if (finalchain.size() > kl.at(0).size())
         {
-          local_chains.push_back(std::move(finalchain));
+          local_chains.push_back(finalchain);
         }
         else
         {
@@ -899,7 +894,7 @@ bool PHSimpleKFProp::PropagateStep(
   double query_pt[3] = {new_tx, new_ty, new_tz};
   std::vector<long unsigned int> index_out(1);
   std::vector<double> distance_out(1);
-  int n_results = _kdtrees[next_layer]->knnSearch(&query_pt[0], 1, &index_out[0], &distance_out[0]);
+  int n_results = _kdtrees[next_layer]->knnSearch(&query_pt[0], 1, index_out.data(), distance_out.data());
 
   // if no results, then no cluster to add, but propagation is not necessarily done
   if (!n_results)
@@ -912,10 +907,9 @@ bool PHSimpleKFProp::PropagateStep(
     return true;
   }
   const std::vector<double>& point = _ptclouds[next_layer]->pts[index_out[0]];
-  //TrkrDefs::cluskey closest_ckey = (*(int64_t*) &point[3]);
   TrkrDefs::cluskey closest_ckey = std::bit_cast<int64_t>(point[3]);
   TrkrCluster* clusterCandidate = _cluster_map->findCluster(closest_ckey);
-  const auto candidate_globalpos = globalPositions.at(closest_ckey);
+  const auto &candidate_globalpos = globalPositions.at(closest_ckey);
   const double cand_x = candidate_globalpos(0);
   const double cand_y = candidate_globalpos(1);
   const double cand_z = candidate_globalpos(2);

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -912,7 +912,8 @@ bool PHSimpleKFProp::PropagateStep(
     return true;
   }
   const std::vector<double>& point = _ptclouds[next_layer]->pts[index_out[0]];
-  TrkrDefs::cluskey closest_ckey = (*((int64_t*) &point[3]));
+  //TrkrDefs::cluskey closest_ckey = (*(int64_t*) &point[3]);
+  TrkrDefs::cluskey closest_ckey = std::bit_cast<int64_t>(point[3]);
   TrkrCluster* clusterCandidate = _cluster_map->findCluster(closest_ckey);
   const auto candidate_globalpos = globalPositions.at(closest_ckey);
   const double cand_x = candidate_globalpos(0);

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -47,7 +47,6 @@ class PHSimpleKFProp : public SubsysReco
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
-  int End(PHCompositeNode* topNode) override;
 
   // noop
   void set_field_dir(const double)
@@ -141,8 +140,8 @@ class PHSimpleKFProp : public SubsysReco
   PositionMap PrepareKDTrees();
 
   bool TransportAndRotate(
-    double old_layer,
-    double new_layer,
+    double old_radius,
+    double new_radius,
     double& phi,
     GPUTPCTrackParam& kftrack,
     GPUTPCTrackParam::GPUTPCTrackFitParam& fp) const;
@@ -161,7 +160,7 @@ class PHSimpleKFProp : public SubsysReco
   // which means we have to have a way to directly pass a list of clusters in order to extend looping tracks
   std::vector<TrkrDefs::cluskey> PropagateTrack(TrackSeed* track, PropagationDirection direction, GPUTPCTrackParam& aliceSeed, const PositionMap& globalPositions) const;
   std::vector<TrkrDefs::cluskey> PropagateTrack(TrackSeed* track, std::vector<TrkrDefs::cluskey>& ckeys, PropagationDirection direction, GPUTPCTrackParam& aliceSeed, const PositionMap& globalPositions) const;
-  std::vector<std::vector<TrkrDefs::cluskey>> RemoveBadClusters(const std::vector<std::vector<TrkrDefs::cluskey>>& seeds, const PositionMap& globalPositions) const;
+  std::vector<std::vector<TrkrDefs::cluskey>> RemoveBadClusters(const std::vector<std::vector<TrkrDefs::cluskey>>& chains, const PositionMap& globalPositions) const;
 
   template <typename T>
   struct KDPointCloud

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -292,7 +292,7 @@ int PHTrackPruner::GetNodes(PHCompositeNode *topNode)
   _pruned_svtx_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _pruned_svtx_seed_map_name);
   if (!_pruned_svtx_seed_map)
   {
-    std::cout << "Creating node " << _pruned_svtx_seed_map_name.c_str() << std::endl;
+    std::cout << "Creating node " << _pruned_svtx_seed_map_name << std::endl;
     /// Get the DST Node
     PHNodeIterator iter(topNode);
     PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
@@ -234,7 +234,7 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
 #if XERCES_VERSION_MAJOR >= 3
   // DOM L3 as per Xerces 3.0 API
   xercesc::DOMLSSerializer* writer =
-      ((xercesc::DOMImplementationLS*) impl)->createLSSerializer();
+    static_cast<xercesc::DOMImplementationLS*>(impl)->createLSSerializer();
 
   xercesc::DOMConfiguration* dc = writer->getDomConfig();
   dc->setParameter(xercesc::XMLUni::fgDOMWRTFormatPrettyPrint, true);
@@ -242,8 +242,7 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
 #else
 
   xercesc::DOMWriter* writer =
-      ((xercesc::DOMImplementationLS*) impl)->createDOMWriter();
-
+    static_cast<xercesc::DOMImplementationLS*>(impl)->createDOMWriter();
   if (writer->canSetFeature(xercesc::XMLUni::fgDOMWRTFormatPrettyPrint, true))
     writer->setFeature(xercesc::XMLUni::fgDOMWRTFormatPrettyPrint, true);
 
@@ -273,7 +272,7 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
 #if XERCES_VERSION_MAJOR >= 3
     // DOM L3 as per Xerces 3.0 API
     xercesc::DOMLSOutput* theOutput =
-        ((xercesc::DOMImplementationLS*) impl)->createLSOutput();
+      static_cast<xercesc::DOMImplementationLS*>(impl)->createLSOutput();
     theOutput->setByteStream(myFormTarget);
     writer->write(doc, theOutput);
 #else

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.cc
@@ -77,7 +77,7 @@ PHG4ProcessMap::GetMCProcess(const G4VProcess* process) const
   {
     std::string text = "Unknown process code for ";
     text += process->GetProcessName();
-    std::cerr << "PHG4ProcessMap::GetCodes " << text.c_str() << std::endl;
+    std::cerr << "PHG4ProcessMap::GetCodes " << text << std::endl;
     return kPNoProcess;
   }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes the warnings from the new cppcheck version before we switch

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR applies targeted fixes across the codebase to address warnings raised by cppcheck 2.20 and to modernize some C++ usage. Changes are intended as non-breaking quality/maintenance fixes (casts, formatting, small refactors, safer initializations) rather than new features or algorithmic changes.

## Motivation / context

Prepare the repository for adoption of cppcheck 2.20 and reduce static-analysis noise by correcting or silencing flagged issues. The edits adopt safer, well-defined C++ idioms (C++20 where used) and improve code clarity for future maintenance.

## Key changes

- Modernized formatting and casts:
  - Replaced boost::format with C++20 std::format for histogram name construction (ClusterCDFCalculator).
  - Replaced C-style casts with static_cast and std::bit_cast where appropriate (examples: PHSimpleKFProp, JetProbeMaker, PixelData, PHG4GDMLWrite Xerces-LS calls).
- Logging and string streaming:
  - Many log/error messages now stream std::string objects directly instead of using .c_str().
- Initialization and safety:
  - Value-initialized GBTWord::data8 byte array to zeros to avoid uninitialized memory.
  - Replaced C-style cast of a vector reference with static_cast in mvtx::ChipPixelData::getData().
- API/implementation cleanups:
  - Move/inline small implementations (MvtxEventInfov2 getter moved inline in header).
  - Change trivial destructor to = default (JetProbeMaker).
  - Remove End(PHCompositeNode*) override from PHSimpleKFProp and corresponding declaration.
  - Several local-variable changes in PHSimpleKFProp: pointer vs value bindings, passing index/distance buffers via .data(), use of std::bit_cast for cluster key extraction.
- Minor refactors and whitespace/formatting changes across multiple files.

## Potential risk areas

- Build/toolchain:
  - std::format and std::bit_cast require C++20; CI/toolchains must support C++20 (libstdc++/libc++ and compiler). Verify build configurations and packaging.
- Semantic/behavior risks:
  - GBTWord::data8 zero-initialization changes default content of previously uninitialized memory. This is generally safer but could alter behavior of low-level decoding or code that (incorrectly) depended on indeterminate values—careful testing recommended.
  - Replacing pointer-reinterpretation with std::bit_cast is well-defined in C++20, but reviewers should confirm bit-level compatibility with prior behavior (endian/size assumptions).
  - Moving the MvtxEventInfov2 getter inline or changing copy/reference semantics should be checked for ABI/caller expectations.
  - Removing the PHSimpleKFProp::End override may affect code relying on that override to run cleanup—verify higher-level control flow.
- Thread-safety/performance:
  - No deliberate threading or algorithmic changes were made, but small changes (e.g., copying vs moving finalchain in PHSimpleKFProp) could impact performance or memory behavior in hot code paths—spot-check performance-critical paths.
- IO/reconstruction:
  - No intentional IO format or reconstruction-algorithm changes, but reviewers should validate histograms/name lookups (ClusterCDFCalculator) and KD-tree/cluster-key reconstruction codepaths.

## Suggested follow-ups / possible future improvements

- Enable cppcheck 2.20 in CI and run it repository-wide to catch remaining issues early.
- Add unit/integration tests for low-level decoding and KD-tree/cluster-key reconstruction to detect regressions from initialization or reinterpretation changes.
- Verify and document C++20 requirement in build/CI configs; consider feature-gating if older toolchains must be supported.
- Audit any remaining cppcheck suppressions and document rationale for future maintainers.

Note: This summary was produced with AI assistance. While file-level patterns and risks are reported based on the provided diffs and repository listing, automated analysis can make mistakes—please validate changes in code review (especially zero-initialization and bit-cast/reinterpretation areas).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->