### PR TITLE
Add affine transform from TPC envelope frame to world frame to the TP…

### DIFF
--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -147,6 +147,9 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
     Acts::Vector3 world,
     TrkrDefs::subsurfkey& subsurfkey) const
 {
+  // this method needs the world position in tpc envelope coordinates
+  Acts::Vector3 tpc_world = _tpc_world_transform.inverse() * world;
+  
   unsigned int layer = TrkrDefs::getLayer(hitsetkey);
   unsigned int side = TpcDefs::getSide(hitsetkey);
   
@@ -158,7 +161,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
               << hitsetkey << std::endl;
     return nullptr;
   }
-  double world_phi = atan2(world[1], world[0]);
+  double tpc_world_phi = atan2(tpc_world[1], tpc_world[0]);
 
   const auto& surf_vec = mapIter->second;
   unsigned int surf_index = 999;
@@ -166,7 +169,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   // Predict which surface index this phi and side will correspond to
   // assumes that the vector elements are ordered positive z, -pi to pi, then negative z, -pi to pi
   // we use TPC side from the hitsetkey, since z can be either sign in north and south, depending on crossing
-  double fraction = (world_phi + M_PI) / (2.0 * M_PI);
+  double fraction = (tpc_world_phi + M_PI) / (2.0 * M_PI);
 
   double rounded_nsurf = std::round((double) (surf_vec.size() / 2) * fraction - 0.5);  // NOLINT
   unsigned int nsurfm = (unsigned int) rounded_nsurf;
@@ -177,7 +180,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   }
   unsigned int nsurf = nsurfm % surf_vec.size();
   Surface this_surf = surf_vec[nsurf];
-  //std::cout << "    world_phi " << world_phi << " fraction " << fraction << " rounded_nsurf " << rounded_nsurf << " nsurfm " << nsurfm << " nsurf " << nsurf << std::endl;
+  //std::cout << "   tpc_world_phi " << tpc_world_phi << " fraction " << fraction << " rounded_nsurf " << rounded_nsurf << " nsurfm " << nsurfm << " nsurf " << nsurf << std::endl;
   
   auto vec3d = this_surf->center(m_tGeometry.getGeoContext());
   std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
@@ -185,7 +188,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
   //  std::cout << "    surf_phi " << surf_phi << " surfStepPhi " << surfStepPhi  << " nsurf " << nsurf << std::endl;
   
-  if ((world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0))
+  if ((tpc_world_phi > surf_phi - surfStepPhi / 2.0 && tpc_world_phi < surf_phi + surfStepPhi / 2.0))
   {
     surf_index = nsurf;
     subsurfkey = nsurf;
@@ -196,9 +199,9 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
     auto firstsurf = *surf_vec.begin();
     auto firstsurfcenter = firstsurf->center(geometry().getGeoContext());
     float firstsurf_phi = atan2(firstsurfcenter[1], firstsurfcenter[0]);
-    if (world_phi < firstsurf_phi - surfStepPhi / 2.0)
+    if (tpc_world_phi < firstsurf_phi - surfStepPhi / 2.0)
     {
-      world_phi += 2.0 * M_PI;
+      tpc_world_phi += 2.0 * M_PI;
     }
     //check a few surfaces around this one
     for( int i = -1; i <= 1; i++)
@@ -212,8 +215,8 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
       vec3d = this_surf->center(geometry().getGeoContext());
       surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
       surf_phi = atan2(surf_center[1], surf_center[0]);
-      //std::cout << "    new world_phi " << world_phi << " new surf_phi " << surf_phi  << " new_nsurf " << new_nsurf << std::endl;
-      if ((world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0))
+      //std::cout << "    new tpc_world_phi " << tpc_world_phi << " new surf_phi " << surf_phi  << " new_nsurf " << new_nsurf << std::endl;
+      if ((tpc_world_phi > surf_phi - surfStepPhi / 2.0 && tpc_world_phi < surf_phi + surfStepPhi / 2.0))
       {
         surf_index = new_nsurf;
         subsurfkey = new_nsurf;

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -51,6 +51,7 @@ class ActsGeometry
   void set_CM_halfwidth(double val) { _CM_halfwidth = val; }
   void set_tpc_tzero(double tz) { _tpc_tzero = tz; }
   void set_sampa_tzero_bias(double tzb) { _sampa_tzero_bias = tzb; }
+  void set_tpc_world_transform(Acts::Transform3 val) { _tpc_world_transform = val; }
 
   double get_tpc_tzero() const { return _tpc_tzero; }
   double get_sampa_tzero_bias() const { return _sampa_tzero_bias; }
@@ -88,6 +89,7 @@ class ActsGeometry
   double _CM_halfwidth = 0.28;  // cm
   double _tpc_tzero = 0.0;  // ns
   double _sampa_tzero_bias = 0.0;  // ns
+  Acts::Transform3 _tpc_world_transform;
 };
 
 #endif

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -181,6 +181,7 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   PHG4TpcGeom *layergeom = m_geomContainerTpc->GetLayerCellGeom(20);  // z geometry is the same for all layers
   m_max_driftlength = layergeom->get_max_driftlength();
   m_CM_halfwidth = layergeom->get_CM_halfwidth();
+  m_tpc_world_transform = layergeom->get_tpc_world_transform();
   
   m_maxSurfZ = m_max_driftlength - 0.0001; // add clearance from physical TPC gas volume length to avoid overlaps
     
@@ -298,6 +299,7 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->set_CM_halfwidth(m_CM_halfwidth);
   m_actsGeometry->set_tpc_tzero(m_tpc_tzero);
   m_actsGeometry->set_sampa_tzero_bias(m_sampa_tzero_bias);
+  m_actsGeometry->set_tpc_world_transform(m_tpc_world_transform);
   // alignment_transformation.useInttSurveyGeometry(m_inttSurvey);
 
   if (Verbosity() > 1)

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -286,6 +286,7 @@ private:
   bool m_apply_tpc_tzero_correction = false;
   double m_tpc_tzero = 0.0;  // ns, override from macro
   double m_sampa_tzero_bias = 0.0;  // ns, override from macro
+  Acts::Transform3 m_tpc_world_transform;
   
   /// Magnetic field components to set Acts magnetic field
   std::string m_magField = "1.4";

--- a/simulation/g4simulation/g4detectors/PHG4TpcGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4TpcGeom.h
@@ -7,6 +7,10 @@
 
 #include <phool/phool.h>
 
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+
 #include <array>
 #include <iostream>  // for cout, ostream
 #include <limits>
@@ -186,6 +190,14 @@ class PHG4TpcGeom : public PHObject
     PHOOL_VIRTUAL_WARN("get_tbin_float()");
     return -99999;
   }
+
+  virtual Eigen::Affine3d get_tpc_world_transform() const
+  {
+    PHOOL_VIRTUAL_WARN("get_tpc_world_transform()");
+    Eigen::Affine3d null;
+    return null;
+  }
+    
   virtual int find_phibin(const double, int) const
   {
     PHOOL_VIRTUAL_WARN("get_phibin()");
@@ -237,7 +249,9 @@ class PHG4TpcGeom : public PHObject
   virtual void set_adc_clock(const double) { PHOOL_VIRTUAL_WARN("set_adc_clock(const double)"); }
   virtual void set_extended_readout_time(const double) { PHOOL_VIRTUAL_WARN("set_extended_readout_time(const double)"); }
   virtual void set_drift_velocity_sim(const double) { PHOOL_VIRTUAL_WARN("set_drift_velocity_sim(const double)"); }
-  
+
+  virtual void set_tpc_world_transform(const Eigen::Affine3d) {PHOOL_VIRTUAL_WARN("set_tpc_world_transform(const Eigen::Affine3d)"); }
+    
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
   virtual void ImportParameters(const PHParameters & /*param*/) { return; }
 

--- a/simulation/g4simulation/g4detectors/PHG4TpcGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4TpcGeomv1.h
@@ -5,6 +5,10 @@
 
 #include "PHG4TpcGeom.h"
 
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+
 #include <array>
 #include <cmath>
 #include <iostream>  // for cout, ostream
@@ -54,6 +58,8 @@ class PHG4TpcGeomv1 : public PHG4TpcGeom
   int get_zbin(const double z) const override;
   int get_phibin(const double phi, int side = 0) const override;
   int get_phibin_new(const double phi) const override;
+
+  Eigen::Affine3d get_tpc_world_transform() const override {return tpc_world_transform; };
   
   float get_pad_float(const double phi, int side = 0) const override;
   float get_tbin_float(const double z) const override;
@@ -78,7 +84,8 @@ class PHG4TpcGeomv1 : public PHG4TpcGeom
   void set_adc_clock(const double val) override { adc_clock = val; }
   void set_extended_readout_time(const double val) override { extended_readout_time = val; }
   void set_drift_velocity_sim(const double val) override { drift_velocity_sim = val; }
-  
+  void set_tpc_world_transform(const Eigen::Affine3d val) override {tpc_world_transform = val; }
+
   static const int NSides = 2;
 
   void set_r_bias(const std::array<std::vector<double>, NSides> &dr) override { sector_R_bias = dr; }
@@ -129,6 +136,8 @@ class PHG4TpcGeomv1 : public PHG4TpcGeom
   std::array<std::vector<double>, NSides> sector_min_Phi;
   std::array<std::vector<double>, NSides> sector_max_Phi;
 
+  Eigen::Affine3d tpc_world_transform;
+  
   // streamer
   friend std::ostream& operator<<(std::ostream&, const PHG4TpcGeomv1&);
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -36,6 +36,10 @@
 #include <Geant4/G4UserLimits.hh>
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+
 #include <algorithm>  // for max, copy
 #include <cassert>
 #include <cmath>
@@ -604,6 +608,18 @@ void PHG4TpcDetector::add_geometry_node()
   std::cout << PHWHERE << "MaxT " << MaxT << " TBinWidth " << TBinWidth << " extended readout time "
             << extended_readout_time << " NTBins = " << NTBins << " drift velocity sim " << drift_velocity_sim << std::endl;
 
+  
+  // make the affine transform to go from TPC local coords to world coords
+  Eigen::AngleAxisd grx(m_Params->get_double_param("rot_x"), Eigen::Vector3d::UnitX());
+  Eigen::AngleAxisd gry(m_Params->get_double_param("rot_y"), Eigen::Vector3d::UnitY());
+  Eigen::AngleAxisd grz(m_Params->get_double_param("rot_z"), Eigen::Vector3d::UnitZ());
+  Eigen::Quaternion<double> gqr = grz * gry * grx;
+  Eigen::Matrix3d tpcRotation = gqr.matrix();
+  Eigen::Vector3d tpcTranslation(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z")*cm);
+  Eigen::Affine3d tpc_world_transform;  
+  tpc_world_transform.linear() = tpcRotation;
+  tpc_world_transform.translation() = tpcTranslation;  
+  
   const std::array<int, 3> NPhiBins =
       {{m_Params->get_int_param("ntpc_phibins_inner"),
         m_Params->get_int_param("ntpc_phibins_mid"),
@@ -751,6 +767,7 @@ void PHG4TpcDetector::add_geometry_node()
 	layerseggeo->set_adc_clock(m_Params->get_double_param("tpc_adc_clock"));
 	layerseggeo->set_extended_readout_time(m_Params->get_double_param("extended_readout_time"));
 	layerseggeo->set_drift_velocity_sim(m_Params->get_double_param("drift_velocity_sim"));	
+	layerseggeo->set_tpc_world_transform(tpc_world_transform);
       }
 
       // Chris Pinkenburg: greater causes huge memory growth which causes problems

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -59,6 +59,10 @@
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>  // for gsl_rng_alloc
 
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+
 #include <array>
 #include <cassert>
 #include <cmath>    // for sqrt, abs, NAN
@@ -191,8 +195,13 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   seggeo = findNode::getClass<PHG4TpcGeomContainer>(topNode, seggeonodename);
   assert(seggeo);
 
-    // the z geometry is the same for all layers
+  // the z geometry and TPC tilt are the same for all layers
   PHG4TpcGeom *layergeom = seggeo->GetLayerCellGeom(20);
+
+  // get the local to global transform for TPC to world
+  // This reproduces the G4PVPlacement orientation used to build the TPC model
+  m_tpc_world_transform =  layergeom->get_tpc_world_transform();
+
   // from top of GEM stack to top of GEM stack
   tpc_length = 2 * (layergeom->get_max_driftlength() + layergeom->get_CM_halfwidth());
   
@@ -556,11 +565,19 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       // values between 0 and 1
       const double f = gsl_ran_flat(RandomGenerator.get(), 0.0, 1.0);
 
-      const double x_start = hiter->second->get_x(0) + f * (hiter->second->get_x(1) - hiter->second->get_x(0));
-      const double y_start = hiter->second->get_y(0) + f * (hiter->second->get_y(1) - hiter->second->get_y(0));
-      const double z_start = hiter->second->get_z(0) + f * (hiter->second->get_z(1) - hiter->second->get_z(0));
+      const double x_start_glob = hiter->second->get_x(0) + f * (hiter->second->get_x(1) - hiter->second->get_x(0));
+      const double y_start_glob = hiter->second->get_y(0) + f * (hiter->second->get_y(1) - hiter->second->get_y(0));
+      const double z_start_glob = hiter->second->get_z(0) + f * (hiter->second->get_z(1) - hiter->second->get_z(0));
       const double t_start = hiter->second->get_t(0) + f * (hiter->second->get_t(1) - hiter->second->get_t(0));
 
+      // transform the g4 global position to a TPC local position for transport to readout plane
+      Eigen::Vector3d g4glob(x_start_glob, y_start_glob, z_start_glob);
+      Eigen::Vector3d g4tpc = m_tpc_world_transform.inverse() * g4glob;
+
+      double x_start = g4tpc.x();
+      double y_start = g4tpc.y();
+      double z_start = g4tpc.z();
+      
       unsigned int side = 0;
       if (z_start > 0)
       {

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -5,8 +5,6 @@
 
 #include "TpcClusterBuilder.h"
 
-#include <trackbase/ActsGeometry.h>
-
 #include <g4main/PHG4HitContainer.h>
 
 #include <phparameter/PHParameterInterface.h>
@@ -154,6 +152,9 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   std::string hitnodename;
   std::string seggeonodename;
 
+  Acts::Transform3 m_tpc_world_transform;
+ 
+  
   //! rng de-allocator
   class Deleter
   {


### PR DESCRIPTION
…C layergeom object. Use the inverse to convert world positions to the TPC envelope reference frame. Used in electron drift code so that drift is in the direction of the E field, and in get_tpc_surface_from_coords.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Incremental changes for adding TPC tilt in simulation.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

