### PR TITLE
New setters for lamination fitting code

### DIFF
--- a/offline/packages/tpccalib/TpcLaminationFitting.cc
+++ b/offline/packages/tpccalib/TpcLaminationFitting.cc
@@ -57,6 +57,13 @@ void TpcLaminationFitting::set_grid_dimensions(int phibins, int rbins)
   m_rbins = rbins;
 }
 
+//___________________________________________________________
+void TpcLaminationFitting::set_lam_grid_dimensions(int phibins, int rbins)
+{
+  m_lamPhiBins = phibins;
+  m_lamRBins = rbins;
+}
+
 //____________________________________________
 int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
 {
@@ -91,7 +98,7 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
 
       if(m_fieldOff)
       {
-        m_hLamination[l][s] = new TH2D((boost::format("hLamination%d_%s") %l %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("Lamination %d %s, #phi_{ideal}=%.2f;R [cm];#phi") %l %(s == 1 ? "North" : "South") %m_laminationIdeal[l][s]).str().c_str(), 200, 30, 80, 200, m_laminationIdeal[l][s] - 0.2, m_laminationIdeal[l][s] + 0.2);
+        m_hLamination[l][s] = new TH2D((boost::format("hLamination%d_%s") %l %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("Lamination %d %s, #phi_{ideal}=%.2f;R [cm];#phi") %l %(s == 1 ? "North" : "South") %m_laminationIdeal[l][s]).str().c_str(), m_lamRBins, 30, 80, m_lamPhiBins, m_laminationIdeal[l][s] - 0.2, m_laminationIdeal[l][s] + 0.2);
         m_fLamination[l][s] = new TF1((boost::format("fLamination%d_%s") %l %(s == 1 ? "North" : "South")).str().c_str(), "[0]+[1]", 30, 80);
         m_fLamination[l][s]->SetParameters(m_laminationOffset[l][s], m_laminationIdeal[l][s]);
         m_fLamination[l][s]->SetParLimits(0, -0.05, 0.05);
@@ -99,7 +106,7 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
       }
       else
       {
-        m_hLamination[l][s] = new TH2D((boost::format("hLamination%d_%s") %l %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("Lamination %d %s, #phi_{nominal}=%.2f;R [cm];#phi") %l %(s == 1 ? "North" : "South") %(m_laminationIdeal[l][s]+m_laminationOffset[l][s])).str().c_str(), 200, 30, 80, 200, m_laminationIdeal[l][s]+m_laminationOffset[l][s] - 0.2, m_laminationIdeal[l][s]+m_laminationOffset[l][s] + 0.2);
+        m_hLamination[l][s] = new TH2D((boost::format("hLamination%d_%s") %l %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("Lamination %d %s, #phi_{nominal}=%.2f;R [cm];#phi") %l %(s == 1 ? "North" : "South") %(m_laminationIdeal[l][s]+m_laminationOffset[l][s])).str().c_str(), m_lamRBins, 30, 80, m_lamPhiBins, m_laminationIdeal[l][s]+m_laminationOffset[l][s] - 0.2, m_laminationIdeal[l][s]+m_laminationOffset[l][s] + 0.2);
         m_fLamination[l][s] = new TF1((boost::format("fLamination%d_%s") %l %(s == 1 ? "North" : "South")).str().c_str(), "[3]+[0]*(1-exp(-[2]*(x-[1])))", 30, 80);
         m_fLamination[l][s]->SetParameters(-0.08, 38, 0.16, 0.0);
         m_fLamination[l][s]->SetParLimits(0, -0.02, 0.0);
@@ -394,6 +401,12 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
       continue;
     }
 
+    double weight = 1.0;
+    if(m_adcWeight)
+    {
+      weight = 1.0*cmclus->getAdc();
+    }
+
     
     //Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), cmclus->getZ());
     Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), (side ? 1.0 : -1.0));
@@ -408,7 +421,7 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
 
     TVector3 tmp_pos(pos[0], pos[1], pos[2]);
 
-    if(cmclus->getNLayers() > m_nLayerCut && cmclus->getSDWeightedLayer() > 0.5)
+    if(cmclus->getNLayers() > m_nLayerCut && (!m_useSDLayerCut || cmclus->getSDWeightedLayer() > 0.5))
     {
       for (int l = 0; l < 18; l++)
       {
@@ -426,12 +439,12 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
 	
       	if (phi2pi > shift - 0.2 && phi2pi < shift + 0.2)
 	      {
-	        m_hLamination[l][side]->Fill(tmp_pos.Perp(), phi2pi);
+	        m_hLamination[l][side]->Fill(tmp_pos.Perp(), phi2pi, weight);
 	      }
       }
     }
 
-    if(cmclus->getSDWeightedLayer() > 0.5)
+    if(m_useSDLayerCut && cmclus->getSDWeightedLayer() > 0.5)
     {
       continue;
     }
@@ -450,7 +463,7 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
       phi2pimod -= M_PI / 9;
     }
 
-    m_hPetal[side]->Fill(phi2pimod, tmp_pos.Perp());
+    m_hPetal[side]->Fill(phi2pimod, tmp_pos.Perp(), weight);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/tpccalib/TpcLaminationFitting.h
+++ b/offline/packages/tpccalib/TpcLaminationFitting.h
@@ -60,6 +60,12 @@ class TpcLaminationFitting : public SubsysReco
 
   void set_nLayerCut(unsigned int cut) { m_nLayerCut = cut; }
 
+  void set_useSDLayerCut(bool useCut) { m_useSDLayerCut = useCut; }
+
+  void set_adcWeight(bool useADC) { m_adcWeight = useADC; }
+
+  void set_lam_grid_dimensions(int phibins, int rbins);
+
   int InitRun(PHCompositeNode *topNode) override;
 
   int process_event(PHCompositeNode *topNode) override;
@@ -110,6 +116,8 @@ class TpcLaminationFitting : public SubsysReco
   //TH2 *scaleFactorMap[2]{nullptr};
 
   unsigned int m_nLayerCut{1};
+  bool m_useSDLayerCut{true};
+  bool m_adcWeight{false};
   
   bool m_useHeader{true};
 
@@ -147,6 +155,9 @@ class TpcLaminationFitting : public SubsysReco
   double m_dist{0};
   double m_rmse{};
   int m_nBins{0};
+
+  int m_lamPhiBins{200};
+  int m_lamRBins{200};
 
   int m_phibins{80};
   static constexpr float m_phiMin{0};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
New setter functions to allow for easy toggling of layer standard deviation cut and adc weighting of histograms. Also new function to set the number of phi and R bins of the lamination histograms. All setters default to the same settings as before.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation
This PR adds three new configurable setter methods to the TPC lamination fitting calibration code, enabling physics analysts to tune lamination histogram binning and adjust event selection and weighting strategies without code modifications. These settings control how lamination distortions are measured and corrected for the TPC detector's space charge effects. The changes maintain backward compatibility by preserving existing default behavior.

## Key Changes
- **Lamination histogram grid configuration**: New `set_lam_grid_dimensions(int phibins, int rbins)` setter allows customization of lamination histogram bin counts in the φ (azimuthal) and R (radial) dimensions (default: 200 bins each). Previously hardcoded, these dimensions are now applied during `InitRun()` for all 18 laminations on both TPC sides (lines 101, 109 in TpcLaminationFitting.cc).

- **Structured digit (SD) layer cut toggle**: New `set_useSDLayerCut(bool useCut)` setter enables/disables SD-layer-based filtering (default: `true` to maintain existing behavior). The logic is inverted from typical naming:
  - When `m_useSDLayerCut = true`: Clusters with high SD-weighted layer values (> 0.5) are **excluded** from petal histogram filling (line 248-250) but **included** in lamination filling (line 225)
  - When `m_useSDLayerCut = false`: All clusters pass through to petal histogram filling without SD filtering

- **ADC-weighted histogram filling**: New `set_adcWeight(bool useADC)` setter enables optional cluster ADC-value-based event weighting (default: `false`). When enabled, each cluster's ADC value is used as a weight when filling both lamination and petal histograms (lines 206-209, 243, 267).

- **Member variables added**: `m_useSDLayerCut`, `m_adcWeight`, `m_lamPhiBins`, and `m_lamRBins` with appropriate defaults.

## Potential Risk Areas
- **Non-intuitive SD-layer cut logic**: The `m_useSDLayerCut` flag performs different filtering for laminations (includes high-SD clusters) versus petal histograms (excludes high-SD clusters). This asymmetric behavior could lead to unexpected results if analysts misunderstand the intent.

- **Reconstruction behavior changes**: The conditional SD-layer filtering for petal histogram affects which clusters contribute to the global R-matching and overall distortion correction strategy, potentially impacting the final distortion maps when the flag is toggled.

- **ADC weighting impact**: The optional ADC weighting changes the statistical weight of events and could affect lamination fitting convergence, especially for events with very high or very low ADC values. Unvalidated ADC weighting configurations could bias the extracted corrections.

- **Histogram resolution sensitivity**: Different phi/R bin dimensions directly affect histogram granularity and fitting precision. Under-binned histograms may increase statistical noise in fits; over-binned histograms may lose spatial resolution of lamination features.

- **Silent configuration dependency**: Default-disabled features may lead to subtle behavior changes if users forget to enable ADC weighting when expected, or if different analyses use different `m_useSDLayerCut` settings without documentation.

## Possible Future Improvements
- Add getter methods to query current configuration state
- Clarify or rename `m_useSDLayerCut` to better convey the filtering logic (e.g., `m_filterHighSDClusters`)
- Provide validation or warning messages for extreme bin count choices (e.g., < 10 or > 1000 bins)
- Document the asymmetric SD-layer filtering behavior and rationale in code comments and configuration guides
- Add debug output or logging to track which configuration is active during initialization
- Consider extending configuration to other histogram parameters (bin ranges, axis scaling)

---
**Note**: This summary is AI-generated and may contain inaccuracies. The asymmetric SD-layer filtering logic (different behavior for laminations vs. petal histograms) warrants careful review with collaboration experts to confirm the intended physics behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->