### PR TITLE
feat: cosmic track fitter with Acts

### DIFF
--- a/offline/packages/trackbase/ActsTrackFittingAlgorithm.h
+++ b/offline/packages/trackbase/ActsTrackFittingAlgorithm.h
@@ -27,6 +27,23 @@ namespace Acts
 {
   class TrackingGeometry;
 }
+struct MaterialSurfaceSelector
+  {
+    std::vector<const Acts::Surface*> surfaces = {};
+
+    /// @param surface is the test surface
+    void operator()(const Acts::Surface* surface)
+    {
+      if (surface->surfaceMaterial() != nullptr)
+      {
+        if (std::find(surfaces.begin(), surfaces.end(), surface) ==
+            surfaces.end())
+        {
+          surfaces.push_back(surface);
+        }
+      }
+    }
+  };
 
 class ActsTrackFittingAlgorithm final
 {

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -295,23 +295,6 @@ class PHActsTrkFitter : public SubsysReco
 
   std::vector<const Acts::Surface*> m_materialSurfaces = {};
 
-  struct MaterialSurfaceSelector
-  {
-    std::vector<const Acts::Surface*> surfaces = {};
-
-    /// @param surface is the test surface
-    void operator()(const Acts::Surface* surface)
-    {
-      if (surface->surfaceMaterial() != nullptr)
-      {
-        if (std::find(surfaces.begin(), surfaces.end(), surface) ==
-            surfaces.end())
-        {
-          surfaces.push_back(surface);
-        }
-      }
-    }
-  };
 };
 
 #endif

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -341,7 +341,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     // copy transient map for this track into transient geoContext
     m_transient_geocontext = geoContext;
 
-    {
+    std::vector<Acts::Vector3> pos, sorted_positions;
       // get positions from cluster keys
       // TODO: should implement distortions
       TrackSeedHelper::position_map_t positions;
@@ -349,18 +349,63 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       {
         const auto& key(*key_iter);
         positions.emplace(key, m_tGeometry->getGlobalPosition( key, m_clusterContainer->findCluster(key)));
+        pos.push_back(positions[key]);
       }
+      sorted_positions = pos;
 
       TrackSeedHelper::circleFitByTaubin(tpcseed, positions, 0, 58);
+
+      float tpcR = fabs(1. / tpcseed->get_qOverR());
+      float tpcx = tpcseed->get_X0();
+      float tpcy = tpcseed->get_Y0();
+
+      float dx = -tpcx;
+      float dy = m_vertexRadius - tpcy;
+
+      float dist = std::sqrt(dx * dx + dy * dy);
+      float pcaxclaude = tpcx + tpcR * (dx / dist);
+      float pcayclaude = tpcy + tpcR * (dy / dist);
+
+      std::sort(sorted_positions.begin(), sorted_positions.end(), [](const Acts::Vector3& a, const Acts::Vector3& b)
+                {
+    float aradius = std::sqrt(a.x()*a.x()+a.y()*a.y());
+    if(a.y() < 0)
+    {
+      aradius *= -1;
     }
+    float bradius = std::sqrt(b.x()*b.x()+b.y()*b.y());
+    if(b.y() < 0)
+    {
+      bradius *= -1;
+    }
+    return aradius > bradius; });
 
-    float tpcR = fabs(1. / tpcseed->get_qOverR());
-    float tpcx = tpcseed->get_X0();
-    float tpcy = tpcseed->get_Y0();
 
-    const auto intersect =
-        TrackFitUtils::circle_circle_intersection(m_vertexRadius,
-                                                  tpcR, tpcx, tpcy);
+    auto arcLength = [&](float x, float y)
+    {
+      float angle = std::atan2(y - tpcy, x - tpcx);
+      return tpcR * angle;
+    };
+    float sum_s = 0, sum_z = 0, sum_ss = 0, sum_sz = 0;
+    int n = sorted_positions.size();
+    for(auto& p : sorted_positions)
+    {
+      float s = arcLength(p.x(), p.y());
+      sum_s += s;
+      sum_z += p.z();
+      sum_ss += s*s;
+      sum_sz += s*p.z();
+    }
+    float denom = n * sum_ss - sum_s * sum_s;
+    float b = (n * sum_sz - sum_s * sum_z) / denom;
+    float a = (sum_z - b * sum_s) / n;
+
+    float s_ca = arcLength(pcaxclaude, pcayclaude);
+    float z_ca = a + b * s_ca;
+
+    Acts::Vector3 claudepca(pcaxclaude, pcayclaude, z_ca);
+
+    const auto intersect = TrackFitUtils::circle_circle_intersection(m_vertexRadius, tpcR, tpcx, tpcy);
     float intx, inty;
 
     if (std::get<1>(intersect) > std::get<3>(intersect))
@@ -384,10 +429,10 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     TrackFitUtils::getTrackletClusters(m_tGeometry, m_clusterContainer,
                                        clusPos, keys);
     TrackFitUtils::position_vector_t xypoints, rzpoints;
-    for (auto& pos : clusPos)
+    for (auto& p : clusPos)
     {
-      float clusr = radius(pos.x(), pos.y());
-      if (pos.y() < 0)
+      float clusr = radius(p.x(), p.y());
+      if (p.y() < 0)
       {
         clusr *= -1;
       }
@@ -397,8 +442,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       {
         continue;
       }
-      xypoints.push_back(std::make_pair(pos.x(), pos.y()));
-      rzpoints.push_back(std::make_pair(pos.z(), clusr));
+      xypoints.push_back(std::make_pair(p.x(), p.y()));
+      rzpoints.push_back(std::make_pair(p.z(), clusr));
     }
 
     auto rzparams = TrackFitUtils::line_fit(rzpoints);
@@ -417,7 +462,6 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
                                                     inter);
 
     auto tan = tangent.second;
-    auto pca = tangent.first;
 
     float p;
     if (m_ConstField)
@@ -474,8 +518,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
 
     momentum.z() = pz;
-    Acts::Vector3 position(pca.x(), pca.y(),
-                           (m_vertexRadius - fulllineintz) / fulllineslope);
+    Acts::Vector3 position = claudepca;
 
     position *= Acts::UnitConstants::cm;
     if (!is_valid(momentum))
@@ -513,6 +556,10 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_pz = momentum(2);
       m_charge = charge;
       fillVectors(siseed, tpcseed);
+      m_x.push_back(claudepca.x());
+      m_y.push_back(claudepca.y());
+      m_z.push_back(claudepca.z());
+      m_r.push_back(radius(claudepca.x(), claudepca.y()));
       m_tree->Fill();
     }
     if(m_dumpSeeds)
@@ -527,9 +574,9 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       newTrack.set_px(momentum.x());
       newTrack.set_py(momentum.y());
       newTrack.set_pz(momentum.z());
-      newTrack.set_x(position.x()/Acts::UnitConstants::cm);
-      newTrack.set_y(position.y()/Acts::UnitConstants::cm);
-      newTrack.set_z(position.z()/Acts::UnitConstants::cm);
+      newTrack.set_x(claudepca.x());
+      newTrack.set_y(claudepca.y());
+      newTrack.set_z(claudepca.z());
       newTrack.set_charge(charge);
       m_trackMap->insertWithKey(&newTrack, trid);
       continue;
@@ -970,26 +1017,16 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
       auto key = *it;
       auto cluster = m_clusterContainer->findCluster(key);
       m_locx.push_back(cluster->getLocalX());
-      float ly = cluster->getLocalY();
-      if (TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::tpcId)
-      {
-        double drift_velocity = m_tGeometry->get_drift_velocity();
-        double zdriftlength = cluster->getLocalY() * drift_velocity;
-        double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
-        double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
-        unsigned int side = TpcDefs::getSide(key);
-        if (side == 0)
-        {
-          zloc = -zloc;
-        }
-        ly = zloc * 10;
-      }
-      m_locy.push_back(ly);
+      m_locy.push_back(cluster->getLocalY());
       auto glob = m_tGeometry->getGlobalPosition(key, cluster);
       m_x.push_back(glob.x());
       m_y.push_back(glob.y());
       m_z.push_back(glob.z());
       float r = std::sqrt(glob.x() * glob.x() + glob.y() * glob.y());
+      if(glob.y() < 0)
+      {
+        r *= -1;
+      }
       m_r.push_back(r);
       TVector3 globt(glob.x(), glob.y(), glob.z());
       m_phi.push_back(globt.Phi());

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -353,58 +353,27 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
     sorted_positions = pos;
 
-    TrackSeedHelper::circleFitByTaubin(tpcseed, positions, 0, 58);
-
-    float tpcR = fabs(1. / tpcseed->get_qOverR());
-    float tpcx = tpcseed->get_X0();
-    float tpcy = tpcseed->get_Y0();
-
-    float dx = -tpcx;
-    float dy = m_vertexRadius - tpcy;
-
-    float dist = std::sqrt(dx * dx + dy * dy);
-    float pcaxclaude = tpcx + tpcR * (dx / dist);
-    float pcayclaude = tpcy + tpcR * (dy / dist);
-
     std::sort(sorted_positions.begin(), sorted_positions.end(), [](const Acts::Vector3& a, const Acts::Vector3& b)
               {
-    float aradius = std::sqrt(a.x()*a.x()+a.y()*a.y());
-    if(a.y() < 0)
-    {
-      aradius *= -1;
-    }
-    float bradius = std::sqrt(b.x()*b.x()+b.y()*b.y());
-    if(b.y() < 0)
-    {
-      bradius *= -1;
-    }
-    return aradius > bradius; });
+                float aradius = std::sqrt(a.x()*a.x()+a.y()*a.y());
+                if(a.y() < 0)
+                {
+                  aradius *= -1;
+                }
+                float bradius = std::sqrt(b.x()*b.x()+b.y()*b.y());
+                if(b.y() < 0)
+                {
+                  bradius *= -1;
+                }
+                return aradius > bradius; });
 
-    auto arcLength = [&](float x, float y)
-    {
-      float angle = std::atan2(y - tpcy, x - tpcx);
-      return tpcR * angle;
-    };
-    float sum_s = 0, sum_z = 0, sum_ss = 0, sum_sz = 0;
-    int n = sorted_positions.size();
-    for (auto& p : sorted_positions)
-    {
-      float s = arcLength(p.x(), p.y());
-      sum_s += s;
-      sum_z += p.z();
-      sum_ss += s * s;
-      sum_sz += s * p.z();
-    }
-    float denom = n * sum_ss - sum_s * sum_s;
-    float b = (n * sum_sz - sum_s * sum_z) / denom;
-    float a = (sum_z - b * sum_s) / n;
+    TrackSeedHelper::circleFitByTaubin(tpcseed, positions, 0, 58);
 
-    float s_ca = arcLength(pcaxclaude, pcayclaude);
-    float z_ca = a + b * s_ca;
+    Acts::Vector3 pca = calculatePCA(tpcseed, sorted_positions);
 
-    Acts::Vector3 claudepca(pcaxclaude, pcayclaude, z_ca);
 
-    const auto intersect = TrackFitUtils::circle_circle_intersection(m_vertexRadius, tpcR, tpcx, tpcy);
+    // now calculate the momentum vector
+    const auto intersect = TrackFitUtils::circle_circle_intersection(m_vertexRadius, std::abs(1./tpcseed->get_qOverR()), tpcseed->get_X0(), tpcseed->get_Y0());
     float intx, inty;
 
     if (std::get<1>(intersect) > std::get<3>(intersect))
@@ -454,7 +423,10 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     Acts::Vector3 inter(intx, inty, intz);
 
-    std::vector<float> tpcparams{tpcR, tpcx, tpcy, tpcseed->get_slope(),
+    std::vector<float> tpcparams{(float) std::abs(1./tpcseed->get_qOverR()), 
+                                 tpcseed->get_X0(), 
+                                 tpcseed->get_Y0(), 
+                                 tpcseed->get_slope(),
                                  tpcseed->get_Z0()};
     auto tangent = TrackFitUtils::get_helix_tangent(tpcparams,
                                                     inter);
@@ -516,7 +488,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
 
     momentum.z() = pz;
-    Acts::Vector3 position = claudepca;
+    Acts::Vector3 position = pca;
 
     position *= Acts::UnitConstants::cm;
     if (!is_valid(momentum))
@@ -541,9 +513,9 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       clearVectors();
       m_seed = tpcid;
-      m_R = tpcR;
-      m_X0 = tpcx;
-      m_Y0 = tpcy;
+      m_R = std::abs(1./tpcseed->get_qOverR());
+      m_X0 = tpcseed->get_X0();
+      m_Y0 = tpcseed->get_Y0();
       m_Z0 = fulllineintz;
       m_slope = fulllineslope;
       m_pcax = position(0);
@@ -554,10 +526,10 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_pz = momentum(2);
       m_charge = charge;
       fillVectors(siseed, tpcseed);
-      m_x.push_back(claudepca.x());
-      m_y.push_back(claudepca.y());
-      m_z.push_back(claudepca.z());
-      m_r.push_back(radius(claudepca.x(), claudepca.y()));
+      m_x.push_back(position.x());
+      m_y.push_back(position.y());
+      m_z.push_back(position.z());
+      m_r.push_back(radius(position.x(), position.y()));
       m_tree->Fill();
     }
     if (m_dumpSeeds)
@@ -572,9 +544,9 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       newTrack.set_px(momentum.x());
       newTrack.set_py(momentum.y());
       newTrack.set_pz(momentum.z());
-      newTrack.set_x(claudepca.x());
-      newTrack.set_y(claudepca.y());
-      newTrack.set_z(claudepca.z());
+      newTrack.set_x(position.x());
+      newTrack.set_y(position.y());
+      newTrack.set_z(position.z());
       newTrack.set_charge(charge);
       m_trackMap->insertWithKey(&newTrack, trid);
       continue;
@@ -1103,4 +1075,47 @@ int PHCosmicsTrkFitter::getCharge(
   }
 
   return charge;
+}
+
+Acts::Vector3 PHCosmicsTrkFitter::calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions)
+{
+  float tpcR = fabs(1. / seed->get_qOverR());
+  float tpcx = seed->get_X0();
+  float tpcy = seed->get_Y0();
+
+  // calculate the pcaxy for the seed wrt a line surface located at (0,m_vertexRadius) in x-y plane
+  float dx = -tpcx;
+  float dy = m_vertexRadius - tpcy;
+  float dist = std::sqrt(dx * dx + dy * dy);
+  float pcax = tpcx + tpcR * (dx / dist);
+  float pcay = tpcy + tpcR * (dy / dist);
+
+  auto arcLength = [&](float x, float y)
+  {
+    float angle = std::atan2(y - tpcy, x - tpcx);
+    return tpcR * angle;
+  };
+
+  float sum_s = 0, sum_z = 0, sum_ss = 0, sum_sz = 0;
+  int n = sorted_positions.size();
+  // Compute the arc-length parameter for each cluster, then fit to a line
+  // Fit z = a + b*s using simple linear regression
+  for (auto& p : sorted_positions)
+  {
+    float s = arcLength(p.x(), p.y());
+    sum_s += s;
+    sum_z += p.z();
+    sum_ss += s * s;
+    sum_sz += s * p.z();
+  }
+
+  float denom = n * sum_ss - sum_s * sum_s;
+  float b = (n * sum_sz - sum_s * sum_z) / denom;
+  float a = (sum_z - b * sum_s) / n;
+
+  // Then evaluate at the arc length of the PCA to get the z position of the PCA
+  float s_ca = arcLength(pcax, pcay);
+  float z_ca = a + b * s_ca;
+
+  return Acts::Vector3(pcax, pcay, z_ca);
 }

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -45,8 +45,8 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
-#include <TTree.h>
 #include <TFile.h>
+#include <TTree.h>
 #include <TVector3.h>
 
 #include <cmath>
@@ -309,7 +309,19 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       // silicon source links
       sourceLinks = makeSourceLinks.getSourceLinks(
-        siseed,
+          siseed,
+          measurements,
+          m_clusterContainer,
+          m_tGeometry,
+          m_globalPositionWrapper,
+          m_alignmentTransformationMapTransient,
+          m_transient_id_set,
+          crossing);
+    }
+
+    // tpc source links
+    const auto tpcSourceLinks = makeSourceLinks.getSourceLinks(
+        tpcseed,
         measurements,
         m_clusterContainer,
         m_tGeometry,
@@ -317,18 +329,6 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
         m_alignmentTransformationMapTransient,
         m_transient_id_set,
         crossing);
-    }
-
-    // tpc source links
-    const auto tpcSourceLinks = makeSourceLinks.getSourceLinks(
-      tpcseed,
-      measurements,
-      m_clusterContainer,
-      m_tGeometry,
-      m_globalPositionWrapper,
-      m_alignmentTransformationMapTransient,
-      m_transient_id_set,
-      crossing);
 
     sourceLinks.insert(sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end());
 
@@ -342,32 +342,32 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     m_transient_geocontext = geoContext;
 
     std::vector<Acts::Vector3> pos, sorted_positions;
-      // get positions from cluster keys
-      // TODO: should implement distortions
-      TrackSeedHelper::position_map_t positions;
-      for( auto key_iter = tpcseed->begin_cluster_keys(); key_iter != tpcseed->end_cluster_keys(); ++key_iter )
-      {
-        const auto& key(*key_iter);
-        positions.emplace(key, m_tGeometry->getGlobalPosition( key, m_clusterContainer->findCluster(key)));
-        pos.push_back(positions[key]);
-      }
-      sorted_positions = pos;
+    // get positions from cluster keys
+    // TODO: should implement distortions
+    TrackSeedHelper::position_map_t positions;
+    for (auto key_iter = tpcseed->begin_cluster_keys(); key_iter != tpcseed->end_cluster_keys(); ++key_iter)
+    {
+      const auto& key(*key_iter);
+      positions.emplace(key, m_tGeometry->getGlobalPosition(key, m_clusterContainer->findCluster(key)));
+      pos.push_back(positions[key]);
+    }
+    sorted_positions = pos;
 
-      TrackSeedHelper::circleFitByTaubin(tpcseed, positions, 0, 58);
+    TrackSeedHelper::circleFitByTaubin(tpcseed, positions, 0, 58);
 
-      float tpcR = fabs(1. / tpcseed->get_qOverR());
-      float tpcx = tpcseed->get_X0();
-      float tpcy = tpcseed->get_Y0();
+    float tpcR = fabs(1. / tpcseed->get_qOverR());
+    float tpcx = tpcseed->get_X0();
+    float tpcy = tpcseed->get_Y0();
 
-      float dx = -tpcx;
-      float dy = m_vertexRadius - tpcy;
+    float dx = -tpcx;
+    float dy = m_vertexRadius - tpcy;
 
-      float dist = std::sqrt(dx * dx + dy * dy);
-      float pcaxclaude = tpcx + tpcR * (dx / dist);
-      float pcayclaude = tpcy + tpcR * (dy / dist);
+    float dist = std::sqrt(dx * dx + dy * dy);
+    float pcaxclaude = tpcx + tpcR * (dx / dist);
+    float pcayclaude = tpcy + tpcR * (dy / dist);
 
-      std::sort(sorted_positions.begin(), sorted_positions.end(), [](const Acts::Vector3& a, const Acts::Vector3& b)
-                {
+    std::sort(sorted_positions.begin(), sorted_positions.end(), [](const Acts::Vector3& a, const Acts::Vector3& b)
+              {
     float aradius = std::sqrt(a.x()*a.x()+a.y()*a.y());
     if(a.y() < 0)
     {
@@ -380,7 +380,6 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
     return aradius > bradius; });
 
-
     auto arcLength = [&](float x, float y)
     {
       float angle = std::atan2(y - tpcy, x - tpcx);
@@ -388,13 +387,13 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     };
     float sum_s = 0, sum_z = 0, sum_ss = 0, sum_sz = 0;
     int n = sorted_positions.size();
-    for(auto& p : sorted_positions)
+    for (auto& p : sorted_positions)
     {
       float s = arcLength(p.x(), p.y());
       sum_s += s;
       sum_z += p.z();
-      sum_ss += s*s;
-      sum_sz += s*p.z();
+      sum_ss += s * s;
+      sum_sz += s * p.z();
     }
     float denom = n * sum_ss - sum_s * sum_s;
     float b = (n * sum_sz - sum_s * sum_z) / denom;
@@ -418,7 +417,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       intx = std::get<2>(intersect);
       inty = std::get<3>(intersect);
     }
-    if(Verbosity() > 2)
+    if (Verbosity() > 2)
     {
       std::cout << "XY intersection options " << std::get<0>(intersect) << ", " << std::get<1>(intersect) << " and " << std::get<2>(intersect) << ", " << std::get<3>(intersect) << std::endl;
     }
@@ -452,7 +451,6 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     float slope = tpcseed->get_slope();
     float intz = m_vertexRadius * slope + tpcseed->get_Z0();
-
 
     Acts::Vector3 inter(intx, inty, intz);
 
@@ -562,7 +560,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_r.push_back(radius(claudepca.x(), claudepca.y()));
       m_tree->Fill();
     }
-    if(m_dumpSeeds)
+    if (m_dumpSeeds)
     {
       SvtxTrack_v4 newTrack;
       newTrack.set_tpc_seed(tpcseed);
@@ -609,7 +607,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     auto magcontext = m_tGeometry->geometry().magFieldContext;
     auto calibcontext = m_tGeometry->geometry().calibContext;
-      auto ppPlainOptions = Acts::PropagatorPlainOptions(m_transient_geocontext, magcontext);
+    auto ppPlainOptions = Acts::PropagatorPlainOptions(m_transient_geocontext, magcontext);
 
     ActsTrackFittingAlgorithm::GeneralFitterOptions
         kfOptions{
@@ -1023,7 +1021,7 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
       m_y.push_back(glob.y());
       m_z.push_back(glob.z());
       float r = std::sqrt(glob.x() * glob.x() + glob.y() * glob.y());
-      if(glob.y() < 0)
+      if (glob.y() < 0)
       {
         r *= -1;
       }
@@ -1043,7 +1041,6 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
 }
 void PHCosmicsTrkFitter::clearVectors()
 {
-  
   m_locx.clear();
   m_locy.clear();
   m_x.clear();
@@ -1090,7 +1087,7 @@ int PHCosmicsTrkFitter::getCharge(
     auto cluspos = sorted_positions[i];
 
     float phi = std::atan2(cluspos.y() - tpccparams[2], cluspos.x() - tpccparams[1]);
-    if(phi > phi0)
+    if (phi > phi0)
     {
       posphi++;
     }

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -453,8 +453,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     if (!m_zeroField)
     {
-      momentum.x() = charge < 0 ? tan.x() : tan.x() * -1;
-      momentum.y() = charge < 0 ? tan.y() : tan.y() * -1;
+      momentum.x() = tan.x() * -1; 
+      momentum.y() = tan.y() * -1;
     }
     else
     {

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -377,13 +377,13 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     Acts::Vector3 position = pca * Acts::UnitConstants::cm;
 
-    if (!is_valid(momentum))
+    if (!is_valid(momentum) || !is_valid(position))
     {
       continue;
     }
 
     int charge = getCharge(tpcseed, sorted_positions);
-
+    
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
         position);
     auto actsFourPos = Acts::Vector4(position(0), position(1),
@@ -410,8 +410,9 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_px = momentum(0);
       m_py = momentum(1);
       m_pz = momentum(2);
+      
       m_charge = charge;
-      fillVectors(siseed, tpcseed);
+      fillVectors(tpcseed, siseed);
       m_x.push_back(position.x() / Acts::UnitConstants::cm);
       m_y.push_back(position.y() / Acts::UnitConstants::cm);
       m_z.push_back(position.z() / Acts::UnitConstants::cm);

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -402,18 +402,18 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_Y0 = tpcseed->get_Y0();
       m_Z0 = tpcseed->get_Z0();
       m_slope = tpcseed->get_slope();
-      m_pcax = position(0);
-      m_pcay = position(1);
-      m_pcaz = position(2);
+      m_pcax = position(0) / Acts::UnitConstants::cm;
+      m_pcay = position(1) / Acts::UnitConstants::cm;
+      m_pcaz = position(2) / Acts::UnitConstants::cm;
       m_px = momentum(0);
       m_py = momentum(1);
       m_pz = momentum(2);
       m_charge = charge;
       fillVectors(siseed, tpcseed);
-      m_x.push_back(position.x());
-      m_y.push_back(position.y());
-      m_z.push_back(position.z());
-      m_r.push_back(radius(position.x(), position.y()));
+      m_x.push_back(position.x() / Acts::UnitConstants::cm);
+      m_y.push_back(position.y() / Acts::UnitConstants::cm);
+      m_z.push_back(position.z() / Acts::UnitConstants::cm);
+      m_r.push_back(radius(position.x(), position.y()) / Acts::UnitConstants::cm);
       m_tree->Fill();
     }
     if (m_dumpSeeds)

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -371,132 +371,16 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     Acts::Vector3 pca = calculatePCA(tpcseed, sorted_positions);
 
+    Acts::Vector3 momentum = calculateMomentum(tpcseed, sorted_positions);
 
-    // now calculate the momentum vector
-    const auto intersect = TrackFitUtils::circle_circle_intersection(m_vertexRadius, std::abs(1./tpcseed->get_qOverR()), tpcseed->get_X0(), tpcseed->get_Y0());
-    float intx, inty;
+    Acts::Vector3 position = pca * Acts::UnitConstants::cm;
 
-    if (std::get<1>(intersect) > std::get<3>(intersect))
-    {
-      intx = std::get<0>(intersect);
-      inty = std::get<1>(intersect);
-    }
-    else
-    {
-      intx = std::get<2>(intersect);
-      inty = std::get<3>(intersect);
-    }
-    if (Verbosity() > 2)
-    {
-      std::cout << "XY intersection options " << std::get<0>(intersect) << ", " << std::get<1>(intersect) << " and " << std::get<2>(intersect) << ", " << std::get<3>(intersect) << std::endl;
-    }
-
-    std::vector<TrkrDefs::cluskey> keys;
-    std::vector<Acts::Vector3> clusPos;
-    std::copy(tpcseed->begin_cluster_keys(), tpcseed->end_cluster_keys(), std::back_inserter(keys));
-    TrackFitUtils::getTrackletClusters(m_tGeometry, m_clusterContainer,
-                                       clusPos, keys);
-    TrackFitUtils::position_vector_t xypoints, rzpoints;
-    for (auto& p : clusPos)
-    {
-      float clusr = radius(p.x(), p.y());
-      if (p.y() < 0)
-      {
-        clusr *= -1;
-      }
-
-      // exclude silicon and tpot clusters for now
-      if (std::abs(clusr) > 80 || std::abs(clusr) < 30)
-      {
-        continue;
-      }
-      xypoints.push_back(std::make_pair(p.x(), p.y()));
-      rzpoints.push_back(std::make_pair(p.z(), clusr));
-    }
-
-    auto rzparams = TrackFitUtils::line_fit(rzpoints);
-    float fulllineintz = std::get<1>(rzparams);
-    float fulllineslope = std::get<0>(rzparams);
-
-    float slope = tpcseed->get_slope();
-    float intz = m_vertexRadius * slope + tpcseed->get_Z0();
-
-    Acts::Vector3 inter(intx, inty, intz);
-
-    std::vector<float> tpcparams{(float) std::abs(1./tpcseed->get_qOverR()), 
-                                 tpcseed->get_X0(), 
-                                 tpcseed->get_Y0(), 
-                                 tpcseed->get_slope(),
-                                 tpcseed->get_Z0()};
-    auto tangent = TrackFitUtils::get_helix_tangent(tpcparams,
-                                                    inter);
-
-    auto tan = tangent.second;
-
-    float p;
-    if (m_ConstField)
-    {
-      p = std::cosh(tpcseed->get_eta()) * fabs(1. / tpcseed->get_qOverR()) * (0.3 / 100) * fieldstrength;
-    }
-    else
-    {
-      p = tpcseed->get_p();
-    }
-
-    tan *= p;
-
-    //! if we got the opposite seed then z will be backwards, so we take the
-    //! value of tan.z() multiplied by the sign of the slope determined for
-    //! the full cosmic track
-    //! same with px/py since a single cosmic produces two seeds that bend
-    //! in opposite directions
-    float theta = std::atan(fulllineslope);
-    /// Normalize to 0<theta<pi
-    if (theta < 0)
-    {
-      theta += M_PI;
-    }
-    float pz = std::cos(theta) * p;
-    if (fulllineslope < 0)
-    {
-      pz = std::abs(pz);
-    }
-    else
-    {
-      pz = std::abs(pz) * -1;
-    }
-    Acts::Vector3 momentum = Acts::Vector3::Zero();
-
-    if (!m_zeroField)
-    {
-      momentum.x() = tan.x() * -1;
-      momentum.y() = tan.y() * -1;
-    }
-    else
-    {
-      auto xyparams = TrackFitUtils::line_fit(xypoints);
-      float fulllineslopexy = std::get<0>(xyparams);
-      if (fulllineslopexy < 0)
-      {
-        momentum.x() = fabs(tan.x());
-      }
-      else
-      {
-        momentum.x() = fabs(tan.x()) * -1;
-      }
-      momentum.y() = fabs(tan.y()) * -1;
-    }
-
-    momentum.z() = pz;
-    Acts::Vector3 position = pca;
-
-    position *= Acts::UnitConstants::cm;
     if (!is_valid(momentum))
     {
       continue;
     }
 
-    int charge = getCharge(clusPos, tpcparams);
+    int charge = getCharge(tpcseed, sorted_positions);
 
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
         position);
@@ -516,8 +400,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_R = std::abs(1./tpcseed->get_qOverR());
       m_X0 = tpcseed->get_X0();
       m_Y0 = tpcseed->get_Y0();
-      m_Z0 = fulllineintz;
-      m_slope = fulllineslope;
+      m_Z0 = tpcseed->get_Z0();
+      m_slope = tpcseed->get_slope();
       m_pcax = position(0);
       m_pcay = position(1);
       m_pcaz = position(2);
@@ -1028,28 +912,18 @@ void PHCosmicsTrkFitter::clearVectors()
   m_ez.clear();
 }
 
-int PHCosmicsTrkFitter::getCharge(
-    const std::vector<Acts::Vector3>& positions,
-    const std::vector<float>& tpccparams)
+int PHCosmicsTrkFitter::getCharge(TrackSeed *tpcseed,
+    const std::vector<Acts::Vector3>& sorted_positions)
 {
   Acts::GeometryContext transient_geocontext{m_alignmentTransformationMapTransient};
-  std::vector<Acts::Vector3> sorted_positions = positions;
-  // sort the clusters in order of outermost radius to innermost radius
-  std::sort(sorted_positions.begin(), sorted_positions.end(), [](const Acts::Vector3& a, const Acts::Vector3& b)
-            {
-    float aradius = std::sqrt(a.x()*a.x()+a.y()*a.y());
-    if(a.y() < 0)
-    {
-      aradius *= -1;
-    }
-    float bradius = std::sqrt(b.x()*b.x()+b.y()*b.y());
-    if(b.y() < 0)
-    {
-      bradius *= -1;
-    }
-    return aradius > bradius; });
 
-  float phi0 = std::atan2(sorted_positions[0].y() - tpccparams[2], sorted_positions[0].x() - tpccparams[1]);
+  std::vector<float> tpcparams{(float) std::abs(1. / tpcseed->get_qOverR()),
+                               tpcseed->get_X0(),
+                               tpcseed->get_Y0(),
+                               tpcseed->get_slope(),
+                               tpcseed->get_Z0()};
+
+  float phi0 = std::atan2(sorted_positions[0].y() - tpcparams[2], sorted_positions[0].x() - tpcparams[1]);
   int posphi = 0;
   int negphi = 0;
   // just take the first 4 outermost clusters as a test to determine the bend angle
@@ -1058,7 +932,7 @@ int PHCosmicsTrkFitter::getCharge(
   {
     auto cluspos = sorted_positions[i];
 
-    float phi = std::atan2(cluspos.y() - tpccparams[2], cluspos.x() - tpccparams[1]);
+    float phi = std::atan2(cluspos.y() - tpcparams[2], cluspos.x() - tpcparams[1]);
     if (phi > phi0)
     {
       posphi++;
@@ -1118,4 +992,121 @@ Acts::Vector3 PHCosmicsTrkFitter::calculatePCA(TrackSeed* seed, const std::vecto
   float z_ca = a + b * s_ca;
 
   return Acts::Vector3(pcax, pcay, z_ca);
+}
+
+
+Acts::Vector3 PHCosmicsTrkFitter::calculateMomentum(TrackSeed* tpcseed, const std::vector<Acts::Vector3>& sorted_positions)
+{
+  // now calculate the momentum vector
+  const auto intersect = TrackFitUtils::circle_circle_intersection(m_vertexRadius, std::abs(1. / tpcseed->get_qOverR()), tpcseed->get_X0(), tpcseed->get_Y0());
+  float intx, inty;
+
+  if (std::get<1>(intersect) > std::get<3>(intersect))
+  {
+    intx = std::get<0>(intersect);
+    inty = std::get<1>(intersect);
+  }
+  else
+  {
+    intx = std::get<2>(intersect);
+    inty = std::get<3>(intersect);
+  }
+  if (Verbosity() > 2)
+  {
+    std::cout << "XY intersection options " << std::get<0>(intersect) << ", " << std::get<1>(intersect) << " and " << std::get<2>(intersect) << ", " << std::get<3>(intersect) << std::endl;
+  }
+
+  TrackFitUtils::position_vector_t xypoints, rzpoints;
+  for (auto& p : sorted_positions)
+  {
+    float clusr = radius(p.x(), p.y());
+    if (p.y() < 0)
+    {
+      clusr *= -1;
+    }
+
+    // exclude silicon and tpot clusters for now
+    if (std::abs(clusr) > 80 || std::abs(clusr) < 30)
+    {
+      continue;
+    }
+    xypoints.push_back(std::make_pair(p.x(), p.y()));
+    rzpoints.push_back(std::make_pair(p.z(), clusr));
+  }
+
+  auto rzparams = TrackFitUtils::line_fit(rzpoints);
+  float fulllineslope = std::get<0>(rzparams);
+
+  float slope = tpcseed->get_slope();
+  float intz = m_vertexRadius * slope + tpcseed->get_Z0();
+
+  Acts::Vector3 inter(intx, inty, intz);
+
+  std::vector<float> tpcparams{(float) std::abs(1. / tpcseed->get_qOverR()),
+                               tpcseed->get_X0(),
+                               tpcseed->get_Y0(),
+                               tpcseed->get_slope(),
+                               tpcseed->get_Z0()};
+  auto tangent = TrackFitUtils::get_helix_tangent(tpcparams,
+                                                  inter);
+
+  auto tan = tangent.second;
+
+  float p;
+  if (m_ConstField)
+  {
+    p = std::cosh(tpcseed->get_eta()) * fabs(1. / tpcseed->get_qOverR()) * (0.3 / 100) * fieldstrength;
+  }
+  else
+  {
+    p = tpcseed->get_p();
+  }
+
+  tan *= p;
+
+  //! if we got the opposite seed then z will be backwards, so we take the
+  //! value of tan.z() multiplied by the sign of the slope determined for
+  //! the full cosmic track
+  //! same with px/py since a single cosmic produces two seeds that bend
+  //! in opposite directions
+  float theta = std::atan(fulllineslope);
+  /// Normalize to 0<theta<pi
+  if (theta < 0)
+  {
+    theta += M_PI;
+  }
+  float pz = std::cos(theta) * p;
+  if (fulllineslope < 0)
+  {
+    pz = std::abs(pz);
+  }
+  else
+  {
+    pz = std::abs(pz) * -1;
+  }
+  Acts::Vector3 momentum = Acts::Vector3::Zero();
+
+  if (!m_zeroField)
+  {
+    momentum.x() = tan.x() * -1;
+    momentum.y() = tan.y() * -1;
+  }
+  else
+  {
+    auto xyparams = TrackFitUtils::line_fit(xypoints);
+    float fulllineslopexy = std::get<0>(xyparams);
+    if (fulllineslopexy < 0)
+    {
+      momentum.x() = fabs(tan.x());
+    }
+    else
+    {
+      momentum.x() = fabs(tan.x()) * -1;
+    }
+    momentum.y() = fabs(tan.y()) * -1;
+  }
+
+  momentum.z() = pz;
+
+  return momentum;
 }

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -11,6 +11,7 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 
+#include <trackbase/ActsTrackFittingAlgorithm.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentStateMap_v1.h>
 #include <trackbase_historic/SvtxTrackMap_v2.h>
@@ -258,7 +259,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     std::cout << " seed map size " << m_seedMap->size() << std::endl;
   }
 
-  for (auto track : *m_seedMap)
+  for (auto* track : *m_seedMap)
   {
     if (!track)
     {
@@ -269,10 +270,10 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     unsigned int siid = track->get_silicon_seed_index();
 
     // get the crossing number
-    auto siseed = m_siliconSeeds->get(siid);
+    auto* siseed = m_siliconSeeds->get(siid);
     short crossing = 0;
 
-    auto tpcseed = m_tpcSeeds->get(tpcid);
+    auto* tpcseed = m_tpcSeeds->get(tpcid);
     if (Verbosity() > 1)
     {
       std::cout << "TPC id " << tpcid << std::endl;
@@ -341,7 +342,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     // copy transient map for this track into transient geoContext
     m_transient_geocontext = geoContext;
 
-    std::vector<Acts::Vector3> pos, sorted_positions;
+    std::vector<Acts::Vector3> pos;
+    std::vector<Acts::Vector3> sorted_positions;
     // get positions from cluster keys
     // TODO: should implement distortions
     TrackSeedHelper::position_map_t positions;
@@ -739,7 +741,7 @@ int PHCosmicsTrkFitter::createNodes(PHCompositeNode* topNode)
   if (!m_alignmentStateMap)
   {
     m_alignmentStateMap = new SvtxAlignmentStateMap_v1;
-    auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap, "SvtxAlignmentStateMap", "PHObject");
+    auto* node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap, "SvtxAlignmentStateMap", "PHObject");
     svtxNode->addNode(node);
   }
 
@@ -858,7 +860,7 @@ void PHCosmicsTrkFitter::makeBranches()
 }
 void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
 {
-  for (auto seed : {tpcseed, siseed})
+  for (auto* seed : {tpcseed, siseed})
   {
     if (!seed)
     {
@@ -869,7 +871,7 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
          ++it)
     {
       auto key = *it;
-      auto cluster = m_clusterContainer->findCluster(key);
+      auto* cluster = m_clusterContainer->findCluster(key);
       m_locx.push_back(cluster->getLocalX());
       m_locy.push_back(cluster->getLocalY());
       auto glob = m_tGeometry->getGlobalPosition(key, cluster);
@@ -888,7 +890,7 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
       m_phisize.push_back(cluster->getPhiSize());
       m_zsize.push_back(cluster->getZSize());
       auto para_errors =
-          m_clusErrPara.get_clusterv5_modified_error(cluster, r, key);
+          ClusterErrorPara::get_clusterv5_modified_error(cluster, r, key);
 
       m_ephi.push_back(std::sqrt(para_errors.first));
       m_ez.push_back(std::sqrt(para_errors.second));
@@ -951,7 +953,7 @@ int PHCosmicsTrkFitter::getCharge(TrackSeed* tpcseed,
   return charge;
 }
 
-Acts::Vector3 PHCosmicsTrkFitter::calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions)
+Acts::Vector3 PHCosmicsTrkFitter::calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions) const
 {
   float tpcR = fabs(1. / seed->get_qOverR());
   float tpcx = seed->get_X0();
@@ -970,11 +972,14 @@ Acts::Vector3 PHCosmicsTrkFitter::calculatePCA(TrackSeed* seed, const std::vecto
     return tpcR * angle;
   };
 
-  float sum_s = 0, sum_z = 0, sum_ss = 0, sum_sz = 0;
+  float sum_s = 0;
+  float sum_z = 0;
+  float sum_ss = 0;
+  float sum_sz = 0;
   int n = sorted_positions.size();
   // Compute the arc-length parameter for each cluster, then fit to a line
   // Fit z = a + b*s using simple linear regression
-  for (auto& p : sorted_positions)
+  for (const auto& p : sorted_positions)
   {
     float s = arcLength(p.x(), p.y());
     sum_s += s;
@@ -998,7 +1003,8 @@ Acts::Vector3 PHCosmicsTrkFitter::calculateMomentum(TrackSeed* tpcseed, const st
 {
   // now calculate the momentum vector
   const auto intersect = TrackFitUtils::circle_circle_intersection(m_vertexRadius, std::abs(1. / tpcseed->get_qOverR()), tpcseed->get_X0(), tpcseed->get_Y0());
-  float intx, inty;
+  float intx;
+  float inty;
 
   if (std::get<1>(intersect) > std::get<3>(intersect))
   {
@@ -1015,8 +1021,9 @@ Acts::Vector3 PHCosmicsTrkFitter::calculateMomentum(TrackSeed* tpcseed, const st
     std::cout << "XY intersection options " << std::get<0>(intersect) << ", " << std::get<1>(intersect) << " and " << std::get<2>(intersect) << ", " << std::get<3>(intersect) << std::endl;
   }
 
-  TrackFitUtils::position_vector_t xypoints, rzpoints;
-  for (auto& p : sorted_positions)
+  TrackFitUtils::position_vector_t xypoints;
+  TrackFitUtils::position_vector_t rzpoints;
+  for (const auto& p : sorted_positions)
   {
     float clusr = radius(p.x(), p.y());
     if (p.y() < 0)
@@ -1029,8 +1036,8 @@ Acts::Vector3 PHCosmicsTrkFitter::calculateMomentum(TrackSeed* tpcseed, const st
     {
       continue;
     }
-    xypoints.push_back(std::make_pair(p.x(), p.y()));
-    rzpoints.push_back(std::make_pair(p.z(), clusr));
+    xypoints.emplace_back(p.x(), p.y());
+    rzpoints.emplace_back(p.z(), clusr);
   }
 
   auto rzparams = TrackFitUtils::line_fit(rzpoints);

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -397,7 +397,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       clearVectors();
       m_seed = tpcid;
-      m_R = std::abs(1./tpcseed->get_qOverR());
+      m_R = std::abs(1. / tpcseed->get_qOverR());
       m_X0 = tpcseed->get_X0();
       m_Y0 = tpcseed->get_Y0();
       m_Z0 = tpcseed->get_Z0();
@@ -912,8 +912,8 @@ void PHCosmicsTrkFitter::clearVectors()
   m_ez.clear();
 }
 
-int PHCosmicsTrkFitter::getCharge(TrackSeed *tpcseed,
-    const std::vector<Acts::Vector3>& sorted_positions)
+int PHCosmicsTrkFitter::getCharge(TrackSeed* tpcseed,
+                                  const std::vector<Acts::Vector3>& sorted_positions)
 {
   Acts::GeometryContext transient_geocontext{m_alignmentTransformationMapTransient};
 
@@ -993,7 +993,6 @@ Acts::Vector3 PHCosmicsTrkFitter::calculatePCA(TrackSeed* seed, const std::vecto
 
   return Acts::Vector3(pcax, pcay, z_ca);
 }
-
 
 Acts::Vector3 PHCosmicsTrkFitter::calculateMomentum(TrackSeed* tpcseed, const std::vector<Acts::Vector3>& sorted_positions)
 {

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -113,10 +113,27 @@ int PHCosmicsTrkFitter::InitRun(PHCompositeNode* topNode)
   {
     m_ConstField = true;
   }
+  auto level = Acts::Logging::FATAL;
+  if (Verbosity() > 5)
+  {
+    level = Acts::Logging::VERBOSE;
+  }
 
   m_fitCfg.fit = ActsTrackFittingAlgorithm::makeKalmanFitterFunction(
       m_tGeometry->geometry().tGeometry,
-      m_tGeometry->geometry().magField);
+      m_tGeometry->geometry().magField,
+      true, true, 0.0, Acts::FreeToBoundCorrection(), *Acts::getDefaultLogger("Kalman", level));
+
+  m_fitCfg.dFit = ActsTrackFittingAlgorithm::makeDirectedKalmanFitterFunction(
+      m_tGeometry->geometry().tGeometry,
+      m_tGeometry->geometry().magField, true, true, 0.0, Acts::FreeToBoundCorrection(), *Acts::getDefaultLogger("DirectedKalman", level));
+
+  MaterialSurfaceSelector selector;
+  if (m_directNavigation)
+  {
+    m_tGeometry->geometry().tGeometry->visitSurfaces(selector, false);
+    m_materialSurfaces = selector.surfaces;
+  }
 
   m_outlierFinder.verbosity = Verbosity();
   std::map<long unsigned int, float> chi2Cuts;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -983,6 +983,7 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
 }
 void PHCosmicsTrkFitter::clearVectors()
 {
+  
   m_locx.clear();
   m_locy.clear();
   m_x.clear();
@@ -1000,10 +1001,6 @@ void PHCosmicsTrkFitter::clearVectors()
 
 void PHCosmicsTrkFitter::getCharge(
     TrackSeed* track,
-    // TrkrClusterContainer*  clusterContainer,
-    // ActsGeometry* tGeometry,
-    // alignmentTransformationContainer* transformMapTransient,
-    // float vertexRadius,
     int& charge,
     float& cosmicslope)
 {
@@ -1105,7 +1102,10 @@ void PHCosmicsTrkFitter::getCharge(
   {
     charge = 1;
   }
-
+  if(Verbosity() > 2)
+  {
+    std::cout << "charge is " << charge << std::endl;
+  }
   float r1 = std::sqrt(square(globalMostOuter.x()) + square(globalMostOuter.y()));
   float r2 = std::sqrt(square(globalSecondMostOuter.x()) + square(globalSecondMostOuter.y()));
   float z1 = globalMostOuter.z();

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -336,10 +336,6 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       continue;
     }
-    int charge = 0;
-    float cosmicslope = 0;
-
-    getCharge(tpcseed, charge, cosmicslope);
 
     Acts::GeometryContext geoContext{m_alignmentTransformationMapTransient};
     // copy transient map for this track into transient geoContext
@@ -377,6 +373,11 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       intx = std::get<2>(intersect);
       inty = std::get<3>(intersect);
     }
+    if(Verbosity() > 2)
+    {
+      std::cout << "XY intersection options " << std::get<0>(intersect) << ", " << std::get<1>(intersect) << " and " << std::get<2>(intersect) << ", " << std::get<3>(intersect) << std::endl;
+    }
+
     std::vector<TrkrDefs::cluskey> keys;
     std::vector<Acts::Vector3> clusPos;
     std::copy(tpcseed->begin_cluster_keys(), tpcseed->end_cluster_keys(), std::back_inserter(keys));
@@ -406,6 +407,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     float slope = tpcseed->get_slope();
     float intz = m_vertexRadius * slope + tpcseed->get_Z0();
+
 
     Acts::Vector3 inter(intx, inty, intz);
 
@@ -453,7 +455,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     if (!m_zeroField)
     {
-      momentum.x() = tan.x() * -1; 
+      momentum.x() = tan.x() * -1;
       momentum.y() = tan.y() * -1;
     }
     else
@@ -480,6 +482,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       continue;
     }
+
+    int charge = getCharge(clusPos, tpcparams);
 
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
         position);
@@ -510,6 +514,25 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       m_charge = charge;
       fillVectors(siseed, tpcseed);
       m_tree->Fill();
+    }
+    if(m_dumpSeeds)
+    {
+      SvtxTrack_v4 newTrack;
+      newTrack.set_tpc_seed(tpcseed);
+      newTrack.set_crossing(crossing);
+      newTrack.set_silicon_seed(siseed);
+
+      unsigned int trid = m_trackMap->size();
+      newTrack.set_id(trid);
+      newTrack.set_px(momentum.x());
+      newTrack.set_py(momentum.y());
+      newTrack.set_pz(momentum.z());
+      newTrack.set_x(position.x()/Acts::UnitConstants::cm);
+      newTrack.set_y(position.y()/Acts::UnitConstants::cm);
+      newTrack.set_z(position.z()/Acts::UnitConstants::cm);
+      newTrack.set_charge(charge);
+      m_trackMap->insertWithKey(&newTrack, trid);
+      continue;
     }
     //! Reset the track seed with the dummy covariance
     auto seed = ActsTrackFittingAlgorithm::TrackParameters::create(
@@ -999,117 +1022,51 @@ void PHCosmicsTrkFitter::clearVectors()
   m_ez.clear();
 }
 
-void PHCosmicsTrkFitter::getCharge(
-    TrackSeed* track,
-    int& charge,
-    float& cosmicslope)
+int PHCosmicsTrkFitter::getCharge(
+    const std::vector<Acts::Vector3>& positions,
+    const std::vector<float>& tpccparams)
 {
   Acts::GeometryContext transient_geocontext{m_alignmentTransformationMapTransient};
-
-  std::vector<Acts::Vector3> global_vec;
-
-  for (auto clusIter = track->begin_cluster_keys();
-       clusIter != track->end_cluster_keys();
-       ++clusIter)
-  {
-    auto key = *clusIter;
-    auto cluster = m_clusterContainer->findCluster(key);
-    if (!cluster)
+  std::vector<Acts::Vector3> sorted_positions = positions;
+  // sort the clusters in order of outermost radius to innermost radius
+  std::sort(sorted_positions.begin(), sorted_positions.end(), [](const Acts::Vector3& a, const Acts::Vector3& b)
+            {
+    float aradius = std::sqrt(a.x()*a.x()+a.y()*a.y());
+    if(a.y() < 0)
     {
-      std::cout << "MakeSourceLinks::getCharge: Failed to get cluster with key " << key << " for track seed" << std::endl;
-      continue;
+      aradius *= -1;
     }
-
-    auto surf = m_tGeometry->maps().getSurface(key, cluster);
-    if (!surf)
+    float bradius = std::sqrt(b.x()*b.x()+b.y()*b.y());
+    if(b.y() < 0)
     {
-      continue;
+      bradius *= -1;
     }
+    return aradius > bradius; });
 
-    // get cluster global positions
-    Acts::Vector2 local = m_tGeometry->getLocalCoords(key, cluster);  // converts TPC time to z
-    Acts::Vector3 glob = surf->localToGlobal(transient_geocontext,
-                                             local * Acts::UnitConstants::cm,
-                                             Acts::Vector3(1, 1, 1));
-    glob /= Acts::UnitConstants::cm;
-
-    global_vec.push_back(glob);
-  }
-
-  Acts::Vector3 globalMostOuter(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
-  Acts::Vector3 globalSecondMostOuter(0, 999999, 0);
-  float largestR = 0;
-  // loop over global positions
-  for (auto& i : global_vec)
+  float phi0 = std::atan2(sorted_positions[0].y() - tpccparams[2], sorted_positions[0].x() - tpccparams[1]);
+  int posphi = 0;
+  int negphi = 0;
+  // just take the first 4 outermost clusters as a test to determine the bend angle
+  // from the outermost radial cluster
+  for (size_t i = 1; i < 5; i++)
   {
-    Acts::Vector3 global = i;
-    // float r = std::sqrt(square(global.x()) + square(global.y()));
-    float r = radius(global.x(), global.y());
+    auto cluspos = sorted_positions[i];
 
-    /// use the top hemisphere to determine the charge
-    if (r > largestR && global.y() > 0)
+    float phi = std::atan2(cluspos.y() - tpccparams[2], cluspos.x() - tpccparams[1]);
+    if(phi > phi0)
     {
-      globalMostOuter = i;
-      largestR = r;
+      posphi++;
+    }
+    else
+    {
+      negphi++;
     }
   }
-
-  //! find the closest cluster to the outermost cluster
-  float maxdr = std::numeric_limits<float>::max();
-  for (auto& i : global_vec)
-  {
-    if (i.y() < 0)
-    {
-      continue;
-    }
-
-    float dr = std::sqrt(square(globalMostOuter.x()) + square(globalMostOuter.y())) - std::sqrt(square(i.x()) + square(i.y()));
-    //! Place a dr cut to get maximum bend due to TPC clusters having
-    //! larger fluctuations
-    if (dr < maxdr && dr > 10)
-    {
-      maxdr = dr;
-      globalSecondMostOuter = i;
-    }
-  }
-
-  //! we have to calculate phi WRT the vertex position outside the detector,
-  //! not at (0,0)
-  Acts::Vector3 vertex(0, m_vertexRadius, 0);
-  globalMostOuter -= vertex;
-  globalSecondMostOuter -= vertex;
-
-  const auto firstphi = atan2(globalMostOuter.y(), globalMostOuter.x());
-  const auto secondphi = atan2(globalSecondMostOuter.y(),
-                               globalSecondMostOuter.x());
-  auto dphi = secondphi - firstphi;
-
-  if (dphi > M_PI)
-  {
-    dphi = 2. * M_PI - dphi;
-  }
-  if (dphi < -M_PI)
-  {
-    dphi = 2 * M_PI + dphi;
-  }
-
-  if (dphi > 0)
-  {
-    charge = -1;
-  }
-  else
-  {
-    charge = 1;
-  }
-  if(Verbosity() > 2)
+  int charge = posphi > negphi ? -1 : 1;
+  if (Verbosity() > 2)
   {
     std::cout << "charge is " << charge << std::endl;
   }
-  float r1 = std::sqrt(square(globalMostOuter.x()) + square(globalMostOuter.y()));
-  float r2 = std::sqrt(square(globalSecondMostOuter.x()) + square(globalSecondMostOuter.y()));
-  float z1 = globalMostOuter.z();
-  float z2 = globalSecondMostOuter.z();
-  cosmicslope = (r2 - r1) / (z2 - z1);
 
-  return;
+  return charge;
 }

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -66,7 +66,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   {
     m_fillSvtxTrackStates = fillSvtxTrackStates;
   }
-
+  void directNavigator() { m_directNavigation = true; }
   void useActsEvaluator(bool actsEvaluator)
   {
     m_actsEvaluator = actsEvaluator;
@@ -162,6 +162,8 @@ class PHCosmicsTrkFitter : public SubsysReco
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates = true;
 
+  bool m_directNavigation = false;
+
   // do we have a constant field
   bool m_ConstField = false;
   double fieldstrength{std::numeric_limits<double>::quiet_NaN()};
@@ -197,6 +199,8 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
   ActsAlignmentStates m_alignStates;
+
+  std::vector<const Acts::Surface*> m_materialSurfaces = {};
 
   bool m_zeroField = false;
   PHG4TpcGeomContainer* _tpccellgeo = nullptr;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -112,6 +112,7 @@ class PHCosmicsTrkFitter : public SubsysReco
                        Trajectory::IndexedParameters& paramsMap,
                        ActsTrackFittingAlgorithm::TrackContainer& tracks,
                        SvtxTrack* track);
+  Acts::Vector3 calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions);
 
   /// Helper function to call either the regular navigation or direct
   /// navigation, depending on m_fitSiliconMMs

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -105,7 +105,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   int createNodes(PHCompositeNode* topNode);
 
   void loopTracks(Acts::Logging::Level logLevel);
-  int getCharge(const std::vector<Acts::Vector3>& positions, const std::vector<float>& tpcparams);
+  int getCharge(TrackSeed *tpcseed, const std::vector<Acts::Vector3>& sorted_positions);
 
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(std::vector<Acts::TrackIndexType>& tips,
@@ -113,7 +113,7 @@ class PHCosmicsTrkFitter : public SubsysReco
                        ActsTrackFittingAlgorithm::TrackContainer& tracks,
                        SvtxTrack* track);
   Acts::Vector3 calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions);
-
+  Acts::Vector3 calculateMomentum(TrackSeed* tpcseed, const std::vector<Acts::Vector3>& sorted_positions);
   /// Helper function to call either the regular navigation or direct
   /// navigation, depending on m_fitSiliconMMs
   inline ActsTrackFittingAlgorithm::TrackFitterResult fitTrack(

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -62,6 +62,8 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   int ResetEvent(PHCompositeNode* topNode) override;
 
+  void convertSeeds() { m_dumpSeeds = true; }
+
   void setUpdateSvtxTrackStates(bool fillSvtxTrackStates)
   {
     m_fillSvtxTrackStates = fillSvtxTrackStates;
@@ -103,7 +105,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   int createNodes(PHCompositeNode* topNode);
 
   void loopTracks(Acts::Logging::Level logLevel);
-  void getCharge(TrackSeed* track, int& charge, float& cosmicslope);
+  int getCharge(const std::vector<Acts::Vector3>& positions, const std::vector<float>& tpcparams);
 
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(std::vector<Acts::TrackIndexType>& tips,
@@ -204,6 +206,8 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   bool m_zeroField = false;
   PHG4TpcGeomContainer* _tpccellgeo = nullptr;
+
+  bool m_dumpSeeds = false;
 
   //! for diagnosing seed param + clusters
   bool m_seedClusAnalysis = false;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -112,7 +112,7 @@ class PHCosmicsTrkFitter : public SubsysReco
                        Trajectory::IndexedParameters& paramsMap,
                        ActsTrackFittingAlgorithm::TrackContainer& tracks,
                        SvtxTrack* track);
-  Acts::Vector3 calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions);
+  Acts::Vector3 calculatePCA(TrackSeed* seed, const std::vector<Acts::Vector3>& sorted_positions) const;
   Acts::Vector3 calculateMomentum(TrackSeed* tpcseed, const std::vector<Acts::Vector3>& sorted_positions);
   /// Helper function to call either the regular navigation or direct
   /// navigation, depending on m_fitSiliconMMs

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -105,7 +105,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   int createNodes(PHCompositeNode* topNode);
 
   void loopTracks(Acts::Logging::Level logLevel);
-  int getCharge(TrackSeed *tpcseed, const std::vector<Acts::Vector3>& sorted_positions);
+  int getCharge(TrackSeed* tpcseed, const std::vector<Acts::Vector3>& sorted_positions);
 
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(std::vector<Acts::TrackIndexType>& tips,


### PR DESCRIPTION
Overhaul of the cosmic track fitter with Acts.
1. Improved the seed PCA calculation 
2. Improved the seed charge determination
3. Refactored a bunch of code to make it more readable

Fits single muons that originate outside of the nominal tracking volume now in simulation, next to test on data

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Cosmic Track Fitter Improvements Using Acts Framework

### Motivation / context
Cosmic muons that originate outside the nominal tracking volume need different seeding and fitting logic than collision tracks. This PR overhauls the Acts-based cosmic track fitter to improve seed PCA, seed momentum/charge estimation, direct-navigation/material handling, and diagnostics to better reconstruct single-muon cosmic tracks in simulation (data validation planned next).

### Key changes
- Seed processing
  - Build signed-transverse-radius-sorted lists of cluster global positions for each seed.
  - New calculatePCA(seed, sorted_positions) to compute point-of-closest-approach (PCA) from cluster positions.
  - New calculateMomentum(seed, sorted_positions) that derives momentum from circle fit + helix-tangent construction (handles const/zero field).
- Charge determination
  - Replaced surface-coordinate geometry-based logic with a bend-direction (outer-cluster) counting approach: getCharge(TrackSeed*, const std::vector<Acts::Vector3>&).
  - getCharge signature changed accordingly.
- Material / navigation
  - Added MaterialSurfaceSelector helper (ActsTrackFittingAlgorithm.h) to collect unique Acts::Surface* with surfaceMaterial() for optional preselection.
  - PHCosmicsTrkFitter supports an optional direct navigation path and can precompute material surfaces when directNavigator() is enabled.
  - ActsTrackFittingAlgorithm gained direct-navigation-aware config and dispatcher for directed fits.
- Diagnostics / configuration
  - Seed-dump ROOT TTree updated to store computed per-track quantities (PCA, momentum components, signed radius, explicit charge) and per-cluster position entries; fillVectors simplified (local Y read directly; TPC drift/surface-center z-local correction removed).
  - Public inline setters added: convertSeeds() (enable seed dump) and directNavigator() (enable direct navigation).
  - Kalman fitter construction now uses verbosity-dependent Acts loggers and optional chi2 outlier finder.
- Refactoring / cleanup
  - Interfaces simplified and helper functions introduced; PHActsTrkFitter removed a duplicated MaterialSurfaceSelector helper (consolidated in ActsTrackFittingAlgorithm.h).
  - Minor clang-tidy cleanup and a small fix for occasional surface-parameter issues (commit message).

### Potential risk areas
- Reconstruction behavior
  - Charge assignment logic changed fundamentally → possible systematic shifts in reconstructed charge and downstream quantities.
  - PCA and momentum derived from circle-fit + tangent may introduce differences vs previous seed estimates; impacts on fit convergence and final kinematics expected and must be validated.
- IO / diagnostics
  - Seed-dump ROOT TTree branch layout changed — analysis macros/tools consuming the old branches will need updates.
  - convertSeeds() and seed-cluster-tree behaviour may affect diagnostic workflows.
- Navigation & geometry
  - directNavigator() and material-surface preselection change propagation/navigation choices and material-interaction modeling; fits in complex regions may be affected.
- Performance / thread-safety
  - Extra per-seed computations and optional surface preselection increase CPU work; measure throughput impact on large samples.
  - No explicit threading changes, but refactored helpers should be reviewed for thread-safety if used in multi-threaded processing.
- Edge cases
  - Circle-fit / bend-count methods assume adequate and well-ordered clusters; sparse, ambiguous, or edge-cluster patterns may yield unstable momentum/charge estimates.

### Possible future improvements
- Validate and tune new charge/PCA/momentum logic on real cosmic data and on larger simulation samples; compare to truth and previous fitter behavior using automated tests.
- Add unit/integration tests that exercise sparse and edge-case cluster patterns.
- Provide a compatibility mode or migration helper for tools that read the seed-dump ROOT TTree.
- Benchmark and, if needed, optimize heavy helper paths or make them configurable (fast vs robust).
- Expand diagnostics and failure-mode logging for problematic seeds and fits.

Note: I used the repository headers/sources to produce this summary; AI can make mistakes or miss subtleties—please review the modified algorithms (charge, PCA, momentum), ROOT tree branch changes, and navigation/material preselection behavior carefully before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->