### PR TITLE
Fix include order

### DIFF
--- a/calibrations/tpc/dEdx/dEdxFitter.h
+++ b/calibrations/tpc/dEdx/dEdxFitter.h
@@ -1,15 +1,19 @@
 #ifndef DEDXFITTER_H_
 #define DEDXFITTER_H_
 
-#include <fun4all/SubsysReco.h>
-#include <string>
+#include "GlobaldEdxFitter.h"
+
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/ActsGeometry.h>
+
 #include <g4detectors/PHG4TpcGeomContainer.h>
+
 #include <globalvertex/SvtxVertexMap.h>
 
-#include "GlobaldEdxFitter.h"
+#include <fun4all/SubsysReco.h>
+
+#include <string>
 
 //Forward declerations
 class PHCompositeNode;
@@ -59,29 +63,29 @@ class dEdxFitter: public SubsysReco
   { ntracks_to_fit = ntrk; }
 
  private:
-  //output filename
-  std::string _outfile = "dedx_outfile.root";
-  TFile* outf = nullptr;
-  size_t _event = 0;
-   
-  SvtxTrackMap* _trackmap = nullptr;
-  TrkrClusterContainer* _clustermap = nullptr;
-  ActsGeometry* _geometry = nullptr;
-  PHG4TpcGeomContainer* _tpcgeom = nullptr;
-  SvtxVertexMap* _vertexmap = nullptr;
-  
   //Get all the nodes
   void GetNodes(PHCompositeNode * /*topNode*/);
 
   void process_tracks();
 
-  int nmaps_cut = 1;
-  int nintt_cut = 1;
-  int ntpc_cut = 30;
-  float eta_cut = 1.;
-  float dcaxy_cut = 0.5;
+  //output filename
+  std::string _outfile {"dedx_outfile.root"};
+  TFile* outf {nullptr};
+  size_t _event {0};
+   
+  SvtxTrackMap* _trackmap {nullptr};
+  TrkrClusterContainer* _clustermap {nullptr};
+  ActsGeometry* _geometry {nullptr};
+  PHG4TpcGeomContainer* _tpcgeom {nullptr};
+  SvtxVertexMap* _vertexmap {nullptr};
+  
+  int nmaps_cut {1};
+  int nintt_cut {1};
+  int ntpc_cut {30};
+  float eta_cut {1.};
+  float dcaxy_cut {0.5};
 
-  size_t ntracks_to_fit = 40000;
+  size_t ntracks_to_fit {40000};
   std::vector<double> minima;
   std::unique_ptr<GlobaldEdxFitter> fitter;
 

--- a/generators/flowAfterburner/flowAfterburner.h
+++ b/generators/flowAfterburner/flowAfterburner.h
@@ -1,10 +1,10 @@
 #ifndef FLOWAFTERBURNER_FLOWAFTERBURNER_H
 #define FLOWAFTERBURNER_FLOWAFTERBURNER_H
 
+#include "AfterburnerAlgo.h"
+
 #include <string>
 #include <array>
-
-#include "AfterburnerAlgo.h"
 
 namespace CLHEP
 {
@@ -63,18 +63,18 @@ class Afterburner
 
  private:
     
-  AfterburnerAlgo * m_algo = nullptr;
-  CLHEP::HepRandomEngine * m_engine = nullptr;
-  bool m_ownAlgo = false;
-  bool m_ownEngine = false;
-  float m_mineta = -5.0f;
-  float m_maxeta = 5.0f;
-  float m_minpt = 0.0f;
-  float m_maxpt = 100.0f;
-  double m_phishift = 0.0; // shift of the reaction plane angle in phi, used to align with the impact parameter
+  AfterburnerAlgo * m_algo {nullptr};
+  CLHEP::HepRandomEngine * m_engine {nullptr};
+  bool m_ownAlgo {false};
+  bool m_ownEngine {false};
+  float m_mineta {-5.0};
+  float m_maxeta {5.0};
+  float m_minpt {0.0};
+  float m_maxpt {100.0};
+  double m_phishift {0.0}; // shift of the reaction plane angle in phi, used to align with the impact parameter
 
   void setPsiN(unsigned int n, float psi);
-  float m_psi_n[6] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}; // reaction plane angles
+  float m_psi_n[6] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // reaction plane angles
 
   // Legacy arguments
   void readLegacyArguments(

--- a/generators/sHijing/xml_test.cc
+++ b/generators/sHijing/xml_test.cc
@@ -3,6 +3,14 @@
 //
 // Inspired by code from ATLAS.  Thanks!
 //
+#define f2cFortran
+#define gFortran
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#include "cfortran.h"
+#pragma GCC diagnostic pop
+
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
@@ -12,15 +20,6 @@
 #include <iostream>
 #include <string>
 
-#define f2cFortran
-#define gFortran
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#include "cfortran.h"
-#pragma GCC diagnostic pop
-
-//using namespace boost;
 
 float atl_ran(int * /*unused*/)
 {

--- a/offline/QA/KFParticle/QAKFParticle.h
+++ b/offline/QA/KFParticle/QAKFParticle.h
@@ -3,6 +3,8 @@
 #ifndef QA_KFPARTICLE_QAKFPARTICLE_H
 #define QA_KFPARTICLE_QAKFPARTICLE_H
 
+#include "QAKFParticleTrackPtAsymmetry.h"
+
 #include <g4eval/SvtxEvalStack.h>
 
 #include <calotrigger/TriggerAnalyzer.h>
@@ -15,7 +17,6 @@
 
 #include <KFParticle.h>
 
-#include "QAKFParticleTrackPtAsymmetry.h"
 
 class KFParticle_Container;
 class PHCompositeNode;

--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -287,7 +287,7 @@ void CDBTTree::SetSingleIntValue(const std::string &name, int value)
 void CDBTTree::SetSingleUInt64Value(const std::string &name, uint64_t value)
 {
   std::string fieldname = "g" + name;
-  //  if (m_SingleUInt64EntryMap.contains(fieldname))
+  //  if (!m_SingleUInt64EntryMap.contains(fieldname))
   // NOLINTNEXTLINE(readability-container-contains)
   if (m_SingleUInt64EntryMap.find(fieldname) == m_SingleUInt64EntryMap.end())
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -26,6 +26,7 @@
 /*****************/
 
 #include "KFParticle_Tools.h"
+#include "KFParticle_truthAndDetTools.h"
 
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -55,8 +56,6 @@
 #include <Rtypes.h>
 #include <TDatabasePDG.h>
 #include <TMatrixD.h>
-#include "KFParticle_truthAndDetTools.h"
-
 #include <TFile.h>
 #include <TMatrixDfwd.h>  // for TMatrixD
 #include <TMatrixT.h>     // for TMatrixT, operator*
@@ -68,6 +67,7 @@
 #include <cstdlib>    // for abs, NULL
 #include <iostream>   // for operator<<, basic_ostream
 #include <iterator>   // for end
+#include <limits>
 #include <map>        // for _Rb_tree_iterator, map
 #include <memory>     // for allocator_traits<>::va...
 
@@ -78,13 +78,13 @@ KFParticle_Tools::KFParticle_Tools()
   : m_has_intermediates(false)
   , m_min_mass(0)
   , m_max_mass(0)
-  , m_min_decayTime(-1 * FLT_MAX)
-  , m_max_decayTime(FLT_MAX)
-  , m_min_decayLength(-1 * FLT_MAX)
-  , m_max_decayLength(FLT_MAX)
+  , m_min_decayTime(-1 * std::numeric_limits<float>::max())
+  , m_max_decayTime(std::numeric_limits<float>::max())
+  , m_min_decayLength(-1 * std::numeric_limits<float>::max())
+  , m_max_decayLength(std::numeric_limits<float>::max())
   , m_track_min_pt(0.)
   , m_track_max_pt(5e3)
-  , m_track_ptchi2(FLT_MAX)
+  , m_track_ptchi2(std::numeric_limits<float>::max())
   , m_track_ip_xy(-100.)
   , m_track_ipchi2_xy(-1)
   , m_track_ip(-1.)
@@ -101,7 +101,7 @@ KFParticle_Tools::KFParticle_Tools()
   , m_dira_min(-1.01)
   , m_dira_max(1.01)
   , m_mother_pt(0.)
-  , m_mother_ipchi2(FLT_MAX)
+  , m_mother_ipchi2(std::numeric_limits<float>::max())
   , m_get_charge_conjugate(false)
   , m_extrapolateTracksToSV(true)
   , m_vtx_map_node_name("SvtxVertexMap")
@@ -477,10 +477,10 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFPart
     {
       printSelectionCheck("Track pT", m_track_min_pt, pt, m_track_max_pt);
       printSelectionCheck("Track pT chi^2", 0, ptchi2, m_track_ptchi2);
-      printSelectionCheck("IP", m_track_ip, min_ip, FLT_MAX);
-      printSelectionCheck("IP chi^2", m_track_ipchi2, min_ipchi2, FLT_MAX);
-      printSelectionCheck("IP xy", m_track_ip_xy, min_ip_xy, FLT_MAX);
-      printSelectionCheck("IP xy chi^2", m_track_ipchi2_xy, min_ipchi2_xy, FLT_MAX);
+      printSelectionCheck("IP", m_track_ip, min_ip, std::numeric_limits<float>::max());
+      printSelectionCheck("IP chi^2", m_track_ipchi2, min_ipchi2, std::numeric_limits<float>::max());
+      printSelectionCheck("IP xy", m_track_ip_xy, min_ip_xy, std::numeric_limits<float>::max());
+      printSelectionCheck("IP xy chi^2", m_track_ipchi2_xy, min_ipchi2_xy, std::numeric_limits<float>::max());
       printSelectionCheck("Track chi^2/nDoF", 0, trackchi2ndof, m_track_chi2ndof);
     }
   }
@@ -576,7 +576,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
             if (m_verbosity >= 11)
             {
               printSelectionCheck("SV chi^2/nDoFA", 0., vertexchi2ndof, m_vertex_chi2ndof);
-              printSelectionCheck("SV radius", m_min_radial_SV, sv_radial_position, FLT_MAX);
+              printSelectionCheck("SV radius", m_min_radial_SV, sv_radial_position, std::numeric_limits<float>::max());
             }
           }
 
@@ -662,7 +662,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
             if (m_verbosity >= 11)
             {
               printSelectionCheck("SV chi^2/nDoFA", 0., vertexchi2ndof, m_vertex_chi2ndof);
-              printSelectionCheck("SV radius", m_min_radial_SV, sv_radial_position, FLT_MAX);
+              printSelectionCheck("SV radius", m_min_radial_SV, sv_radial_position, std::numeric_limits<float>::max());
             }
           }
 
@@ -1008,8 +1008,8 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
         printSelectionCheck("", "Accepted", "Rejected", "the intermediate selection", goodCandidate);
         if (m_verbosity >= 11)
         {
-          printSelectionCheck("Intermediate DIRA", m_intermediate_min_dira[k], intermediate_DIRA, FLT_MAX);
-          printSelectionCheck("Intermediate FD chi^2", m_intermediate_min_fdchi2[k], intermediate_FDchi2, FLT_MAX);
+          printSelectionCheck("Intermediate DIRA", m_intermediate_min_dira[k], intermediate_DIRA, std::numeric_limits<float>::max());
+          printSelectionCheck("Intermediate FD chi^2", m_intermediate_min_fdchi2[k], intermediate_FDchi2, std::numeric_limits<float>::max());
         }
       }
     }
@@ -1022,7 +1022,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     {
       printSelectionCheck("Vertex charge is", "right", "wrong", "", chargeCheck);
       printSelectionCheck("Invariant Mass", min_mass, calculated_mass, max_mass);
-      printSelectionCheck("Mother pT", min_pt, calculated_pt, FLT_MAX);
+      printSelectionCheck("Mother pT", min_pt, calculated_pt, std::numeric_limits<float>::max());
       printSelectionCheck("Mother SV volume", 0., calculateEllipsoidVolume(mother), max_vertex_volume);
     }
   }
@@ -1079,18 +1079,18 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
     {
       printSelectionCheck("Mother DIRA", m_dira_min, calculated_dira, m_dira_max);
       printSelectionCheck("Mother DIRA xy", m_dira_xy_min, calculated_dira_xy, m_dira_xy_max);
-      printSelectionCheck("Mother FD chi^2", m_fdchi2, calculated_fdchi2, FLT_MAX);
+      printSelectionCheck("Mother FD chi^2", m_fdchi2, calculated_fdchi2, std::numeric_limits<float>::max());
       printSelectionCheck("Mother IP", 0, calculated_ip, m_mother_ip);
       printSelectionCheck("Mother IP chi^2", 0., calculated_ipchi2, m_mother_ipchi2);
       printSelectionCheck("Mother IP xy", 0., calculated_ip_xy, m_mother_ip_xy);
       printSelectionCheck("Mother IP xy chi^2", 0., calculated_ipchi2_xy, m_mother_ipchi2_xy);
       printSelectionCheck("Mother Decay Time", m_min_decayTime, calculated_decayTime, m_max_decayTime);
-      printSelectionCheck("Mother Decay Time Significance", m_mother_min_decay_time_significance, calculated_decay_time_significance, FLT_MAX);
+      printSelectionCheck("Mother Decay Time Significance", m_mother_min_decay_time_significance, calculated_decay_time_significance, std::numeric_limits<float>::max());
       printSelectionCheck("Mother Decay Time xy", m_min_decayTime_xy, calculated_decayTime_xy, m_max_decayTime_xy);
       printSelectionCheck("Mother Decay Length", m_min_decayLength, calculated_decayLength, m_max_decayLength);
-      printSelectionCheck("Mother Decay Length Significance", m_mother_min_decay_length_significance, calculated_decay_length_significance, FLT_MAX);
+      printSelectionCheck("Mother Decay Length Significance", m_mother_min_decay_length_significance, calculated_decay_length_significance, std::numeric_limits<float>::max());
       printSelectionCheck("Mother Decay Length xy", m_min_decayLength_xy, calculated_decayLength_xy, m_max_decayLength_xy);
-      printSelectionCheck("Mother Decay Length xy Significance", m_mother_min_decay_length_xy_significance, calculated_decay_length_xy_significance, FLT_MAX);
+      printSelectionCheck("Mother Decay Length xy Significance", m_mother_min_decay_length_xy_significance, calculated_decay_length_xy_significance, std::numeric_limits<float>::max());
     }
   }
 }

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -13,7 +13,7 @@
 #include <phgenfit/Track.h>
 
 #include <GenFit/EventDisplay.h>
-#include "GenFit/Exception.h"
+#include <GenFit/Exception.h>
 
 #include <string>
 

--- a/offline/packages/TruthNeutralMesonFinder/TruthNeutralMesonv1.h
+++ b/offline/packages/TruthNeutralMesonFinder/TruthNeutralMesonv1.h
@@ -1,8 +1,9 @@
 #ifndef TRUTHNEUTRALMESONV1_H
 #define TRUTHNEUTRALMESONV1_H
 
-#include <array>
 #include "TruthNeutralMeson.h"
+
+#include <array>
 
 class TruthNeutralMesonv1 : public TruthNeutralMeson
 {

--- a/offline/packages/bcolumicount/StreamingBcoLumiReco.cc
+++ b/offline/packages/bcolumicount/StreamingBcoLumiReco.cc
@@ -28,6 +28,8 @@
 #include <Event/EventTypes.h>
 #include <Event/packet.h>  // for Packet
 
+#include <TH1.h>
+
 #include <iostream>
 
 StreamingBcoLumiReco::StreamingBcoLumiReco(const std::string &name)

--- a/offline/packages/bcolumicount/StreamingBcoLumiReco.h
+++ b/offline/packages/bcolumicount/StreamingBcoLumiReco.h
@@ -1,16 +1,16 @@
 #ifndef BCOLUMICOUNT_STREAMINGBCOLUMIRECO_H
 #define BCOLUMICOUNT_STREAMINGBCOLUMIRECO_H
 
+#include "StreamingLumiInfo.h"
+
 #include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllHistoManager.h>
-#include "StreamingLumiInfo.h"
 
 #include <string>
 #include <utility>
 #include <array>
 
-#include <TH1.h>
-
+class TH1;
 
 class StreamingBcoLumiReco : public SubsysReco
 {
@@ -44,9 +44,9 @@ class StreamingBcoLumiReco : public SubsysReco
   static int CreateNodeTree(PHCompositeNode *topNode);
   const int trigbits = 40;
   Fun4AllHistoManager *hm = nullptr; 
-  TH1I *h_bco_diff = nullptr;
-  TH1I *h_bco_diff_trigbits[40] = {nullptr};
-  TH1I *h_bco_tag = nullptr;
+  TH1 *h_bco_diff = nullptr;
+  TH1 *h_bco_diff_trigbits[40] = {nullptr};
+  TH1 *h_bco_tag = nullptr;
 
   uint64_t m_bco{0};
   int m_bunches = 120;

--- a/offline/packages/globalvertex/GlobalVertexMap.h
+++ b/offline/packages/globalvertex/GlobalVertexMap.h
@@ -3,9 +3,11 @@
 #ifndef GLOBALVERTEX_GLOBALVERTEXMAP_H
 #define GLOBALVERTEX_GLOBALVERTEXMAP_H
 
-#include <phool/PHObject.h>
 #include "Vertex.h"
 #include "GlobalVertex.h"
+
+#include <phool/PHObject.h>
+
 #include <iostream>
 #include <map>
 
@@ -15,7 +17,7 @@ class GlobalVertexMap : public PHObject
   typedef std::map<unsigned int, GlobalVertex*>::const_iterator ConstIter;
   typedef std::map<unsigned int, GlobalVertex*>::iterator Iter;
 
-  ~GlobalVertexMap() override {}
+  ~GlobalVertexMap() override = default;
 
   void identify(std::ostream& os = std::cout) const override { os << "GlobalVertexMap base class" << std::endl; }
   int isValid() const override { return 0; }
@@ -42,7 +44,7 @@ class GlobalVertexMap : public PHObject
   virtual Iter end();
 
  protected:
-  GlobalVertexMap() {}
+  GlobalVertexMap() = default;
 
  private:
   ClassDefOverride(GlobalVertexMap, 1);

--- a/offline/packages/globalvertex/GlobalVertexReco.h
+++ b/offline/packages/globalvertex/GlobalVertexReco.h
@@ -10,8 +10,9 @@
 /// \author Mike McCumber
 //===========================================================
 
-#include <fun4all/SubsysReco.h>
 #include "GlobalVertex.h"
+
+#include <fun4all/SubsysReco.h>
 
 #include <string>  // for string
 

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -180,11 +180,6 @@ void MvtxCombinedRawDataDecoder::GetNodes(PHCompositeNode *topNode)
   }
 }
 
-//_____________________________________________________________________
-int MvtxCombinedRawDataDecoder::Init(PHCompositeNode * /*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
 
 //____________________________________________________________________________..
 int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
@@ -362,12 +357,6 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     }
   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-//_____________________________________________________________________
-int MvtxCombinedRawDataDecoder::End(PHCompositeNode * /*topNode*/)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -7,6 +7,8 @@
  * \author Jakub Kvapil <jakub.kvapil@cern.ch>
  */
 
+#include "MvtxPixelMask.h"
+
 #include <fun4all/SubsysReco.h>
 
 #include <trackbase/TrkrDefs.h>
@@ -16,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "MvtxPixelMask.h"
 
 class MvtxEventInfo;
 class MvtxRawEvtHeader;
@@ -33,17 +34,11 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   /// constructor
   explicit MvtxCombinedRawDataDecoder(const std::string& name = "MvtxCombinedRawDataDecoder");
 
-  /// global initialization
-  int Init(PHCompositeNode* /*dummy*/) override;
-
   /// run initialization
-  int InitRun(PHCompositeNode* /*dummy*/) override;
+  int InitRun(PHCompositeNode *topNode) override;
 
   /// event processing
-  int process_event(PHCompositeNode* /*dummy*/) override;
-
-  /// end of processing
-  int End(PHCompositeNode* /*dummy*/) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   void useRawHitNodeName(const std::string& name) { m_MvtxRawHitNodeName = name; }
 
@@ -63,20 +58,20 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   void CreateNodes(PHCompositeNode*);
   void GetNodes(PHCompositeNode*);
 
-  uint64_t gl1rawhitbco = 0;
+  uint64_t gl1rawhitbco {0};
 
-  TrkrHitSetContainer* hit_set_container = nullptr;
-  TrkrHitSetContMvtxHelper* mvtx_hit_set_helper = nullptr;
-  MvtxEventInfo* mvtx_event_header = nullptr;
-  MvtxRawEvtHeader* mvtx_raw_event_header = nullptr;
-  MvtxRawHitContainer* mvtx_raw_hit_container = nullptr;
-  MvtxRawHit* mvtx_rawhit = nullptr;
+  TrkrHitSetContainer* hit_set_container {nullptr};
+  TrkrHitSetContMvtxHelper* mvtx_hit_set_helper {nullptr};
+  MvtxEventInfo* mvtx_event_header {nullptr};
+  MvtxRawEvtHeader* mvtx_raw_event_header {nullptr};
+  MvtxRawHitContainer* mvtx_raw_hit_container {nullptr};
+  MvtxRawHit* mvtx_rawhit {nullptr};
 
-  std::string m_MvtxRawHitNodeName = "MVTXRAWHIT";
-  std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
+  std::string m_MvtxRawHitNodeName {"MVTXRAWHIT"};
+  std::string m_MvtxRawEvtHeaderNodeName {"MVTXRAWEVTHEADER"};
 
-  bool m_readStrWidthFromDB = true;
-  float m_strobeWidth = 89.;  //! microseconds
+  bool m_readStrWidthFromDB {true};
+  float m_strobeWidth {89.};  //! microseconds
 
   // mask hot pixels
   bool m_doOfflineMasking{false};

--- a/offline/packages/tpc/TrainingHitsContainer.h
+++ b/offline/packages/tpc/TrainingHitsContainer.h
@@ -1,14 +1,15 @@
 #ifndef TRAININGHITSCONTAINER_H
 #define TRAININGHITSCONTAINER_H
 
-#include <vector>
 #include "TrainingHits.h"
+
+#include <vector>
 
 class TrainingHitsContainer : public PHObject
 {
  public:
   TrainingHitsContainer();
-  ~TrainingHitsContainer() override {}
+  ~TrainingHitsContainer() override = default;
   void Reset() override;
 
   std::vector<TrainingHits> v_hits;

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -1,15 +1,17 @@
 #include "ActsGeometry.h"
-#include <Acts/Definitions/Algebra.hpp>
 #include "TpcDefs.h"
 #include "TrkrCluster.h"
 #include "alignmentTransformationContainer.h"
+
 #include <phool/sphenix_constants.h>
+
+#include <Acts/Definitions/Algebra.hpp>
 
 namespace
 {
   /// square
   template <class T>
-  inline constexpr T square(const T& x)
+  constexpr T square(const T& x)
   {
     return x * x;
   }

--- a/offline/packages/trackbase/MvtxEventInfov1.h
+++ b/offline/packages/trackbase/MvtxEventInfov1.h
@@ -10,11 +10,10 @@
 /*          29/09/2023     */
 /***************************/
 
-#include <iostream>
-
-#include <set>
-
 #include "MvtxEventInfo.h"
+
+#include <iostream>
+#include <set>
 
 typedef std::pair<uint64_t, uint64_t> strobe_L1_pair;
 

--- a/offline/packages/trackbase/MvtxEventInfov2.h
+++ b/offline/packages/trackbase/MvtxEventInfov2.h
@@ -10,11 +10,10 @@
 /*          09/11/2023     */
 /***************************/
 
-#include <iostream>
-
-#include <set>
-
 #include "MvtxEventInfo.h"
+
+#include <iostream>
+#include <set>
 
 typedef std::pair<uint64_t, uint64_t> strobe_L1_pair;
 

--- a/offline/packages/trackbase/MvtxEventInfov3.h
+++ b/offline/packages/trackbase/MvtxEventInfov3.h
@@ -10,11 +10,11 @@
 /*          29/09/2023     */
 /***************************/
 
-#include <iostream>
+#include "MvtxEventInfo.h"
 
+#include <iostream>
 #include <set>
 
-#include "MvtxEventInfo.h"
 
 ///
 class MvtxEventInfov3 : public MvtxEventInfo

--- a/offline/packages/trackbase/ResidualOutlierFinder.h
+++ b/offline/packages/trackbase/ResidualOutlierFinder.h
@@ -1,19 +1,23 @@
 #ifndef TRACKBASE_RESIDUALOUTLIERFINDER_H
 #define TRACKBASE_RESIDUALOUTLIERFINDER_H
 
+#include <phool/phool.h>
+
 #include <TFile.h>
 #include <TH2.h>
 #include <TNtuple.h>
-#include <phool/phool.h>
+
 #include <Acts/Definitions/Units.hpp>
 
 #include <ActsExamples/EventData/Measurement.hpp>
+
 #include <Acts/EventData/MeasurementHelpers.hpp>
 #include <Acts/EventData/MultiTrajectory.hpp>
+#include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
+
 #include <Acts/Utilities/TrackHelpers.hpp>
 
-#include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 struct ResidualOutlierFinder
 {
   ActsGeometry* m_tGeometry = nullptr;

--- a/offline/packages/trackbase/SpacePoint.h
+++ b/offline/packages/trackbase/SpacePoint.h
@@ -1,13 +1,14 @@
 #ifndef TRACKBASE_SPACEPOINT_H
 #define TRACKBASE_SPACEPOINT_H
 
-#include <memory>
-#include <optional>
-#include "trackbase/TrkrDefs.h"
+#include <trackbase/TrkrDefs.h>
 
 #include <ActsExamples/EventData/SpacePointContainer.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/EventData/Seed.hpp>
+
+#include <memory>
+#include <optional>
 
 /**
  * A struct for Acts to take cluster information for seeding

--- a/offline/packages/trackbase/TrkrClusterv2.h
+++ b/offline/packages/trackbase/TrkrClusterv2.h
@@ -7,9 +7,10 @@
 #ifndef TRACKBASE_TRKRCLUSTERV2_H
 #define TRACKBASE_TRKRCLUSTERV2_H
 
-#include <iostream>
 #include "TrkrCluster.h"
 #include "TrkrDefs.h"
+
+#include <iostream>
 
 class PHObject;
 

--- a/offline/packages/trackbase/TrkrClusterv3.h
+++ b/offline/packages/trackbase/TrkrClusterv3.h
@@ -7,9 +7,10 @@
 #ifndef TRACKBASE_TRKRCLUSTERV3_H
 #define TRACKBASE_TRKRCLUSTERV3_H
 
-#include <iostream>
 #include "TrkrCluster.h"
 #include "TrkrDefs.h"
+
+#include <iostream>
 
 class PHObject;
 

--- a/offline/packages/trackbase/TrkrClusterv4.h
+++ b/offline/packages/trackbase/TrkrClusterv4.h
@@ -7,9 +7,10 @@
 #ifndef TRACKBASE_TRKRCLUSTERV4_H
 #define TRACKBASE_TRKRCLUSTERV4_H
 
-#include <iostream>
 #include "TrkrCluster.h"
 #include "TrkrDefs.h"
+
+#include <iostream>
 
 class PHObject;
 

--- a/offline/packages/trackbase/TrkrClusterv5.h
+++ b/offline/packages/trackbase/TrkrClusterv5.h
@@ -7,9 +7,10 @@
 #ifndef TRACKBASE_TRKRCLUSTERV5_H
 #define TRACKBASE_TRKRCLUSTERV5_H
 
-#include <iostream>
 #include "TrkrCluster.h"
 #include "TrkrDefs.h"
+
+#include <iostream>
 
 class PHObject;
 

--- a/offline/packages/trackbase/TrkrClusterv6.h
+++ b/offline/packages/trackbase/TrkrClusterv6.h
@@ -10,7 +10,7 @@
 #include "TrkrCluster.h"
 #include "TrkrDefs.h"
 
-#include <climits>
+#include <limits>
 #include <iostream>
 
 class PHObject;

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v2.h
@@ -1,13 +1,13 @@
 #ifndef TRACKBASEHISTORIC_SVTXTRACKSEED_V2_H
 #define TRACKBASEHISTORIC_SVTXTRACKSEED_V2_H
 
-#include <phool/PHObject.h>
-
 #include "TrackSeed.h"
 
-#include <climits>
+#include <phool/PHObject.h>
+
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 class SvtxTrackSeed_v2 : public TrackSeed
 {
@@ -33,9 +33,9 @@ class SvtxTrackSeed_v2 : public TrackSeed
   void set_crossing_estimate(const short int cross) override { m_crossing_estimate = cross; }
 
  private:
-  unsigned int m_silicon_seed = std::numeric_limits<unsigned int>::max();
-  unsigned int m_tpc_seed = std::numeric_limits<unsigned int>::max();
-  short int m_crossing_estimate = SHRT_MAX;
+  unsigned int m_silicon_seed {std::numeric_limits<unsigned int>::max()};
+  unsigned int m_tpc_seed {std::numeric_limits<unsigned int>::max()};
+  short int m_crossing_estimate {std::numeric_limits<short>::max()};
 
   ClassDefOverride(SvtxTrackSeed_v2, 1);
 };

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -1,9 +1,9 @@
 #include "TrackAnalysisUtils.h"
 
-#include <globalvertex/GlobalVertex.h>
+#include "SvtxTrack.h"
+#include "TrackSeed.h"
 
-#include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
+#include <globalvertex/GlobalVertex.h>
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TpcDefs.h>
@@ -11,8 +11,9 @@
 #include <trackbase/TrkrClusterContainer.h>
 
 #include <g4detectors/PHG4TpcGeomContainer.h>
-#include "SvtxTrack.h"
-#include "TrackSeed.h"
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
 
 #include <cmath>
 

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
@@ -1,10 +1,11 @@
 #ifndef TRACKINFOCONTAINERV3_H
 #define TRACKINFOCONTAINERV3_H
 
-#include <phool/PHObject.h>
 #include "SvtxTrackInfo.h"
 #include "SvtxTrackInfo_v3.h"
 #include "TrackInfoContainer.h"
+
+#include <phool/PHObject.h>
 
 #include <TClonesArray.h>
 
@@ -38,7 +39,7 @@ class TrackInfoContainer_v3 : public TrackInfoContainer
   }
 
  protected:
-  TClonesArray *_clones = nullptr;
+  TClonesArray *_clones {nullptr};
 
  private:
   ClassDefOverride(TrackInfoContainer_v3, 1);

--- a/offline/packages/trackreco/ALICEKF.h
+++ b/offline/packages/trackreco/ALICEKF.h
@@ -1,13 +1,15 @@
 #ifndef ALICEKF_H
 #define ALICEKF_H
 
+#include "GPUTPCTrackParam.h"
+
 #include <phfield/PHField.h>
+
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/TrackSeed_v2.h>
-#include "GPUTPCTrackParam.h"
 
 #include <Acts/Definitions/Algebra.hpp>
 

--- a/offline/packages/trackreco/PHActsGSF.cc
+++ b/offline/packages/trackreco/PHActsGSF.cc
@@ -1,15 +1,7 @@
 #include "PHActsGSF.h"
 #include "MakeSourceLinks.h"
 
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/PHDataNode.h>
-#include <phool/PHNode.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>
-#include <phool/PHTimer.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
+#include "ActsEvaluator.h"
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ActsGsfTrackFittingAlgorithm.h>
@@ -29,6 +21,17 @@
 #include <globalvertex/SvtxVertex.h>
 #include <globalvertex/SvtxVertexMap.h>
 
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/SourceLink.hpp>
@@ -40,7 +43,6 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
-#include "ActsEvaluator.h"
 
 #include <TDatabasePDG.h>
 

--- a/offline/packages/trackreco/PHActsGSF.cc
+++ b/offline/packages/trackreco/PHActsGSF.cc
@@ -1,7 +1,15 @@
 #include "PHActsGSF.h"
 #include "MakeSourceLinks.h"
 
-#include "ActsEvaluator.h"
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ActsGsfTrackFittingAlgorithm.h>
@@ -21,17 +29,6 @@
 #include <globalvertex/SvtxVertex.h>
 #include <globalvertex/SvtxVertexMap.h>
 
-#include <fun4all/Fun4AllReturnCodes.h>
-
-#include <phool/PHCompositeNode.h>
-#include <phool/PHDataNode.h>
-#include <phool/PHNode.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>
-#include <phool/PHTimer.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
-
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/SourceLink.hpp>
@@ -43,6 +40,7 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
+#include "ActsEvaluator.h"
 
 #include <TDatabasePDG.h>
 

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -1,13 +1,14 @@
 #ifndef TRACKRECO_PHACTSTRACKPROJECTION_H
 #define TRACKRECO_PHACTSTRACKPROJECTION_H
 
-#include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrDefs.h>
-#include <trackbase_historic/SvtxTrack.h>
+#include "ActsPropagator.h"
 
 #include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrDefs.h>
 
-#include "ActsPropagator.h"
+#include <trackbase_historic/SvtxTrack.h>
+
+#include <fun4all/SubsysReco.h>
 
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/EventData/TrackParameters.hpp>
@@ -17,6 +18,8 @@
 #include <ActsExamples/EventData/Trajectories.hpp>
 
 #include <map>
+#include <memory>
+#include <string>
 
 class PHCompositeNode;
 class RawClusterContainer;
@@ -25,10 +28,6 @@ class RawTowerGeomContainer;
 class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
-
-#include <map>
-#include <memory>
-#include <string>
 
 /**
  * This class takes final fitted tracks from the Acts track fitting

--- a/offline/packages/uspin/SpinDBNode.cc
+++ b/offline/packages/uspin/SpinDBNode.cc
@@ -1,6 +1,14 @@
 #include "SpinDBNode.h"
 
+#include "SpinDBContent.h"
+#include "SpinDBContentv1.h"
+#include "SpinDBOutput.h"
+
+#include <ffaobjects/RunHeader.h>
+
+#include <fun4all/Fun4AllBase.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -9,14 +17,6 @@
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
 
-#include <ffaobjects/RunHeader.h>
-
-#include <fun4all/Fun4AllBase.h>
-#include <fun4all/SubsysReco.h>
-
-#include "SpinDBContent.h"
-#include "SpinDBContentv1.h"
-#include "SpinDBOutput.h"
 
 SpinDBNode::SpinDBNode(const std::string &name)
   : SubsysReco(name)

--- a/simulation/g4simulation/g4eval/compressor_generator.h
+++ b/simulation/g4simulation/g4eval/compressor_generator.h
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "RtypesCore.h"
+#include <RtypesCore.h>
 //-----------------------------------------------------------------------------
 
 UShort_t residesIn(Float_t raw, std::vector<Float_t>* dict)

--- a/simulation/g4simulation/g4eval/g4evalfn.cc
+++ b/simulation/g4simulation/g4eval/g4evalfn.cc
@@ -1,12 +1,14 @@
+#include "g4evalfn.h"
+
+#include "TrkrClusLoc.h"
+#include "TrkrClusterIsMatcher.h"
+
 #include <g4tracking/EmbRecoMatchContainer.h>
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase_historic/SvtxTrackMap.h>
-#include "TrkrClusLoc.h"
-#include "TrkrClusterIsMatcher.h"
-#include "g4evalfn.h"
 
 #include <algorithm>
 #include <cmath>

--- a/simulation/g4simulation/g4gdml/PHG4GDMLAuxStructType.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLAuxStructType.hh
@@ -36,6 +36,8 @@
 #ifndef _PHG4GDMLAUXSTRUCTTYPE_INCLUDED_
 #define _PHG4GDMLAUXSTRUCTTYPE_INCLUDED_
 
+#include <Geant4/G4String.hh>
+
 #include <vector>
 
 struct PHG4GDMLAuxStructType

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWrite.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWrite.hh
@@ -40,7 +40,7 @@
 #ifndef _PHG4GDMLWRITE_INCLUDED_
 #define _PHG4GDMLWRITE_INCLUDED_
 
-#include <map>
+#include "PHG4GDMLAuxStructType.hh"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -52,8 +52,8 @@
 
 #include <Geant4/G4Transform3D.hh>
 
+#include <map>
 
-#include "PHG4GDMLAuxStructType.hh"
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteDefine.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteDefine.hh
@@ -40,11 +40,11 @@
 #ifndef _PHG4GDMLWRITEDEFINE_INCLUDED_
 #define _PHG4GDMLWRITEDEFINE_INCLUDED_
 
+#include "PHG4GDMLWrite.hh"
+
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/G4RotationMatrix.hh>
-
-#include "PHG4GDMLWrite.hh"
 
 class PHG4GDMLWriteDefine : public PHG4GDMLWrite
 {

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.hh
@@ -40,11 +40,12 @@
 #ifndef _PHG4GDMLWRITEMATERIALS_INCLUDED_
 #define _PHG4GDMLWRITEMATERIALS_INCLUDED_
 
+#include "PHG4GDMLWriteDefine.hh"
+
 #include <Geant4/G4Types.hh>
-#include <vector>
 #include <Geant4/G4Version.hh>
 
-#include "PHG4GDMLWriteDefine.hh"
+#include <vector>
 
 class G4Isotope;
 class G4Element;

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.hh
@@ -40,10 +40,10 @@
 #ifndef _PHG4GDMLWRITESOLIDS_INCLUDED_
 #define _PHG4GDMLWRITESOLIDS_INCLUDED_
 
+#include "PHG4GDMLWriteMaterials.hh"
+
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4MultiUnion.hh>
-
-#include "PHG4GDMLWriteMaterials.hh"
 
 class G4BooleanSolid;
 class G4Box;

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.hh
@@ -40,10 +40,10 @@
 #ifndef _PHG4GDMLWRITESTRUCTURE_INCLUDED_
 #define _PHG4GDMLWRITESTRUCTURE_INCLUDED_
 
+#include "PHG4GDMLWriteParamvol.hh"
+
 #include <Geant4/G4Transform3D.hh>
 #include <Geant4/G4Types.hh>
-
-#include "PHG4GDMLWriteParamvol.hh"
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.cc
@@ -1,7 +1,7 @@
 #include "PHG4MvtxDisplayAction.h"
 
 #include <g4main/PHG4Utils.h>
-#include "g4main/PHG4DisplayAction.h"  // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -1,12 +1,13 @@
 #ifndef G4TPC_PHG4TPCPADPLANE_H
 #define G4TPC_PHG4TPCPADPLANE_H
 
-#include <fun4all/SubsysReco.h>
-
-#include <g4main/PHG4HitContainer.h>
 #include "TpcClusterBuilder.h"
 
+#include <g4main/PHG4HitContainer.h>
+
 #include <phparameter/PHParameterInterface.h>
+
+#include <fun4all/SubsysReco.h>
 
 #include <string>  // for string
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
We had a bunch of sources where the include order was not correct, include "" before include <>: https://wiki.sphenix.bnl.gov/index.php?title=Codingconventions#Include_Files which can lead to very hard to debug problems when using private builds. This touched a few files which fail clang-tidy, I don't expect this PR to succeed on the first try

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request addresses include-file ordering issues and modernizes member initialization across 37 source and header files to comply with the repository's coding convention (placing project-local includes before system/third-party includes) and resolve clang-tidy failures that occurred when using private builds.

## Key Changes

**Include Order Refactoring:**
- Reorganized include directives in headers throughout the codebase to place local/project-specific includes (quoted `""`) before system/external includes (angled `<>`), affecting files across calibration, generator, offline packages, and simulation modules
- Adjusted include ordering for files in trackbase, trackbase_historic, trackreco, g4simulation, and phgenfit modules

**Member Initialization Modernization:**
- Replaced empty inline destructors (`{}`) with defaulted destructors (`= default`) in several classes (GlobalVertexMap, TrainingHitsContainer, others)
- Updated member default initializers from assignment style (`= nullptr`) to brace initialization (`{nullptr}`) for consistency
- Converted pointer initialization syntax in private member sections across dEdxFitter, flowAfterburner, MvtxCombinedRawDataDecoder, and related classes

**Standard Library Header Updates:**
- Changed `<climits>` to `<limits>` and replaced `FLT_MAX` usage with `std::numeric_limits<float>::max()` in KFParticle_Tools.cc and related headers
- Added missing ROOT histogram header (`TH1.h`) to StreamingBcoLumiReco.cc

**Code Cleanup:**
- Removed unused `Init()` and `End()` method overrides from MvtxCombinedRawDataDecoder that unconditionally returned `EVENT_OK`
- Updated method signatures to use explicit parameter names instead of commented-out dummy parameters

**Include Path Modernization:**
- Changed some includes from quoted to angled format where appropriate (e.g., `RtypesCore.h`, `PHG4DisplayAction.h`)
- Added forward declarations instead of full includes where beneficial (e.g., TH1 in StreamingBcoLumiReco.h)

## Potential Risk Areas

- **Include dependency changes**: Reordering includes and switching between quoted/angled formats could expose hidden dependencies; verification that all includes resolve correctly is important
- **Removed methods**: Deletion of `Init()` and `End()` overrides assumes default behavior is acceptable; confirm no derived classes depend on these method signatures
- **Standard library header changes**: Switching from `<climits>` to `<limits>` and using `std::numeric_limits` should be functionally equivalent but may affect compilation on non-standard platforms
- **Member initialization changes**: Brace-initialization and `= default` are functionally equivalent to previous forms but may interact differently with move semantics or copy operations in edge cases

## Notes

The AI-generated change summaries may contain errors in interpretation. Manual verification of include dependency chains and method removal impacts is recommended before merging.

## Possible Future Improvements

- Establish automated linting to enforce consistent include ordering on submission
- Complete modernization of remaining empty destructors and constructors across the codebase
- Audit for additional opportunities to use standard library utilities (e.g., `std::numeric_limits`) in place of platform-specific macros
<!-- end of auto-generated comment: release notes by coderabbit.ai -->