### PR TITLE
use std::array, add access method for radii

### DIFF
--- a/offline/packages/PHGarfield/PHGarfield.cc
+++ b/offline/packages/PHGarfield/PHGarfield.cc
@@ -236,11 +236,8 @@ void PHGarfield::InitializeGas(const std::string &dir)
   }
 }
 
-int PHGarfield::process_event(PHCompositeNode* topNode)
+int PHGarfield::process_event(PHCompositeNode*)
 {
-  // Avoids the compiler error for having nore used the topNode.
-  (void) topNode;
-
   // Initial implementation doesn't do anything event-by-event.
   // Nonetheless, a future user might want do do something here...
 

--- a/offline/packages/PHGarfield/PHGarfield.cc
+++ b/offline/packages/PHGarfield/PHGarfield.cc
@@ -84,7 +84,7 @@ void PHGarfield::FillRadii()
   }
 }
 
-void PHGarfield::PrintGarfield(double x, double y, double z)
+void PHGarfield::PrintGarfield(double x, double y, double z) const
 {
   double ex;
   double ey;
@@ -113,7 +113,7 @@ void PHGarfield::PrintGarfield(double x, double y, double z)
             << std::endl;
 }
 
-void PHGarfield::PrintMaps()
+void PHGarfield::PrintMaps() const
 {
   //  Print out a few test points of the Garfield information
   PrintGarfield(0.0, 0.0, 0.1);
@@ -160,7 +160,7 @@ void PHGarfield::PrintMaps()
   }
 }
 
-void PHGarfield::GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double& bx_t, double& by_t, double& bz_t)
+void PHGarfield::GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double& bx_t, double& by_t, double& bz_t) const
 {
   // NOTE:  Garfield uses  cm, V/cm, and Tesla.
   //        CLHEP    uses  mm, V/mm, and kiloTesla
@@ -184,7 +184,7 @@ void PHGarfield::GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, do
   bz_t = bfield[2] / CLHEP::tesla;
 }
 
-void PHGarfield::GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, double& ex_vcm, double& ey_vcm, double& ez_vcm)
+void PHGarfield::GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, double& ex_vcm, double& ey_vcm, double& ez_vcm) const
 {
   // NOTE:  Garfield uses  cm, V/cm, and Tesla.
   (void) x_cm;
@@ -195,7 +195,7 @@ void PHGarfield::GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, doub
   ez_vcm = z_cm > 0 ? -400.0 : 400.0;
 }
 
-void PHGarfield::InitializeGas(std::string dir)
+void PHGarfield::InitializeGas(const std::string &dir)
 {
   //  Create and fill the gas object so that we can trace particles through the gas...
   m_gas = new Garfield::MediumMagboltz();

--- a/offline/packages/PHGarfield/PHGarfield.h
+++ b/offline/packages/PHGarfield/PHGarfield.h
@@ -24,25 +24,25 @@ class PHGarfield : public SubsysReco
   ~PHGarfield() override = default;
 
   int InitRun(PHCompositeNode *) override;
-  int process_event(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode * /*topNode*/) override;
 
   bool StopHere(const double x, const double y, const double z, const double zPrevious);
 
-  void PrintMaps();
-  void PrintGarfield(double x, double y, double z);
+  void PrintMaps() const;
+  void PrintGarfield(double x, double y, double z) const;
 
   //  These are left in public namespace for easy plotting macros...
   //  The user is encouraged to add more routine to fit their analysis goals...
   TPolyLine3D *ReverseDrift(double x_cm, double y_cm, double z_cm, double step_ns = 50.0);  // Drifts electrons from some initial point until they hit a detector boundary...
 
-  double GetRadius(size_t index) {return radii.at(index);}
+  double GetRadius(size_t index) const {return radii.at(index);}
 
  private:
-  void GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double &bx_t, double &by_t, double &bz_t);      // Feeds magnetic field to Garfield
-  void GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, double &ex_vcm, double &ey_vcm, double &ez_vcm);  // Feeds electric field to Garfield
-  void InitializeGas(std::string dir);
+  void GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double &bx_t, double &by_t, double &bz_t) const;      // Feeds magnetic field to Garfield
+  void GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, double &ex_vcm, double &ey_vcm, double &ez_vcm) const;  // Feeds electric field to Garfield
+  void InitializeGas(const std::string &dir);
   void FillRadii();
-  double bounder(double phi, double phi_min);
+  static double bounder(double phi, double phi_min);
 
   CDBTTree *m_cdbTPCMAPttree{nullptr};            // Locations of the pads from CDB...
   PHField3DCartesian *m_field{nullptr};           // The stanards sPHENIX field holding container.

--- a/offline/packages/PHGarfield/PHGarfield.h
+++ b/offline/packages/PHGarfield/PHGarfield.h
@@ -3,6 +3,7 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <array>
 #include <numbers>
 #include <string>
 
@@ -34,6 +35,8 @@ class PHGarfield : public SubsysReco
   //  The user is encouraged to add more routine to fit their analysis goals...
   TPolyLine3D *ReverseDrift(double x_cm, double y_cm, double z_cm, double step_ns = 50.0);  // Drifts electrons from some initial point until they hit a detector boundary...
 
+  double GetRadius(size_t index) {return radii.at(index);}
+
  private:
   void GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double &bx_t, double &by_t, double &bz_t);      // Feeds magnetic field to Garfield
   void GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, double &ex_vcm, double &ey_vcm, double &ez_vcm);  // Feeds electric field to Garfield
@@ -50,7 +53,7 @@ class PHGarfield : public SubsysReco
   // std::string calibdir;
   // std::string m_DiodeContainerName;
   double PHI_MIN{-std::numbers::pi};
-  double radii[48]{};  // Radius on each layer just for test purposes...need to be cm!
+  std::array<double, 48> radii{};  // Radius on each layer just for test purposes...need to be cm!
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
A macro uses the radii from PHGarfield. This PR adds an accessor for it and uses std::array so we can easily do bounds checking

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PHGarfield: Enhanced Radii Storage with Bounds Checking (and Const-Correctness)

### Motivation / Context
This change updates `PHGarfield`’s internal radii storage to support macros that need access to per-layer radii values, while improving safety via bounds-checked access.

### Key Changes
- **Radii container update**: Replaced the fixed C array `double radii[48]` with `std::array<double, 48> radii{}`.
- **Bounds-checked accessor**: Added `double GetRadius(size_t index) const` returning `radii.at(index)` for safe macro/API usage.
- **API const-correctness improvements**:
  - Marked `PrintMaps`, `PrintGarfield`, `GetMagneticFieldTesla`, and `GetElectricFieldVcm` as `const`.
  - Updated `InitializeGas` to take `const std::string&` instead of `std::string` (avoids an extra copy).
  - Adjusted `process_event` parameter name to an ignored parameter in the override signature.
  
### Potential Risk Areas
- **Downstream compilation/API expectations**: Calls that relied on non-`const` method signatures may require adjustments (e.g., invoking methods on `const PHGarfield` instances now works, but overridden signatures/qualifiers could expose mismatches in some downstream code).
- **Binary/ABI compatibility**: Changing the member type from `double[48]` to `std::array<double, 48>` can affect ABI compatibility across builds if anything external depended on the exact layout.
- **Behavioral differences from access patterns**: Code that continues to use direct indexing bypasses bounds checking; using `GetRadius()` is recommended to benefit from `.at()` checks.
- **Performance**: Likely negligible; bounds checking occurs only when using `GetRadius()`.

### Possible Future Improvements
- Add a bulk accessor (e.g., returning a `std::span`/view over all 48 radii) to reduce repetitive indexing in macros.
- Consider migrating remaining internal uses to the accessor for consistent bounds-checking.

*Note: AI-assisted analysis can make mistakes—please use best judgment when reviewing these changes against your build and downstream usage patterns.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->