### PR TITLE
get mbd zvtx and track vtx comparison

### DIFF
--- a/calibrations/mbd/Makefile.am
+++ b/calibrations/mbd/Makefile.am
@@ -1,0 +1,45 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -isystem$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64
+
+pkginclude_HEADERS = \
+  MbdTrackVertex.h
+
+lib_LTLIBRARIES = \
+  libmbdcalib.la
+
+libmbdcalib_la_SOURCES = \
+  MbdTrackVertex.cc
+
+libmbdcalib_la_LIBADD = \
+  -lphool \
+  -lSubsysReco \
+  -lglobalvertex_io \
+  -lffarawobjects \
+  -lffaobjects
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD   = libmbdcalib.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -1,0 +1,181 @@
+#include "MbdTrackVertex.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <ffarawobjects/Gl1Packet.h>
+
+#include <ffaobjects/EventHeader.h>
+
+#include <globalvertex/GlobalVertex.h>
+#include <globalvertex/GlobalVertexMap.h>
+#include <globalvertex/MbdVertex.h>
+#include <globalvertex/MbdVertexMap.h>
+#include <globalvertex/SvtxVertex.h>
+#include <globalvertex/SvtxVertexMap.h>
+
+GlobalVertex::VTXTYPE trkType = GlobalVertex::SVTX;
+GlobalVertex::VTXTYPE mbdType = GlobalVertex::MBD;
+//____________________________________________________________________________..
+MbdTrackVertex::MbdTrackVertex(const std::string &name):
+ SubsysReco(name)
+{
+  std::cout << "MbdTrackVertex::MbdTrackVertex(const std::string &name) Calling ctor" << std::endl;
+}
+
+//____________________________________________________________________________..
+MbdTrackVertex::~MbdTrackVertex()
+{
+  std::cout << "MbdTrackVertex::~MbdTrackVertex() Calling dtor" << std::endl;
+}
+
+//____________________________________________________________________________..
+int MbdTrackVertex::Init(PHCompositeNode * /*topNode*/)
+{
+  outFile = new TFile(outFileName.c_str(), "RECREATE");
+  if (_treeflag)
+  {
+    outTree = new TTree("mz", "MBD-TRK ZVTX");
+    outTree->OptimizeBaskets();
+    outTree->SetAutoSave(-5e6);
+
+    outTree->Branch("evt", &_evt, "evt/I");
+    outTree->Branch("mbdz", &_mbdVertex, "mbdz/F");
+    outTree->Branch("trkz", &_trackerVertex, "trkz/F");
+    outTree->Branch("ntrks", &_nTracks, "ntrks/i");
+    outTree->Branch("nbz", &_nMBDVertex, "nbz/i");
+    outTree->Branch("ntz", &_nTRKVertex, "ntz/i");
+  }
+
+  // h_mbdtrkz: dz = _mbdVertex - trackerVertex, range (-15,15) cm, 0.25 cm bins → 120 bins
+  h_mbdtrkz = new TH1F("h_mbdtrkz", "MBD - Tracker z-vertex;dz (cm);Counts", 120, -15., 15.);
+  h_bz   = new TH1F("h_bz",   "MBD z-vertex;z (cm);Counts", 400, -20., 20.);
+  h_trkz = new TH1F("h_trkz", "Tracker z-vertex;z (cm);Counts", 400, -20., 20.);
+
+  // h2_mbdtrkz: THnSparseF, x = _trackerVertex, y = _mbdVertex, (-20,20) cm, 0.1 cm bins → 400 bins each
+  const int    nbins2[2] = {400, 400};
+  const double xmin2[2]  = {-20., -20.};
+  const double xmax2[2]  = { 20.,  20.};
+  h2_mbdtrkz = new THnSparseF("h2_mbdtrkz", "MBD vs Tracker z-vertex", 2, nbins2, xmin2, xmax2);
+  h2_mbdtrkz->GetAxis(0)->SetTitle("Tracker z (cm)");
+  h2_mbdtrkz->GetAxis(1)->SetTitle("MBD z (cm)");
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int MbdTrackVertex::process_event(PHCompositeNode *topNode)
+{
+  EventHeader *eventheader = findNode::getClass<EventHeader>(topNode, "EventHeader");
+  _evt = eventheader ? eventheader->get_EvtSequence() : -1;
+
+  if (_gl1_trigmask != 0)
+  {
+    Gl1Packet *gl1 = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+    if (gl1)
+    {
+      if ((gl1->getScaledVector() & _gl1_trigmask) == 0)
+      {
+        return Fun4AllReturnCodes::DISCARDEVENT;
+      }
+    }
+    else
+    {
+      std::cout << PHWHERE << " GL1Packet node not found, skipping trigger mask check" << std::endl;
+    }
+  }
+
+  MbdVertexMap *m_dst_mbdvertexmap = findNode::getClass<MbdVertexMap>(topNode, "MbdVertexMap");
+  SvtxVertexMap *m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+
+  GlobalVertexMap *globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+
+  _mbdVertex = _trackerVertex = std::numeric_limits<float>::quiet_NaN();
+  _nTracks = _nMBDVertex = _nTRKVertex = std::numeric_limits<unsigned int>::quiet_NaN();
+
+  _hasMBD = false;
+  _hasTRK = false;
+
+  for (GlobalVertexMap::ConstIter iter = globalvertexmap->begin(); iter != globalvertexmap->end(); ++iter)
+  {
+    GlobalVertex *gvertex = iter->second;
+
+    if (gvertex->count_vtxs(mbdType) != 0)
+    {
+      _hasMBD = true;
+
+      auto mbditer = gvertex->find_vertexes(mbdType);
+      auto mbdvertexvector = mbditer->second;
+
+      _nMBDVertex = mbdvertexvector.size();
+      for (auto &vertex : mbdvertexvector)
+      {
+        MbdVertex *m_dst_vertex = m_dst_mbdvertexmap->find(vertex->get_id())->second;
+        _mbdVertex = m_dst_vertex->get_z();
+      }
+    }
+
+    if (gvertex->count_vtxs(trkType) != 0)
+    { 
+      _hasTRK = true; 
+
+      auto trkiter = gvertex->find_vertexes(trkType);
+      auto trkvertexvector = trkiter->second;
+
+      _nTRKVertex = trkvertexvector.size();
+      for (auto &vertex : trkvertexvector)
+      {
+        SvtxVertex *m_dst_vertex = m_dst_vertexmap->find(vertex->get_id())->second;
+        if ( m_dst_vertex->get_beam_crossing() != 0 ) 
+        {
+          continue;
+        }
+        if ( m_dst_vertex->size_tracks() > _nTracks)
+        {
+          _trackerVertex = m_dst_vertex->get_z();
+          _nTracks = m_dst_vertex->size_tracks();
+        }
+        if (_nTracks == 0)
+        {
+          _hasTRK = false; 
+        }
+      }
+    }
+  }
+
+  if (_hasMBD)
+  {
+    h_bz->Fill(_mbdVertex);
+  }
+  if (_hasTRK)
+  {
+    h_trkz->Fill(_trackerVertex);
+  }
+
+  if (_hasMBD && _hasTRK)
+  {
+    h_mbdtrkz->Fill(_mbdVertex - _trackerVertex);
+    const double coords[2] = {_trackerVertex, _mbdVertex};
+    h2_mbdtrkz->Fill(coords);
+  }
+
+  if (_treeflag) outTree->Fill();
+
+  ++_counter;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int MbdTrackVertex::End(PHCompositeNode * /*topNode*/)
+{
+  outFile->Write();
+  outFile->Close();
+  delete outFile;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -84,7 +84,8 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
     }
     else
     {
-      std::cout << PHWHERE << " GL1Packet node not found, skipping trigger mask check" << std::endl;
+      std::cout << PHWHERE << " GL1Packet node not found; discarding event because trigger masking was requested" << std::endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
     }
   }
 

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -162,7 +162,10 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
     h2_mbdtrkz->Fill(coords);
   }
 
-  if (_treeflag) outTree->Fill();
+  if (_treeflag)
+  {
+    outTree->Fill();
+  }
 
   ++_counter;
 

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -92,6 +92,11 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
   SvtxVertexMap *m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
 
   GlobalVertexMap *globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+  if (!m_dst_mbdvertexmap || !m_dst_vertexmap || !globalvertexmap)
+  {
+    std::cout << PHWHERE << " missing required vertex node(s)" << std::endl;
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
 
   _mbdVertex = _trackerVertex = std::numeric_limits<float>::quiet_NaN();
   _nTracks = _nMBDVertex = _nTRKVertex = std::numeric_limits<unsigned int>::quiet_NaN();

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -17,8 +17,8 @@
 #include <globalvertex/SvtxVertex.h>
 #include <globalvertex/SvtxVertexMap.h>
 
-GlobalVertex::VTXTYPE trkType = GlobalVertex::SVTX;
-GlobalVertex::VTXTYPE mbdType = GlobalVertex::MBD;
+constexpr GlobalVertex::VTXTYPE trkType = GlobalVertex::SVTX;
+constexpr GlobalVertex::VTXTYPE mbdType = GlobalVertex::MBD;
 //____________________________________________________________________________..
 MbdTrackVertex::MbdTrackVertex(const std::string &name):
  SubsysReco(name)

--- a/calibrations/mbd/MbdTrackVertex.h
+++ b/calibrations/mbd/MbdTrackVertex.h
@@ -1,0 +1,68 @@
+#ifndef MBDTRACKVERTEX_H
+#define MBDTRACKVERTEX_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <TFile.h>
+#include <TH1.h>
+#include <THnSparse.h>
+#include <TTree.h>
+
+#include <cstdint>
+#include <string>
+
+class PHCompositeNode;
+
+class MbdTrackVertex : public SubsysReco
+{
+ public:
+
+  MbdTrackVertex(const std::string &name = "MbdTrackVertex");
+
+  ~MbdTrackVertex() override;
+
+  /** Called during initialization.
+      Typically this is where you can book histograms, and e.g.
+      register them to Fun4AllServer (so they can be output to file
+      using Fun4AllServer::dumpHistos() method).
+   */
+  int Init(PHCompositeNode *topNode) override;
+
+  /** Called for each event.
+      This is where you do the real work.
+   */
+  int process_event(PHCompositeNode *topNode) override;
+
+  /// Called at the end of all processing.
+  int End(PHCompositeNode *topNode) override;
+
+  void setOutputName(const std::string& name) { outFileName = name; };
+  void SetTreeFlag(bool flag) { _treeflag = flag; }
+  void SetTriggerMask(uint64_t mask) { _gl1_trigmask = mask; }
+
+ private:
+
+  TFile* outFile {nullptr};
+  TTree* outTree {nullptr};
+  TH1F* h_mbdtrkz {nullptr};
+  TH1F* h_bz {nullptr};
+  TH1F* h_trkz {nullptr};
+  THnSparseF* h2_mbdtrkz {nullptr};
+  std::string outFileName = "mbdtrk_vertex.root";
+
+  Float_t _mbdVertex {std::numeric_limits<float>::quiet_NaN()};
+  Float_t _trackerVertex {std::numeric_limits<float>::quiet_NaN()};
+  UInt_t  _nTracks {std::numeric_limits<unsigned int>::quiet_NaN()};
+  UInt_t  _nMBDVertex {std::numeric_limits<unsigned int>::quiet_NaN()};
+  UInt_t  _nTRKVertex {std::numeric_limits<unsigned int>::quiet_NaN()};
+
+  bool _hasMBD {false};
+  bool _hasTRK {false};
+
+  bool _treeflag {true};
+  uint64_t _gl1_trigmask {0};
+  int _counter{0};
+  int _evt{0};
+};
+
+#endif // MBDTRACKVERTEX_H

--- a/calibrations/mbd/autogen.sh
+++ b/calibrations/mbd/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"

--- a/calibrations/mbd/configure.ac
+++ b/calibrations/mbd/configure.ac
@@ -1,0 +1,19 @@
+AC_INIT(mbdcalib,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wshadow -Werror"
+fi
+
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
[comment]: get run to run vtx comparison

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation & Context
This PR adds a standalone calibration/analysis tool to perform run‑to‑run comparisons of z‑vertex reconstruction between the Mini‑Bang Detector (MBD) and the tracking detector (Svtx). Comparing independent vertex measurements helps validate alignment, timing/calibration, and reveal systematic differences between the two reconstruction chains.

## Key changes
- New Fun4All SubsysReco module MbdTrackVertex (calibrations/mbd/MbdTrackVertex.h, MbdTrackVertex.cc)
  - Reads EventHeader, GlobalVertexMap, MbdVertexMap, SvtxVertexMap, and optional GL1Packet for trigger filtering.
  - Selects a tracker vertex per global vertex by beam_crossing()==0 and largest size_tracks(); records MBD vertex(es).
  - Produces diagnostics: TH1F histograms (MBD z, tracker z, dz), THnSparseF 2D correlation (tracker z vs MBD z), and optional TTree ("mz") with per-event fields (evt, mbdz, trkz, ntrks, nbz, ntz).
  - Configurable output filename and tree enable flag; configurable GL1 trigger mask to drop events.
- Standalone build scaffolding for mbd calibration:
  - Added calibrations/mbd/Makefile.am, calibrations/mbd/configure.ac, and calibrations/mbd/autogen.sh to build libmbdcalib and a small local test executable.
  - Installs header MbdTrackVertex.h; builds libmbdcalib.la from MbdTrackVertex.cc and links against existing offline libraries.

## Potential risk areas
- Vertex selection bias: choosing the tracker vertex with the largest size_tracks() may bias results toward high‑multiplicity vertices and implicitly ignores other valid vertices in multi‑collision events.
- Event filtering: GL1 trigger mask removes events early; misconfigured masks can silently drop data and bias run comparisons.
- IO/format compatibility: produces a custom ROOT file/TTrees and histograms—downstream analysis scripts must match the schema; changes to the tree/histogram layout are not versioned.
- Reconstruction behavior: no changes to core reconstruction algorithms, but analysis‑level choices (vertex selection, trigger filtering) affect comparisons and conclusions.
- Thread‑safety / concurrency: uses ROOT objects and event‑local state in the standard Fun4All pattern; no explicit thread‑safety measures—validate before running in multi‑threaded execution.
- Performance: per‑event iteration over GlobalVertexMap and creation/filling of THnSparse/TTrees is straightforward but should be profiled on large datasets.

## Possible future improvements
- Optionally record multiple vertices per event (rather than only the largest‑track vertex) to support multi‑vertex studies.
- Save run number and per‑run summary metrics for automated stability/regression monitoring.
- Expose and store additional vertex quality metrics (χ2, covariance entries, per‑vertex multiplicity distributions).
- Add unit/regression tests for vertex selection and trigger filtering; add versioning or a schema description for the output ROOT files.
- Add verbose/debug logging (or configurable verbosity) around trigger filtering and vertex selection to aid diagnosis.

Note: AI-generated summaries can be mistaken or omit details—please review the implementation (especially vertex selection, trigger filtering, and ROOT output layout) before relying on these results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->