### PR TITLE
Micromegas decoder update

### DIFF
--- a/offline/framework/ffarawobjects/MicromegasRawHitv3.cc
+++ b/offline/framework/ffarawobjects/MicromegasRawHitv3.cc
@@ -11,7 +11,7 @@ MicromegasRawHitv3::MicromegasRawHitv3(MicromegasRawHit *source)
   {
     once = false;
     std::cout << "MicromegasRawHitv3::MicromegasRawHitv3(MicromegasRawHit *tpchit) - "
-              << "WARNING: This moethod is slow and should be avoided as much as possible! Please use the move constructor."
+              << "WARNING: This method is slow and should be avoided as much as possible! Please use the move constructor."
               << std::endl;
   }
 

--- a/offline/framework/ffarawobjects/MicromegasRawHitv3.h
+++ b/offline/framework/ffarawobjects/MicromegasRawHitv3.h
@@ -65,8 +65,13 @@ class MicromegasRawHitv3 : public MicromegasRawHit
 
   //! adc list
   using adc_list_t = std::vector<uint16_t>;
+  using waveform_pair_t = std::pair<uint16_t, adc_list_t>;
 
-  // set adc values
+  // get adc values
+  const std::vector<waveform_pair_t>& get_adc_waveforms() const
+  { return m_adcData; }
+
+  // set adc values (move operator)
   void move_adc_waveform(const uint16_t start_time, adc_list_t &&adc);
 
  private:
@@ -83,7 +88,6 @@ class MicromegasRawHitv3 : public MicromegasRawHit
 
   //! list of waveforms
   /** each pair contains the start sample of the waveform and the constituting adc values */
-  using waveform_pair_t = std::pair<uint16_t, adc_list_t>;
   std::vector<waveform_pair_t> m_adcData;
 
   ClassDefOverride(MicromegasRawHitv3, 1)

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -794,7 +794,7 @@ int Fun4AllStreamingInputManager::FillIntt()
       }
       inttcont->AddHit(intthititer);
     }
-  } 
+  }
   return 0;
 }
 int Fun4AllStreamingInputManager::FillMvtx()
@@ -987,7 +987,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
 
     if (Verbosity() > 2)
     {
-      std::cout << "Adding 0x" << std::hex << bco 
+      std::cout << "Adding 0x" << std::hex << bco
                 << " ref: 0x" << select_crossings << std::dec << std::endl;
     }
     for (auto *mvtxFeeIdInfo : hitinfo.MvtxFeeIdInfoVector)
@@ -1333,13 +1333,20 @@ int Fun4AllStreamingInputManager::FillTpcPool()
 
 int Fun4AllStreamingInputManager::FillMicromegasPool()
 {
+
+  uint64_t ref_bco_minus_range = 0;
+  if (m_RefBCO > m_micromegas_negative_bco)
+  {
+    ref_bco_minus_range = m_RefBCO - m_micromegas_negative_bco;
+  }
+
   for (auto *iter : m_MicromegasInputVector)
   {
     if (Verbosity() > 0)
     {
       std::cout << "Fun4AllStreamingInputManager::FillMicromegasPool - fill pool for " << iter->Name() << std::endl;
     }
-    iter->FillPool();
+    iter->FillPool(ref_bco_minus_range);
     if (m_RunNumber == 0)
     {
       m_RunNumber = iter->RunNumber();

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -80,15 +80,8 @@ namespace
     return o;
   }
 
-  // get the difference between two BCO.
-  template <class T>
-  constexpr T get_bco_diff(const T& first, const T& second)
-  {
-    return first < second ? (second - first) : (first - second);
-  }
-
   // define limit for matching two fee_bco
-  constexpr unsigned int m_max_fee_bco_diff = 10;
+  constexpr uint32_t m_max_fee_bco_diff = 10;
 
   // needed to avoid memory leak. Assumes that we will not be assembling more than 50 events at the same time
   constexpr unsigned int m_max_matching_data_size = 50;
@@ -98,10 +91,16 @@ namespace
 
   // gtm clock bits
   /* used for rollover calculation */
-  static constexpr unsigned int m_GTM_CLOCK_BITS = 40;
-
+  static constexpr unsigned int m_GTM_CLOCK_BITS = 40U;
   static constexpr uint64_t m_GTM_CLOCK_MASK = (1ULL << m_GTM_CLOCK_BITS)-1;
-  static constexpr uint64_t m_GTM_CLOCK_ROLLOVER = 1ULL << m_GTM_CLOCK_BITS;
+  static constexpr int64_t m_GTM_CLOCK_RANGE = 1ULL << m_GTM_CLOCK_BITS;
+  static constexpr int64_t m_GTM_CLOCK_HALF_RANGE = 1ULL << (m_GTM_CLOCK_BITS-1);
+
+  // Fee clock bits
+  static constexpr unsigned int m_FEE_CLOCK_BITS = 20U;
+  static constexpr uint32_t m_FEE_CLOCK_MASK = (1ULL << m_FEE_CLOCK_BITS)-1;
+  static constexpr int32_t m_FEE_CLOCK_RANGE = 1ULL << m_FEE_CLOCK_BITS;
+  static constexpr int32_t m_FEE_CLOCK_HALF_RANGE = 1ULL << (m_FEE_CLOCK_BITS-1);
 
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType
@@ -121,6 +120,7 @@ namespace
     BX_COUNTER_SYNC_T = 0b001,
     ELINK_HEARTBEAT_T = 0b010
   };
+
 }  // namespace
 
 // this is the clock multiplier from lvl1 to fee clock
@@ -143,6 +143,46 @@ unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 100;
 unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 32;
 
 //___________________________________________________
+int64_t MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff(uint64_t first, uint64_t second)
+{
+  // calculate raw diff
+  int64_t diff = static_cast<int64_t>(first & m_GTM_CLOCK_MASK) - static_cast<int64_t>(second & m_GTM_CLOCK_MASK);
+
+  // make sure result is within +/- m_GTM_CLOCK_HALF_RANGE
+  if (diff > m_GTM_CLOCK_HALF_RANGE) { diff -= m_GTM_CLOCK_RANGE; }
+  else if (diff < -m_GTM_CLOCK_HALF_RANGE) { diff += m_GTM_CLOCK_RANGE; }
+
+  return diff;
+}
+
+//___________________________________________________
+int32_t MicromegasBcoMatchingInformation_v2::get_signed_fee_bco_diff(uint32_t first, uint32_t second)
+{
+  // calculate raw diff
+  int32_t diff = static_cast<int32_t>(first & m_FEE_CLOCK_MASK) - static_cast<int32_t>(second & m_FEE_CLOCK_MASK);
+
+  // make sure result is within +/- m_FEE_CLOCK_HALF_RANGE
+  if (diff > m_FEE_CLOCK_HALF_RANGE) { diff -= m_FEE_CLOCK_RANGE; }
+  else if (diff < -m_FEE_CLOCK_HALF_RANGE) { diff += m_FEE_CLOCK_RANGE; }
+
+  return diff;
+}
+
+//___________________________________________________
+uint64_t MicromegasBcoMatchingInformation_v2::get_unsigned_gtm_bco_diff(uint64_t first, uint64_t second)
+{
+  const auto diff = get_signed_gtm_bco_diff(first, second);
+  return uint64_t((diff<0) ? -diff:diff);
+}
+
+//___________________________________________________
+uint32_t MicromegasBcoMatchingInformation_v2::get_unsigned_fee_bco_diff(uint32_t first, uint32_t second)
+{
+  const auto diff = get_signed_fee_bco_diff(first, second);
+  return uint32_t((diff<0) ? -diff:diff);
+}
+
+//___________________________________________________
 std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_bco(uint64_t gtm_bco) const
 {
   // check proper initialization
@@ -151,12 +191,12 @@ std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_b
     return std::nullopt;
   }
 
-  // get gtm bco difference with proper rollover accounting
-  const uint64_t gtm_bco_difference = get_gtm_rollover_correction(gtm_bco) - m_bco_reference.second;
+  // get gtm bco difference
+  const int64_t gtm_bco_difference = get_signed_gtm_bco_diff(gtm_bco, m_bco_reference.second);
 
   // convert to fee bco, and truncate to 20 bits
-  const uint64_t fee_bco_predicted = m_bco_reference.first + get_adjusted_multiplier() * gtm_bco_difference;
-  return uint32_t(fee_bco_predicted & 0xFFFFFU);
+  const int64_t fee_bco_predicted = m_bco_reference.first + get_adjusted_multiplier() * gtm_bco_difference;
+  return uint32_t(fee_bco_predicted & m_FEE_CLOCK_MASK);
 }
 
 //___________________________________________________
@@ -189,38 +229,26 @@ void MicromegasBcoMatchingInformation_v2::print_gtm_bco_information() const
 }
 
 //___________________________________________________
-uint64_t MicromegasBcoMatchingInformation_v2::get_gtm_rollover_correction(uint64_t gtm_bco) const
-{
-  // check proper initialization
-  if (!is_verified()) { return gtm_bco; }
-  else if( gtm_bco >= m_bco_reference.second ) return gtm_bco;
-  else return gtm_bco+m_GTM_CLOCK_ROLLOVER;
-}
-
-//___________________________________________________
 bool MicromegasBcoMatchingInformation_v2::is_more_data_required( uint64_t gtm_bco ) const
 {
   // check proper initialization
   if( !is_verified() ) return true;
 
-  // get rollover corrected gtm
-  const auto gtm_bco_corrected = get_gtm_rollover_correction( gtm_bco );
-
-  // check against reference
-  if (m_bco_reference.second > gtm_bco_corrected + m_max_fee_sync_time)
+  // compare to reference
+  if( get_signed_gtm_bco_diff( m_bco_reference.second, gtm_bco ) > m_max_fee_sync_time )
   { return false; }
 
   // check against stored bco
   if( !m_gtm_bco_list.empty() )
   {
-    if (m_gtm_bco_list.back() > gtm_bco_corrected + m_max_fee_sync_time)
+    if( get_signed_gtm_bco_diff( m_gtm_bco_list.back(), gtm_bco ) > m_max_fee_sync_time )
     { return false; }
   }
 
   // check against matched BCOs
   if( !m_bco_matching_list.empty() )
   {
-    if (m_bco_matching_list.back().second > gtm_bco_corrected + m_max_fee_sync_time)
+    if( get_signed_gtm_bco_diff( m_bco_matching_list.back().second, gtm_bco ) > m_max_fee_sync_time )
     { return false; }
   }
 
@@ -288,15 +316,15 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
 {
   // store gtm bco and diff to previous in an array
   std::vector<uint64_t> gtm_bco_list;
-  std::vector<uint64_t> gtm_bco_diff_list;
+  std::vector<int64_t> fee_bco_diff_list;
   for (const auto& gtm_bco : m_gtm_bco_list)
   {
     if (!gtm_bco_list.empty())
     {
       // add difference to last
       // get gtm bco difference with proper rollover accounting
-      const uint64_t gtm_bco_difference = get_gtm_rollover_correction( gtm_bco ) - gtm_bco_list.back();
-      gtm_bco_diff_list.push_back(get_adjusted_multiplier() * gtm_bco_difference);
+      const int64_t gtm_bco_difference = get_signed_gtm_bco_diff( gtm_bco, gtm_bco_list.back() );
+      fee_bco_diff_list.push_back(get_adjusted_multiplier() * gtm_bco_difference);
     }
 
     // append to list
@@ -306,7 +334,7 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
   // print all differences
   if (verbosity())
   {
-    std::cout << "MicromegasBcoMatchingInformation_v2::find_reference_from_data - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl;
+    std::cout << "MicromegasBcoMatchingInformation_v2::find_reference_from_data - fee_bco_diff_list: " << fee_bco_diff_list << std::endl;
   }
 
   // skip hearbeat
@@ -330,7 +358,7 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
   }
 
   // calculate difference
-  const uint64_t fee_bco_diff = get_bco_diff(fee_bco, m_fee_bco_prev);
+  const uint32_t fee_bco_diff = get_unsigned_fee_bco_diff(fee_bco, m_fee_bco_prev);
 
   // discard identical fee_bco
   if (fee_bco_diff < m_max_fee_bco_diff)
@@ -341,13 +369,13 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
   std::cout << "MicromegasBcoMatchingInformation_v2::find_reference_from_data - fee_bco_diff: " << fee_bco_diff << std::endl;
 
   // look for matching diff in gtm_bco array
-  for (size_t i = 0; i < gtm_bco_diff_list.size(); ++i)
+  for (size_t i = 0; i < fee_bco_diff_list.size(); ++i)
   {
-    uint64_t sum = 0;
-    for (size_t j = i; j < gtm_bco_diff_list.size(); ++j)
+    uint32_t sum = 0;
+    for (size_t j = i; j < fee_bco_diff_list.size(); ++j)
     {
-      sum += gtm_bco_diff_list[j];
-      if (get_bco_diff(sum, fee_bco_diff) < m_max_fee_bco_diff)
+      sum += fee_bco_diff_list[j];
+      if (get_unsigned_fee_bco_diff(sum, fee_bco_diff) < m_max_fee_bco_diff)
       {
         m_verified_from_data = true;
         m_bco_reference = { m_fee_bco_prev, gtm_bco_list[i] };
@@ -388,7 +416,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
       m_bco_matching_list.begin(),
       m_bco_matching_list.end(),
       [fee_bco](const m_bco_matching_pair_t& pair)
-      { return get_bco_diff(pair.first, fee_bco) < m_max_fee_bco_diff; });
+      { return get_unsigned_fee_bco_diff(pair.first, fee_bco) < m_max_fee_bco_diff; });
 
   if (bco_matching_iter != m_bco_matching_list.end())
   {
@@ -399,7 +427,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
       m_gtm_bco_list.begin(),
       m_gtm_bco_list.end(),
       [this, fee_bco](const uint64_t& gtm_bco)
-      { return get_bco_diff(get_predicted_fee_bco(gtm_bco).value(), fee_bco) < m_max_gtm_bco_diff; });
+      { return get_unsigned_fee_bco_diff(get_predicted_fee_bco(gtm_bco).value(), fee_bco) < m_max_gtm_bco_diff; });
 
   // check
   if (iter != m_gtm_bco_list.end())
@@ -410,7 +438,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
       if (auto opt_fee_bco = get_predicted_fee_bco(gtm_bco))  // check if optional exists
       {
         const auto fee_bco_predicted = *opt_fee_bco;  // get_predicted_fee_bco(gtm_bco).value();
-        const auto fee_bco_diff = get_bco_diff(fee_bco_predicted, fee_bco);
+        const auto fee_bco_diff = get_unsigned_fee_bco_diff(fee_bco_predicted, fee_bco);
 
         std::cout << "MicromegasBcoMatchingInformation_v2::find_gtm_bco -"
                   << " packet_id: " << packet_id
@@ -448,9 +476,8 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
           m_gtm_bco_list.begin(),
           m_gtm_bco_list.end(),
           [this, fee_bco](const uint64_t& first, const uint64_t& second)
-          { return get_bco_diff(get_predicted_fee_bco(first).value(), fee_bco) < get_bco_diff(get_predicted_fee_bco(second).value(), fee_bco); });
+          { return get_unsigned_fee_bco_diff(get_predicted_fee_bco(first).value(), fee_bco) < get_unsigned_fee_bco_diff(get_predicted_fee_bco(second).value(), fee_bco); });
 
-      // const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ? get_bco_diff(get_predicted_fee_bco(*iter2).value(), fee_bco) : -1;
       // compared to the previous statement, this checks if the optional
       int fee_bco_diff = -1;
 
@@ -460,7 +487,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
 
         if (predicted)
         {
-          fee_bco_diff = get_bco_diff(*predicted, fee_bco);
+          fee_bco_diff = get_unsigned_fee_bco_diff(*predicted, fee_bco);
         }
       }
 
@@ -541,12 +568,12 @@ void MicromegasBcoMatchingInformation_v2::update_multiplier_adjustment(uint64_t 
     gSystem->Exit(1);
     exit(1);
   }
-  const uint32_t fee_bco_predicted = *predicted_opt;
-  const double delta_fee_bco = double(fee_bco) - double(fee_bco_predicted);
-  const double gtm_bco_difference = (gtm_bco >= m_bco_reference.second) ? (gtm_bco - m_bco_reference.second) : (gtm_bco + (1ULL << m_GTM_CLOCK_BITS) - m_bco_reference.second);
+  const uint32_t fee_bco_predicted = predicted_opt.value();
+  const double delta_fee_bco = get_signed_fee_bco_diff(fee_bco,fee_bco_predicted);
+  const double gtm_bco_difference = get_signed_gtm_bco_diff(gtm_bco,m_bco_reference.second);
 
-  m_multiplier_adjustment_numerator += gtm_bco_difference * delta_fee_bco;
-  m_multiplier_adjustment_denominator += gtm_bco_difference * gtm_bco_difference;
+  m_multiplier_adjustment_numerator += gtm_bco_difference*delta_fee_bco;
+  m_multiplier_adjustment_denominator += gtm_bco_difference*gtm_bco_difference;
   ++m_multiplier_adjustment_count;
 
   if (verbosity())

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -98,9 +98,9 @@ namespace
 
   // Fee clock bits
   static constexpr unsigned int m_FEE_CLOCK_BITS = 20U;
-  static constexpr uint32_t m_FEE_CLOCK_MASK = (1ULL << m_FEE_CLOCK_BITS)-1;
-  static constexpr int32_t m_FEE_CLOCK_RANGE = 1ULL << m_FEE_CLOCK_BITS;
-  static constexpr int32_t m_FEE_CLOCK_HALF_RANGE = 1ULL << (m_FEE_CLOCK_BITS-1);
+  static constexpr uint32_t m_FEE_CLOCK_MASK = (1UL << m_FEE_CLOCK_BITS)-1ULL;
+  static constexpr int32_t m_FEE_CLOCK_RANGE = 1UL << m_FEE_CLOCK_BITS;
+  static constexpr int32_t m_FEE_CLOCK_HALF_RANGE = 1UL << (m_FEE_CLOCK_BITS-1UL);
 
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -20,8 +20,6 @@ namespace
 {
 
   // streamer for lists
-
-  // streamer for lists
   template <class T>
   std::ostream& operator<<(std::ostream& o, const std::list<T>& list)
   {
@@ -102,6 +100,9 @@ namespace
   /* used for rollover calculation */
   static constexpr unsigned int m_GTM_CLOCK_BITS = 40;
 
+  static constexpr uint64_t m_GTM_CLOCK_MASK = (1ULL << m_GTM_CLOCK_BITS)-1;
+  static constexpr uint64_t m_GTM_CLOCK_ROLLOVER = 1ULL << m_GTM_CLOCK_BITS;
+
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType
   {
@@ -140,7 +141,6 @@ unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 100;
 // unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 8;
 // unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 16;
 unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 32;
-
 
 //___________________________________________________
 std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_bco(uint64_t gtm_bco) const
@@ -194,7 +194,7 @@ uint64_t MicromegasBcoMatchingInformation_v2::get_gtm_rollover_correction(uint64
   // check proper initialization
   if (!is_verified()) { return gtm_bco; }
   else if( gtm_bco >= m_bco_reference.second ) return gtm_bco;
-  else return gtm_bco+(1ULL << m_GTM_CLOCK_BITS);
+  else return gtm_bco+m_GTM_CLOCK_ROLLOVER;
 }
 
 //___________________________________________________

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -98,6 +98,10 @@ namespace
   //! copied from micromegas/MicromegasDefs.h, not available here
   constexpr int m_nchannels_fee = 256;
 
+  // gtm clock bits
+  /* used for rollover calculation */
+  static constexpr unsigned int m_GTM_CLOCK_BITS = 40;
+
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType
   {
@@ -132,6 +136,12 @@ unsigned int MicromegasBcoMatchingInformation_v2::m_max_multiplier_adjustment_co
 // define limit for matching fee_bco to fee_bco_predicted
 unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 100;
 
+//
+// unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 8;
+// unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 16;
+unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 32;
+
+
 //___________________________________________________
 std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_bco(uint64_t gtm_bco) const
 {
@@ -142,7 +152,7 @@ std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_b
   }
 
   // get gtm bco difference with proper rollover accounting
-  const uint64_t gtm_bco_difference = (gtm_bco >= m_bco_reference.second) ? (gtm_bco - m_bco_reference.second) : (gtm_bco + (1ULL << 40U) - m_bco_reference.second);
+  const uint64_t gtm_bco_difference = get_gtm_rollover_correction(gtm_bco) - m_bco_reference.second;
 
   // convert to fee bco, and truncate to 20 bits
   const uint64_t fee_bco_predicted = m_bco_reference.first + get_adjusted_multiplier() * gtm_bco_difference;
@@ -177,6 +187,46 @@ void MicromegasBcoMatchingInformation_v2::print_gtm_bco_information() const
     }
   }
 }
+
+//___________________________________________________
+uint64_t MicromegasBcoMatchingInformation_v2::get_gtm_rollover_correction(uint64_t gtm_bco) const
+{
+  // check proper initialization
+  if (!is_verified()) { return gtm_bco; }
+  else if( gtm_bco >= m_bco_reference.second ) return gtm_bco;
+  else return gtm_bco+(1ULL << m_GTM_CLOCK_BITS);
+}
+
+//___________________________________________________
+bool MicromegasBcoMatchingInformation_v2::is_more_data_required( uint64_t gtm_bco ) const
+{
+  // check proper initialization
+  if( !is_verified() ) return true;
+
+  // get rollover corrected gtm
+  const auto gtm_bco_corrected = get_gtm_rollover_correction( gtm_bco );
+
+  // check against reference
+  if (m_bco_reference.second > gtm_bco_corrected + m_max_fee_sync_time)
+  { return false; }
+
+  // check against stored bco
+  if( !m_gtm_bco_list.empty() )
+  {
+    if (m_gtm_bco_list.back() > gtm_bco_corrected + m_max_fee_sync_time)
+    { return false; }
+  }
+
+  // check against matched BCOs
+  if( !m_bco_matching_list.empty() )
+  {
+    if (m_bco_matching_list.back().second > gtm_bco_corrected + m_max_fee_sync_time)
+    { return false; }
+  }
+
+  return true;
+}
+
 
 //___________________________________________________
 void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(int /*packet_id*/, const MicromegasBcoMatchingInformation_v2::gtm_payload& payload)
@@ -245,8 +295,7 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
     {
       // add difference to last
       // get gtm bco difference with proper rollover accounting
-      const uint64_t gtm_bco_difference = (gtm_bco >= gtm_bco_list.back()) ? (gtm_bco - gtm_bco_list.back()) : (gtm_bco + (1ULL << 40U) - gtm_bco_list.back());
-
+      const uint64_t gtm_bco_difference = get_gtm_rollover_correction( gtm_bco ) - gtm_bco_list.back();
       gtm_bco_diff_list.push_back(get_adjusted_multiplier() * gtm_bco_difference);
     }
 
@@ -494,7 +543,7 @@ void MicromegasBcoMatchingInformation_v2::update_multiplier_adjustment(uint64_t 
   }
   const uint32_t fee_bco_predicted = *predicted_opt;
   const double delta_fee_bco = double(fee_bco) - double(fee_bco_predicted);
-  const double gtm_bco_difference = (gtm_bco >= m_bco_reference.second) ? (gtm_bco - m_bco_reference.second) : (gtm_bco + (1ULL << 40U) - m_bco_reference.second);
+  const double gtm_bco_difference = (gtm_bco >= m_bco_reference.second) ? (gtm_bco - m_bco_reference.second) : (gtm_bco + (1ULL << m_GTM_CLOCK_BITS) - m_bco_reference.second);
 
   m_multiplier_adjustment_numerator += gtm_bco_difference * delta_fee_bco;
   m_multiplier_adjustment_denominator += gtm_bco_difference * gtm_bco_difference;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -271,7 +271,7 @@ void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(int /*packet_
     const auto& gtm_bco = payload.bco;
 
     // add to list if difference to last entry is big enough
-    if (m_gtm_bco_list.empty() || (gtm_bco - m_gtm_bco_list.back()) > 10)
+    if (m_gtm_bco_list.empty() || get_signed_gtm_bco_diff(gtm_bco,m_gtm_bco_list.back()) > 10)
     {
       m_gtm_bco_list.push_back(gtm_bco);
     }
@@ -441,15 +441,15 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
         const auto fee_bco_diff = get_unsigned_fee_bco_diff(fee_bco_predicted, fee_bco);
 
         std::cout << "MicromegasBcoMatchingInformation_v2::find_gtm_bco -"
-                  << " packet_id: " << packet_id
-                  << " fee_id: " << fee_id
-                  << std::hex
-                  << " fee_bco: 0x" << fee_bco
-                  << " predicted: 0x" << fee_bco_predicted
-                  << " gtm_bco: 0x" << gtm_bco
-                  << std::dec
-                  << " difference: " << fee_bco_diff
-                  << std::endl;
+          << " packet_id: " << packet_id
+          << " fee_id: " << fee_id
+          << std::hex
+          << " fee_bco: 0x" << fee_bco
+          << " predicted: 0x" << fee_bco_predicted
+          << " gtm_bco: 0x" << gtm_bco
+          << std::dec
+          << " difference: " << fee_bco_diff
+          << std::endl;
       }
     }
     // save fee_bco and gtm_bco matching in map
@@ -526,14 +526,13 @@ void MicromegasBcoMatchingInformation_v2::cleanup()
 void MicromegasBcoMatchingInformation_v2::cleanup(uint64_t ref_bco)
 {
   // erase all elements from bco_list that are less than or equal to ref_bco
-  m_gtm_bco_list.erase(std::remove_if(m_gtm_bco_list.begin(), m_gtm_bco_list.end(), [ref_bco](const uint64_t& bco)
-                                      { return bco <= ref_bco; }),
-                       m_gtm_bco_list.end());
+  m_gtm_bco_list.erase(std::remove_if(m_gtm_bco_list.begin(), m_gtm_bco_list.end(),
+    [ref_bco](const uint64_t& bco) { return get_signed_gtm_bco_diff( bco,ref_bco ) <= 0; }), m_gtm_bco_list.end());
 
   // erase all elements from bco_list that are less than or equal to ref_bco
-  m_bco_matching_list.erase(std::remove_if(m_bco_matching_list.begin(), m_bco_matching_list.end(), [ref_bco](const m_bco_matching_pair_t& pair)
-                                           { return pair.second <= ref_bco; }),
-                            m_bco_matching_list.end());
+  m_bco_matching_list.erase(std::remove_if(m_bco_matching_list.begin(), m_bco_matching_list.end(),
+    [ref_bco](const m_bco_matching_pair_t& pair) { return get_signed_gtm_bco_diff( pair.second, ref_bco ) <= 0; }),
+    m_bco_matching_list.end());
 
   // clear orphans
   m_orphans.clear();

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -138,7 +138,7 @@ unsigned int MicromegasBcoMatchingInformation_v2::m_max_multiplier_adjustment_co
 unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 60;
 
 //! Max time forward to ensure that a given
-unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 32;
+unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 96;
 
 //___________________________________________________
 int64_t MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff(uint64_t first, uint64_t second)

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -91,16 +91,16 @@ namespace
 
   // gtm clock bits
   /* used for rollover calculation */
-  static constexpr unsigned int m_GTM_CLOCK_BITS = 40U;
-  static constexpr uint64_t m_GTM_CLOCK_MASK = (1ULL << m_GTM_CLOCK_BITS)-1;
-  static constexpr int64_t m_GTM_CLOCK_RANGE = 1ULL << m_GTM_CLOCK_BITS;
-  static constexpr int64_t m_GTM_CLOCK_HALF_RANGE = 1ULL << (m_GTM_CLOCK_BITS-1);
+  constexpr unsigned int m_GTM_CLOCK_BITS = 40U;
+  constexpr uint64_t m_GTM_CLOCK_MASK = (1ULL << m_GTM_CLOCK_BITS)-1;
+  constexpr int64_t m_GTM_CLOCK_RANGE = 1ULL << m_GTM_CLOCK_BITS;
+  constexpr int64_t m_GTM_CLOCK_HALF_RANGE = 1ULL << (m_GTM_CLOCK_BITS-1);
 
   // Fee clock bits
-  static constexpr unsigned int m_FEE_CLOCK_BITS = 20U;
-  static constexpr uint32_t m_FEE_CLOCK_MASK = (1UL << m_FEE_CLOCK_BITS)-1ULL;
-  static constexpr int32_t m_FEE_CLOCK_RANGE = 1UL << m_FEE_CLOCK_BITS;
-  static constexpr int32_t m_FEE_CLOCK_HALF_RANGE = 1UL << (m_FEE_CLOCK_BITS-1UL);
+  constexpr unsigned int m_FEE_CLOCK_BITS = 20U;
+  constexpr uint32_t m_FEE_CLOCK_MASK = (1UL << m_FEE_CLOCK_BITS)-1ULL;
+  constexpr int32_t m_FEE_CLOCK_RANGE = 1UL << m_FEE_CLOCK_BITS;
+  constexpr int32_t m_FEE_CLOCK_HALF_RANGE = 1UL << (m_FEE_CLOCK_BITS-1UL);
 
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType
@@ -196,7 +196,7 @@ std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_b
 
   // convert to fee bco, and truncate to 20 bits
   const int64_t fee_bco_predicted = m_bco_reference.first + get_adjusted_multiplier() * gtm_bco_difference;
-  return uint32_t(fee_bco_predicted & m_FEE_CLOCK_MASK);
+  return static_cast<uint32_t>(fee_bco_predicted) & m_FEE_CLOCK_MASK;
 }
 
 //___________________________________________________
@@ -232,7 +232,7 @@ void MicromegasBcoMatchingInformation_v2::print_gtm_bco_information() const
 bool MicromegasBcoMatchingInformation_v2::is_more_data_required( uint64_t gtm_bco ) const
 {
   // check proper initialization
-  if( !is_verified() ) return true;
+  if( !is_verified() ) { return true; }
 
   // compare to reference
   if( get_signed_gtm_bco_diff( m_bco_reference.second, gtm_bco ) > m_max_fee_sync_time )

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -123,23 +123,21 @@ namespace
 
 }  // namespace
 
-// this is the clock multiplier from lvl1 to fee clock
+//! this is the clock multiplier from lvl1 to fee clock
 bool MicromegasBcoMatchingInformation_v2::m_multiplier_is_set = false;
 double MicromegasBcoMatchingInformation_v2::m_multiplier = 0;
 
-// true if on-fly multiplier adjustment is enabled
+//! true if on-fly multiplier adjustment is enabled
 bool MicromegasBcoMatchingInformation_v2::m_multiplier_adjustment_enabled = true;
 
-// muliplier adjustment count
+//! muliplier adjustment count
 /* controls how often the gtm multiplier is automatically adjusted */
 unsigned int MicromegasBcoMatchingInformation_v2::m_max_multiplier_adjustment_count = 200;
 
-// define limit for matching fee_bco to fee_bco_predicted
-unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 100;
+//! define limit for matching fee_bco to fee_bco_predicted
+unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 60;
 
-//
-// unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 8;
-// unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 16;
+//! Max time forward to ensure that a given
 unsigned int MicromegasBcoMatchingInformation_v2::m_max_fee_sync_time = 1024 * 32;
 
 //___________________________________________________
@@ -422,6 +420,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
   {
     return bco_matching_iter->second;
   }
+
   // find element for which predicted fee_bco matches fee_bco, within limit
   const auto iter = std::find_if(
       m_gtm_bco_list.begin(),

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -142,10 +142,10 @@ std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_b
   }
 
   // get gtm bco difference with proper rollover accounting
-  const uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ? (gtm_bco - m_gtm_bco_first) : (gtm_bco + (1ULL << 40U) - m_gtm_bco_first);
+  const uint64_t gtm_bco_difference = (gtm_bco >= m_bco_reference.second) ? (gtm_bco - m_bco_reference.second) : (gtm_bco + (1ULL << 40U) - m_bco_reference.second);
 
   // convert to fee bco, and truncate to 20 bits
-  const uint64_t fee_bco_predicted = m_fee_bco_first + get_adjusted_multiplier() * gtm_bco_difference;
+  const uint64_t fee_bco_predicted = m_bco_reference.first + get_adjusted_multiplier() * gtm_bco_difference;
   return uint32_t(fee_bco_predicted & 0xFFFFFU);
 }
 
@@ -225,8 +225,7 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_modebits(const Mic
 
       // get BCO and assign
       const auto& gtm_bco = payload.bco;
-      m_gtm_bco_first = gtm_bco;
-      m_fee_bco_first = 0;
+      m_bco_reference = {0, gtm_bco};
       m_verified_from_modebits = true;
       return true;
     }
@@ -302,19 +301,18 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
       if (get_bco_diff(sum, fee_bco_diff) < m_max_fee_bco_diff)
       {
         m_verified_from_data = true;
-        m_gtm_bco_first = gtm_bco_list[i];
-        m_fee_bco_first = m_fee_bco_prev;
+        m_bco_reference = { m_fee_bco_prev, gtm_bco_list[i] };
 
         if (verbosity())
         {
           std::cout << "MicromegasBcoMatchingInformation_v2::find_reference_from_data - matching is verified" << std::endl;
           std::cout
               << "MicromegasBcoMatchingInformation_v2::find_reference_from_data -"
-              << " m_gtm_bco_first: " << std::hex << m_gtm_bco_first << std::dec
-              << std::endl;
-          std::cout
-              << "MicromegasBcoMatchingInformation_v2::find_reference_from_data -"
-              << " m_fee_bco_first: " << std::hex << m_fee_bco_first << std::dec
+              << std::hex
+              << " m_bco_reference: ( 0x"
+              << m_bco_reference.first
+              << ", 0x" << m_bco_reference.second << ")"
+              << std::dec
               << std::endl;
         }
         return true;
@@ -481,7 +479,7 @@ void MicromegasBcoMatchingInformation_v2::update_multiplier_adjustment(uint64_t 
   }
 
   // skip if trivial
-  if (gtm_bco == m_gtm_bco_first)
+  if (gtm_bco == m_bco_reference.second)
   {
     return;
   }
@@ -496,7 +494,7 @@ void MicromegasBcoMatchingInformation_v2::update_multiplier_adjustment(uint64_t 
   }
   const uint32_t fee_bco_predicted = *predicted_opt;
   const double delta_fee_bco = double(fee_bco) - double(fee_bco_predicted);
-  const double gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ? (gtm_bco - m_gtm_bco_first) : (gtm_bco + (1ULL << 40U) - m_gtm_bco_first);
+  const double gtm_bco_difference = (gtm_bco >= m_bco_reference.second) ? (gtm_bco - m_bco_reference.second) : (gtm_bco + (1ULL << 40U) - m_bco_reference.second);
 
   m_multiplier_adjustment_numerator += gtm_bco_difference * delta_fee_bco;
   m_multiplier_adjustment_denominator += gtm_bco_difference * gtm_bco_difference;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -106,13 +106,9 @@ class MicromegasBcoMatchingInformation_v2
   uint64_t get_gtm_bco_last() const
   { return m_gtm_bco_list.empty() ? 0:*m_gtm_bco_list.rbegin(); }
 
-  //! get rollover corrected GTM bco depending on reference
-  uint64_t get_gtm_rollover_correction(uint64_t /*gtm_bco*/) const;
-
   //! returns true if more data needs to be fetched.
   /** it is based on the latest BCO read from the data stream, from either tagger or heartbeat */
   bool is_more_data_required(uint64_t /*gtm_bco*/) const;
-
 
   //@}
 
@@ -176,6 +172,25 @@ class MicromegasBcoMatchingInformation_v2
 
   //! cleanup
   void cleanup(uint64_t /*ref_bco*/);
+
+  //@}
+
+  //!@name utilities
+  //@{
+
+  //! get difference between two GTM BCO, properly accounting for 40bits rollover
+  /** based on Jin's code in TpcTimeFrameBuilder */
+  static int64_t get_signed_gtm_bco_diff(uint64_t /*first*/, uint64_t /*second*/);
+
+  //! get difference between two FEE BCO, properly accounting for 20bits rollover
+  /** based on Jin's code in TpcTimeFrameBuilder */
+  static int32_t get_signed_fee_bco_diff(uint32_t /*first*/, uint32_t /*second*/);
+
+  //! get difference between two GTM BCO, properly accounting for 40bits rollover
+  static uint64_t get_unsigned_gtm_bco_diff(uint64_t /*first*/, uint64_t /*second*/);
+
+  //! get difference between two FEE BCO, properly accounting for 20bits rollover
+  static uint32_t get_unsigned_fee_bco_diff(uint32_t /*first*/, uint32_t /*second*/);
 
   //@}
 

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -106,6 +106,14 @@ class MicromegasBcoMatchingInformation_v2
   uint64_t get_gtm_bco_last() const
   { return m_gtm_bco_list.empty() ? 0:*m_gtm_bco_list.rbegin(); }
 
+  //! get rollover corrected GTM bco depending on reference
+  uint64_t get_gtm_rollover_correction(uint64_t /*gtm_bco*/) const;
+
+  //! returns true if more data needs to be fetched.
+  /** it is based on the latest BCO read from the data stream, from either tagger or heartbeat */
+  bool is_more_data_required(uint64_t /*gtm_bco*/) const;
+
+
   //@}
 
   //!@name modifiers
@@ -139,6 +147,12 @@ class MicromegasBcoMatchingInformation_v2
   static void set_gtm_bco_diff( unsigned int value )
   {
     m_max_gtm_bco_diff = value;
+  }
+
+  //! max time in GTM BCO for FEE data to sync over to datastream
+  static void set_m_max_fee_sync_time( unsigned int value )
+  {
+    m_max_fee_sync_time = value;
   }
 
   //! find reference from modebits
@@ -209,6 +223,9 @@ class MicromegasBcoMatchingInformation_v2
 
   // define limit for matching fee_bco to fee_bco_predicted
   static unsigned int m_max_gtm_bco_diff;
+
+  //! max time in GTM BCO for FEE data to sync over to datastream
+  static unsigned int m_max_fee_sync_time;
 
   //! adjustment to multiplier
   double m_multiplier_adjustment = 0;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -97,13 +97,10 @@ class MicromegasBcoMatchingInformation_v2
   //! print gtm bco information
   void print_gtm_bco_information() const;
 
-  //! get first gtm bco
-  unsigned int get_fee_bco_first() const
-  { return m_fee_bco_first; }
-
-  //! get first gtm bco
-  uint64_t get_gtm_bco_first() const
-  { return m_gtm_bco_first; }
+  //! get BCO matching reference
+  using m_bco_matching_pair_t = std::pair<uint32_t, uint64_t>;
+  const m_bco_matching_pair_t& get_bco_matching_reference() const
+  { return m_bco_reference; }
 
   //! get last gtm bco
   uint64_t get_gtm_bco_last() const
@@ -178,14 +175,7 @@ class MicromegasBcoMatchingInformation_v2
 
   //! verified
   bool m_verified_from_modebits = false;
-
   bool m_verified_from_data = false;
-
-  //! first lvl1 bco (40 bits)
-  uint64_t m_gtm_bco_first = 0;
-
-  //! first fee bco (20 bits)
-  uint32_t m_fee_bco_first = 0;
 
   //! last found fee_bco
   /** used to try finding bco reference from data */
@@ -195,8 +185,10 @@ class MicromegasBcoMatchingInformation_v2
   //! list of available bco
   std::list<uint64_t> m_gtm_bco_list;
 
+  //! reference matching
+  m_bco_matching_pair_t m_bco_reference;
+
   //! matching between fee bco and lvl1 bco
-  using m_bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
   std::list<m_bco_matching_pair_t> m_bco_matching_list;
 
   //! keep track or  fee_bco for which no gtm_bco is found

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -773,19 +773,18 @@ void SingleMicromegasPoolInput_v2::decode_gtm_data(int packet_id, const SingleMi
   if (m_do_evaluation)
   {
     m_waveform.packet_id = packet_id;
-    m_waveform.gtm_bco_first = bco_matching_information.get_gtm_bco_first();
+    m_waveform.gtm_bco_first = bco_matching_information.get_bco_matching_reference().second;
     m_waveform.gtm_bco = bco_matching_information.get_gtm_bco_last();
 
     {
       const auto predicted = bco_matching_information.get_predicted_fee_bco(m_waveform.gtm_bco);
-      ;
       if (predicted)
       {
         m_waveform.fee_bco_predicted = predicted.value();
       }
     }
 
-    m_waveform.fee_bco_first = bco_matching_information.get_fee_bco_first();
+    m_waveform.fee_bco_first = bco_matching_information.get_bco_matching_reference().first;
   }
 }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -1047,13 +1047,6 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
       if( bco > found_bco && bco <= found_bco + truncatedWaveformGTMWindow )
       {
 
-//         std::cout << "SingleMicromegasPoolInput_v2::recover_truncated_waveforms -"
-//           << " fee: " << fee
-//           << " target_bco: " << target_bco
-//           << " found_bco: " << found_bco
-//           << " bco: " << bco
-//           << std::endl;
-
         // perform overlap restoration
         for( auto* source:rawhitlist )
         {
@@ -1079,7 +1072,6 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
 
             // get FEE BCO from GTM
             auto result =  bco_matching.get_predicted_fee_bco( target_bco );
-            // auto result =  bco_matching.get_predicted_fee_bco( found_bco );
             if( !result ) { continue; }
 
             const auto target_fee_bco = result.value();
@@ -1094,14 +1086,15 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
             target->set_fee(source->get_fee());
             target->set_channel(source->get_channel());
             target->set_sampaaddress(source->get_sampaaddress());
+            target->set_sampachannel(source->get_sampachannel());
 
             // store in new array
             new_rawhits[target->get_channel()] = target;
-            target->set_sampachannel(source->get_sampachannel());
 
           }
 
           // calculate waveform shift
+          // TODO: get proper diff with proper rollover
           const uint64_t fee_bco_diff = source->get_bco() - target->get_bco();
           const uint16_t fee_clock_shift = static_cast<uint16_t>(fee_bco_diff/kFEEClockPerADCClock);
 
@@ -1110,7 +1103,17 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
 
           // move copy to target hit, with properly shifted start time
           for( auto&& [start_time,adc_list]:waveformlist)
-          { target->move_adc_waveform( start_time+fee_clock_shift, std::move(adc_list) ); }
+          {
+
+            // make sure shifted start time is in acceptable window
+            if( start_time+fee_clock_shift >= kTruncatedWaveformWindow ) continue;
+
+            // make sure all samples are in acceptable range
+            if( start_time+fee_clock_shift + adc_list.size() >=  kTruncatedWaveformWindow )
+            { adc_list.resize( start_time+fee_clock_shift - kTruncatedWaveformWindow ); }
+
+            target->move_adc_waveform( start_time+fee_clock_shift, std::move(adc_list) );
+          }
 
         }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -310,6 +310,9 @@ void SingleMicromegasPoolInput_v2::FillPool(const uint64_t target_bco)
     m_timer.stop();
   }
 
+  if( m_do_evaluation )
+  { fill_evaluation_tree( target_bco ); }
+
   // recover truncated FEEs for target bco
   recover_truncated_waveforms( target_bco );
 
@@ -561,20 +564,18 @@ void SingleMicromegasPoolInput_v2::createQAHistos()
   {
     m_evaluation_file.reset(new TFile(m_evaluation_filename.c_str(), "RECREATE"));
     m_evaluation_tree = new TTree("T", "T");
-    m_evaluation_tree->Branch("is_heartbeat", &m_waveform.is_heartbeat);
-    m_evaluation_tree->Branch("matched", &m_waveform.matched);
     m_evaluation_tree->Branch("packet_id", &m_waveform.packet_id);
     m_evaluation_tree->Branch("fee_id", &m_waveform.fee_id);
     m_evaluation_tree->Branch("channel", &m_waveform.channel);
 
     m_evaluation_tree->Branch("gtm_bco_first", &m_waveform.gtm_bco_first);
-    m_evaluation_tree->Branch("gtm_bco", &m_waveform.gtm_bco);
-    m_evaluation_tree->Branch("gtm_bco_matched", &m_waveform.gtm_bco_matched);
+    m_evaluation_tree->Branch("gtm_bco_tagger", &m_waveform.gtm_bco_tagger);
+    m_evaluation_tree->Branch("gtm_bco_gl1", &m_waveform.gtm_bco_gl1);
 
     m_evaluation_tree->Branch("fee_bco_first", &m_waveform.fee_bco_first);
     m_evaluation_tree->Branch("fee_bco", &m_waveform.fee_bco);
-    m_evaluation_tree->Branch("fee_bco_predicted", &m_waveform.fee_bco_predicted);
-    m_evaluation_tree->Branch("fee_bco_predicted_matched", &m_waveform.fee_bco_predicted_matched);
+    m_evaluation_tree->Branch("fee_bco_predicted_tagger", &m_waveform.fee_bco_predicted_tagger);
+    m_evaluation_tree->Branch("fee_bco_predicted_gl1", &m_waveform.fee_bco_predicted_gl1);
   }
 }
 
@@ -727,24 +728,6 @@ void SingleMicromegasPoolInput_v2::decode_gtm_data(int packet_id, const SingleMi
    * because any BX_COUNTER_SYNC_T event will break past references
    */
   bco_matching_information.find_reference_from_modebits(payload);
-
-  // store in running waveform
-  if (m_do_evaluation)
-  {
-    m_waveform.packet_id = packet_id;
-    m_waveform.gtm_bco_first = bco_matching_information.get_bco_matching_reference().second;
-    m_waveform.gtm_bco = bco_matching_information.get_gtm_bco_last();
-
-    {
-      const auto predicted = bco_matching_information.get_predicted_fee_bco(m_waveform.gtm_bco);
-      if (predicted)
-      {
-        m_waveform.fee_bco_predicted = predicted.value();
-      }
-    }
-
-    m_waveform.fee_bco_first = bco_matching_information.get_bco_matching_reference().first;
-  }
 }
 
 //____________________________________________________________________
@@ -871,13 +854,6 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
 
     // try get gtm bco matching fee
     const auto& fee_bco = payload.bx_timestamp;
-    if( m_do_evaluation )
-    {
-      m_waveform.is_heartbeat = is_heartbeat;
-      m_waveform.fee_id = fee_id;
-      m_waveform.channel = payload.channel;
-      m_waveform.fee_bco = fee_bco;
-    }
 
     // find matching gtm bco
     uint64_t gtm_bco = 0;
@@ -886,20 +862,9 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
     {
       // assign gtm bco
       gtm_bco = result.value();
-      if( m_do_evaluation )
-      {
-        m_waveform.matched = true;
-        m_waveform.gtm_bco_matched = gtm_bco;
-        {
-          const auto predicted = bco_matching_information.get_predicted_fee_bco(gtm_bco);;
-          if( predicted )
-          {
-            m_waveform.fee_bco_predicted_matched = predicted.value();
-          }
-        }
-        m_evaluation_tree->Fill();
-      }
+
     } else {
+
       // increment counter and histogram
       ++m_waveform_counters[packet_id].dropped_bco;
       ++m_fee_waveform_counters[fee_id].dropped_bco;
@@ -910,14 +875,6 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
       {
         ++m_heartbeat_counters[packet_id].dropped_bco;
         ++m_fee_heartbeat_counters[fee_id].dropped_bco;
-      }
-
-      if( m_do_evaluation )
-      {
-        m_waveform.matched = false;
-        m_waveform.gtm_bco_matched = 0;
-        m_waveform.fee_bco_predicted_matched = 0;
-        m_evaluation_tree->Fill();
       }
 
       // skip the waverform
@@ -992,6 +949,58 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
 }
 
 //____________________________________________________________________
+void SingleMicromegasPoolInput_v2::fill_evaluation_tree( const uint64_t target_bco )
+{
+
+  // loop over fees
+  for( size_t fee = 0; fee < MAX_FEECOUNT; ++fee )
+  {
+
+    // get local raw hitmap
+    auto&& rawhitmap = m_MicromegasRawHitMap[fee];
+    if( rawhitmap.empty() ) { continue; }
+
+    // get the relevant BCO matching information object
+    const auto& bco_matching_information = m_bco_matching_information_map.at( m_fee_packet[fee] );
+    if( !bco_matching_information.is_verified() )
+    { continue; }
+
+    m_waveform.packet_id = m_fee_packet[fee];
+    m_waveform.fee_id = fee;
+    m_waveform.gtm_bco_first = bco_matching_information.get_bco_matching_reference().second;
+    m_waveform.fee_bco_first = bco_matching_information.get_bco_matching_reference().first;
+
+    // assign target bco and prediction
+    m_waveform.gtm_bco_gl1 = target_bco;
+    m_waveform.fee_bco_predicted_gl1 = bco_matching_information.get_predicted_fee_bco(target_bco).value();
+
+    // find matching bco if any and store raw hits
+    // list of raw hits (channel ordered) matching target BCO
+    for( auto&& [bco, rawhitlist]:rawhitmap )
+    {
+
+      // compare bco to target, within acceptable range
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco );
+      if( bco_diff >= -(int64_t)m_NegativeBco && bco_diff < m_BcoRange )
+      {
+
+        // assign found bco and prediction
+        m_waveform.gtm_bco_tagger = bco;
+        m_waveform.fee_bco_predicted_tagger = bco_matching_information.get_predicted_fee_bco(bco).value();
+        for( auto&& rawhit:rawhitlist )
+        {
+          m_waveform.channel = rawhit->get_channel();
+          m_waveform.fee_bco = rawhit->get_bco();
+          m_evaluation_tree->Fill();
+        }
+        break;
+      }
+    }
+
+  } // FEE loop
+}
+
+//____________________________________________________________________
 void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t target_bco )
 {
 
@@ -1014,8 +1023,12 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     if( rawhitmap.empty() ) { continue; }
 
     // get the relevant BCO matching information object
-    const auto& bco_matching = m_bco_matching_information_map.at( m_fee_packet[fee] );
-    const double truncatedWaveformGTMWindow = kTruncatedWaveformFEEWindow/bco_matching.get_adjusted_multiplier();
+    const auto& bco_matching_information = m_bco_matching_information_map.at( m_fee_packet[fee] );
+
+    // do nothing if bco_matching_information is not verified
+    if( !bco_matching_information.is_verified() ) { continue; }
+
+    const double truncatedWaveformGTMWindow = kTruncatedWaveformFEEWindow/bco_matching_information.get_adjusted_multiplier();
 
     // find matching bco if any and store raw hits
     // list of raw hits (channel ordered) matching target BCO
@@ -1093,10 +1106,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
           } else {
 
             // get FEE BCO from GTM
-            auto result =  bco_matching.get_predicted_fee_bco( target_bco );
-            if( !result ) { continue; }
-
-            const auto target_fee_bco = result.value();
+            const auto target_fee_bco = bco_matching_information.get_predicted_fee_bco( target_bco ).value();
 
             // create new hit with shifted waveform
             target = new MicromegasRawHit_impl;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -314,7 +314,7 @@ void SingleMicromegasPoolInput_v2::FillPool(const uint64_t target_bco)
   { fill_evaluation_tree( target_bco ); }
 
   // recover truncated FEEs for target bco
-  recover_truncated_waveforms( target_bco );
+  if( m_recover_truncated_waveforms ) { recover_truncated_waveforms( target_bco ); }
 
 }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -1000,8 +1000,6 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
   static constexpr uint32_t kFEEClockPerADCClock = 2U;
   static constexpr uint32_t kTruncatedWaveformFEEWindow = kTruncatedWaveformWindow*kFEEClockPerADCClock;
 
-  using rawhit_array_t = std::array<MicromegasRawHit*, MAX_FEECHANNELCOUNT>;
-
   // keep track of exact BCO
   uint64_t found_bco = target_bco;
 
@@ -1010,6 +1008,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
   {
 
     // get local raw hitmap
+    using rawhit_array_t = std::array<MicromegasRawHit*, MAX_FEECHANNELCOUNT>;
     auto&& rawhitmap = m_MicromegasRawHitMap[fee];
     if( rawhitmap.empty() ) continue;
 
@@ -1039,7 +1038,8 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     }
 
     // keep track of newly created hits
-    [[maybe_unused]] rawhit_array_t new_rawhits{};
+    using rawhit_impl_array_t = std::array<MicromegasRawHit_impl*, MAX_FEECHANNELCOUNT>;
+    rawhit_impl_array_t new_rawhits{};
 
     // find candidate overlapping bco if any
     for( auto&& [bco, rawhitlist]:rawhitmap )
@@ -1109,10 +1109,11 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
             if( start_time+fee_clock_shift >= kTruncatedWaveformWindow ) continue;
 
             // make sure all samples are in acceptable range
-            if( start_time+fee_clock_shift + adc_list.size() >=  kTruncatedWaveformWindow )
-            { adc_list.resize( start_time+fee_clock_shift - kTruncatedWaveformWindow ); }
+            if( start_time+fee_clock_shift + adc_list.size() >  kTruncatedWaveformWindow )
+            { adc_list.resize( kTruncatedWaveformWindow - start_time - fee_clock_shift ); }
 
             target->move_adc_waveform( start_time+fee_clock_shift, std::move(adc_list) );
+
           }
 
         }
@@ -1127,12 +1128,17 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     {
       if( rawhit )
       {
-        // add hit to streaming input manager
-        if (StreamingInputManager())
-        { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit); }
+        if( !rawhit->get_adc_waveforms().empty() )
+        {
+          // add hit to streaming input manager
+          if (StreamingInputManager())
+          { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit); }
 
-        // add hit to insternal storage
-        m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit);
+          // add hit to insternal storage
+          m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit);
+        } else {
+          delete rawhit;
+        }
       }
     }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -142,6 +142,8 @@ namespace
 
 }  // namespace
 
+using MicromegasRawHit_impl = MicromegasRawHitv3;
+
 //______________________________________________________________
 SingleMicromegasPoolInput_v2::SingleMicromegasPoolInput_v2(const std::string& name)
   : SingleStreamingInput(name)
@@ -308,6 +310,9 @@ void SingleMicromegasPoolInput_v2::FillPool(const uint64_t target_bco)
     m_timer.stop();
   }
 
+  // recover truncated FEEs for target bco
+  recover_truncated_waveforms( target_bco );
+
 }
 
 //______________________________________________________________
@@ -473,6 +478,7 @@ void SingleMicromegasPoolInput_v2::FillBcoQA(uint64_t gtm_bco)
   // how many waveforms found for this BCO
   h_waveform->Fill(n_waveforms);
 }
+
 //_______________________________________________________
 void SingleMicromegasPoolInput_v2::createQAHistos()
 {
@@ -956,7 +962,7 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
     }
 
     // create new hit
-    auto newhit = std::make_unique<MicromegasRawHitv3>();
+    auto newhit = std::make_unique<MicromegasRawHit_impl>();
     newhit->set_bco(fee_bco);
     newhit->set_gtm_bco(gtm_bco);
 
@@ -980,6 +986,155 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
     { StreamingInputManager()->AddMicromegasRawHit(gtm_bco, newhit.get()); }
 
     // add to local map
-    m_MicromegasRawHitMap[fee_id][gtm_bco].push_back(newhit.release());
+    m_MicromegasRawHitMap[fee_id][gtm_bco].emplace_back(newhit.release());
   }
+}
+
+//____________________________________________________________________
+void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t target_bco )
+{
+
+  // TODO: consolidate everything (ahah)
+
+  static constexpr uint32_t kTruncatedWaveformWindow = 1024U;
+  static constexpr uint32_t kFEEClockPerADCClock = 2U;
+  static constexpr uint32_t kTruncatedWaveformFEEWindow = kTruncatedWaveformWindow*kFEEClockPerADCClock;
+
+  using rawhit_array_t = std::array<MicromegasRawHit*, MAX_FEECHANNELCOUNT>;
+
+  // keep track of exact BCO
+  uint64_t found_bco = target_bco;
+
+  // loop over fees
+  for( size_t fee = 0; fee < MAX_FEECOUNT; ++fee )
+  {
+
+    // get local raw hitmap
+    auto&& rawhitmap = m_MicromegasRawHitMap[fee];
+    if( rawhitmap.empty() ) continue;
+
+    // get the relevant BCO matching information object
+    const auto& bco_matching = m_bco_matching_information_map.at( m_fee_packet[fee] );
+    const double truncatedWaveformGTMWindow = kTruncatedWaveformFEEWindow/bco_matching.get_adjusted_multiplier();
+
+    // find matching bco if any and store raw hits
+    // list of raw hits (channel ordered) matching target BCO
+    rawhit_array_t current_rawhits{};
+    for( auto&& [bco, rawhitlist]:rawhitmap )
+    {
+
+      // compare bco to target, within acceptable range
+      // TODO properly acount for rollover. introduce a get_signed_diff
+      if( bco >= target_bco-m_NegativeBco && bco < target_bco+m_BcoRange )
+      {
+        found_bco = bco;
+        for( auto&& rawhit:rawhitlist )
+        {
+          if( rawhit->get_channel() < MAX_FEECHANNELCOUNT )
+          { current_rawhits[rawhit->get_channel()] = rawhit; }
+        }
+
+        break;
+      }
+    }
+
+    // keep track of newly created hits
+    [[maybe_unused]] rawhit_array_t new_rawhits{};
+
+    // find candidate overlapping bco if any
+    for( auto&& [bco, rawhitlist]:rawhitmap )
+    {
+      if( bco > found_bco && bco <= found_bco + truncatedWaveformGTMWindow )
+      {
+
+//         std::cout << "SingleMicromegasPoolInput_v2::recover_truncated_waveforms -"
+//           << " fee: " << fee
+//           << " target_bco: " << target_bco
+//           << " found_bco: " << found_bco
+//           << " bco: " << bco
+//           << std::endl;
+
+        // perform overlap restoration
+        for( auto* source:rawhitlist )
+        {
+
+          // cast to versioned raw hit
+          auto* source_impl = static_cast<MicromegasRawHit_impl*>(source);
+
+          // get channel and check
+          const auto channel = source->get_channel();
+          if( channel >= MAX_FEECHANNELCOUNT ) { continue; }
+
+          // keep track of target hit
+          MicromegasRawHit_impl* target = nullptr;
+
+          // check if there is an existing raw hit in current BCO at the same channel
+          if( current_rawhits[channel] )
+          {
+
+            // cast to versioned raw hit
+            target = static_cast<MicromegasRawHit_impl*>(current_rawhits[channel]);
+
+          } else {
+
+            // get FEE BCO from GTM
+            auto result =  bco_matching.get_predicted_fee_bco( target_bco );
+            // auto result =  bco_matching.get_predicted_fee_bco( found_bco );
+            if( !result ) { continue; }
+
+            const auto target_fee_bco = result.value();
+
+            // create new hit with shifted waveform
+            target = new MicromegasRawHit_impl;
+
+            // copy relevant members from source
+            target->set_bco(target_fee_bco);
+            target->set_gtm_bco(source->get_gtm_bco());
+            target->set_packetid(source->get_packetid());
+            target->set_fee(source->get_fee());
+            target->set_channel(source->get_channel());
+            target->set_sampaaddress(source->get_sampaaddress());
+
+            // store in new array
+            new_rawhits[target->get_channel()] = target;
+            target->set_sampachannel(source->get_sampachannel());
+
+          }
+
+          // calculate waveform shift
+          const uint64_t fee_bco_diff = source->get_bco() - target->get_bco();
+          const uint16_t fee_clock_shift = static_cast<uint16_t>(fee_bco_diff/kFEEClockPerADCClock);
+
+          // get waveforms (copy)
+          auto waveformlist = source_impl->get_adc_waveforms();
+
+          // move copy to target hit, with properly shifted start time
+          for( auto&& [start_time,adc_list]:waveformlist)
+          { target->move_adc_waveform( start_time+fee_clock_shift, std::move(adc_list) ); }
+
+        }
+
+        // found overlapping BCO. stop here
+        break;
+      }
+    }
+
+    // copy new hits in internal storage and add to streaming manager
+    for( auto* rawhit:new_rawhits )
+    {
+      if( rawhit )
+      {
+        // add hit to streaming input manager
+        if (StreamingInputManager())
+        { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit); }
+
+        // add hit to insternal storage
+        m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit);
+      }
+    }
+
+    // TODO: should mark target BCO as corrected
+
+  }
+
 }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -941,12 +941,13 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
       {
         if (Verbosity())
         {
-          std::cout << "SingleMicromegasPoolInput_v2::process_fee_data -"
-                    << " samples: " << samples
-                    << " pos: " << pos
-                    << " pkt_length: " << pkt_length
-                    << " format error"
-                    << std::endl;
+          std::cout
+            << "SingleMicromegasPoolInput_v2::process_fee_data -"
+            << " samples: " << samples
+            << " pos: " << pos
+            << " pkt_length: " << pkt_length
+            << " format error"
+            << std::endl;
         }
         break;
       }
@@ -1023,10 +1024,19 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     {
 
       // compare bco to target, within acceptable range
-      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, found_bco );
-      if( bco_diff >= -m_NegativeBco && bco_diff < m_BcoRange )
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco );
+      if( bco_diff >= -(int64_t)m_NegativeBco && bco_diff < m_BcoRange )
       {
         found_bco = bco;
+        if( Verbosity() )
+        {
+          std::cout << "SingleMicromegasPoolInput_v2::recover_truncated_waveforms -"
+            << " fee: " << fee
+            << " target_bco: " << target_bco
+            << " found_bco: " << found_bco
+            << std::endl;
+        }
+
         for( auto&& rawhit:rawhitlist )
         {
           if( rawhit->get_channel() < MAX_FEECHANNELCOUNT )
@@ -1045,9 +1055,19 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     // find candidate overlapping bco if any
     for( auto&& [bco, rawhitlist]:rawhitmap )
     {
-      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, found_bco );
-      if( bco_diff > 0 && bco_diff < truncatedWaveformGTMWindow )
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco );
+      if( bco_diff >= m_BcoRange && bco_diff < truncatedWaveformGTMWindow )
       {
+
+        if( Verbosity() )
+        {
+          std::cout << "SingleMicromegasPoolInput_v2::recover_truncated_waveforms -"
+            << " fee: " << fee
+            << " target_bco: " << target_bco
+            << " found_bco: " << found_bco
+            << " overlaping bco: " << bco
+            << std::endl;
+        }
 
         // perform overlap restoration
         for( auto* source:rawhitlist )
@@ -1128,19 +1148,17 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     // copy new hits in internal storage and add to streaming manager
     for( auto&& rawhit:new_rawhits )
     {
-      if( rawhit )
+      if( rawhit && !rawhit->get_adc_waveforms().empty() )
       {
-        if( !rawhit->get_adc_waveforms().empty() )
-        {
-          // add hit to streaming input manager
-          if (StreamingInputManager())
-          { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit.get()); }
+        // add hit to streaming input manager
+        if (StreamingInputManager())
+        { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit.get()); }
 
-          // add hit to insternal storage
-          m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit.release());
-        }
+        // add hit to insternal storage
+        m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit.release());
       }
     }
-  }
+
+  } // FEE loop
 
 }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -1038,7 +1038,8 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     }
 
     // keep track of newly created hits
-    using rawhit_impl_array_t = std::array<MicromegasRawHit_impl*, MAX_FEECHANNELCOUNT>;
+    using rawhit_impl_pointer_t = std::unique_ptr<MicromegasRawHit_impl>; // unique_ptr to raw hit implementation object
+    using rawhit_impl_array_t = std::array<rawhit_impl_pointer_t, MAX_FEECHANNELCOUNT>; // fixed size array of the above
     rawhit_impl_array_t new_rawhits{};
 
     // find candidate overlapping bco if any
@@ -1090,7 +1091,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
             target->set_sampachannel(source->get_sampachannel());
 
             // store in new array
-            new_rawhits[target->get_channel()] = target;
+            new_rawhits[target->get_channel()].reset(target);
 
           }
 
@@ -1125,7 +1126,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     }
 
     // copy new hits in internal storage and add to streaming manager
-    for( auto* rawhit:new_rawhits )
+    for( auto&& rawhit:new_rawhits )
     {
       if( rawhit )
       {
@@ -1133,12 +1134,10 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
         {
           // add hit to streaming input manager
           if (StreamingInputManager())
-          { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit); }
+          { StreamingInputManager()->AddMicromegasRawHit(found_bco, rawhit.get()); }
 
           // add hit to insternal storage
-          m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit);
-        } else {
-          delete rawhit;
+          m_MicromegasRawHitMap[fee][found_bco].emplace_back(rawhit.release());
         }
       }
     }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -391,9 +391,11 @@ bool SingleMicromegasPoolInput_v2::is_more_data_required(const uint64_t target_b
   if( m_bco_matching_information_map.empty() )
   { return true; }
 
+  // correct target_bco by negative BCO and Tagger offset
+  const uint64_t target_bco_corrected = target_bco + m_NegativeBco + m_TaggerBcoOffset;
   for( const auto& [packet, bco_matching_information]:m_bco_matching_information_map )
   {
-    if( bco_matching_information.is_more_data_required( target_bco ) )
+    if( bco_matching_information.is_more_data_required( target_bco_corrected ) )
     { return true; }
   }
 
@@ -972,7 +974,10 @@ void SingleMicromegasPoolInput_v2::fill_evaluation_tree( const uint64_t target_b
 
     // assign target bco and prediction
     m_waveform.gtm_bco_gl1 = target_bco;
-    m_waveform.fee_bco_predicted_gl1 = bco_matching_information.get_predicted_fee_bco(target_bco).value();
+
+    // get prediction
+    const uint64_t target_bco_corrected = target_bco + m_NegativeBco + m_TaggerBcoOffset;
+    m_waveform.fee_bco_predicted_gl1 = bco_matching_information.get_predicted_fee_bco(target_bco_corrected).value();
 
     // find matching bco if any and store raw hits
     // list of raw hits (channel ordered) matching target BCO
@@ -980,7 +985,7 @@ void SingleMicromegasPoolInput_v2::fill_evaluation_tree( const uint64_t target_b
     {
 
       // compare bco to target, within acceptable range
-      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco );
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco_corrected );
       if( bco_diff >= -(int64_t)m_NegativeBco && bco_diff < m_BcoRange )
       {
 
@@ -1011,7 +1016,8 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
   static constexpr int32_t kTruncatedWaveformFEEWindow = kTruncatedWaveformWindow*kFEEClockPerADCClock;
 
   // keep track of exact BCO
-  uint64_t found_bco = target_bco;
+  const uint64_t target_bco_corrected = target_bco + m_NegativeBco + m_TaggerBcoOffset;
+  uint64_t found_bco = target_bco_corrected;
 
   // loop over fees
   for( size_t fee = 0; fee < MAX_FEECOUNT; ++fee )
@@ -1037,7 +1043,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     {
 
       // compare bco to target, within acceptable range
-      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco );
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco_corrected );
       if( bco_diff >= -(int64_t)m_NegativeBco && bco_diff < m_BcoRange )
       {
         found_bco = bco;
@@ -1068,7 +1074,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     // find candidate overlapping bco if any
     for( auto&& [bco, rawhitlist]:rawhitmap )
     {
-      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco );
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, target_bco_corrected );
       if( bco_diff >= m_BcoRange && bco_diff < truncatedWaveformGTMWindow )
       {
 
@@ -1106,7 +1112,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
           } else {
 
             // get FEE BCO from GTM
-            const auto target_fee_bco = bco_matching_information.get_predicted_fee_bco( target_bco ).value();
+            const auto target_fee_bco = bco_matching_information.get_predicted_fee_bco( target_bco_corrected ).value();
 
             // create new hit with shifted waveform
             target = new MicromegasRawHit_impl;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -996,9 +996,9 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
 
   // TODO: consolidate everything (ahah)
 
-  static constexpr uint32_t kTruncatedWaveformWindow = 1024U;
-  static constexpr uint32_t kFEEClockPerADCClock = 2U;
-  static constexpr uint32_t kTruncatedWaveformFEEWindow = kTruncatedWaveformWindow*kFEEClockPerADCClock;
+  static constexpr int32_t kTruncatedWaveformWindow = 1024U;
+  static constexpr int32_t kFEEClockPerADCClock = 2U;
+  static constexpr int32_t kTruncatedWaveformFEEWindow = kTruncatedWaveformWindow*kFEEClockPerADCClock;
 
   // keep track of exact BCO
   uint64_t found_bco = target_bco;
@@ -1023,8 +1023,8 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     {
 
       // compare bco to target, within acceptable range
-      // TODO properly acount for rollover. introduce a get_signed_diff
-      if( bco >= target_bco-m_NegativeBco && bco < target_bco+m_BcoRange )
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, found_bco );
+      if( bco_diff >= -m_NegativeBco && bco_diff < m_BcoRange )
       {
         found_bco = bco;
         for( auto&& rawhit:rawhitlist )
@@ -1044,7 +1044,8 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     // find candidate overlapping bco if any
     for( auto&& [bco, rawhitlist]:rawhitmap )
     {
-      if( bco > found_bco && bco <= found_bco + truncatedWaveformGTMWindow )
+      const auto bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_gtm_bco_diff( bco, found_bco );
+      if( bco_diff > 0 && bco_diff < truncatedWaveformGTMWindow )
       {
 
         // perform overlap restoration
@@ -1095,8 +1096,8 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
 
           // calculate waveform shift
           // TODO: get proper diff with proper rollover
-          const uint64_t fee_bco_diff = source->get_bco() - target->get_bco();
-          const uint16_t fee_clock_shift = static_cast<uint16_t>(fee_bco_diff/kFEEClockPerADCClock);
+          const int64_t fee_bco_diff = MicromegasBcoMatchingInformation_v2::get_signed_fee_bco_diff( source->get_bco(), target->get_bco() );
+          const int16_t fee_clock_shift = static_cast<int16_t>(fee_bco_diff/kFEEClockPerADCClock);
 
           // get waveforms (copy)
           auto waveformlist = source_impl->get_adc_waveforms();

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -1010,7 +1010,7 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
     // get local raw hitmap
     using rawhit_array_t = std::array<MicromegasRawHit*, MAX_FEECHANNELCOUNT>;
     auto&& rawhitmap = m_MicromegasRawHitMap[fee];
-    if( rawhitmap.empty() ) continue;
+    if( rawhitmap.empty() ) { continue; }
 
     // get the relevant BCO matching information object
     const auto& bco_matching = m_bco_matching_information_map.at( m_fee_packet[fee] );

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -1142,9 +1142,6 @@ void SingleMicromegasPoolInput_v2::recover_truncated_waveforms( const uint64_t t
         }
       }
     }
-
-    // TODO: should mark target BCO as corrected
-
   }
 
 }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -307,6 +307,7 @@ void SingleMicromegasPoolInput_v2::FillPool(const uint64_t target_bco)
 
     m_timer.stop();
   }
+
 }
 
 //______________________________________________________________
@@ -323,41 +324,34 @@ void SingleMicromegasPoolInput_v2::Print(const std::string& what) const
       }
     }
   }
-
-  if (what == "ALL" || what == "STORAGE")
-  {
-    for (const auto& bcliter : m_MicromegasRawHitMap)
-    {
-      std::cout << "Beam clock 0x" << std::hex << bcliter.first << std::dec << std::endl;
-      for (auto* feeiter : bcliter.second)
-      {
-        std::cout
-            << "fee: " << feeiter->get_fee()
-            << " at " << std::hex << feeiter << std::dec
-            << std::endl;
-      }
-    }
-  }
-
 }
 
 //____________________________________________________________________________
 void SingleMicromegasPoolInput_v2::CleanupUsedPackets(const uint64_t bclk, bool dropped)
 {
   // delete all raw hits associated to bco smaller than reference, and remove from map
-  for (auto iter = m_MicromegasRawHitMap.begin(); iter != m_MicromegasRawHitMap.end() && (iter->first <= bclk); iter = m_MicromegasRawHitMap.erase(iter))
+  // loop over per-FEE maps
+  for( auto&& rawhitmap: m_MicromegasRawHitMap )
   {
-    for (const auto& rawhit : iter->second)
+    // loop over rawhit lists for which gtm bco is below request
+    // delete hits in list and remove list from map
+    for (auto iter = rawhitmap.begin(); iter != rawhitmap.end() && (iter->first <= bclk); iter = rawhitmap.erase(iter))
     {
-      if (dropped)
+      for (const auto& rawhit : iter->second)
       {
-        // increment dropped waveform counter and histogram
-        ++m_waveform_counters[rawhit->get_packetid()].dropped_pool;
-        ++m_fee_waveform_counters[rawhit->get_fee()].dropped_pool;
-        h_waveform_count_dropped_pool->Fill(std::to_string(rawhit->get_packetid()).c_str(), 1);
-        h_fee_waveform_count_dropped_pool->Fill(rawhit->get_fee(), 1);
+        // increment dropped waveform counters
+        if (dropped)
+        {
+          // increment dropped waveform counter and histogram
+          ++m_waveform_counters[rawhit->get_packetid()].dropped_pool;
+          ++m_fee_waveform_counters[rawhit->get_fee()].dropped_pool;
+          h_waveform_count_dropped_pool->Fill(std::to_string(rawhit->get_packetid()).c_str(), 1);
+          h_fee_waveform_count_dropped_pool->Fill(rawhit->get_fee(), 1);
+        }
+
+        // delete raw hit
+        delete rawhit;
       }
-      delete rawhit;
     }
   }
 
@@ -455,10 +449,12 @@ void SingleMicromegasPoolInput_v2::FillBcoQA(uint64_t gtm_bco)
     }
 
     // waveforms
-    const auto wf_iter = m_MicromegasRawHitMap.find(gtm_bco_loc);
-    if (wf_iter != m_MicromegasRawHitMap.end())
+    // loop over FEEs, find gtm bco and increment by number of rawhits in corresponding list
+    for( const auto& rawhitmap:m_MicromegasRawHitMap )
     {
-      n_waveforms += wf_iter->second.size();
+      const auto wf_iter = rawhitmap.find(gtm_bco_loc);
+      if (wf_iter != rawhitmap.end())
+      { n_waveforms += wf_iter->second.size(); }
     }
   }
 
@@ -657,6 +653,10 @@ void SingleMicromegasPoolInput_v2::process_packet(Packet* packet)
       // populate fee buffer
       if (fee_id < MAX_FEECOUNT)
       {
+
+        // update FEE packet ID
+        m_fee_packet[fee_id] = packet_id;
+
         // NOLINTNEXTLINE(modernize-loop-convert)
         for (unsigned int i = 0; i < DAM_DMA_WORD_LENGTH - 1; i++)
         {
@@ -665,6 +665,7 @@ void SingleMicromegasPoolInput_v2::process_packet(Packet* packet)
 
         // immediate fee buffer processing to reduce memory consuption
         process_fee_data(packet_id, fee_id);
+
       }
     }
   }
@@ -974,11 +975,11 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
 
     m_BeamClockFEE[gtm_bco].insert(fee_id);
 
+    // add hit to streaming input manager
     if (StreamingInputManager())
-    {
-      StreamingInputManager()->AddMicromegasRawHit(gtm_bco, newhit.get());
-    }
+    { StreamingInputManager()->AddMicromegasRawHit(gtm_bco, newhit.get()); }
 
-    m_MicromegasRawHitMap[gtm_bco].push_back(newhit.release());
+    // add to local map
+    m_MicromegasRawHitMap[fee_id][gtm_bco].push_back(newhit.release());
   }
 }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -228,12 +228,11 @@ SingleMicromegasPoolInput_v2::~SingleMicromegasPoolInput_v2()
 }
 
 //______________________________________________________________
-void SingleMicromegasPoolInput_v2::FillPool(const unsigned int /*nbclks*/)
+void SingleMicromegasPoolInput_v2::FillPool(const uint64_t target_bco)
 {
+
   if (AllDone())  // no more files and all events read
-  {
-    return;
-  }
+  { return; }
 
   while (!GetEventiterator())  // at startup this is a null pointer
   {
@@ -244,9 +243,8 @@ void SingleMicromegasPoolInput_v2::FillPool(const unsigned int /*nbclks*/)
     }
   }
 
-  while (GetSomeMoreEvents())
+  while( is_more_data_required(target_bco) )
   {
-    // std::cout << "SingleMicromegasPoolInput_v2::FillPool" << std::endl;
     std::unique_ptr<Event> evt(GetEventiterator()->getNextEvent());
     while (!evt)
     {
@@ -326,15 +324,6 @@ void SingleMicromegasPoolInput_v2::Print(const std::string& what) const
     }
   }
 
-  if (what == "ALL" || what == "FEEBCLK")
-  {
-    for (auto bcliter : m_FEEBclkMap)
-    {
-      std::cout << "FEE" << bcliter.first << " bclk: 0x"
-                << std::hex << bcliter.second << std::dec << std::endl;
-    }
-  }
-
   if (what == "ALL" || what == "STORAGE")
   {
     for (const auto& bcliter : m_MicromegasRawHitMap)
@@ -350,13 +339,6 @@ void SingleMicromegasPoolInput_v2::Print(const std::string& what) const
     }
   }
 
-  if (what == "ALL" || what == "STACK")
-  {
-    for (const auto& iter : m_BclkStack)
-    {
-      std::cout << "stacked bclk: 0x" << std::hex << iter << std::dec << std::endl;
-    }
-  }
 }
 
 //____________________________________________________________________________
@@ -380,8 +362,6 @@ void SingleMicromegasPoolInput_v2::CleanupUsedPackets(const uint64_t bclk, bool 
   }
 
   // cleanup bco stacks
-  /* it erases all elements for which the bco is no greater than the provided one */
-  m_BclkStack.erase(m_BclkStack.begin(), m_BclkStack.upper_bound(bclk));
   m_BeamClockFEE.erase(m_BeamClockFEE.begin(), m_BeamClockFEE.upper_bound(bclk));
   m_BeamClockPacket.erase(m_BeamClockPacket.begin(), m_BeamClockPacket.upper_bound(bclk));
 
@@ -395,51 +375,24 @@ void SingleMicromegasPoolInput_v2::CleanupUsedPackets(const uint64_t bclk, bool 
 //_______________________________________________________
 void SingleMicromegasPoolInput_v2::ClearCurrentEvent()
 {
-  std::cout << "SingleMicromegasPoolInput_v2::ClearCurrentEvent." << std::endl;
-  uint64_t currentbclk = *m_BclkStack.begin();
-  CleanupUsedPackets(currentbclk);
-  return;
+  std::cout << "SingleTpcTimeFrameInput::ClearCurrentEvent() - deprecated " << std::endl;
 }
 
 //_______________________________________________________
-bool SingleMicromegasPoolInput_v2::GetSomeMoreEvents()
+bool SingleMicromegasPoolInput_v2::is_more_data_required(const uint64_t target_bco) const
 {
   if (AllDone())
   {
     return false;
   }
 
-  // check minimum pool size
-  if (m_MicromegasRawHitMap.size() < m_BcoPoolSize)
-  {
-    return true;
-  }
+  if( m_bco_matching_information_map.empty() )
+  { return true; }
 
-  // make sure that the latest BCO received by each FEEs is past the current BCO
-  std::set<int> toerase;
-  uint64_t lowest_bclk = m_MicromegasRawHitMap.begin()->first + m_BcoRange;
-  for (auto bcliter : m_FEEBclkMap)
+  for( const auto& [packet, bco_matching_information]:m_bco_matching_information_map )
   {
-    if (bcliter.second <= lowest_bclk)
-    {
-      uint64_t highest_bclk = m_MicromegasRawHitMap.rbegin()->first;
-      if ((highest_bclk - m_MicromegasRawHitMap.begin()->first) < MaxBclkDiff())
-      {
-        return true;
-      }
-
-      std::cout << PHWHERE << Name() << ": erasing FEE " << bcliter.first
-                << " with stuck bclk: " << std::hex << bcliter.second
-                << " current bco range: 0x" << m_MicromegasRawHitMap.begin()->first
-                << ", to: 0x" << highest_bclk << ", delta: " << std::dec
-                << (highest_bclk - m_MicromegasRawHitMap.begin()->first)
-                << std::dec << std::endl;
-      toerase.insert(bcliter.first);
-    }
-  }
-  for (const auto& fee : toerase)
-  {
-    m_FEEBclkMap.erase(fee);
+    if( bco_matching_information.is_more_data_required( target_bco ) )
+    { return true; }
   }
 
   return false;
@@ -759,7 +712,6 @@ void SingleMicromegasPoolInput_v2::decode_gtm_data(int packet_id, const SingleMi
   {
     const auto& gtm_bco = payload.bco;
     m_BeamClockPacket[gtm_bco].insert(packet_id);
-    m_BclkStack.insert(gtm_bco);
   }
 
   // find reference from modebits, using BX_COUNTER_SYNC_T
@@ -1021,7 +973,6 @@ void SingleMicromegasPoolInput_v2::process_fee_data(int packet_id, unsigned int 
     }
 
     m_BeamClockFEE[gtm_bco].insert(fee_id);
-    m_FEEBclkMap[fee_id] = gtm_bco;
 
     if (StreamingInputManager())
     {

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -140,7 +140,7 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   unsigned int m_NegativeBco{0};
 
   /// offset between FELIX tagger BCO (internal) and GL1 (external) BCO
-  int m_TaggerBcoOffset{0};
+  int m_TaggerBcoOffset{3};
 
   /// store list of packets that have data for a given beam clock
   /**

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -104,6 +104,9 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   void decode_gtm_data(int /*packet_id*/, const dma_word &);
   void process_fee_data(int /*packet_id*/, unsigned int /*fee_id*/);
 
+  // fill evaluation tree
+  void fill_evaluation_tree( const uint64_t /*target_bco*/ );
+
   // recover truncated waveforms for a given gtm bco
   void recover_truncated_waveforms( const uint64_t /*target_bco*/ );
 
@@ -247,20 +250,14 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
     /// channel id
     unsigned short channel {0};
 
-    /// true if measurement is hearbeat
-    bool is_heartbeat = false;
-
-    /// true if matched
-    bool matched = false;
-
     /// ll1 bco
     uint64_t gtm_bco_first {0};
 
-    /// ll1 bco
-    uint64_t gtm_bco {0};
+    /// bco
+    uint64_t gtm_bco_tagger {0};
 
-    /// ll1 bco
-    uint64_t gtm_bco_matched {0};
+    /// bco
+    uint64_t gtm_bco_gl1 {0};
 
     /// fee bco
     unsigned int fee_bco_first {0};
@@ -268,11 +265,12 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
     /// fee bco
     unsigned int fee_bco {0};
 
-    /// fee bco predicted (from gtm)
-    unsigned int fee_bco_predicted {0};
+    /// fee bco predicted (from gtm tagger)
+    unsigned int fee_bco_predicted_tagger {0};
 
-    /// fee bco match (from gtm)
-    unsigned int fee_bco_predicted_matched {0};
+    /// fee bco predicted (from gtm gl1)
+    unsigned int fee_bco_predicted_gl1 {0};
+
   };
 
   Waveform m_waveform;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -60,8 +60,9 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
   //! define minimum pool size in terms of how many BCO are stored
-  /** obsolete */
-  void SetBcoPoolSize(const unsigned int /*value*/) {}
+  /** deprecated */
+  void SetBcoPoolSize(const unsigned int /*value*/)
+  { std::cout << "SingleMicromegasPoolInput_v2::SetBcoPoolSize is deprecated" << std::endl; }
 
   //! save some statistics for BCO QA
   void FillBcoQA(uint64_t /*gtm_bco*/) override;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -84,6 +84,9 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   /// max number of FEE per OBDC
   static constexpr uint16_t MAX_FEECOUNT = 26;
 
+  /// max number of channels per FEE
+  static constexpr uint16_t MAX_FEECHANNELCOUNT = 256;
+
   // Length for the 256-bit wide Round Robin Multiplexer for the data stream
   static constexpr size_t DAM_DMA_WORD_LENGTH = 16;
   //@}
@@ -99,8 +102,11 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   void decode_gtm_data(int /*packet_id*/, const dma_word &);
   void process_fee_data(int /*packet_id*/, unsigned int /*fee_id*/);
 
+  // recover truncated waveforms for a given gtm bco
+  void recover_truncated_waveforms( const uint64_t /*target_bco*/ );
+
   // fee data buffer
-  std::vector<std::deque<uint16_t>> m_feeData{MAX_FEECOUNT};
+  std::array<std::deque<uint16_t>, MAX_FEECOUNT> m_feeData{};
 
   // list of packets from data stream
   std::array<Packet *, 10> plist{};
@@ -136,11 +142,11 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 
   //! map bco_information_t to packet id
   using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation_v2>;
-  bco_matching_information_map_t m_bco_matching_information_map;
+  bco_matching_information_map_t m_bco_matching_information_map{};
 
   //! map packet to FEE ID
   /* it is filled on the fly. It allows to quickly retrieve BCO matching information from FEE index */
-  std::array<unsigned int,MAX_FEECOUNT> m_fee_packet;
+  std::array<unsigned int,MAX_FEECOUNT> m_fee_packet{};
 
   class counter_t
   {

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -26,31 +26,31 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 {
  public:
 
-  //! constructor
+  /// constructor
   explicit SingleMicromegasPoolInput_v2(const std::string &name = "SingleMicromegasPoolInput_v2");
 
-  //! destructor
+  /// destructor
   ~SingleMicromegasPoolInput_v2() override;
 
-  //! pool filling
+  /// pool filling
   void FillPool(const uint64_t /*target_bco*/) override;
 
-  //! cleanup
+  /// cleanup
   void CleanupUsedPackets(const uint64_t bclk) override
   {
     CleanupUsedPackets(bclk, false);
   }
 
-  //! specialized verion of cleaning up packets, with an extra flag about wheter the cleanup hits are dropped or not
+  /// specialized verion of cleaning up packets, with an extra flag about wheter the cleanup hits are dropped or not
   void CleanupUsedPackets(const uint64_t /* bclk */, bool /*dropped */) override;
 
-  //! current event cleaning
+  /// current event cleaning
   void ClearCurrentEvent() override;
 
-  //! print
+  /// print
   void Print(const std::string &what = "ALL") const override;
 
-  //!
+  ///
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
   void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
@@ -59,12 +59,21 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
-  //! define minimum pool size in terms of how many BCO are stored
+  /// set the offset between FELIX tagger BCO (internal) and GL1 (external) BCO
+  /**
+   * explicitly taggerBCO = GL1 BCO + offset
+   * this is somewhat redundant with m_Negative BCO, unfortunately, but
+   * 1/ m_NegativeBco is also used upstream by Fun4AllStreamingInputManager
+   * 2/ m_NegativeBCO is unsigned int
+  */
+  void SetTaggerBcoOffset( const int value ) { m_TaggerBcoOffset = value; }
+
+  /// define minimum pool size in terms of how many BCO are stored
   /** deprecated */
   void SetBcoPoolSize(const unsigned int /*value*/)
   { std::cout << "SingleMicromegasPoolInput_v2::SetBcoPoolSize is deprecated" << std::endl; }
 
-  //! save some statistics for BCO QA
+  /// save some statistics for BCO QA
   void FillBcoQA(uint64_t /*gtm_bco*/) override;
 
   // write the initial histograms for QA manager
@@ -78,10 +87,10 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 
   private:
 
-  //! true if more data is to be processed for collecting that of a given bco
+  /// true if more data is to be processed for collecting that of a given bco
   bool is_more_data_required(const uint64_t /*target_bco*/) const;
 
-  //!@name decoding constants
+  ///@name decoding constants
   //@{
   /// max number of FEE per OBDC
   static constexpr uint16_t MAX_FEECOUNT = 26;
@@ -93,7 +102,7 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   static constexpr size_t DAM_DMA_WORD_LENGTH = 16;
   //@}
 
-  //! DMA word structure
+  /// DMA word structure
   struct dma_word
   {
     uint16_t dma_header;
@@ -104,16 +113,16 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   void decode_gtm_data(int /*packet_id*/, const dma_word &);
   void process_fee_data(int /*packet_id*/, unsigned int /*fee_id*/);
 
-  // fill evaluation tree
+  /// fill evaluation tree
   void fill_evaluation_tree( const uint64_t /*target_bco*/ );
 
-  // recover truncated waveforms for a given gtm bco
+  /// recover truncated waveforms for a given gtm bco
   void recover_truncated_waveforms( const uint64_t /*target_bco*/ );
 
-  // fee data buffer
+  /// fee data buffer
   std::array<std::deque<uint16_t>, MAX_FEECOUNT> m_feeData{};
 
-  // list of packets from data stream
+  /// list of packets from data stream
   std::array<Packet *, 10> plist{};
 
   /// keep track of number of non data events
@@ -125,7 +134,10 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   /// bco adjustment for matching across subsystems
   unsigned int m_NegativeBco{0};
 
-  //! store list of packets that have data for a given beam clock
+  /// offset between FELIX tagger BCO (internal) and GL1 (external) BCO
+  int m_TaggerBcoOffset{0};
+
+  /// store list of packets that have data for a given beam clock
   /**
    * all packets in taggers are stored,
    * disregarding whether there is data associated to it or not
@@ -133,42 +145,42 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
    */
   std::map<uint64_t, std::set<int>> m_BeamClockPacket;
 
-  //! store list of FEE that have data for a given beam clock
+  /// store list of FEE that have data for a given beam clock
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;
 
-  //! list of raw hits
+  /// list of raw hits
   using rawhit_list_t = std::vector<MicromegasRawHit*>;
 
-  //! maps list of raw hits on GTM BCO values
+  /// maps list of raw hits on GTM BCO values
   using rawhit_map_t = std::map<uint64_t, rawhit_list_t>;
 
-  //! store list of raw hits matching a given GTM bco on a per FEE basis
+  /// store list of raw hits matching a given GTM bco on a per FEE basis
   std::array<rawhit_map_t,MAX_FEECOUNT> m_MicromegasRawHitMap{};
 
-  //! map bco_information_t to packet id
+  /// map bco_information_t to packet id
   using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation_v2>;
   bco_matching_information_map_t m_bco_matching_information_map{};
 
-  //! map packet to FEE ID
+  /// map packet to FEE ID
   /* it is filled on the fly. It allows to quickly retrieve BCO matching information from FEE index */
   std::array<unsigned int,MAX_FEECOUNT> m_fee_packet{};
 
   class counter_t
   {
    public:
-    //! total count
+    /// total count
     uint64_t total {0};
 
-    //! drop count due to unmatched bco
+    /// drop count due to unmatched bco
     uint64_t dropped_bco {0};
 
-    //! drop count due to pools
+    /// drop count due to pools
     uint64_t dropped_pool {0};
 
-    //! dropped fraction (bco)
+    /// dropped fraction (bco)
     double dropped_fraction_bco() const { return double(dropped_bco) / total; }
 
-    //! dropped fraction (pool)
+    /// dropped fraction (pool)
     double dropped_fraction_pool() const { return double(dropped_pool) / total; }
   };
 
@@ -187,50 +199,50 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   // timer
   PHTimer m_timer{"SingleMicromegasPoolInput_v2"};
 
-  //!@name QA histograms
+  ///@name QA histograms
   //@{
 
-  //! keeps track of how often a given (or all) packets are found for a given BCO
+  /// keeps track of how often a given (or all) packets are found for a given BCO
   TH1 *h_packet_stat{nullptr};
 
-  //! keep track of how many heartbeats are found per FEE sampa
+  /// keep track of how many heartbeats are found per FEE sampa
   TH1 *h_heartbeat_stat{nullptr};
 
-  //! keeps track of how many packets are found for a given BCO
+  /// keeps track of how many packets are found for a given BCO
   TH1 *h_packet{nullptr};
 
-  //! keeps track of how many waveforms are found for a given BCO
+  /// keeps track of how many waveforms are found for a given BCO
   TH1 *h_waveform{nullptr};
 
-  //! total number of waveforms per packet
+  /// total number of waveforms per packet
   TH1 *h_waveform_count_total{nullptr};
 
-  //! total number of dropped waveforms per packet due to bco mismatch
+  /// total number of dropped waveforms per packet due to bco mismatch
   /*! waveforms are dropped when their FEE-BCO cannot be associated to any global BCO */
   TH1 *h_waveform_count_dropped_bco{nullptr};
 
-  //! total number of dropped waveforms per packet due to fun4all pool mismatch
+  /// total number of dropped waveforms per packet due to fun4all pool mismatch
   TH1 *h_waveform_count_dropped_pool{nullptr};
 
-  //! total number of waveforms per packet
+  /// total number of waveforms per packet
   TH1 *h_fee_waveform_count_total{nullptr};
 
-  //! total number of dropped waveforms per fee due to bco mismatch
+  /// total number of dropped waveforms per fee due to bco mismatch
   /*! waveforms are dropped when their FEE-BCO cannot be associated to any global BCO */
   TH1 *h_fee_waveform_count_dropped_bco{nullptr};
 
-  //! total number of dropped waveforms per fee due to fun4all pool mismatch
+  /// total number of dropped waveforms per fee due to fun4all pool mismatch
   TH1 *h_fee_waveform_count_dropped_pool{nullptr};
 
   //@}
 
-  //!@name evaluation
+  ///@name evaluation
   //@{
 
-  //! evaluation
+  /// evaluation
   bool m_do_evaluation = false;
 
-  //! evaluation output filename
+  /// evaluation output filename
   std::string m_evaluation_filename = "SingleMicromegasPoolInput.root";
   std::unique_ptr<TFile> m_evaluation_file;
 
@@ -275,7 +287,7 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 
   Waveform m_waveform;
 
-  //! tree
+  /// tree
   TTree *m_evaluation_tree {nullptr};
 
   //*}

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -25,10 +25,17 @@ class TH1;
 class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 {
  public:
-  explicit SingleMicromegasPoolInput_v2(const std::string &name = "SingleMicromegasPoolInput_v2");
-  ~SingleMicromegasPoolInput_v2() override;
-  void FillPool(const unsigned int nevents = 1) override;
 
+  //! constructor
+  explicit SingleMicromegasPoolInput_v2(const std::string &name = "SingleMicromegasPoolInput_v2");
+
+  //! destructor
+  ~SingleMicromegasPoolInput_v2() override;
+
+  //! pool filling
+  void FillPool(const uint64_t /*target_bco*/) override;
+
+  //! cleanup
   void CleanupUsedPackets(const uint64_t bclk) override
   {
     CleanupUsedPackets(bclk, false);
@@ -37,17 +44,23 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   //! specialized verion of cleaning up packets, with an extra flag about wheter the cleanup hits are dropped or not
   void CleanupUsedPackets(const uint64_t /* bclk */, bool /*dropped */) override;
 
+  //! current event cleaning
   void ClearCurrentEvent() override;
-  bool GetSomeMoreEvents();
+
+  //! print
   void Print(const std::string &what = "ALL") const override;
+
+  //!
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
   void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
+
   void ConfigureStreamingInputManager() override;
+
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
   //! define minimum pool size in terms of how many BCO are stored
-  void SetBcoPoolSize(const unsigned int value) { m_BcoPoolSize = value; }
+  void SetBcoPoolSize(const unsigned int /*value*/) {}
 
   //! save some statistics for BCO QA
   void FillBcoQA(uint64_t /*gtm_bco*/) override;
@@ -61,7 +74,11 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   /// output file name for evaluation histograms
   void set_evaluation_outputfile(const std::string &outputfile) { m_evaluation_filename = outputfile; }
 
- private:
+  private:
+
+  //! true if more data is to be processed for collecting that of a given bco
+  bool is_more_data_required(const uint64_t /*target_bco*/) const;
+
   //!@name decoding constants
   //@{
   /// max number of FEE per OBDC
@@ -97,9 +114,6 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   /// bco adjustment for matching across subsystems
   unsigned int m_NegativeBco{0};
 
-  //! minimum number of BCO required in Micromegas Pools
-  unsigned int m_BcoPoolSize{1};
-
   //! store list of packets that have data for a given beam clock
   /**
    * all packets in taggers are stored,
@@ -113,18 +127,6 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 
   //! store list of raw hits matching a given bco
   std::map<uint64_t, std::vector<MicromegasRawHit *>> m_MicromegasRawHitMap;
-
-  //! store current list of BCO on a per fee basis.
-  /** only packets for which a given FEE have data are stored */
-  std::map<int, uint64_t> m_FEEBclkMap;
-
-  //! store current list of BCO
-  /**
-   * all packets in taggers are stored,
-   * disregarding whether there is data associated to it or not
-   * this allows to keep track of dropped data, also in zero-suppression mode
-   */
-  std::set<uint64_t> m_BclkStack;
 
   //! map bco_information_t to packet id
   using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation_v2>;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -125,12 +125,22 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   //! store list of FEE that have data for a given beam clock
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;
 
-  //! store list of raw hits matching a given bco
-  std::map<uint64_t, std::vector<MicromegasRawHit *>> m_MicromegasRawHitMap;
+  //! list of raw hits
+  using rawhit_list_t = std::vector<MicromegasRawHit*>;
+
+  //! maps list of raw hits on GTM BCO values
+  using rawhit_map_t = std::map<uint64_t, rawhit_list_t>;
+
+  //! store list of raw hits matching a given GTM bco on a per FEE basis
+  std::array<rawhit_map_t,MAX_FEECOUNT> m_MicromegasRawHitMap{};
 
   //! map bco_information_t to packet id
   using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation_v2>;
   bco_matching_information_map_t m_bco_matching_information_map;
+
+  //! map packet to FEE ID
+  /* it is filled on the fly. It allows to quickly retrieve BCO matching information from FEE index */
+  std::array<unsigned int,MAX_FEECOUNT> m_fee_packet;
 
   class counter_t
   {

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -53,6 +53,8 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   ///
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
+  void SetRecoverTruncatedWaveforms( bool value ) { m_recover_truncated_waveforms = value; }
+
   void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
 
   void ConfigureStreamingInputManager() override;
@@ -118,6 +120,9 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
 
   /// recover truncated waveforms for a given gtm bco
   void recover_truncated_waveforms( const uint64_t /*target_bco*/ );
+
+  /// true to recover waveform truncated due to overlapping timeframes
+  bool m_recover_truncated_waveforms{true};
 
   /// fee data buffer
   std::array<std::deque<uint16_t>, MAX_FEECOUNT> m_feeData{};

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -60,6 +60,7 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
   //! define minimum pool size in terms of how many BCO are stored
+  /** obsolete */
   void SetBcoPoolSize(const unsigned int /*value*/) {}
 
   //! save some statistics for BCO QA


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This is TPOT fix for overlapping time frames, similar to https://github.com/sPHENIX-Collaboration/coresoftware/pull/4292
TPOT decoder still uses taggers (GTM and enddat) to associate FEE data to 40bits gtm BCO, unlike the TPC, but this is really an orthogonal change. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Micromegas decoder update (TPOT): fix overlapping time frames

### Motivation / context
TPOT Micromegas decoding could mis-associate FEE data to neighboring 40-bit GTM BCOs when time frames overlap. This PR improves the rollover-aware GTM↔FEE BCO matching and updates the streaming/pool filling workflow so evaluation and (optional) truncated/overlapping waveform recovery are driven by a target BCO.

### Key changes
- **Rollover-aware BCO matching utilities + tuning**
  - Added signed/unsigned clock-difference helpers and updated GTM↔FEE matching logic to use them consistently.
  - Updated matching parameters: **`m_max_gtm_bco_diff = 60`** and **`m_max_fee_sync_time = 1024 * 96`**.
- **Target-BCO driven streaming/pool filling**
  - `FillPool(...)` API changed to `FillPool(const uint64_t target_bco)` and is now filled in a loop controlled by `is_more_data_required(target_bco)`.
  - After pool filling, it calls `fill_evaluation_tree(target_bco)` and (if enabled) `recover_truncated_waveforms(target_bco)`.
  - In `FillMicromegasPool()` the streaming manager computes/passes a **`ref_bco_minus_range`** into micromegas `FillPool(...)`.
- **Waveform recovery for truncated/overlapping channels**
  - Implemented `recover_truncated_waveforms(target_bco)` to scan for an overlapping BCO, create shifted/truncated waveform copies for missing channels, and reinsert recovered hits for downstream use.
  - Added an enable/disable flag: `m_recover_truncated_waveforms` / `SetRecoverTruncatedWaveforms(...)`.
- **Micromegas raw-hit interface + minor fixes**
  - `MicromegasRawHitv3` now exposes `get_adc_waveforms()` for waveform access.
  - Minor messaging cleanup in `MicromegasRawHitv3.cc` (typo in warning text).

### Potential risk areas
- **Reconstruction behavior changes:** BCO association rules/tolerances and the reference computation path were modified, which can change which BCOs/waveforms are treated as matched and/or recovered.
- **Streaming/pool workflow changes:** `FillPool` signature and the “fill → evaluate → recover” sequencing are changed; verify downstream expectations for evaluation-tree fields and stored raw-hit bookkeeping.
- **Interface/data-structure impacts:** SingleMicromegas pool internals were refactored (including raw-hit storage patterns) and `MicromegasRawHitv3` added a public accessor—confirm consumer compatibility.
- **Performance:** waveform recovery adds additional scanning/copying work for overlapping/truncated scenarios; validate timing/CPU under high occupancy.

### Possible future improvements
- Add focused regression tests specifically covering **rollover boundaries** and **overlapping time-frame recovery** (including negative/offset adjustments between Tagger and GL1/target BCO path).
- Profile recovery scanning/allocation patterns and reduce copying where possible.
- Consolidate and document the signed/unsigned diff conventions to reduce future drift across decoders.
- AI can make mistakes—please validate against the matching/recovery code paths and relevant QA outputs before approving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->