### PR TITLE
fix: improve cpu speed of kfprop

### DIFF
--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -242,7 +242,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         // copy seed clusters position into local map
         std::map<TrkrDefs::cluskey, Acts::Vector3> trackClusPositions;
         std::transform(track->begin_cluster_keys(), track->end_cluster_keys(), std::inserter(trackClusPositions, trackClusPositions.end()),
-          [globalPositions](const auto& key)
+          [&globalPositions](const auto& key)
         { return std::make_pair(key, globalPositions.at(key)); });
 
         /// Can't circle fit a seed with less than 3 clusters, skip it
@@ -317,7 +317,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         // copy seed clusters position into local map
         std::map<TrkrDefs::cluskey, Acts::Vector3> pretrackClusPositions;
         std::transform(pretrack.begin_cluster_keys(), pretrack.end_cluster_keys(), std::inserter(pretrackClusPositions, pretrackClusPositions.end()),
-          [globalPositions](const auto& key)
+          [&globalPositions](const auto& key)
           { return std::make_pair(key, globalPositions.at(key)); });
 
         // fit seed
@@ -892,8 +892,8 @@ bool PHSimpleKFProp::PropagateStep(
 
   // search for closest available cluster within window
   double query_pt[3] = {new_tx, new_ty, new_tz};
-  std::vector<long unsigned int> index_out(1);
-  std::vector<double> distance_out(1);
+  std::array<size_t, 1> index_out;
+  std::array<double, 1> distance_out;
   int n_results = _kdtrees[next_layer]->knnSearch(&query_pt[0], 1, index_out.data(), distance_out.data());
 
   // if no results, then no cluster to add, but propagation is not necessarily done
@@ -1230,11 +1230,6 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
     std::cout << std::endl;
   }
 
-  // get layer for each cluster
-  std::vector<unsigned int> layers;
-  std::transform(ckeys.begin(), ckeys.end(), std::back_inserter(layers), [](const TrkrDefs::cluskey& key)
-                 { return TrkrDefs::getLayer(key); });
-
   double old_phi = track_phi;
   unsigned int old_layer = TrkrDefs::getLayer(ckeys[0]);
   if (Verbosity() > 1)
@@ -1371,7 +1366,7 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
 
       PositionMap local;
       std::transform(seed.begin_cluster_keys(), seed.end_cluster_keys(), std::inserter(local, local.end()),
-        [positions](const auto& key)
+        [&positions](const auto& key)
         { return std::make_pair(key, positions.at(key)); });
       TrackSeedHelper::circleFitByTaubin(&seed,local, 7, 55);
       TrackSeedHelper::lineFit(&seed,local, 7, 55);

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -892,8 +892,8 @@ bool PHSimpleKFProp::PropagateStep(
 
   // search for closest available cluster within window
   double query_pt[3] = {new_tx, new_ty, new_tz};
-  std::array<size_t, 1> index_out;
-  std::array<double, 1> distance_out;
+  std::array<size_t, 1> index_out{};
+  std::array<double, 1> distance_out{};
   int n_results = _kdtrees[next_layer]->knnSearch(&query_pt[0], 1, index_out.data(), distance_out.data());
 
   // if no results, then no cluster to add, but propagation is not necessarily done


### PR DESCRIPTION
Codex identified some very simple low hanging fruit to speed up the kfprop module. In local tests over ~50 events this improves speed by ~33% over the run3pp data.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CPU Speed Improvement for KF Propagation Module

### Motivation
The kfprop module was identified as a performance bottleneck. Codex analysis revealed several straightforward optimization opportunities to reduce CPU overhead without changing reconstruction behavior.

### Key Changes
- **Lambda capture optimization**: Changed lambda captures in position map construction from by-value to by-reference, eliminating unnecessary vector copies during `std::transform` operations
- **Buffer allocation optimization**: Replaced `std::vector` temporary buffers for `nanoflann`'s `knnSearch` indices and distances with fixed-size `std::array` containers, reducing dynamic allocation overhead
- **Code cleanup**: Removed unused computation of per-cluster layer IDs (`layers`) inside `PropagateTrack`

### Performance Results
- **~33% CPU speed improvement** observed in testing over ~50 events using run3pp data

### Potential Risk Areas
- **Reconstruction behavior**: Code changes are optimizations only; no algorithmic changes affect track reconstruction
- **Thread-safety**: By-reference captures require careful attention to variable lifetimes within the lambda scope—verify that captured references remain valid throughout the transform operation
- **Buffer sizes**: Fixed-size `std::array` for knnSearch results assumes consistent output dimensions; verify this assumption holds for all search configurations

### Notes for Reviewers
*Emphasis: AI-generated summaries can contain errors. Please apply best judgment when reviewing the actual code changes to verify optimization correctness and impact.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->