### PR TITLE
add option to not do rescaling in RetowerCEMC

### DIFF
--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -159,8 +159,8 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
           {
             towerinfo->set_time((retower_time_temp / retower_e_temp));
           }
-          towerinfo->set_chi2(scalefactor);
         }
+	towerinfo->set_chi2(scalefactor); //store the fraction of bad towers as the chi2
       }
     }
   }

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -149,7 +149,8 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 	  {
 	    towerinfo->set_energy(retower_e_temp / (double) (1 - scalefactor));
 	  }
-	  else towerinfo->set_energy(retower_e_temp);
+	  else { towerinfo->set_energy(retower_e_temp);
+}
 
 	  if (retower_e_temp == 0)
           {

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -145,14 +145,16 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         }
         else
         {
-          if(_do_rescale)
-	  {
-	    towerinfo->set_energy(retower_e_temp / (double) (1 - scalefactor));
-	  }
-	  else { towerinfo->set_energy(retower_e_temp);
-}
+          if (_do_rescale)
+          {
+            towerinfo->set_energy(retower_e_temp / (double) (1 - scalefactor));
+          }
+          else
+          {
+            towerinfo->set_energy(retower_e_temp);
+          }
 
-	  if (retower_e_temp == 0)
+          if (retower_e_temp == 0)
           {
             towerinfo->set_time(0);
           }
@@ -161,7 +163,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
             towerinfo->set_time((retower_time_temp / retower_e_temp));
           }
         }
-	towerinfo->set_chi2(scalefactor); //store the fraction of bad towers as the chi2
+        towerinfo->set_chi2(scalefactor);  // store the fraction of bad towers as the chi2
       }
     }
   }

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -145,8 +145,13 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         }
         else
         {
-          towerinfo->set_energy(retower_e_temp / (double) (1 - scalefactor));
-          if (retower_e_temp == 0)
+          if(_do_rescale)
+	  {
+	    towerinfo->set_energy(retower_e_temp / (double) (1 - scalefactor));
+	  }
+	  else towerinfo->set_energy(retower_e_temp);
+
+	  if (retower_e_temp == 0)
           {
             towerinfo->set_time(0);
           }

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -18,7 +18,7 @@ class RetowerCEMC : public SubsysReco
 
   void SetEnergyDistribution(int val) { _weighted_energy_distribution = val; }
   void set_frac_cut(double frac_cut) { _frac_cut = frac_cut; }
-  void set_do_rescale(bool do_rescale) {_do_rescale = do_rescale;}
+  void set_do_rescale(bool do_rescale) { _do_rescale = do_rescale; }
   void set_towerinfo(bool use_towerinfo) { m_use_towerinfo = use_towerinfo; }
   void set_towerNodePrefix(const std::string &prefix)
   {
@@ -38,21 +38,21 @@ class RetowerCEMC : public SubsysReco
   bool m_use_towerinfo{false};
   std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
 
-  static const int neta_ihcal = 24;
-  static const int neta_emcal = 96;
-  static const int nphi_ihcal = 64;
-  static const int nphi_emcal = 256;
+  static const int neta_ihcal{24};
+  static const int neta_emcal{96};
+  static const int nphi_ihcal{64};
+  static const int nphi_emcal{256};
 
-  int retower_lowerbound_originaltower_ieta[neta_ihcal] = {0};
-  int retower_upperbound_originaltower_ieta[neta_ihcal] = {0};
-  double retower_lowerbound_originaltower_fraction[neta_ihcal] = {0.0};
-  double retower_upperbound_originaltower_fraction[neta_ihcal] = {0.0};
-  double retower_totalarea[neta_ihcal] = {0.0};
+  int retower_lowerbound_originaltower_ieta[neta_ihcal]{0};
+  int retower_upperbound_originaltower_ieta[neta_ihcal]{0};
+  double retower_lowerbound_originaltower_fraction[neta_ihcal]{0.0};
+  double retower_upperbound_originaltower_fraction[neta_ihcal]{0.0};
+  double retower_totalarea[neta_ihcal]{0.0};
   int retower_first_lowerbound_originaltower_iphi{-1};
 
-  double rawtower_e[neta_emcal][nphi_emcal] = {{0.0}};
-  double rawtower_time[neta_emcal][nphi_emcal] = {{0.0}};
-  int rawtower_status[neta_emcal][nphi_emcal] = {{0}};
+  double rawtower_e[neta_emcal][nphi_emcal]{{0.0}};
+  double rawtower_time[neta_emcal][nphi_emcal]{{0.0}};
+  int rawtower_status[neta_emcal][nphi_emcal]{{0}};
 
   std::string EMTowerName;
   std::string IHTowerName;

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -18,6 +18,7 @@ class RetowerCEMC : public SubsysReco
 
   void SetEnergyDistribution(int val) { _weighted_energy_distribution = val; }
   void set_frac_cut(double frac_cut) { _frac_cut = frac_cut; }
+  void set_do_rescale(bool do_rescale) {_do_rescale = do_rescale;}
   void set_towerinfo(bool use_towerinfo) { m_use_towerinfo = use_towerinfo; }
   void set_towerNodePrefix(const std::string &prefix)
   {
@@ -32,7 +33,8 @@ class RetowerCEMC : public SubsysReco
   void get_weighted_fraction(PHCompositeNode *topNode);
 
   int _weighted_energy_distribution{1};
-  double _frac_cut{0.5};
+  double _frac_cut{1};
+  bool _do_rescale{false};
   bool m_use_towerinfo{false};
   std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adding flag to not rescale EMCal retower energy by fraction of dead area. See details of the problems this causes in Dennis's presentation here: https://indico.bnl.gov/event/33114/

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
HIJetReco update coming


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context
EMCal retowering previously unconditionally rescaled retowered energy by the fraction of good area when towers exceeded a dead-area threshold. That behavior can bias reconstruction in regions with dead towers; this PR introduces a configurable option to disable that rescaling so groups can choose the reconstruction strategy that matches their analyses (motivated by Dennis's presentation).

Note: this summary was produced with AI assistance — AI can make mistakes; please verify details against the code and tests.

## Key changes
- Add boolean configuration flag _do_rescale with public setter set_do_rescale(bool) to control whether retowered energy is divided by (1 - dead_fraction).
  - Default is false (no rescaling).
- Change default _frac_cut from 0.5 → 1.0 (effectively disabling automatic masking by default).
- In RetowerCEMC::process_event (TowerInfo path), conditionalize rescaling:
  - If scalefactor > _frac_cut → set energy=0 and mark hot.
  - Else set energy = retower_e_temp / (1 - scalefactor) when _do_rescale==true, otherwise set energy = retower_e_temp.
  - Time calculation unchanged; chi2 is used to store scalefactor for monitoring.
- No exported API removals; only a setter added.

## Potential risk areas
- Reconstruction behavior change: defaults now avoid rescaling and use _frac_cut = 1.0. Workflows expecting previous behavior must explicitly set _do_rescale = true or restore _frac_cut.
- Inconsistency risk: the conditional rescaling is applied in the TowerInfo/code path shown in the diff; ensure the RawTower path (used when m_use_towerinfo==false) is treated consistently if needed (current RawTower path builds retower energies without dead-area handling).
- IO / format: no new persisted data formats, but retowered energy interpretation changes unless macros are updated.
- Validation risk: physics-level validation (jet energy scale, efficiencies) required to quantify effects.
- Thread-safety / performance: no new shared mutable state or algorithmic complexity; _do_rescale is a simple config flag.

## Possible future improvements
- Apply the _do_rescale conditional (or equivalent dead-area handling) to alternate code paths (RawTower path) for consistent behavior.
- Add unit/integration tests that exercise both settings and document expected physics impacts.
- Add runtime logging/verbosity to report masking/rescaling decisions for validation.
- Provide migration notes and update macros (HIJetReco) alongside this PR to avoid surprises in downstream workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->