### PR TITLE
Cdb from file

### DIFF
--- a/offline/database/sphenixnpc/CDBUtils.cc
+++ b/offline/database/sphenixnpc/CDBUtils.cc
@@ -85,7 +85,7 @@ std::map<std::string, std::tuple<std::string, uint64_t, uint64_t>> CDBUtils::Pay
     return iovs;
   }
   nlohmann::json payload_iovs = resp["msg"];
-  for (auto &[pt, val] : payload_iovs.items())
+  for (const auto &[pt, val] : payload_iovs.items())
   {
     std::string url = val["payload_url"];
     uint64_t bts = val["minor_iov_start"];
@@ -94,10 +94,10 @@ std::map<std::string, std::tuple<std::string, uint64_t, uint64_t>> CDBUtils::Pay
     {
       if (!ptype.empty())
       {
-	if (pt.find(ptype) == std::string::npos)
-	{
-	  continue;
-	}
+        if (pt.find(ptype) == std::string::npos)
+        {
+          continue;
+        }
       }
       iovs.insert(std::make_pair(pt, std::make_tuple(url, bts, ets)));
     }
@@ -107,7 +107,7 @@ std::map<std::string, std::tuple<std::string, uint64_t, uint64_t>> CDBUtils::Pay
 
 void CDBUtils::listPayloadIOVs(uint64_t iov, const std::string &ptype)
 {
-  auto iovs = PayloadIOVs(iov,ptype);
+  auto iovs = PayloadIOVs(iov, ptype);
   for (const auto &it : iovs)
   {
     std::cout << it.first << ": " << std::get<0>(it.second)
@@ -123,7 +123,7 @@ int CDBUtils::cloneGlobalTag(const std::string &source, const std::string &targe
   nlohmann::json resp = cdbclient->getGlobalTags();
   nlohmann::json msgcont = resp["msg"];
   std::set<std::string> gtset;
-  for (auto &it : msgcont.items())
+  for (const auto &it : msgcont.items())
   {
     std::string exist_gt = it.value().at("name");
     gtset.insert(exist_gt);
@@ -149,7 +149,7 @@ void CDBUtils::listGlobalTags()
   nlohmann::json resp = cdbclient->getGlobalTags();
   nlohmann::json msgcont = resp["msg"];
   std::set<std::string> globaltags;
-  for (auto &it : msgcont.items())
+  for (const auto &it : msgcont.items())
   {
     std::string exist_gt = it.value().at("name");
     globaltags.insert(exist_gt);
@@ -166,7 +166,7 @@ void CDBUtils::listPayloadTypes()
   nlohmann::json resp = cdbclient->getPayloadTypes();
   nlohmann::json msgcont = resp["msg"];
   std::set<std::string> payloadtypes;
-  for (auto &it : msgcont.items())
+  for (const auto &it : msgcont.items())
   {
     std::string exist_pl = it.value().at("name");
     payloadtypes.insert(exist_pl);

--- a/offline/database/sphenixnpc/CDBUtils.h
+++ b/offline/database/sphenixnpc/CDBUtils.h
@@ -42,8 +42,8 @@ class CDBUtils
   std::map<std::string, std::tuple<std::string, uint64_t, uint64_t>> PayloadIOVs(uint64_t iov, const std::string &ptype = "");
   void listPayloadIOVs(uint64_t iov, const std::string &ptype = "");
 
-private:
-  int m_Verbosity {0};
+ private:
+  int m_Verbosity{0};
   std::unique_ptr<SphenixClient> cdbclient;
   std::string m_CachedGlobalTag;
   std::set<std::string> m_PayloadTypeCache;

--- a/offline/database/sphenixnpc/SphenixClient.cc
+++ b/offline/database/sphenixnpc/SphenixClient.cc
@@ -61,7 +61,7 @@ nlohmann::json SphenixClient::getUrlDict(long long iov)
   }
   for (auto it = resp["msg"].begin(); it != resp["msg"].end();)
   {
-    if (it.value()["minor_iov_end"] < iov)
+    if (it.value()["minor_iov_end"] <= iov)
     {
       it = resp["msg"].erase(it);
     }
@@ -87,7 +87,7 @@ void SphenixClient::DumpCalibrations(long long iov, const std::string& filename)
   }
   for (auto it = resp["msg"].begin(); it != resp["msg"].end();)
   {
-    if (it.value()["minor_iov_end"] < iov)
+    if (it.value()["minor_iov_end"] <= iov)
     {
       it = resp["msg"].erase(it);
     }

--- a/offline/database/sphenixnpc/SphenixClient.cc
+++ b/offline/database/sphenixnpc/SphenixClient.cc
@@ -5,6 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 
@@ -69,11 +70,51 @@ nlohmann::json SphenixClient::getUrlDict(long long iov)
       ++it;
     }
   }
-  for (auto& piov : resp["msg"].items())
+  for (const auto& piov : resp["msg"].items())
   {
     piov.value() = piov.value()["payload_url"];
   }
   return resp;
+}
+
+void SphenixClient::DumpCalibrations(long long iov, const std::string& filename)
+{
+  nlohmann::json resp = getPayloadIOVs(iov);
+  if (resp["code"] != 0)
+  {
+    std::cout << "not writing " << filename << std::endl;
+    return;
+  }
+  for (auto it = resp["msg"].begin(); it != resp["msg"].end();)
+  {
+    if (it.value()["minor_iov_end"] < iov)
+    {
+      it = resp["msg"].erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+  std::ofstream dumpfile(filename);
+  if (dumpfile.is_open())
+  {
+    for (const auto& piov : resp["msg"].items())
+    {
+      std::string payload_url = piov.value()["payload_url"];
+      if (!payload_url.empty() && payload_url.front() == '"' && payload_url.back() == '"')
+      {
+        payload_url = payload_url.substr(1, payload_url.size() - 2);
+      }
+      dumpfile << piov.key() << " " << payload_url << std::endl;
+    }
+    dumpfile.close();
+  }
+  else
+  {
+    std::cout << "Could not open " << filename << std::endl;
+  }
+  return;
 }
 
 nlohmann::json SphenixClient::deletePayloadIOV(const std::string& pl_type, long long iov_start)
@@ -162,7 +203,7 @@ int SphenixClient::cache_set_GlobalTag(const std::string& tagname)
   bool found_gt = false;
   nlohmann::json resp = nopayloadclient::NoPayloadClient::getGlobalTags();
   nlohmann::json msgcont = resp["msg"];
-  for (auto& it : msgcont.items())
+  for (const auto& it : msgcont.items())
   {
     std::string exist_gt = it.value().at("name");
     std::cout << "global tag: " << exist_gt << std::endl;
@@ -196,7 +237,7 @@ int SphenixClient::createDomain(const std::string& domain)
   {
     resp = nopayloadclient::NoPayloadClient::getPayloadTypes();
     nlohmann::json msgcont = resp["msg"];
-    for (auto& it : msgcont.items())
+    for (const auto& it : msgcont.items())
     {
       std::string existent_domain = it.value().at("name");
       m_DomainCache.insert(existent_domain);
@@ -235,7 +276,7 @@ bool SphenixClient::existGlobalTag(const std::string& gt_name)
   }
   nlohmann::json resp = nopayloadclient::NoPayloadClient::getGlobalTags();
   nlohmann::json msgcont = resp["msg"];
-  for (auto& it : msgcont.items())
+  for (const auto& it : msgcont.items())
   {
     std::string exist_gt = it.value().at("name");
     m_GlobalTagCache.insert(gt_name);

--- a/offline/database/sphenixnpc/SphenixClient.h
+++ b/offline/database/sphenixnpc/SphenixClient.h
@@ -39,9 +39,10 @@ class SphenixClient : public nopayloadclient::NoPayloadClient
   bool isGlobalTagSet();
   void Verbosity(int i) { m_Verbosity = i; }
   int Verbosity() const { return m_Verbosity; }
+  void DumpCalibrations(long long iov, const std::string& filename);
 
  private:
-  int m_Verbosity = 0;
+  int m_Verbosity{0};
   std::string m_CachedGlobalTag;
   std::set<std::string> m_DomainCache;
   std::set<std::string> m_GlobalTagCache;

--- a/offline/framework/ffamodules/CDBInterface.cc
+++ b/offline/framework/ffamodules/CDBInterface.cc
@@ -20,10 +20,13 @@
 
 #include <TSystem.h>
 
-#include <cstdint>   // for uint64_t
+#include <cstdint>  // for uint64_t
+#include <filesystem>
+#include <fstream>
 #include <iostream>  // for operator<<, basic_ostream, endl
-#include <utility>   // for pair
-#include <vector>    // for vector
+#include <sstream>
+#include <utility>  // for pair
+#include <vector>   // for vector
 
 CDBInterface *CDBInterface::__instance{nullptr};
 
@@ -55,7 +58,8 @@ CDBInterface::~CDBInterface()
 //____________________________________________________________________________..
 int CDBInterface::End(PHCompositeNode *topNode)
 {
-  int iret = UpdateRunNode(topNode);PHNodeIterator iter(topNode);
+  int iret = UpdateRunNode(topNode);
+  PHNodeIterator iter(topNode);
   return iret;
 }
 
@@ -127,6 +131,15 @@ std::string CDBInterface::getUrl(const std::string &domain, const std::string &f
     return "";
   }
   std::string domain_noconst = domain;
+  if (m_Read_From_File_Flag)
+  {
+    if (m_Payload_Url_Cache.contains(domain_noconst))
+    {
+      return m_Payload_Url_Cache[domain_noconst];
+    }
+    std::cout << "calibration " << domain << " not found in local cache" << std::endl;
+    return "";
+  }
   recoConsts *rc = recoConsts::instance();
   if (!rc->FlagExist("CDB_GLOBALTAG"))
   {
@@ -185,14 +198,85 @@ std::string CDBInterface::getUrl(const std::string &domain, const std::string &f
       std::cout << "... reply: " << return_url << std::endl;
     }
   }
-  if (! return_url.empty())
+  if (!return_url.empty())
   {
     auto pret = m_UrlVector.insert(make_tuple(domain_noconst, return_url, timestamp));
     if (!pret.second && Verbosity() > 1)
     {
       std::cout << PHWHERE << "not adding again " << domain_noconst << ", url: " << return_url
-		<< ", time stamp: " << timestamp << std::endl;
+                << ", time stamp: " << timestamp << std::endl;
     }
   }
   return return_url;
+}
+
+void CDBInterface::DumpCalibrations(const std::string &filename)
+{
+  recoConsts *rc = recoConsts::instance();
+  if (!rc->FlagExist("CDB_GLOBALTAG"))
+  {
+    std::cout << PHWHERE << "CDB_GLOBALTAG flag needs to be set via" << std::endl;
+    std::cout << "rc->set_StringFlag(\"CDB_GLOBALTAG\",<global tag>)" << std::endl;
+    gSystem->Exit(1);
+  }
+  if (!rc->FlagExist("TIMESTAMP"))
+  {
+    std::cout << PHWHERE << "TIMESTAMP flag needs to be set via" << std::endl;
+    std::cout << "rc->set_uint64Flag(\"TIMESTAMP\",<64 bit timestamp>)" << std::endl;
+    gSystem->Exit(1);
+  }
+  if (cdbclient == nullptr)
+  {
+    cdbclient = new SphenixClient(rc->get_StringFlag("CDB_GLOBALTAG"));
+  }
+  uint64_t timestamp = rc->get_uint64Flag("TIMESTAMP");
+  cdbclient->DumpCalibrations(timestamp, filename);
+  return;
+}
+
+void CDBInterface::ReadCalibrationsFromFile(const std::string &filename)
+{
+  std::filesystem::path filePath = filename;
+  if (!std::filesystem::exists(filePath))
+  {
+    std::cout << PHWHERE << " cannot locate " << filename << std::endl;
+    gSystem->Exit(1);
+  }
+  if (!std::filesystem::is_regular_file(filePath))
+  {
+    std::cout << PHWHERE << " not a regular file " << filename << std::endl;
+    gSystem->Exit(1);
+  }
+  std::ifstream calibsfile(filename);
+  if (calibsfile.is_open())
+  {
+    std::string line;
+    while (std::getline(calibsfile, line))
+    {
+      // Skip empty lines
+      if (line.empty())
+      {
+        continue;
+      }
+
+      // Skip comments
+      if (line[0] == '#')
+      {
+        continue;
+      }
+      std::istringstream iss(line);
+      std::string key;
+      std::string payload_url;
+      if (iss >> key >> payload_url)
+      {
+        m_Payload_Url_Cache.insert(std::make_pair(key, payload_url));
+      }
+    }
+    m_Read_From_File_Flag = true;
+  }
+  else
+  {
+    std::cout << "could not open " << filename << std::endl;
+  }
+  return;
 }

--- a/offline/framework/ffamodules/CDBInterface.h
+++ b/offline/framework/ffamodules/CDBInterface.h
@@ -6,6 +6,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <cstdint>  // for uint64_t
+#include <map>
 #include <set>
 #include <string>
 #include <tuple>  // for tuple
@@ -34,6 +35,9 @@ class CDBInterface : public SubsysReco
 
   std::string getUrl(const std::string &domain, const std::string &filename = "");
 
+  void DumpCalibrations(const std::string &filename);
+  void ReadCalibrationsFromFile(const std::string &filename);
+
  private:
   CDBInterface(const std::string &name = "CDBInterface");
 
@@ -41,6 +45,8 @@ class CDBInterface : public SubsysReco
   SphenixClient *cdbclient{nullptr};
   bool disable{false};
   bool disable_default{false};
+  bool m_Read_From_File_Flag{false};
+  std::map<std::string, std::string> m_Payload_Url_Cache;
   std::set<std::tuple<std::string, std::string, uint64_t>> m_UrlVector;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR allows to dump cdb calibrations into a text file and read it back - so the reconstruction can be run outside of scdf without access to the cdb.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This PR implements offline calibration data persistence for the sPHENIX experiment. Users can now dump CDB calibrations to a text file during data processing and read them back in subsequent reconstruction jobs, enabling offline physics analysis workflows without direct access to the central calibration database—essential for sites with limited network connectivity or when working with frozen calibration snapshots.

## Key Changes

- **SphenixClient::DumpCalibrations()**: New method that queries the CDB for payload IOV data at a specified timestamp, filters valid entries, and writes `payload_type → payload_url` pairs to a text file (one pair per line, space-separated)

- **CDBInterface::DumpCalibrations()**: High-level wrapper that validates required `CDB_GLOBALTAG` and `TIMESTAMP` flags, lazily initializes the CDB client, and invokes the low-level dump

- **CDBInterface::ReadCalibrationsFromFile()**: New method that parses a calibration dump file (supporting comments with `#` and blank lines), populates an internal URL cache, and enables read-from-file mode for subsequent URL lookups

- **CDBInterface::getUrl()**: Modified to short-circuit CDB queries when read-from-file mode is active, returning cached URLs instead

- **Minor refactoring**: Const-correctness improvements (const references in JSON iteration loops) and spacing/style normalization across multiple files

## Potential Risk Areas

- **IO Format Stability**: The plain-text file format (key → URL pairs) lacks versioning or schema markers. Changes to CDB payload structure or URL patterns could silently break existing calibration files without detection

- **Stale Data**: Cached calibrations become disconnected from live CDB updates. If calibration constants are revised upstream, offline jobs using dumped files will not reflect those changes (by design, but worth documenting)

- **Hard Exits on Validation Failure**: `DumpCalibrations()` calls `gSystem->Exit(1)` for missing flags or file errors rather than throwing exceptions or returning error codes. This prevents graceful error handling in analysis frameworks

- **Incomplete Error Recovery**: `ReadCalibrationsFromFile()` silently skips malformed lines; corrupt dump files may load partially without alerting users to inconsistency

- **Thread Safety**: No synchronization visible for `m_Payload_Url_Cache` or `m_Read_From_File_Flag` access—concurrent calls to `getUrl()` and file operations could race

- **Reconstruction Behavior Change**: When read-from-file mode is enabled, all URL resolution bypasses live CDB lookups. Production workflows relying on dynamic global-tag resolution must be carefully tested to ensure dumped calibrations are appropriate

## Possible Future Improvements

- Add versioning/magic number to dump file format to detect incompatibilities
- Implement file checksums or timestamps to warn about stale calibration data
- Provide optional validation that cached calibrations match live CDB at job startup
- Replace hard `gSystem->Exit(1)` calls with exceptions or error return codes
- Add thread-safety locks around cache access if multi-threaded use is anticipated
- Support filtering/partial dumps (e.g., specific detector subsystems) to reduce file size
- Document CDB epoch and validity windows in the dump file header

---

*Note: This summary was generated with AI assistance. Please review the actual code changes in the referenced files for details, as AI analyses can contain errors or miss important implementation subtleties.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->