### PR TITLE
added MbdCalib::Write_SlewCorr and MbdCalib::Save_CDB_URL

### DIFF
--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -7,6 +7,7 @@
 #ifndef ONLINE
 #include <ffamodules/CDBInterface.h>
 #include <cdbobjects/CDBTTree.h>
+#include <TNamed.h>
 #endif
 
 #include <phool/phool.h>
@@ -80,112 +81,112 @@ int MbdCalib::Download_All()
   if (!_rc->FlagExist("MBD_CALDIR"))
   {
     // Always load Status
-    std::string status_url = _cdb->getUrl("MBD_STATUS");
-    if ( ! status_url.empty() )
+    _cdb_urls["MBD_STATUS"] = _cdb->getUrl("MBD_STATUS");
+    if ( !_cdb_urls["MBD_STATUS"].empty() )
     {
       // if this doesn't exist, the status is assumed to be all good
-      Download_Status(status_url);
+      Download_Status(_cdb_urls["MBD_STATUS"]);
     }
     if (Verbosity() > 0)
     {
-      std::cout << "status_url " << status_url << std::endl;
+      std::cout << "MBD_STATUS url " << _cdb_urls["MBD_STATUS"] << std::endl;
     }
+
+    // note: sampmax and ped will be calculated on the fly if calibs don't exist
+    _cdb_urls["MBD_SAMPMAX"] = _cdb->getUrl("MBD_SAMPMAX");
+    if (Verbosity() > 0)
+    {
+      std::cout << "MBD_SAMPMAX url " << _cdb_urls["MBD_SAMPMAX"] << std::endl;
+    }
+    Download_SampMax(_cdb_urls["MBD_SAMPMAX"]);
 
     if ( !_rawdstflag )
     {
-      // sampmax and ped will be calculated on the fly if calibs don't exist
-      std::string sampmax_url = _cdb->getUrl("MBD_SAMPMAX");
+      _cdb_urls["MBD_PED"] = _cdb->getUrl("MBD_PED");
       if (Verbosity() > 0)
       {
-        std::cout << "sampmax_url " << sampmax_url << std::endl;
+        std::cout << "MBD_PED url " << _cdb_urls["MBD_PED"] << std::endl;
       }
-      Download_SampMax(sampmax_url);
+      Download_Ped(_cdb_urls["MBD_PED"]);
 
-      std::string ped_url = _cdb->getUrl("MBD_PED");
-      if (Verbosity() > 0)
-      {
-        std::cout << "ped_url " << ped_url << std::endl;
-      }
-      Download_Ped(ped_url);
-
-      std::string pileup_url = _cdb->getUrl("MBD_PILEUP");
-      if ( pileup_url.empty() )
+      _cdb_urls["MBD_PILEUP"] = _cdb->getUrl("MBD_PILEUP");
+      if ( _cdb_urls["MBD_PILEUP"].empty() )
       {
         std::cerr << "ERROR, MBD_PILEUP missing" << std::endl;
         return -1;
       }
       if (Verbosity() > 0)
       {
-        std::cout << "pileup_url " << pileup_url << std::endl;
+        std::cout << "MBD_PILEUP url " << _cdb_urls["MBD_PILEUP"] << std::endl;
       }
-      Download_Pileup(pileup_url);
+      Download_Pileup(_cdb_urls["MBD_PILEUP"]);
 
       if (do_templatefit)
       {
-        std::string shape_url = _cdb->getUrl("MBD_SHAPES");
-        if ( shape_url.empty() )
+        _cdb_urls["MBD_SHAPES"] = _cdb->getUrl("MBD_SHAPES");
+        if ( _cdb_urls["MBD_SHAPES"].empty() )
         {
           std::cerr << "ERROR, MBD_SHAPES missing" << std::endl;
           return -1;
         }
         if (Verbosity() > 0)
         {
-          std::cout << "shape_url " << shape_url << std::endl;
+          std::cout << "MBD_SHAPES url " << _cdb_urls["MBD_SHAPES"] << std::endl;
         }
-        Download_Shapes(shape_url);
+        Download_Shapes(_cdb_urls["MBD_SHAPES"]);
       }
     }
 
     if ( !_fitsonly )
     {
-      std::string qfit_url = _cdb->getUrl("MBD_QFIT");
+      _cdb_urls["MBD_QFIT"] = _cdb->getUrl("MBD_QFIT");
       if (Verbosity() > 0)
       {
-        std::cout << "qfit_url " << qfit_url << std::endl;
+        std::cout << "MBD_QFIT url " << _cdb_urls["MBD_QFIT"] << std::endl;
       }
-      Download_Gains(qfit_url);
+      Download_Gains(_cdb_urls["MBD_QFIT"]);
 
-      std::string tt_t0_url = _cdb->getUrl("MBD_TT_T0");
+      _cdb_urls["MBD_TT_T0"] = _cdb->getUrl("MBD_TT_T0");
       if ( Verbosity() > 0 )
       {
-        std::cout << "tt_t0_url " << tt_t0_url << std::endl;
+        std::cout << "MBD_TT_T0 url " << _cdb_urls["MBD_TT_T0"] << std::endl;
       }
-      Download_TTT0(tt_t0_url);
+      Download_TTT0(_cdb_urls["MBD_TT_T0"]);
 
-      std::string tq_t0_url = _cdb->getUrl("MBD_TQ_T0");
+      _cdb_urls["MBD_TQ_T0"] = _cdb->getUrl("MBD_TQ_T0");
       if (Verbosity() > 0)
       {
-        std::cout << "tq_t0_url " << tq_t0_url << std::endl;
+        std::cout << "MBD_TQ_T0 url " << _cdb_urls["MBD_TQ_T0"] << std::endl;
       }
-      Download_TQT0(tq_t0_url);
+      Download_TQT0(_cdb_urls["MBD_TQ_T0"]);
 
-      std::string t0corr_url = _cdb->getUrl("MBD_T0CORR");
+      _cdb_urls["MBD_T0CORR"] = _cdb->getUrl("MBD_T0CORR");
       if ( Verbosity() > 0 )
       {
-        std::cout << "t0corr_url " << t0corr_url << std::endl;
+        std::cout << "MBD_T0CORR url " << _cdb_urls["MBD_T0CORR"] << std::endl;
       }
-      Download_T0Corr(t0corr_url);
+      Download_T0Corr(_cdb_urls["MBD_T0CORR"]);
 
-      std::string timecorr_url = _cdb->getUrl("MBD_TIMECORR");
+      _cdb_urls["MBD_TIMECORR"] = _cdb->getUrl("MBD_TIMECORR");
       if ( Verbosity() > 0 )
       {
-        std::cout << "timecorr_url " << timecorr_url << std::endl;
+        std::cout << "MBD_TIMECORR url " << _cdb_urls["MBD_TIMECORR"] << std::endl;
       }
-      Download_TimeCorr(timecorr_url);
+      Download_TimeCorr(_cdb_urls["MBD_TIMECORR"]);
 
-      std::string slew_url = _cdb->getUrl("MBD_SLEWCORR");
+      _cdb_urls["MBD_SLEWCORR"] = _cdb->getUrl("MBD_SLEWCORR");
       if ( Verbosity() > 0 )
       {
-        std::cout << "slew_url " << slew_url << std::endl;
+        std::cout << "MBD_SLEWCORR url " << _cdb_urls["MBD_SLEWCORR"] << std::endl;
       }
-      Download_SlewCorr(slew_url);
+      Download_SlewCorr(_cdb_urls["MBD_SLEWCORR"]);
 
-      std::string trms_url = _cdb->getUrl("MBD_TIMERMS");
+      _cdb_urls["MBD_TIMERMS"] = _cdb->getUrl("MBD_TIMERMS");
       if ( Verbosity() > 0 )
       {
-        std::cout << "trms_url " << trms_url << std::endl;
+        std::cout << "MBD_TIMERMS url " << _cdb_urls["MBD_TIMERMS"] << std::endl;
       }
-      Download_TimeRMS(trms_url);
+      Download_TimeRMS(_cdb_urls["MBD_TIMERMS"]);
     }
 
     Verbosity(0);
@@ -2162,6 +2163,40 @@ int MbdCalib::Write_CDB_SlewCorr(const std::string& dbfile)
 }
 #endif
 
+int MbdCalib::Write_SlewCorr(const std::string& dbfile)
+{
+  std::ofstream cal_slewcorr_file;
+  cal_slewcorr_file.open(dbfile);
+  if (!cal_slewcorr_file.is_open())
+  {
+    std::cout << PHWHERE << "unable to open " << dbfile << std::endl;
+    return -1;
+  }
+  for (int ifeech = 0; ifeech < MbdDefs::MBD_N_FEECH; ifeech++)
+  {
+    if ( _mbdgeom->get_type(ifeech) == 1 )
+    {
+      continue;  // skip q-channels
+    }
+    cal_slewcorr_file << ifeech << "\t" << _scorr_npts[ifeech] << "\t" << _scorr_minrange[ifeech] << "\t" << _scorr_maxrange[ifeech] << std::endl;
+    for (int ipt=0; ipt<_scorr_npts[ifeech]; ipt++)
+    {
+      cal_slewcorr_file << _scorr_y[ifeech][ipt];
+      if ( ipt%10 == 9 )
+      {
+        cal_slewcorr_file << std::endl;
+      }
+      else
+      {
+        cal_slewcorr_file << " ";
+      }
+    }
+  }
+  cal_slewcorr_file.close();
+
+  return 1;
+}
+
 #ifndef ONLINE
 int MbdCalib::Write_CDB_TimeRMS(const std::string& dbfile)
 {
@@ -2512,6 +2547,17 @@ void MbdCalib::Reset_Thresholds()
   _thresh_efferr.fill(std::numeric_limits<float>::quiet_NaN());
   _thresh_chi2ndf.fill(std::numeric_limits<float>::quiet_NaN());
 }
+
+#ifndef ONLINE
+void MbdCalib::Save_CDB_URL()
+{
+  for (const auto &kv : _cdb_urls)
+  {
+    auto named = std::make_unique<TNamed>(kv.first.c_str(), kv.second.c_str());
+    named->Write();
+  }
+}
+#endif
 
 void MbdCalib::Reset()
 {

--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -12,12 +12,14 @@
 
 #include <array>
 #include <vector>
+#include <map>
 #include <string>
 #include <string_view>
 #include <memory>
 
 class TTree;
 class TGraph;
+class TNamed;
 class CDBInterface;
 
 class MbdCalib 
@@ -168,6 +170,7 @@ class MbdCalib
   int Write_T0Corr(const std::string& dbfile);
   int Write_Ped(const std::string& dbfile);
   int Write_TimeCorr(const std::string& dbfile);
+  int Write_SlewCorr(const std::string& dbfile);
   int Write_Gains(const std::string& dbfile);
   int Write_Pileup(const std::string& dbfile);
   int Write_Thresholds(const std::string& dbfile);
@@ -185,6 +188,10 @@ class MbdCalib
 
   // void Dump_to_file(const std::string& what = "ALL");
 
+#ifndef ONLINE
+  void Save_CDB_URL();
+#endif
+
   void SetRawDstFlag(const int r) { _rawdstflag = r; }
   void SetFitsOnly(const int f) { _fitsonly = f; }
 
@@ -198,6 +205,7 @@ class MbdCalib
 #ifndef ONLINE
   CDBInterface* _cdb{nullptr};
   recoConsts* _rc{nullptr};
+  std::map<std::string, std::string> _cdb_urls;
 #endif
 
   std::unique_ptr<MbdGeom> _mbdgeom{nullptr};

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -124,7 +124,7 @@ class MbdEvent
   int _verbose{0};
   int _runnum{0};
   int _simflag{0};
-  int _rawdstflag{0};  // dst with raw container
+  int _rawdstflag{0};  // reading from dst with raw container
   int _fitsonly{0};    // stop reco after waveform fits (for DST_CALOFIT pass)
   int _nsamples{31};
   int _calib_done{0}; 


### PR DESCRIPTION
[comment]:  added some helper methods

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## MbdCalib Helper Methods for Calibration I/O and URL Management

### Motivation & Context
This PR extends the MBD (Midrapidity Barrel Detector) calibration infrastructure by adding utility methods for slew correction file I/O and tracking of CDB (Conditions Database) URLs. These methods support offline calibration workflows and improve visibility into calibration data source tracking.

### Key Changes
- **New `Write_SlewCorr()` method**: Serializes slew correction calibration data (`_scorr_npts`, `_scorr_minrange`, `_scorr_maxrange`, `_scorr_y` arrays) to a custom text file format. Follows the existing pattern of other Write_* methods in MbdCalib.
- **New `Save_CDB_URL()` method**: Persists all CDB URLs stored in the `_cdb_urls` map as ROOT `TNamed` objects, enabling URL tracking in ROOT output files for debugging/auditing purposes.
- **Refactored `Download_All()`**: Now centralizes CDB URL retrieval in the `_cdb_urls` map via `_cdb->getUrl()` calls, improving URL bookkeeping and added verbosity output for URL logging.
- **New private member `_cdb_urls`**: `std::map<std::string, std::string>` stores calibration type → URL mappings (e.g., "MBD_STATUS" → URL).
- **Minor documentation update**: Clarified `_rawdstflag` comment in MbdEvent.h.

### Potential Risk Areas
- **IO format**: `Write_SlewCorr()` uses a custom text serialization format. Compatibility depends on downstream consumers of this format; verify parsing expectations.
- **ROOT dependency**: `Save_CDB_URL()` relies on TNamed serialization; may have ROOT version compatibility considerations.
- **Memory overhead**: `_cdb_urls` map stores multiple URL strings; impact is negligible unless URL count or length grows significantly.
- **Non-ONLINE guard**: All new functionality is `#ifndef ONLINE` protected, so online reconstruction paths are unaffected.

### Implementation Notes
- All new code is guarded by `#ifndef ONLINE`, isolating changes to offline-only builds.
- Methods follow existing naming and API conventions in MbdCalib.
- **⚠️ Note on AI analysis**: AI-generated summaries can miss nuances in calibration workflows. Reviewers should verify that the custom text format in `Write_SlewCorr()` matches expected calibration file layouts, and that URL persistence in ROOT doesn't introduce unintended side effects.

### Possible Future Improvements
- Document the text format specification for `Write_SlewCorr()` output.
- Add getter method for `_cdb_urls` to expose URL information programmatically.
- Consider generalizing URL persistence (e.g., a helper method for all calibration types).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->