### PR TITLE
Add vernier scan xsec to sphenix_constants. Value needs to be verified.

### DIFF
--- a/offline/framework/phool/sphenix_constants.h
+++ b/offline/framework/phool/sphenix_constants.h
@@ -12,5 +12,6 @@ namespace sphenix_constants
   //! time between RHIC crossings (ns)
   static constexpr double time_between_crossings = 106.65237;
   static constexpr double CF4_density = 3.86;  // mg / cm3 Tom Hemmick
+  static constexpr double m_xsec_MBDNS = 24.07*1e9; //convert to pb from Vernier scan
 }  // namespace sphenix_constants
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

A simple PR to add the vernier scan xsec into the sphenix_constants file for future use

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

See original suggestion (https://github.com/sPHENIX-Collaboration/coresoftware/pull/4269#discussion_r3276538613). Will eventually update PR [4269](https://github.com/sPHENIX-Collaboration/coresoftware/pull/4269) to use the value from the sphenix_constants file. 

## TODOs (if applicable)

- Verify / validate the vernier scan xsec value

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

Eventually to be used in (https://github.com/sPHENIX-Collaboration/coresoftware/pull/4269) or corresponding codebase. 

