### PR TITLE
Preserve decay history in PHG4TruthTrackingAction

### DIFF
--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -76,8 +76,8 @@ void PHG4TruthTrackingAction::PreUserTrackingAction(const G4Track* track)
   int vtxindex = ti->get_vtx_id();
 
   // maybe we should do the sPHENIX primary tracking here as here is the place where the parent id etc. are finally set
-
-  if (issPHENIXPrimary(*m_TruthInfoList, ti))
+// Old-- for only keeping sPHENIX primary 
+/* if (issPHENIXPrimary(*m_TruthInfoList, ti))
   {
     // we also want to set keep this track
     PHG4TrackUserInfoV1* userinfo = dynamic_cast<PHG4TrackUserInfoV1*>(track->GetUserInformation());
@@ -89,7 +89,30 @@ void PHG4TruthTrackingAction::PreUserTrackingAction(const G4Track* track)
     PHG4Particle* newparticle = dynamic_cast<PHG4Particle*>(ti->CloneMe());
 
     m_TruthInfoList->AddsPHENIXPrimaryParticle(trackid, newparticle);
+  }*/
+
+
+// Now keeping sPHENIX primary as well as decay history 
+  const bool keep_as_sphenix_primary = issPHENIXPrimary(*m_TruthInfoList, ti);
+  const bool keep_as_decay_history = keepDecayHistory(*m_TruthInfoList, ti);
+
+  if (keep_as_sphenix_primary || keep_as_decay_history)
+  {
+    PHG4TrackUserInfoV1* userinfo =
+        dynamic_cast<PHG4TrackUserInfoV1*>(track->GetUserInformation());
+
+    if (userinfo)
+    {
+      userinfo->SetKeep(true);
+    }
   }
+
+  if (keep_as_sphenix_primary)
+  {
+    PHG4Particle* newparticle = dynamic_cast<PHG4Particle*>(ti->CloneMe());
+
+    m_TruthInfoList->AddsPHENIXPrimaryParticle(trackid, newparticle);
+  }//end keeping sPHENIX primary & decay History
 
   m_CurrG4Particle = {track_id_g4, trackid, vtxindex};
 
@@ -232,10 +255,11 @@ int PHG4TruthTrackingAction::ResetEvent(PHCompositeNode* /*unused*/)
   }
 
   return 0;
-}
+} 
 
 PHG4Particle* PHG4TruthTrackingAction::AddParticle(PHG4TruthInfoContainer& truth, G4Track& track)
 {
+
   int trackid = 0;
   if (track.GetParentID())
   {
@@ -357,6 +381,28 @@ PHG4VtxPoint* PHG4TruthTrackingAction::AddVertex(PHG4TruthInfoContainer& truth, 
  * @return true if the particle is classified as an sPHENIX primary, `false` otherwise.
  *
  */
+
+//For keeping all decay truth info 
+bool PHG4TruthTrackingAction::keepDecayHistory(
+    PHG4TruthInfoContainer& truth,
+    PHG4Particle* particle) const
+{
+  if (!particle)
+  {
+    return false;
+  }
+
+  PHG4VtxPoint* vtx = truth.GetVtx(particle->get_vtx_id());
+  if (!vtx)
+  {
+    return false;
+  }
+
+  const bool from_decay = (vtx->get_process() == PHG4MCProcess::kPDecay);
+
+  return from_decay; 
+}//End keep decay History
+
 bool PHG4TruthTrackingAction::issPHENIXPrimary(PHG4TruthInfoContainer& truth, PHG4Particle* particle) const
 {
   PHG4VtxPoint* vtx = truth.GetVtx(particle->get_vtx_id());

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -116,6 +116,9 @@ class PHG4TruthTrackingAction : public PHG4TrackingAction
   // check if track is long-lived
   bool isLongLived(int pid) const;
 
+  // check if track should be kept because it is produced by a decay process 
+  bool keepDecayHistory(PHG4TruthInfoContainer& truth, PHG4Particle* particle) const;
+
   // check if track is sPHENIX primary
   bool issPHENIXPrimary(PHG4TruthInfoContainer& truth, PHG4Particle* particle) const;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Preserve decay history in PHG4TruthTrackingAction
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Bug Fix/truth record improvement.

This PR updates `PHG4TruthTrackingAction` to preserve decay-history particles in the Geant4 truth record. The goal is to keep daughter particles from decays, such as V0 decay products, from being removed during truth cleanup when they are needed for downstream truth matching and efficiency studies.

No reconstruction algorithm or physics selection is changed by this PR. The change only affects which truth particles are kept in the `G4TruthInfo` record. Local build completed successfully for `g4main`.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Preserve Decay History in PHG4TruthTrackingAction

### Motivation / Context
This PR extends the sPHENIX truth tracking system to retain decay-history particles (e.g., products from V0 decays) in the Geant4 truth record. These particles are now available for downstream truth matching and physics efficiency studies in analyses that track particle decay chains beyond primary particles.

### Key Changes
- **New helper method `keepDecayHistory()`**: Identifies particles produced by decay processes (PHG4MCProcess::kPDecay) by examining their production vertex.
- **Expanded track retention logic in `PreUserTrackingAction`**: Tracks are now marked for retention (`SetKeep(true)`) when *either* they are sPHENIX primaries *or* they originate from decay processes.
- **Separated primary particle bookkeeping**: The addition to the PHENIX primary particle list (`AddsPHENIXPrimaryParticle`) now occurs only for actual sPHENIX primaries, not for decay-history particles.
- **No changes to reconstruction algorithms or physics selection**: The modification affects only which truth particles are retained for analysis; it does not alter detector reconstruction or selection logic.

### Potential Risk Areas
- **Truth record size**: Retaining additional decay-history particles will increase memory footprint and I/O volume. Impact should be profiled for large production samples.
- **Downstream analysis assumptions**: Any code relying on the previous stricter truth particle filtering (e.g., assuming only sPHENIX primaries are kept) may require adjustment.
- **Vertex deduplication logic**: The implementation uses (position, process) pairs to distinguish vertices; verify that decay vertices at identical locations with different processes are correctly handled.

### Future Improvements
- Consider configurable retention policies (e.g., filter by particle type or decay modes) to balance physics requirements with I/O constraints.
- Profile and document memory/I/O overhead for typical event samples.
- Extend documentation with examples of relevant decay chains (V0s, etc.) for analysis teams.

*Note: AI summaries can contain errors; review the actual code changes for precise technical details.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/coresoftware/pull/4278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->