### PR TITLE
Store observed sync tagger to BXCounterSync CDB TTree for use in EBDC which failed BXSync

### DIFF
--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -355,6 +355,10 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
         {
           m_TpcTimeFrameBuilderMap[packet_id]->SaveDigitalCurrentDebugTTree(m_digitalCurrentDebugTTreeName);
         }
+        if (!m_bxCounterSyncCDBTTreeName.empty())
+        {
+          m_TpcTimeFrameBuilderMap[packet_id]->SaveBXCounterSyncCDBTTree(m_bxCounterSyncCDBTTreeName);
+        }
       }
 
       if (Verbosity() > 1)

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
@@ -43,6 +43,11 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
     m_digitalCurrentDebugTTreeName = name;
   }
 
+  void setBXCounterSyncCDBTTreeName(const std::string &name)
+  {
+    m_bxCounterSyncCDBTTreeName = name;
+  }
+
  private:
   const int NTPCPACKETS = 3;
 
@@ -83,6 +88,7 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
 
   int m_FillPoolStatus{0};
   std::string m_digitalCurrentDebugTTreeName;
+  std::string m_bxCounterSyncCDBTTreeName;
 };
 
 #endif

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -1124,6 +1124,10 @@ void TpcTimeFrameBuilder::process_fee_data_digital_current(const unsigned int& f
   return;
 }
 
+void TpcTimeFrameBuilder::SaveBXCounterSyncCDBTTree(const std::string& /*name*/)
+{
+}
+
 void TpcTimeFrameBuilder::SaveDigitalCurrentDebugTTree(const std::string& name)
 {
   if (m_verbosity >= 1)

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -47,6 +47,7 @@ class TpcTimeFrameBuilder : public TpcTimeFrameBuilderBase
 
   // enable saving of digital current debug TTree with file name `name`
   void SaveDigitalCurrentDebugTTree(const std::string &name) override;
+  void SaveBXCounterSyncCDBTTree(const std::string &name) override;
 
  protected:
   // Length for the 256-bit wide Round Robin Multiplexer for the data stream

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilderBase.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilderBase.h
@@ -21,6 +21,7 @@ class TpcTimeFrameBuilderBase
   virtual void setVerbosity(int i) = 0;
   virtual void fillBadFeeMap() = 0;
   virtual void SaveDigitalCurrentDebugTTree(const std::string &name) = 0;
+  virtual void SaveBXCounterSyncCDBTTree(const std::string &name) = 0;
 };
 
 #endif

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilderRun3.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilderRun3.cc
@@ -34,6 +34,7 @@
 TpcTimeFrameBuilderRun3::TpcTimeFrameBuilderRun3(const int packet_id)
   : m_packet_id(packet_id)
   , m_HistoPrefix("TpcTimeFrameBuilderRun3_Packet" + std::to_string(packet_id))
+  , m_bxCounterSyncCDBTTreeName(m_HistoPrefix + "_BXCounterSyncCDBTTree.root")
 {
   for (int fee = 0; fee < MAX_FEECOUNT; ++fee)
   {
@@ -266,6 +267,9 @@ TpcTimeFrameBuilderRun3::~TpcTimeFrameBuilderRun3()
       timeFrameEntry.second.pop_back();
     }
   }
+
+  write_bx_counter_sync_cdb_tree();
+
   delete h_Run3PreviousTimeFrameWaveformADC;
   delete h_Run3PreviousTimeFrameRecoveredWaveformADC;
 
@@ -281,6 +285,57 @@ void TpcTimeFrameBuilderRun3::setVerbosity(const int i)
   for (BcoMatchingInformation& bcoMatchingInformation : m_bcoMatchingInformation_vec)
   {
     bcoMatchingInformation.set_verbosity(i);
+  }
+}
+
+void TpcTimeFrameBuilderRun3::write_bx_counter_sync_cdb_tree() const
+{
+  if (m_bxCounterSyncCDBTTreeName.empty())
+  {
+    return;
+  }
+
+  CDBTTree cdbtree(m_bxCounterSyncCDBTTreeName);
+
+  int entry_count = 0;
+  for (size_t fee = 0; fee < m_bcoMatchingInformation_vec.size(); ++fee)
+  {
+    const BcoMatchingInformation& bco_info = m_bcoMatchingInformation_vec[fee];
+    const size_t observation_count = std::min(bco_info.get_bx_counter_sync_observation_count(),
+                                              BcoMatchingInformation::kMaxBXCounterSyncObservations);
+    const auto& observations = bco_info.get_bx_counter_sync_observations();
+    for (size_t observation_index = 0; observation_index < observation_count; ++observation_index)
+    {
+      const BcoMatchingInformation::BXCounterSyncObservation& observation = observations[observation_index];
+      const int channel = static_cast<int>(fee * BcoMatchingInformation::kMaxBXCounterSyncObservations + observation_index);
+      cdbtree.SetIntValue(channel, "packet_id", m_packet_id);
+      cdbtree.SetIntValue(channel, "fee", static_cast<int>(fee));
+      cdbtree.SetIntValue(channel, "observation", static_cast<int>(observation_index));
+      cdbtree.SetUInt64Value(channel, "bx_counter_sync_gtm_bco", observation.bx_counter_sync_gtm_bco);
+      cdbtree.SetUInt64Value(channel, "bco_reference_gtm_bco", observation.bco_reference_gtm_bco);
+      cdbtree.SetUInt64Value(channel, "m_bco_reference_gtm_bco", observation.m_bco_reference.first);
+      cdbtree.SetIntValue(channel, "m_bco_reference_fee_bco", static_cast<int>(observation.m_bco_reference.second));
+      ++entry_count;
+    }
+  }
+
+  if (entry_count == 0)
+  {
+    return;
+  }
+
+  cdbtree.SetSingleIntValue("packet_id", m_packet_id);
+  cdbtree.SetSingleIntValue("n_bx_counter_sync_observations", entry_count);
+  cdbtree.SetSingleIntValue("max_fee_count", MAX_FEECOUNT);
+  cdbtree.SetSingleIntValue("max_observations_per_fee", static_cast<int>(BcoMatchingInformation::kMaxBXCounterSyncObservations));
+  cdbtree.CommitSingle();
+  cdbtree.Commit();
+  cdbtree.WriteCDBTTree();
+
+  if (m_verbosity >= 0)
+  {
+    std::cout << __PRETTY_FUNCTION__ << " - saved " << entry_count
+              << " BX_COUNTER_SYNC_T observations to " << m_bxCounterSyncCDBTTreeName << std::endl;
   }
 }
 
@@ -2007,6 +2062,16 @@ void TpcTimeFrameBuilderRun3::process_fee_data_digital_current(const unsigned in
   return;
 }
 
+void TpcTimeFrameBuilderRun3::SaveBXCounterSyncCDBTTree(const std::string& name)
+{
+  m_bxCounterSyncCDBTTreeName = name;
+
+  if (m_verbosity >= 1)
+  {
+    std::cout << __PRETTY_FUNCTION__ << "\t- : Saving BX counter sync CDB TTree to " << m_bxCounterSyncCDBTTreeName << std::endl;
+  }
+}
+
 void TpcTimeFrameBuilderRun3::SaveDigitalCurrentDebugTTree(const std::string& name)
 {
   if (m_verbosity >= 1)
@@ -2508,6 +2573,23 @@ uint64_t TpcTimeFrameBuilderRun3::BcoMatchingInformation::
 }
 
 //___________________________________________________
+void TpcTimeFrameBuilderRun3::BcoMatchingInformation::save_bx_counter_sync_observation(
+    uint64_t bx_counter_sync_gtm_bco,
+    uint64_t bco_reference_gtm_bco,
+    const TpcTimeFrameBuilderRun3::BcoMatchingInformation::m_gtm_fee_bco_matching_pair_t& bco_reference)
+{
+  if (m_bx_counter_sync_observation_count >= kMaxBXCounterSyncObservations)
+  {
+    return;
+  }
+
+  BXCounterSyncObservation& observation = m_bx_counter_sync_observations[m_bx_counter_sync_observation_count];
+  observation.bx_counter_sync_gtm_bco = bx_counter_sync_gtm_bco;
+  observation.bco_reference_gtm_bco = bco_reference_gtm_bco;
+  observation.m_bco_reference = bco_reference;
+  ++m_bx_counter_sync_observation_count;
+}
+
 void TpcTimeFrameBuilderRun3::BcoMatchingInformation::save_gtm_bco_information(const TpcTimeFrameBuilderRun3::gtm_payload& gtm_tagger)
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
@@ -2619,8 +2701,11 @@ void TpcTimeFrameBuilderRun3::BcoMatchingInformation::save_gtm_bco_information(c
 
       // get BCO and assign
       const uint64_t bco_reference_gtm_bco = gtm_bco + kBXCounterSyncGtmBcoOffset;
+      const m_gtm_fee_bco_matching_pair_t bx_counter_sync_reference =
+          std::make_pair(bco_reference_gtm_bco, static_cast<uint32_t>(kBXCounterSyncFEEBcoOffset));
       m_verified_from_modebits = true;
-      m_bco_reference = std::make_pair(bco_reference_gtm_bco, kBXCounterSyncFEEBcoOffset);
+      m_bco_reference = bx_counter_sync_reference;
+      save_bx_counter_sync_observation(gtm_bco, bco_reference_gtm_bco, bx_counter_sync_reference);
       m_bco_heartbeat_list.clear();
 
       if (m_verbosity)

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilderRun3.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilderRun3.h
@@ -57,6 +57,7 @@ class TpcTimeFrameBuilderRun3 : public TpcTimeFrameBuilderBase
 
   // enable saving of digital current debug TTree with file name `name`
   void SaveDigitalCurrentDebugTTree(const std::string &name) override;
+  void SaveBXCounterSyncCDBTTree(const std::string &name) override;
 
  protected:
   // Length for the 256-bit wide Round Robin Multiplexer for the data stream
@@ -202,11 +203,30 @@ class TpcTimeFrameBuilderRun3 : public TpcTimeFrameBuilderBase
     //! matching between fee bco and lvl1 bco
     using m_gtm_fee_bco_matching_pair_t = std::pair<uint64_t, uint32_t>;
     using m_fee_gtm_bco_matching_pair_t = std::pair<uint32_t, uint64_t>;
+    struct BXCounterSyncObservation
+    {
+      uint64_t bx_counter_sync_gtm_bco = 0;
+      uint64_t bco_reference_gtm_bco = 0;
+      m_gtm_fee_bco_matching_pair_t m_bco_reference = {0, 0};
+    };
+
+    //! expect two but tollerate up to four BX_COUNTER_SYNC_T observations to define the reference clock, depending on data quality. The first few observations will be saved in the CDB for future reference.
+    static constexpr size_t kMaxBXCounterSyncObservations = 4;
 
     //! get reference bco
     const std::optional<m_gtm_fee_bco_matching_pair_t> &get_reference_bco() const
     {
       return m_bco_reference;
+    }
+
+    const std::array<BXCounterSyncObservation, kMaxBXCounterSyncObservations> &get_bx_counter_sync_observations() const
+    {
+      return m_bx_counter_sync_observations;
+    }
+
+    size_t get_bx_counter_sync_observation_count() const
+    {
+      return m_bx_counter_sync_observation_count;
     }
 
     //! whether FEE data has moved pass the given gtm_bco
@@ -328,6 +348,10 @@ class TpcTimeFrameBuilderRun3 : public TpcTimeFrameBuilderBase
     }
 
    private:
+    void save_bx_counter_sync_observation(uint64_t bx_counter_sync_gtm_bco,
+                                          uint64_t bco_reference_gtm_bco,
+                                          const m_gtm_fee_bco_matching_pair_t &bco_reference);
+
     std::string m_name;
 
     //! verbosity
@@ -346,6 +370,10 @@ class TpcTimeFrameBuilderRun3 : public TpcTimeFrameBuilderBase
 
     //! list of available GTM -> FEE bco mapping for synchronization
     std::optional<m_gtm_fee_bco_matching_pair_t> m_bco_reference = std::nullopt;
+
+    //! first BX_COUNTER_SYNC_T observations saved for future CDB reference studies
+    std::array<BXCounterSyncObservation, kMaxBXCounterSyncObservations> m_bx_counter_sync_observations;
+    size_t m_bx_counter_sync_observation_count = 0;
 
     // std::optional< std::pair< uint64_t, uint32_t > > m_bco_reference_candidate = std::nullopt;
     //! not yet matched heart beats
@@ -410,6 +438,7 @@ class TpcTimeFrameBuilderRun3 : public TpcTimeFrameBuilderBase
 
   //! common prefix for QA histograms
   std::string m_HistoPrefix;
+  std::string m_bxCounterSyncCDBTTreeName;
 
   static constexpr uint32_t kFEEClockMask = (1U << 20U) - 1U;
   static constexpr uint32_t kRun3FeeMatchWindow = (GL1_BCO_MATCH_WINDOW * 30U + 7U) / 8U;
@@ -434,6 +463,7 @@ class TpcTimeFrameBuilderRun3 : public TpcTimeFrameBuilderBase
   void fill_waveform_gl1_spacing(TH1 *waveform_adc_cache, TH2 *waveform_gl1_spacing, uint64_t gtm_bco_spacing) const;
   void cache_waveform_adc(TH1 *waveform_adc_cache, const std::vector<TpcRawHit *> &timeframe) const;
   void cache_timeframe_qa(uint64_t gtm_bco, const std::vector<TpcRawHit *> &timeframe, const std::bitset<MAX_FEECOUNT> &exact_matched_fees);
+  void write_bx_counter_sync_cdb_tree() const;
 
   //! FEE -> FEE BCO -> cached TpcRawHit for Run3 exact-ratio matching
   std::vector<std::map<uint32_t, std::vector<TpcRawHit *>>> m_timeHitMap;


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This deals a rare problem in TPC data that was identified in the last iteration of production: some time the beam crossing clock sync tagger (`BX_COUNTER_SYNC_T`) which record the time when the FEE clock is reset. `BX_COUNTER_SYNC_T` is used to predict the synchronization of FEE to sPHENIX clock, without which the event building does not work reliably. This tagger is identical cross 48 independent TPC data streams. 

This PR introduce storing `BX_COUNTER_SYNC_T` to CDB file by default. Then this CDB file can be used to recover the rare cases for one of the 48 TPC data stream missing this tagger. 

## How to use

The output CDB file is available after the first event execution and save out at the end of Fun4All macro by default such as 
```
void TpcTimeFrameBuilderRun3::write_bx_counter_sync_cdb_tree() const - saved 26 BX_COUNTER_SYNC_T observations to TpcTimeFrameBuilderRun3_Packet4110_BXCounterSyncCDBTTree.root
```
And the location can be over written with 
```c++
      SingleTpcTimeFrameInput *tpc_sngl = new SingleTpcTimeFrameInput("SingleTpcTimeFrameInput_" + to_string(i));
      tpc_sngl->setBXCounterSyncCDBTTreeName(iter + "_BXCounterSyncCDBTTree.root");
```

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Add the read function with a problematic run is identified and its CDB file installed. 

## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/coresoftware/pull/4292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## BX Counter Sync Observation CDB Storage

### Motivation
During TPC data production, the beam crossing counter sync tagger (`BX_COUNTER_SYNC_T`) occasionally goes missing from one of the 48 independent TPC data streams. This tagger records the FEE clock reset time and is critical for predicting FEE-to-sPHENIX master clock synchronization. When missing from any stream, event building becomes unreliable. This PR implements automated capture of these synchronization observations to enable recovery in affected runs.

### Key Changes
- **TpcTimeFrameBuilderRun3**: Captures the first 4 BX_COUNTER_SYNC_T observations per FEE (stored in `BXCounterSyncObservation` records) with associated GTM and reference BCO values, fixed clock offsets (GTM: 0, FEE: 12)
- **CDB Output**: Writes observations to a CDBTTree file with per-FEE records indexed as channels, storing packet ID, FEE, observation count, and metadata
- **Default Behavior**: Automatically generates CDB files with naming pattern `TpcTimeFrameBuilderRun3_Packet<id>_BXCounterSyncCDBTTree.root` after first event execution
- **API**: Added `setBXCounterSyncCDBTTreeName()` on `SingleTpcTimeFrameInput` to customize output location; defaults to empty string (no-op on base class)
- **Virtual Interface**: Extended `TpcTimeFrameBuilderBase` with pure virtual `SaveBXCounterSyncCDBTTree()` method; implemented in `TpcTimeFrameBuilderRun3`, empty stub in `TpcTimeFrameBuilder`

### Potential Risk Areas
- **IO Changes**: New CDB files generated automatically; disk space implications for repeated data collection
- **Data Storage Design**: Storage limited to 4 observations per FEE and per packet builder; exceeding this limit silently discards additional observations—verify this cap is sufficient for production use cases
- **Clock Synchronization Dependencies**: Uses fixed hardcoded offsets for GTM and FEE BCO; any hardware or FEE changes may require offset recalibration
- **CDB Integration**: Production readiness depends on CDB installation infrastructure; no read-back function implemented yet (deferred to future iteration per PR notes)

### Possible Future Improvements
- Implement read-back functionality to reconstruct missing taggers using stored CDB observations
- Increase observation storage limit or implement dynamic allocation
- Add configurable BCO offsets for different hardware configurations
- Monitor observation capture statistics and alert on insufficient synchronization events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->