### PR TITLE
add method to return map sizes

### DIFF
--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -230,7 +230,7 @@ void CDBTTree::WriteMultipleCDBTTree()
 void CDBTTree::SetSingleFloatValue(const std::string &name, float value)
 {
   std::string fieldname = "F" + name;
-//  if (!m_SingleFloatEntryMap.contains(fieldname))
+  //  if (!m_SingleFloatEntryMap.contains(fieldname))
   // NOLINTNEXTLINE(readability-container-contains)
   if (m_SingleFloatEntryMap.find(fieldname) == m_SingleFloatEntryMap.end())
   {
@@ -249,7 +249,7 @@ void CDBTTree::SetSingleFloatValue(const std::string &name, float value)
 void CDBTTree::SetSingleDoubleValue(const std::string &name, double value)
 {
   std::string fieldname = "D" + name;
-//  if (!m_SingleDoubleEntryMap.contains(fieldname))
+  //  if (!m_SingleDoubleEntryMap.contains(fieldname))
   // NOLINTNEXTLINE(readability-container-contains)
   if (m_SingleDoubleEntryMap.find(fieldname) == m_SingleDoubleEntryMap.end())
   {
@@ -268,7 +268,7 @@ void CDBTTree::SetSingleDoubleValue(const std::string &name, double value)
 void CDBTTree::SetSingleIntValue(const std::string &name, int value)
 {
   std::string fieldname = "I" + name;
-//  if (!m_SingleIntEntryMap.contains(fieldname))
+  //  if (!m_SingleIntEntryMap.contains(fieldname))
   // NOLINTNEXTLINE(readability-container-contains)
   if (m_SingleIntEntryMap.find(fieldname) == m_SingleIntEntryMap.end())
   {
@@ -287,7 +287,7 @@ void CDBTTree::SetSingleIntValue(const std::string &name, int value)
 void CDBTTree::SetSingleUInt64Value(const std::string &name, uint64_t value)
 {
   std::string fieldname = "g" + name;
-//  if (m_SingleUInt64EntryMap.contains(fieldname))
+  //  if (m_SingleUInt64EntryMap.contains(fieldname))
   // NOLINTNEXTLINE(readability-container-contains)
   if (m_SingleUInt64EntryMap.find(fieldname) == m_SingleUInt64EntryMap.end())
   {

--- a/offline/database/cdbobjects/CDBTTree.h
+++ b/offline/database/cdbobjects/CDBTTree.h
@@ -30,14 +30,22 @@ class CDBTTree
   void Print();
   void SetFilename(const std::string &fname) { m_Filename = fname; }
   void LoadCalibrations();
+
   float GetSingleFloatValue(const std::string &name, int verbose = 0);
   float GetFloatValue(int channel, const std::string &name, int verbose = 0);
+  size_t GetFloatMapSize() const { return m_FloatEntryMap.size(); }
+
   double GetSingleDoubleValue(const std::string &name, int verbose = 0);
   double GetDoubleValue(int channel, const std::string &name, int verbose = 0);
+  size_t GetDoubleMapSize() const { return m_DoubleEntryMap.size(); }
+
   int GetSingleIntValue(const std::string &name, int verbose = 0);
   int GetIntValue(int channel, const std::string &name, int verbose = 0);
+  size_t GetIntMapSize() const { return m_IntEntryMap.size(); }
+
   uint64_t GetSingleUInt64Value(const std::string &name, int verbose = 0);
   uint64_t GetUInt64Value(int channel, const std::string &name, int verbose = 0);
+  size_t GetUInt64MapSize() const { return m_UInt64EntryMap.size(); }
 
   const auto &GetFloatEntryMap() const { return m_FloatEntryMap; }
   const auto &GetDoubleEntryMap() const { return m_DoubleEntryMap; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
In some cases one needs the number of entries in the maps. This PR adds methods which return those.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR Summary: Map Size Accessor Methods for CDBTTree

### Motivation & Context
This PR adds public accessor methods to the `CDBTTree` class, which is part of the sPHENIX Collaboration's Conditions Database Objects system. The CDBTTree class manages calibration parameters organized in internal maps by channel and parameter name, supporting four data types: float, double, int, and uint64_t. These new methods provide direct access to the number of entries stored in each data type's map, enabling users to query map sizes for validation, diagnostics, and data completeness checks.

### Key Changes
- **Four new inline public accessor methods:**
  - `size_t GetFloatMapSize() const` — returns count of float channel entries  
  - `size_t GetDoubleMapSize() const` — returns count of double channel entries  
  - `size_t GetIntMapSize() const` — returns count of int channel entries  
  - `size_t GetUInt64MapSize() const` — returns count of uint64_t channel entries  
- **Inline implementations** in the header file for efficient O(1) access to map sizes
- **Minor comment updates** in the implementation file (no functional changes)
- **Fully backward compatible** — only adds new methods with no modifications to existing functionality or data structures

### Potential Risk Areas
- **None identified:** Changes are purely additive and do not affect existing code paths, data formats, or reconstruction behavior
- **Performance:** Negligible impact; inline methods return pre-computed map sizes with O(1) complexity
- **Thread-safety:** No new thread-safety considerations; inherits existing patterns from CDBTTree class

### Context
The underlying maps (e.g., `m_FloatEntryMap`, `m_DoubleEntryMap`) are nested std::map structures where the outer map key is a channel ID and inner maps contain parameter names to values. The new accessors expose only the outer map sizes, providing a convenient way to check how many channels have calibration data without exposing implementation details.

**Note:** As per collaboration guidelines, AI-generated analysis may contain inaccuracies; code review should verify implementation details directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->