### PR TITLE
mbdvtxmap now being filled during calpass 2

### DIFF
--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -176,7 +176,7 @@ int MbdReco::process_event(PHCompositeNode *topNode)
   m_mbdevent->Calculate(m_mbdpmts, m_mbdout, topNode);
 
   // For multiple global vertex
-  if (m_mbdevent->get_bbcn(0) > 0 && m_mbdevent->get_bbcn(1) > 0 && _calpass==0 )
+  if ( m_mbdevent->get_bbcn(0) > 0 && m_mbdevent->get_bbcn(1) > 0 && !_fitsonly && _calpass!=1 )
   {
     auto *vertex = new MbdVertexv3();
     vertex->set_t(m_mbdevent->get_bbct0());
@@ -185,10 +185,7 @@ int MbdReco::process_event(PHCompositeNode *topNode)
     vertex->set_t_err(m_tres);
     vertex->set_beam_crossing(0);
 
-    if ( !_fitsonly )
-    {
-      m_mbdvtxmap->insert(vertex);
-    }
+    m_mbdvtxmap->insert(vertex);
   }
 
   if (Verbosity() > 0)


### PR DESCRIPTION
[comment]: needed to do vertex match to tracking vertex

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## MBD Vertex Map Population Extended to Calibration Pass 2

### Motivation / Context
The MBD (Minimum Bias Detector) vertex reconstruction is critical for global vertex matching with the tracking system. Previously, the `MbdVertexMap` was only populated during calibration pass 0 (`_calpass==0`), limiting vertex matching availability during other processing stages. This change extends vertex map population to calibration pass 2 and other passes (except pass 1), enabling broader support for vertex matching workflows while maintaining compatibility with fits-only mode.

### Key Changes
- **Reconstruction condition refactored:** Changed from `_calpass==0` to `_calpass!=1`, expanding vertex map population to calibration passes 0, 2, 3, and potentially higher, while explicitly excluding pass 1
- **Simplified logic:** Integrated the `!_fitsonly` check from an inner conditional into the outer condition guard, removing nested logic and directly gating the entire vertex creation block
- **Unified vertex insertion:** Removed the separate `if (!_fitsonly)` guard around `m_mbdvtxmap->insert(vertex)`, now executed directly when the outer condition is satisfied

### Potential Risk Areas
- **Reconstruction behavior change:** Vertices will now be generated during calpass 2 and higher, which may affect downstream analyses that depend on the availability (or absence) of MBD vertices at specific processing stages
- **Pass 1 exclusion specificity:** Pass 1 is explicitly excluded (`_calpass!=1`), likely because it serves a different role in calibration; any modifications to pass numbering conventions could inadvertently affect this logic
- **Consistency with fits-only mode:** The condition now uniformly prevents vertex insertion when `_fitsonly=true` across all passes; verify that this aligns with intended behavior for all calibration configurations

### Possible Future Improvements
- Consider parameterizing the excluded calibration passes to improve configurability
- Document the role and significance of each calibration pass in relation to vertex reconstruction and tracking
- Evaluate whether additional safeguards are needed to handle corner cases during transitions between calibration passes

**Note:** AI-assisted analysis is used throughout this summary. Please validate the reconstruction logic against your collaboration's calibration workflow documentation and test the impact on downstream vertex matching algorithms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->