### PR TITLE
Select only diffuse laser events

### DIFF
--- a/offline/packages/tpc/DiffuseLaserEventSelector.cc
+++ b/offline/packages/tpc/DiffuseLaserEventSelector.cc
@@ -1,0 +1,86 @@
+#include "DiffuseLaserEventSelector.h"
+
+#include <tpc/LaserEventInfo.h>
+
+#include <ffaobjects/EventHeader.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <iostream>
+
+DiffuseLaserEventSelector::DiffuseLaserEventSelector(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+int DiffuseLaserEventSelector::process_event(PHCompositeNode* topNode)
+{
+  LaserEventInfo* laserEventInfo =
+      findNode::getClass<LaserEventInfo>(topNode, "LaserEventInfo");
+
+  if (!laserEventInfo)
+  {
+    std::cout << PHWHERE
+              << " LaserEventInfo node is missing. Rejecting event."
+              << std::endl;
+
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
+
+  EventHeader *eventHeader = findNode::getClass<EventHeader>(topNode, "EventHeader");
+  if (!eventHeader)
+  {
+    std::cout << PHWHERE << " EventHeader Node missing, doing nothing." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  bool accept = true;
+
+  /*
+  if (m_requireTPCDiffuseLaser)
+  {
+    accept = accept && laserEventInfo->isLaserEvent();
+  }
+
+  if (m_requireGL1Laser)
+  {
+    accept = accept && laserEventInfo->isGl1LaserEvent();
+  }
+
+  if (m_rejectGL1Pileup)
+  {
+    accept = accept && !laserEventInfo->isGl1LaserPileupEvent();
+  }
+  */
+
+  if((eventHeader->get_RunNumber() > 66153 && laserEventInfo->isGl1LaserEvent()) || (eventHeader->get_RunNumber() <= 66153 && laserEventInfo->isLaserEvent()))
+  {
+    accept = true;
+  }
+  else
+  {
+    accept = false;
+  }
+
+  /*if (Verbosity() > 1)
+  {
+    std::cout << "DiffuseLaserEventSelector:"
+              << " isLaserEvent = " << laserEventInfo->isLaserEvent()
+              << " isGl1LaserEvent = " << laserEventInfo->isGl1LaserEvent()
+              << " isGl1LaserPileupEvent = "
+              << laserEventInfo->isGl1LaserPileupEvent()
+              << " accept = " << accept
+              << std::endl;
+  }*/
+
+  if (!accept)
+  {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/tpc/DiffuseLaserEventSelector.h
+++ b/offline/packages/tpc/DiffuseLaserEventSelector.h
@@ -1,0 +1,29 @@
+#ifndef DiffuseLaserEventSelector_H
+#define DiffuseLaserEventSelector_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+
+class DiffuseLaserEventSelector : public SubsysReco
+{
+ public:
+  DiffuseLaserEventSelector(const std::string& name = "DiffuseLaserEventSelector");
+
+  ~DiffuseLaserEventSelector() override = default;
+
+  int process_event(PHCompositeNode* topNode) override;
+
+  void RequireTPCDiffuseLaser(bool b) { m_requireTPCDiffuseLaser = b; }
+  void RequireGL1Laser(bool b) { m_requireGL1Laser = b; }
+  void RejectGL1Pileup(bool b) { m_rejectGL1Pileup = b; }
+
+ private:
+  bool m_requireTPCDiffuseLaser = true;
+  bool m_requireGL1Laser = false;
+  bool m_rejectGL1Pileup = true;
+};
+
+#endif

--- a/offline/packages/tpc/Makefile.am
+++ b/offline/packages/tpc/Makefile.am
@@ -41,6 +41,7 @@ pkginclude_HEADERS = \
   LaserEventInfov2.h \
   LaserEventIdentifier.h \
   LaserEventRejecter.h \
+  DiffuseLaserEventSelector.h \
   TrainingHitsContainer.h \
   TrainingHits.h \
   Tpc3DClusterizer.h \
@@ -79,6 +80,7 @@ libtpc_la_SOURCES = \
   LaserEventInfov1.cc \
   LaserEventInfov2.cc \
   LaserEventIdentifier.cc \
+  DiffuseLaserEventSelector.cc \
   LaserEventRejecter.cc \
   TpcRawDataTree.cc \
   Tpc3DClusterizer.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Diffuse Laser Event Selector

### Motivation / Context
This PR introduces a new `DiffuseLaserEventSelector` module to filter events during reconstruction and select only those containing diffuse laser pulses from the TPC laser calibration system. The TPC uses diffuse laser events for alignment validation and detector response calibration. The selector implements a run-dependent laser classification scheme to accommodate different laser trigger mechanisms across detector operation phases.

### Key Changes
- **New class `DiffuseLaserEventSelector`** (derives from `SubsysReco`):
  - `process_event()` filters events based on laser type classification and run number
  - Requires `LaserEventInfo` and `EventHeader` nodes from the event tree
  - **Run-dependent selection logic:**
    - **Run ≤ 66153**: Accepts TPC diffuse laser events (`isLaserEvent()`)
    - **Run > 66153**: Accepts GL1 laser events (`isGl1LaserEvent()`)
  - Rejects non-matching events with `ABORTEVENT`
  - Includes three configurable boolean flags for future flexibility (`m_requireTPCDiffuseLaser`, `m_requireGL1Laser`, `m_rejectGL1Pileup`) with sensible defaults
- **Build system**: Updated `Makefile.am` to install header and compile source

### Potential Risk Areas
- **Hard-coded run threshold**: The actual selection logic bypasses the configurable flags and uses a hard-coded run number (66153) threshold. This inflexible approach may cause issues if run numbering changes or detector operations evolve. Consider making this configurable.
- **Reconstruction filtering impact**: Events rejected by this selector will not reach downstream modules. Verify that all analysis chains account for this reduced event sample.
- **Asymmetric error handling**: Missing `LaserEventInfo` triggers `DISCARDEVENT` while missing `EventHeader` triggers `ABORTRUN`—confirm this difference is intentional.
- **Commented-out configurable logic**: Large sections of the original design using the three boolean flags are commented out, suggesting incomplete implementation or a shift in approach. Clarify the intended design.

### Possible Future Improvements
- Implement the commented-out configurable selection logic to use the defined boolean flags
- Make the run-number threshold configurable via macro parameters rather than hard-coded
- Add conditional verbosity output for monitoring laser event acceptance statistics
- Evaluate whether `ABORTRUN` is the appropriate response for missing `EventHeader`

---
*Note: AI-generated summary—verify the significance of run 66153 (likely related to GL1 laser trigger integration) against detector operations documentation.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->