### PR TITLE
comment out unused variable

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -328,13 +328,13 @@ void PHActsSiliconSeeding::makeSvtxTracksWithTime(const std::vector<seed_type>& 
                                                   const int& strobe)
 
 {
-  int numSeeds = 0;
+  //  int numSeeds = 0;
   int numGoodSeeds = 0;
   m_seedid = -1;
 
   for (const auto& seed : seedVector)
   {
-      numSeeds++;
+    //      numSeeds++;
       if (m_seedAnalysis)
       {
         clearTreeVariables();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR should fix the clang build (barfs with an unused variable which is now commented out)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for Clang Build Failure: Comment Out Unused Variable in Streaming Path

### Motivation
This PR resolves a Clang compiler warning triggered by an unused variable in the track reconstruction seeding code. The `numSeeds` counter was declared and incremented in the streaming version of the track-building function but never used, causing a Clang build failure.

### Key Changes
- **File**: `offline/packages/trackreco/PHActsSiliconSeeding.cc`
- **Function modified**: `makeSvtxTracksWithTime` (streaming variant)
  - Commented out line 331: `int numSeeds = 0;` initialization
  - Commented out line 337: `numSeeds++;` increment in the seed loop
  - The `numGoodSeeds` counter remains active and is the only counter used in this function (incremented at lines 85 and 103)

### Context
The non-streaming variant `makeSvtxTracks` retains an active `numSeeds` variable because it is used there for diagnostics (histogram filling and verbose output at lines 170 and 176). The streaming variant has no such downstream usage, making the variable genuinely unused in that code path.

### Potential Risk Areas
- **Reconstruction behavior**: No risk. The actual seed selection and track-building logic depends exclusively on `numGoodSeeds`, which remains fully functional and unchanged.
- **Diagnostics**: The streaming path loses the total seed count metric, but `numGoodSeeds` provides the essential information for monitoring.
- **Code consistency**: The two functions (`makeSvtxTracksWithTime` and `makeSvtxTracks`) have slightly different variable usage patterns, which is appropriate given their different diagnostic needs.

---
**Note**: AI-generated summaries can contain errors. Code review confirms this is a surgical fix affecting only the unused variable in the streaming function, with no impact on reconstruction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->