### PR TITLE
Back to original try. No change in previous classes. And new v6 class.

### DIFF
--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -115,6 +115,7 @@ pkginclude_HEADERS = \
   TrkrClusterv3.h \
   TrkrClusterv4.h \
   TrkrClusterv5.h \
+  TrkrClusterv6.h \
   TrkrDefs.h \
   TrkrHit.h \
   TrkrHitSet.h \
@@ -187,6 +188,7 @@ ROOTDICTS = \
   TrkrClusterv3_Dict.cc \
   TrkrClusterv4_Dict.cc \
   TrkrClusterv5_Dict.cc \
+  TrkrClusterv6_Dict.cc \
   TrkrHitSetContMvtxHelper_Dict.cc \
   TrkrHitSetContMvtxHelperv1_Dict.cc \
   TrkrHitSetContainer_Dict.cc \
@@ -273,6 +275,7 @@ libtrack_io_la_SOURCES = \
   TrkrClusterv3.cc \
   TrkrClusterv4.cc \
   TrkrClusterv5.cc \
+  TrkrClusterv6.cc \
   TrkrDefs.cc \
   TrkrHitSet.cc \
   TrkrHitSetContMvtxHelper.cc \

--- a/offline/packages/trackbase/TrkrCluster.h
+++ b/offline/packages/trackbase/TrkrCluster.h
@@ -79,6 +79,30 @@ class TrkrCluster : public PHObject
   virtual float getPhiError() const { return NAN; }
   virtual float getRPhiError() const { return NAN; }
   virtual float getZError() const { return NAN; }
+  virtual unsigned int getCenAdc() const { return UINT_MAX; }
+  virtual float getPadCen() const { return NAN; }
+  virtual float getTBinCen() const { return NAN; }
+  virtual float getPadMax() const { return NAN; }
+  virtual float getTBinMax() const { return NAN; }
+  virtual char getSLEdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getSREdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getTLEdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getTREdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getDLEdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getDREdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getHLEdge() const { return std::numeric_limits<char>::max(); }
+  virtual char getHREdge() const { return std::numeric_limits<char>::max(); }
+  virtual int getSLMix() const { return std::numeric_limits<int>::max(); }
+  virtual int getSRMix() const { return std::numeric_limits<int>::max(); }
+  virtual int getTLMix() const { return std::numeric_limits<int>::max(); }
+  virtual int getTRMix() const { return std::numeric_limits<int>::max(); }
+  virtual float getPhiBinLo() const { return NAN; }
+  virtual float getPhiBinHi() const { return NAN; }
+  virtual float getTBinLo() const { return NAN; }
+  virtual float getTBinHi() const { return NAN; }
+  virtual float getPadPhase() const { return NAN; }
+  virtual float getTBinPhase() const { return NAN; }
+  virtual float getRSize() const { return NAN; }
 
   /// Acts functions, for Acts modules use only
   virtual void setActsLocalError(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}

--- a/offline/packages/trackbase/TrkrCluster.h
+++ b/offline/packages/trackbase/TrkrCluster.h
@@ -51,9 +51,9 @@ class TrkrCluster : public PHObject
   //
   // cluster position
   //
-  virtual float getLocalX() const { return NAN; }
+  virtual float getLocalX() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setLocalX(float) {}
-  virtual float getLocalY() const { return NAN; }
+  virtual float getLocalY() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setLocalY(float) {}
 
   //
@@ -68,22 +68,22 @@ class TrkrCluster : public PHObject
   virtual char getEdge() const { return std::numeric_limits<char>::max(); }
   virtual void setEdge(char) {}
   virtual void setTime(const float) {}
-  virtual float getTime() const { return NAN; }
+  virtual float getTime() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual char getSize() const { return std::numeric_limits<char>::max(); }
 
   //
   // convenience interface
   //
-  virtual float getPhiSize() const { return NAN; }
-  virtual float getZSize() const { return NAN; }
-  virtual float getPhiError() const { return NAN; }
-  virtual float getRPhiError() const { return NAN; }
-  virtual float getZError() const { return NAN; }
+  virtual float getPhiSize() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getZSize() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getPhiError() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getRPhiError() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getZError() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual unsigned int getCenAdc() const { return UINT_MAX; }
-  virtual float getPadCen() const { return NAN; }
-  virtual float getTBinCen() const { return NAN; }
-  virtual float getPadMax() const { return NAN; }
-  virtual float getTBinMax() const { return NAN; }
+  virtual float getPadCen() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getTBinCen() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getPadMax() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getTBinMax() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual char getSLEdge() const { return std::numeric_limits<char>::max(); }
   virtual char getSREdge() const { return std::numeric_limits<char>::max(); }
   virtual char getTLEdge() const { return std::numeric_limits<char>::max(); }
@@ -96,36 +96,36 @@ class TrkrCluster : public PHObject
   virtual int getSRMix() const { return std::numeric_limits<int>::max(); }
   virtual int getTLMix() const { return std::numeric_limits<int>::max(); }
   virtual int getTRMix() const { return std::numeric_limits<int>::max(); }
-  virtual float getPhiBinLo() const { return NAN; }
-  virtual float getPhiBinHi() const { return NAN; }
-  virtual float getTBinLo() const { return NAN; }
-  virtual float getTBinHi() const { return NAN; }
-  virtual float getPadPhase() const { return NAN; }
-  virtual float getTBinPhase() const { return NAN; }
-  virtual float getRSize() const { return NAN; }
+  virtual float getPhiBinLo() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getPhiBinHi() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getTBinLo() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getTBinHi() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getPadPhase() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getTBinPhase() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float getRSize() const { return std::numeric_limits<float>::quiet_NaN(); }
 
   /// Acts functions, for Acts modules use only
   virtual void setActsLocalError(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
-  virtual float getActsLocalError(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
+  virtual float getActsLocalError(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual TrkrDefs::subsurfkey getSubSurfKey() const { return TrkrDefs::SUBSURFKEYMAX; }
   virtual void setSubSurfKey(TrkrDefs::subsurfkey /*id*/) {}
 
   // Global coordinate functions are deprecated, use local
   // coordinate functions only
-  virtual float getX() const { return NAN; }
+  virtual float getX() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setX(float) {}
-  virtual float getY() const { return NAN; }
+  virtual float getY() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setY(float) {}
-  virtual float getZ() const { return NAN; }
+  virtual float getZ() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setZ(float) {}
-  virtual float getPosition(int /*coor*/) const { return NAN; }
+  virtual float getPosition(int /*coor*/) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setPosition(int /*coor*/, float /*xi*/) {}
   virtual void setGlobal() {}
   virtual void setLocal() {}
   virtual bool isGlobal() const { return true; }
-  virtual float getError(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
+  virtual float getError(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setError(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
-  virtual float getSize(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
+  virtual float getSize(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setSize(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
 
  protected:

--- a/offline/packages/trackbase/TrkrClusterv6.cc
+++ b/offline/packages/trackbase/TrkrClusterv6.cc
@@ -1,0 +1,141 @@
+/**
+ * @file trackbase/TrkrClusterv6.cc
+ * @author Ishan Goel
+ * @date May 2026
+ * @brief Implementation of TrkrClusterv6
+ */
+#include "TrkrClusterv6.h"
+
+#include <cmath>
+#include <utility>  // for swap
+
+namespace
+{
+  // square convenience function
+  template <class T>
+  constexpr T square(const T& x)
+  {
+    return x * x;
+  }
+}  // namespace
+
+TrkrClusterv6::TrkrClusterv6()
+  : m_subsurfkey(TrkrDefs::SUBSURFKEYMAX)
+  , m_phierr(0)
+  , m_zerr(0)
+  , m_adc(0)
+  , m_maxadc(0)
+  , m_cenadc(0)
+  , m_padcen(0)
+  , m_tbincen(0)
+  , m_padmax(0)
+  , m_tbinmax(0)
+  , m_rsize(0)
+  , m_phisize(0)
+  , m_zsize(0)
+  , m_overlap(0)
+  , m_edge(0)
+  , m_sledge(0)
+  , m_sredge(0)
+  , m_tledge(0)
+  , m_tredge(0)
+  , m_dledge(0)
+  , m_dredge(0)
+  , m_hledge(0)
+  , m_hredge(0)
+  , m_slmix(0)
+  , m_srmix(0)
+  , m_tlmix(0)
+  , m_trmix(0)
+  , m_phibinlo(0)
+  , m_phibinhi(0)
+  , m_tbinlo(0)
+  , m_tbinhi(0)
+  , m_padphase(0)
+  , m_tbinphase(0)
+{
+  for (float& i : m_local)
+  {
+    i = NAN;
+  }
+}
+
+void TrkrClusterv6::identify(std::ostream& os) const
+{
+  os << "---TrkrClusterv6--------------------" << std::endl;
+
+  os << " (rphi,z) =  (" << getLocalX();
+  os << ", " << getLocalY() << ") cm ";
+
+  os << " valid = " << isValid() << std::endl;
+
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
+
+  return;
+}
+
+int TrkrClusterv6::isValid() const
+{
+  for (int i = 0; i < 2; ++i)
+  {
+    if (std::isnan(getPosition(i)))
+    {
+      return 0;
+    }
+  }
+  if (m_adc == 0xFFFF)
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+void TrkrClusterv6::CopyFrom(const TrkrCluster& source)
+{
+  // do nothing if copying onto oneself
+  if (this == &source)
+  {
+    return;
+  }
+
+  // parent class method
+  TrkrCluster::CopyFrom(source);
+
+  setLocalX(source.getLocalX());
+  setLocalY(source.getLocalY());
+  setSubSurfKey(source.getSubSurfKey());
+  setAdc(source.getAdc());
+  setMaxAdc(source.getMaxAdc());
+  setCenAdc(source.getCenAdc());
+  setPadCen(source.getPadCen());
+  setTBinCen(source.getTBinCen());
+  setPadMax(source.getPadMax());
+  setTBinMax(source.getTBinMax());
+  setPhiError(source.getRPhiError());
+  setZError(source.getZError());
+  setRSize(source.getRSize());
+  setPhiSize(source.getPhiSize());
+  setZSize(source.getZSize());
+  setOverlap(source.getOverlap());
+  setEdge(source.getEdge());
+  setSLEdge(source.getSLEdge());
+  setSREdge(source.getSREdge());
+  setTLEdge(source.getTLEdge());
+  setTREdge(source.getTREdge());
+  setDLEdge(source.getDLEdge());
+  setDREdge(source.getDREdge());
+  setHLEdge(source.getHLEdge());
+  setHREdge(source.getHREdge());
+  setSLMix(source.getSLMix());
+  setSRMix(source.getSRMix());
+  setTLMix(source.getTLMix());
+  setTRMix(source.getTRMix());
+  setPhiBinLo(source.getPhiBinLo());
+  setPhiBinHi(source.getPhiBinHi());
+  setTBinLo(source.getTBinLo());
+  setTBinHi(source.getTBinHi());
+  setPadPhase(source.getPadPhase());
+  setTBinPhase(source.getTBinPhase());
+}

--- a/offline/packages/trackbase/TrkrClusterv6.cc
+++ b/offline/packages/trackbase/TrkrClusterv6.cc
@@ -19,47 +19,6 @@ namespace
   }
 }  // namespace
 
-TrkrClusterv6::TrkrClusterv6()
-  : m_subsurfkey(TrkrDefs::SUBSURFKEYMAX)
-  , m_phierr(0)
-  , m_zerr(0)
-  , m_adc(0)
-  , m_maxadc(0)
-  , m_cenadc(0)
-  , m_padcen(0)
-  , m_tbincen(0)
-  , m_padmax(0)
-  , m_tbinmax(0)
-  , m_rsize(0)
-  , m_phisize(0)
-  , m_zsize(0)
-  , m_overlap(0)
-  , m_edge(0)
-  , m_sledge(0)
-  , m_sredge(0)
-  , m_tledge(0)
-  , m_tredge(0)
-  , m_dledge(0)
-  , m_dredge(0)
-  , m_hledge(0)
-  , m_hredge(0)
-  , m_slmix(0)
-  , m_srmix(0)
-  , m_tlmix(0)
-  , m_trmix(0)
-  , m_phibinlo(0)
-  , m_phibinhi(0)
-  , m_tbinlo(0)
-  , m_tbinhi(0)
-  , m_padphase(0)
-  , m_tbinphase(0)
-{
-  for (float& i : m_local)
-  {
-    i = NAN;
-  }
-}
-
 void TrkrClusterv6::identify(std::ostream& os) const
 {
   os << "---TrkrClusterv6--------------------" << std::endl;

--- a/offline/packages/trackbase/TrkrClusterv6.h
+++ b/offline/packages/trackbase/TrkrClusterv6.h
@@ -25,7 +25,7 @@ class TrkrClusterv6 : public TrkrCluster
 {
  public:
   //! ctor
-  TrkrClusterv6();
+  TrkrClusterv6() = default;
 
   //! dtor
   ~TrkrClusterv6() override = default;
@@ -58,7 +58,7 @@ class TrkrClusterv6 : public TrkrCluster
   //
   float getPosition(int coor) const override
   {
-    return (coor >= 0 && coor < 2) ? m_local[coor] : NAN;
+    return (coor >= 0 && coor < 2) ? m_local[coor] : std::numeric_limits<float>::quiet_NaN();
   }
   void setPosition(int coor, float xi) override
   {
@@ -107,53 +107,6 @@ class TrkrClusterv6 : public TrkrCluster
 
   void setPhiError(float phierror) { m_phierr = phierror; }
   void setZError(float zerror) { m_zerr = zerror; }
-
-  /// deprecated global funtions with a warning
-  float getX() const override
-  {
-    std::cout << "Deprecated getx trkrcluster function!" << std::endl;
-    return NAN;
-  }
-  float getY() const override
-  {
-    std::cout << "Deprecated gety trkrcluster function!" << std::endl;
-    return NAN;
-  }
-  float getZ() const override
-  {
-    std::cout << "Deprecated getz trkrcluster function!" << std::endl;
-    return NAN;
-  }
-  void setX(float) override
-  {
-    std::cout << "Deprecated setx trkrcluster function!" << std::endl;
-  }
-  void setY(float) override
-  {
-    std::cout << "Deprecated sety trkrcluster function!" << std::endl;
-  }
-  void setZ(float) override
-  {
-    std::cout << "Deprecated setz trkrcluster function!" << std::endl;
-  }
-  float getSize(unsigned int, unsigned int) const override
-  {
-    std::cout << "Deprecated getsize trkrcluster function!" << std::endl;
-    return NAN;
-  }
-  void setSize(unsigned int, unsigned int, float) override
-  {
-    std::cout << "Deprecated setsize trkrcluster function!" << std::endl;
-  }
-  float getError(unsigned int, unsigned int) const override
-  {
-    std::cout << "Deprecated geterr trkrcluster function!" << std::endl;
-    return NAN;
-  }
-  void setError(unsigned int, unsigned int, float) override
-  {
-    std::cout << "Deprecated seterr trkrcluster function!" << std::endl;
-  }
 
   char getSize() const override { return m_phisize * m_zsize; }
   // void setSize(char size) { m_size = size; }
@@ -227,49 +180,42 @@ class TrkrClusterv6 : public TrkrCluster
   float getTBinPhase() const override { return m_tbinphase; }
   void setTBinPhase(float tbinphase){ m_tbinphase = tbinphase; }
 
-  // float getPhiSize() const override
-  //{ std::cout << "Deprecated size function"<< std::endl; return NAN;}
-  // float getZSize() const override
-  //{std::cout << "Deprecated size function" << std::endl; return NAN;}
-  // float getPhiError() const override
-  //{ std::cout << "Deprecated getPhiError function"<< std::endl; return NAN;}
-
  private:
   float m_local[2]{std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()};
   //< 2D local position [cm] 2 * 32 64bit  - cumul 1*64
-  TrkrDefs::subsurfkey m_subsurfkey;  //< unique identifier for hitsetkey-surface maps 16 bit
-  float m_phierr;
-  float m_zerr;
-  unsigned short int m_adc;     //< cluster sum adc 16
-  unsigned short int m_maxadc;  //< cluster max adc 16
-  unsigned short int m_cenadc;  //< cluster centroid adc 16
-  float m_padcen;
-  float m_tbincen;
-  float m_padmax;
-  float m_tbinmax;
-  unsigned char m_rsize;        // 8bit
-  char m_phisize;               // 8bit
-  char m_zsize;                 // 8bit
-  char m_overlap;               // 8bit
-  char m_edge;                  // 8bit - cumul 2*64
-  char m_sledge;                // 8bit
-  char m_sredge;                // 8bit
-  char m_tledge;                // 8bit
-  char m_tredge;                // 8bit
-  char m_dledge;                // 8bit
-  char m_dredge;                // 8bit
-  char m_hledge;                // 8bit
-  char m_hredge;                // 8bit
-  char m_slmix;                 // 8bit
-  char m_srmix;                 // 8bit
-  char m_tlmix;                 // 8bit
-  char m_trmix;                 // 8bit
-  float m_phibinlo;
-  float m_phibinhi;
-  float m_tbinlo;
-  float m_tbinhi;
-  float m_padphase;
-  float m_tbinphase;
+  TrkrDefs::subsurfkey m_subsurfkey {TrkrDefs::SUBSURFKEYMAX};  //< unique identifier for hitsetkey-surface maps 16 bit
+  float m_phierr{0};
+  float m_zerr{0};
+  unsigned short int m_adc{0};     //< cluster sum adc 16
+  unsigned short int m_maxadc{0};  //< cluster max adc 16
+  unsigned short int m_cenadc{0};  //< cluster centroid adc 16
+  float m_padcen{0};
+  float m_tbincen{0};
+  float m_padmax{0};
+  float m_tbinmax{0};
+  unsigned char m_rsize{0};        // 8bit
+  char m_phisize{0};               // 8bit
+  char m_zsize{0};                 // 8bit
+  char m_overlap{0};               // 8bit
+  char m_edge{0};                  // 8bit - cumul 2*64
+  char m_sledge{0};                // 8bit
+  char m_sredge{0};                // 8bit
+  char m_tledge{0};                // 8bit
+  char m_tredge{0};                // 8bit
+  char m_dledge{0};                // 8bit
+  char m_dredge{0};                // 8bit
+  char m_hledge{0};                // 8bit
+  char m_hredge{0};                // 8bit
+  char m_slmix{0};                 // 8bit
+  char m_srmix{0};                 // 8bit
+  char m_tlmix{0};                 // 8bit
+  char m_trmix{0};                 // 8bit
+  float m_phibinlo{0};
+  float m_phibinhi{0};
+  float m_tbinlo{0};
+  float m_tbinhi{0};
+  float m_padphase{0};
+  float m_tbinphase{0};
 
   ClassDefOverride(TrkrClusterv6, 1)
 };

--- a/offline/packages/trackbase/TrkrClusterv6.h
+++ b/offline/packages/trackbase/TrkrClusterv6.h
@@ -1,0 +1,277 @@
+/**
+ * @file trackbase/TrkrClusterv6.h
+ * @author Ishan Goel
+ * @date May 2026
+ * @brief Version 6 of TrkrCluster
+ */
+#ifndef TRACKBASE_TRKRCLUSTERV6_H
+#define TRACKBASE_TRKRCLUSTERV6_H
+
+#include "TrkrCluster.h"
+#include "TrkrDefs.h"
+
+#include <climits>
+#include <iostream>
+
+class PHObject;
+
+/**
+ * @brief Version 6 of TrkrCluster
+ *
+ * This version of TrkrCluster is blown up to contain a maximum of information
+ */
+
+class TrkrClusterv6 : public TrkrCluster
+{
+ public:
+  //! ctor
+  TrkrClusterv6();
+
+  //! dtor
+  ~TrkrClusterv6() override = default;
+
+  // PHObject virtual overloads
+
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override { *this = TrkrClusterv6(); }
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new TrkrClusterv6(*this); }
+
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+
+  //! copy content from base class
+  void CopyFrom(const TrkrCluster&) override;
+
+  //! copy content from base class
+  void CopyFrom(TrkrCluster* source) override
+  {
+    if (!source)
+    {
+      return;
+    }
+    CopyFrom(*source);
+  }
+
+  //
+  // cluster position
+  //
+  float getPosition(int coor) const override
+  {
+    return (coor >= 0 && coor < 2) ? m_local[coor] : NAN;
+  }
+  void setPosition(int coor, float xi) override
+  {
+    if (coor >= 0 && coor < 2)
+    {
+      m_local[coor] = xi;
+    }
+  }
+  float getLocalX() const override { return m_local[0]; }
+  void setLocalX(float loc0) override { m_local[0] = loc0; }
+  float getLocalY() const override { return m_local[1]; }
+  void setLocalY(float loc1) override { m_local[1] = loc1; }
+
+  TrkrDefs::subsurfkey getSubSurfKey() const override { return m_subsurfkey; }
+  void setSubSurfKey(TrkrDefs::subsurfkey id) override { m_subsurfkey = id; }
+
+  //
+  // cluster info
+  //
+  unsigned int getAdc() const override { return m_adc; }
+  void setAdc(unsigned int adc) override { m_adc = adc; }
+
+  unsigned int getMaxAdc() const override { return m_maxadc; }
+  void setMaxAdc(uint16_t maxadc) override { m_maxadc = maxadc; }
+
+  unsigned int getCenAdc() const override { return m_cenadc; }
+  void setCenAdc(uint16_t cenadc) { m_cenadc = cenadc; }
+
+  float getPadCen() const override { return m_padcen; }
+  void setPadCen(float padcen) { m_padcen = padcen; }
+
+  float getTBinCen() const override { return m_tbincen; }
+  void setTBinCen(float tbincen) { m_tbincen = tbincen; }
+
+  float getPadMax() const override { return m_padmax; }
+  void setPadMax(float padmax) { m_padmax = padmax; }
+
+  float getTBinMax() const override { return m_tbinmax; }
+  void setTBinMax(float tbinmax) { m_tbinmax = tbinmax; }
+
+  //
+  // convenience interface
+  //
+  float getRPhiError() const override { return m_phierr; }
+  float getZError() const override { return m_zerr; }
+
+  void setPhiError(float phierror) { m_phierr = phierror; }
+  void setZError(float zerror) { m_zerr = zerror; }
+
+  /// deprecated global funtions with a warning
+  float getX() const override
+  {
+    std::cout << "Deprecated getx trkrcluster function!" << std::endl;
+    return NAN;
+  }
+  float getY() const override
+  {
+    std::cout << "Deprecated gety trkrcluster function!" << std::endl;
+    return NAN;
+  }
+  float getZ() const override
+  {
+    std::cout << "Deprecated getz trkrcluster function!" << std::endl;
+    return NAN;
+  }
+  void setX(float) override
+  {
+    std::cout << "Deprecated setx trkrcluster function!" << std::endl;
+  }
+  void setY(float) override
+  {
+    std::cout << "Deprecated sety trkrcluster function!" << std::endl;
+  }
+  void setZ(float) override
+  {
+    std::cout << "Deprecated setz trkrcluster function!" << std::endl;
+  }
+  float getSize(unsigned int, unsigned int) const override
+  {
+    std::cout << "Deprecated getsize trkrcluster function!" << std::endl;
+    return NAN;
+  }
+  void setSize(unsigned int, unsigned int, float) override
+  {
+    std::cout << "Deprecated setsize trkrcluster function!" << std::endl;
+  }
+  float getError(unsigned int, unsigned int) const override
+  {
+    std::cout << "Deprecated geterr trkrcluster function!" << std::endl;
+    return NAN;
+  }
+  void setError(unsigned int, unsigned int, float) override
+  {
+    std::cout << "Deprecated seterr trkrcluster function!" << std::endl;
+  }
+
+  char getSize() const override { return m_phisize * m_zsize; }
+  // void setSize(char size) { m_size = size; }
+
+  float getRSize() const override { return (float) m_rsize; }
+  void setRSize(unsigned char rsize) { m_rsize = rsize; }
+
+  float getPhiSize() const override { return (float) m_phisize; }
+  void setPhiSize(char phisize) { m_phisize = phisize; }
+
+  float getZSize() const override { return (float) m_zsize; }
+  void setZSize(char zsize) { m_zsize = zsize; }
+
+  char getOverlap() const override { return m_overlap; }
+  void setOverlap(char overlap) override { m_overlap = overlap; }
+
+  char getEdge() const override { return m_edge; }
+  void setEdge(char edge) override { m_edge = edge; }
+
+  char getSLEdge() const override { return m_sledge; }
+  void setSLEdge(char sledge) { m_sledge = sledge; }
+
+  char getSREdge() const override { return m_sredge; }
+  void setSREdge(char sredge) { m_sredge = sredge; }
+
+  char getTLEdge() const override { return m_tledge; }
+  void setTLEdge(char tledge) { m_tledge = tledge; }
+
+  char getTREdge() const override { return m_tredge; }
+  void setTREdge(char tredge) { m_tredge = tredge; }
+
+  char getDLEdge() const override { return m_dledge; }
+  void setDLEdge(char dledge) { m_dledge = dledge; }
+
+  char getDREdge() const override { return m_dredge; }
+  void setDREdge(char dredge) { m_dredge = dredge; }
+
+  char getHLEdge() const override { return m_hledge; }
+  void setHLEdge(char hledge) { m_hledge = hledge; }
+
+  char getHREdge() const override { return m_hredge; }
+  void setHREdge(char hredge) { m_hredge = hredge; }
+
+  int getSLMix() const override { return m_slmix; }
+  void setSLMix(char slmix) { m_slmix = slmix; }
+
+  int getSRMix() const override { return m_srmix; }
+  void setSRMix(char srmix) { m_srmix = srmix; }
+
+  int getTLMix() const override { return m_tlmix; }
+  void setTLMix(char tlmix) { m_tlmix = tlmix; }
+
+  int getTRMix() const override { return m_trmix; }
+  void setTRMix(char trmix) { m_trmix = trmix; }
+
+  float getPhiBinLo() const override { return m_phibinlo; }
+  void setPhiBinLo(float phibinlo) { m_phibinlo = phibinlo; }
+
+  float getPhiBinHi() const override { return m_phibinhi; }
+  void setPhiBinHi(float phibinhi) { m_phibinhi = phibinhi; }
+
+  float getTBinLo() const override { return m_tbinlo; }
+  void setTBinLo(float tbinlo) { m_tbinlo = tbinlo; }
+
+  float getTBinHi() const override { return m_tbinhi; }
+  void setTBinHi(float tbinhi) { m_tbinhi = tbinhi; }
+
+  float getPadPhase() const override { return m_padphase; }
+  void setPadPhase(float padphase) { m_padphase = padphase; }
+
+  float getTBinPhase() const override { return m_tbinphase; }
+  void setTBinPhase(float tbinphase){ m_tbinphase = tbinphase; }
+
+  // float getPhiSize() const override
+  //{ std::cout << "Deprecated size function"<< std::endl; return NAN;}
+  // float getZSize() const override
+  //{std::cout << "Deprecated size function" << std::endl; return NAN;}
+  // float getPhiError() const override
+  //{ std::cout << "Deprecated getPhiError function"<< std::endl; return NAN;}
+
+ private:
+  float m_local[2]{std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()};
+  //< 2D local position [cm] 2 * 32 64bit  - cumul 1*64
+  TrkrDefs::subsurfkey m_subsurfkey;  //< unique identifier for hitsetkey-surface maps 16 bit
+  float m_phierr;
+  float m_zerr;
+  unsigned short int m_adc;     //< cluster sum adc 16
+  unsigned short int m_maxadc;  //< cluster max adc 16
+  unsigned short int m_cenadc;  //< cluster centroid adc 16
+  float m_padcen;
+  float m_tbincen;
+  float m_padmax;
+  float m_tbinmax;
+  unsigned char m_rsize;        // 8bit
+  char m_phisize;               // 8bit
+  char m_zsize;                 // 8bit
+  char m_overlap;               // 8bit
+  char m_edge;                  // 8bit - cumul 2*64
+  char m_sledge;                // 8bit
+  char m_sredge;                // 8bit
+  char m_tledge;                // 8bit
+  char m_tredge;                // 8bit
+  char m_dledge;                // 8bit
+  char m_dredge;                // 8bit
+  char m_hledge;                // 8bit
+  char m_hredge;                // 8bit
+  char m_slmix;                 // 8bit
+  char m_srmix;                 // 8bit
+  char m_tlmix;                 // 8bit
+  char m_trmix;                 // 8bit
+  float m_phibinlo;
+  float m_phibinhi;
+  float m_tbinlo;
+  float m_tbinhi;
+  float m_padphase;
+  float m_tbinphase;
+
+  ClassDefOverride(TrkrClusterv6, 1)
+};
+
+#endif  // TRACKBASE_TRKRCLUSTERV6_H

--- a/offline/packages/trackbase/TrkrClusterv6LinkDef.h
+++ b/offline/packages/trackbase/TrkrClusterv6LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrClusterv6 + ;
+
+#endif


### PR DESCRIPTION
that I uses.

[comment]: <> (Back to starting point. No changes in old classes and added v6 class that I am using for now which is working and wrote exactly the same way as v5.)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Motivation / context
- Introduce a new cluster version (TrkrClusterv6) following the established v1–v5 pattern to capture additional per-cluster metadata needed by reconstruction and downstream analysis, while leaving existing classes unchanged. Also standardize numeric sentinel usage (replace NaN macros/values with std::numeric_limits where applicable).

Key changes
- New TrkrClusterv6 class
  - Added header and implementation (TrkrClusterv6.h / TrkrClusterv6.cc), ROOT LinkDef entry, and Makefile.am integration (headers, dictionary, and compilation into libtrack_io).
  - Implements PHObject-compatible methods: identify(), Reset(), CloneMe(), CopyFrom(const TrkrCluster&), isValid().
  - Stores local coordinates, subsurface key, ADC/max/centroid ADC, pad/time-bin center & max, RPhi/Z errors and sizes, and getRSize.
  - Tracks overlap/edge flags and mix parameters for 8 directional combinations (SL, SR, TL, TR, DL, DR, HL, HR).
  - Provides phi/time-bin low/high ranges and pad/time-bin phase accessors.
- Base interface extensions
  - TrkrCluster base class extended with many new virtual getters (centroid/max ADCs, pad/tbin centers/max, edge/mix getters, bin-range getters, phase getters, getRSize, etc.) implemented to return sentinel values to preserve backward compatibility.
- Numeric sentinel change
  - Replaced usage of NaN macros/values with std::numeric_limits for float/char/int sentinel returns in relevant getters and internal initializers.
- Build-system updates
  - Makefile.am and LinkDef updated to include and expose TrkrClusterv6 for ROOT dictionary generation and installation.

Potential risk areas
- IO / persistence: New persistent ROOT class/version may affect file I/O and downstream tools; validate ROOT schema evolution, dictionary availability, and ability to read legacy/mixed-version files.
- Reconstruction correctness & validation: New fields change in-memory representation; algorithms consuming clusters must be audited and validated to ensure semantics (CopyFrom, isValid, sentinel values) match reconstruction assumptions.
- Thread-safety & initialization: Ensure all members are reliably initialized and Reset works as intended to avoid NaNs/stale values in multithreaded workflows or when reusing objects from pools.
- Performance & memory: Increased per-cluster footprint may impact memory usage, I/O size, and processing throughput in high-multiplicity or production workflows.
- ABI/override subtleties: Some setters are added without explicit override markers; double-check virtual signatures to avoid subtle override/ABI issues across versions.

Possible future improvements
- Add unit and integration tests for IO (write/read), CopyFrom(), isValid(), and common consumers to validate behavior and schema evolution.
- Document binary compatibility, ROOT streaming/IO expectations for v6, and provide migration guidance for analysis/reconstruction code.
- Consider packing, bitfield optimizations, or optional storage to reduce per-cluster memory/I/O footprint if profiling indicates impact.
- Audit and consolidate setter signatures and add explicit override markings where appropriate to prevent ABI issues.

Caveat
- This summary was prepared with AI assistance. AI can make mistakes; please verify details (especially semantics of edge/mix flags, exact CopyFrom behavior, and ROOT persistence implications) before making production decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->