### PR TITLE
Track trackseed synchronization

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -744,10 +744,10 @@ int PHTpcResiduals::createNodes(PHCompositeNode* /*topNode*/)
 int PHTpcResiduals::getNodes(PHCompositeNode* topNode)
 {
   // clusters
-  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode, m_clustermapname);
   if (!m_clusterContainer)
   {
-    std::cout << PHWHERE << "No TRKR_CLUSTER node on node tree. Exiting." << std::endl;
+    std::cout << "PHTpcResiduals::getNodes - cluster map named " << m_clustermapname << " not found." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -755,7 +755,7 @@ int PHTpcResiduals::getNodes(PHCompositeNode* topNode)
   m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   if (!m_tGeometry)
   {
-    std::cout << "ActsTrackingGeometry not on node tree. Exiting." << std::endl;
+    std::cout << "PHTpcResiduals::getNodes - ActsGeometry not found." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -763,7 +763,7 @@ int PHTpcResiduals::getNodes(PHCompositeNode* topNode)
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, m_trackmapname);
   if (!m_trackMap)
   {
-    std::cout << PHWHERE << " " << m_trackmapname << " not on node tree. Exiting." << std::endl;
+    std::cout << "PHTpcResiduals::getNodes - track map named " << m_trackmapname << " not found." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -130,6 +130,10 @@ class PHTpcResiduals : public SubsysReco
   void setTrackMapName( const std::string& value )
   { m_trackmapname = value; }
 
+  /// modify track map name
+  void setClusterMapName( const std::string& value )
+  { m_clustermapname = value; }
+
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -144,11 +148,19 @@ class PHTpcResiduals : public SubsysReco
   /// Gets distortion cell for identifying bins in TPC
   int getCell(const Acts::Vector3 &loc);
 
-  /// Node information for Acts tracking geometry and silicon+MM
-  /// track fit
+  //! track map name
   std::string m_trackmapname = "SvtxSiliconMMTrackMap";
+
+  //! track map
   SvtxTrackMap *m_trackMap = nullptr;
+
+  //! acts geometry
   ActsGeometry *m_tGeometry = nullptr;
+
+  //! cluster map name
+  std::string m_clustermapname = "TRKR_CLUSTER";
+
+  //! cluster map
   TrkrClusterContainer *m_clusterContainer = nullptr;
 
   //! tpc global position wrapper

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -60,6 +60,7 @@ pkginclude_HEADERS = \
   PHTrackPruner.h \
   PHTrackCleaner.h \
   PHTrackSelector.h \
+  PHTrackTrackSeedSynchronization.h \
   PHRaveVertexing.h \
   PHSiliconHelicalPropagator.h \
   PHSiliconSeedMerger.h \
@@ -155,6 +156,7 @@ libtrack_reco_la_SOURCES = \
   PHTrackClusterAssociator.cc \
   PHTrackSeeding.cc \
   PHTrackSelector.cc \
+  PHTrackTrackSeedSynchronization.cc \
   PHTrackSetMerging.cc \
   PHTrackPropagating.cc \
   PHTrackFitting.cc \

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -130,13 +130,13 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
     }
     if (Verbosity() > 1) { std::cout<<"Pass track selection"<<std::endl; }
 
-    _tpc_seed = _svtx_track->get_tpc_seed();
-    _si_seed = _svtx_track->get_silicon_seed();
-    if (_tpc_seed && _si_seed)
+    auto* tpc_seed = _svtx_track->get_tpc_seed();
+    auto* si_seed = _svtx_track->get_silicon_seed();
+    if (tpc_seed && si_seed)
     {
       if (Verbosity() > 1) { std::cout<<"Insert tpcid and siid into good_matches"<<std::endl; }
-      int tpcid = _tpc_seed_map->find(_tpc_seed);
-      int siid = _si_seed_map->find(_si_seed);
+      int tpcid = _tpc_seed_map->find(tpc_seed);
+      int siid = _si_seed_map->find(si_seed);
       good_matches.insert(std::make_pair(tpcid, siid));
     }
   }

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -122,16 +122,16 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
 
   for (auto &iter : *_svtx_track_map)
   {
-    _svtx_track = iter.second;
+    auto* svtx_track = iter.second;
 
-    if(!checkTrack(_svtx_track))
+    if(!checkTrack(svtx_track))
     {
       continue;
     }
     if (Verbosity() > 1) { std::cout<<"Pass track selection"<<std::endl; }
 
-    auto* tpc_seed = _svtx_track->get_tpc_seed();
-    auto* si_seed = _svtx_track->get_silicon_seed();
+    auto* tpc_seed = svtx_track->get_tpc_seed();
+    auto* si_seed = svtx_track->get_silicon_seed();
     if (tpc_seed && si_seed)
     {
       if (Verbosity() > 1) { std::cout<<"Insert tpcid and siid into good_matches"<<std::endl; }
@@ -173,7 +173,6 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
 
     cout << "PHTrackPruner::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;
   }
-  m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -84,9 +84,6 @@ PHTrackPruner::PHTrackPruner(const std::string &name)
 }
 
 //____________________________________________________________________________..
-PHTrackPruner::~PHTrackPruner() = default;
-
-//____________________________________________________________________________..
 int PHTrackPruner::InitRun(PHCompositeNode *topNode)
 {
   int ret = GetNodes(topNode);

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -103,14 +103,12 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
 {
   // _tpc_seed_map contains the TPC seed track stubs
   // _si_seed_map contains the silicon seed track stubs
-  // _svtx_seed_map contains the combined silicon and tpc track seeds
   // _svtx_track_map contains the fitted acts track stubs
 
   if (Verbosity() > 0)
   {
     cout << PHWHERE << " TPC seed map size " << _tpc_seed_map->size()
 	 << " Silicon seed map size " << _si_seed_map->size()
-	 << " Svtx seed map size " << _svtx_seed_map->size()
 	 << " Svtx track map size " << _svtx_track_map->size()
 	 << endl;
   }
@@ -279,13 +277,6 @@ int PHTrackPruner::GetNodes(PHCompositeNode *topNode)
   if (!_tpc_seed_map)
   {
     cerr << PHWHERE << " ERROR: Can't find " << _tpc_seed_map_name.c_str() << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  _svtx_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _svtx_seed_map_name);
-  if (!_svtx_seed_map)
-  {
-    cerr << PHWHERE << " ERROR: Can't find " << _svtx_seed_map_name.c_str() << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -115,7 +115,7 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
     return Fun4AllReturnCodes::EVENT_OK;
   }
 
-  std::multimap<unsigned int, unsigned int> good_matches;
+  std::multimap<size_t, size_t> good_matches;
 
   for (auto &iter : *_svtx_track_map)
   {
@@ -132,13 +132,16 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
     if (tpc_seed && si_seed)
     {
       if (Verbosity() > 1) { std::cout<<"Insert tpcid and siid into good_matches"<<std::endl; }
-      int tpcid = _tpc_seed_map->find(tpc_seed);
-      int siid = _si_seed_map->find(si_seed);
-      good_matches.insert(std::make_pair(tpcid, siid));
+      const size_t tpcid = _tpc_seed_map->find(tpc_seed);
+      const size_t siid = _si_seed_map->find(si_seed);
+
+      // check index validity
+      if( tpcid < _tpc_seed_map->size() && siid < _si_seed_map->size() )
+      { good_matches.emplace(tpcid, siid); }
     }
   }
 
-  for (auto [tpcid, siid] : good_matches)
+  for (const auto& [tpcid, siid] : good_matches)
   {
       if (Verbosity() > 1) { std::cout<<"Insert pruned svtx seed map"<<std::endl; }
     auto _svtx_seed = std::make_unique<SvtxTrackSeed_v2>();

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -320,10 +320,10 @@ int PHTrackPruner::GetNodes(PHCompositeNode *topNode)
     svtxNode->addNode(node);
   }
 
-  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, _cluster_map_name);
   if (!_cluster_map)
   {
-    std::cout << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
+    std::cout << PHWHERE << " ERROR: Can't find node " << _cluster_map_name << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -258,21 +258,21 @@ int PHTrackPruner::GetNodes(PHCompositeNode *topNode)
   _svtx_track_map = findNode::getClass<SvtxTrackMap>(topNode, _svtx_track_map_name);
   if (!_svtx_track_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _svtx_track_map_name.c_str()  << endl;
+    cerr << PHWHERE << " ERROR: Can't find " << _svtx_track_map_name  << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _si_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _si_seed_map_name);
   if (!_si_seed_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _si_seed_map_name.c_str()  << endl;
+    cerr << PHWHERE << " ERROR: Can't find " << _si_seed_map_name  << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _tpc_seed_map_name);
   if (!_tpc_seed_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _tpc_seed_map_name.c_str() << endl;
+    cerr << PHWHERE << " ERROR: Can't find " << _tpc_seed_map_name << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -34,12 +34,25 @@ class PHTrackPruner : public SubsysReco
 
   int End(PHCompositeNode *) override;
 
-  void set_pruned_svtx_seed_map_name(const std::string &map_name) { _pruned_svtx_seed_map_name = map_name; }
+  //! input cluster map name. Default is TRKR_CLUSTER
+  void set_cluster_map_name(const std::string &map_name) { _cluster_map_name = map_name; }
+
+  //! input seeds map name
   void set_svtx_seed_map_name(const std::string &map_name) { _svtx_seed_map_name = map_name; }
+
+  //! input silicon seeds map name
   void set_si_seed_map_name(const std::string &map_name) { _si_seed_map_name = map_name; }
+
+  //! input tpc seeds map name
   void set_tpc_seed_map_name(const std::string &map_name) { _tpc_seed_map_name = map_name; }
+
+  //! input track map name
   void set_svtx_track_map_name(const std::string &map_name) { _svtx_track_map_name = map_name; }
 
+  //! output pruned track map name
+  void set_pruned_svtx_seed_map_name(const std::string &map_name) { _pruned_svtx_seed_map_name = map_name; }
+
+  /// low pt cut
   void set_track_pt_low_cut(const double val) { m_track_pt_low_cut = val; }
   void set_track_quality_high_cut(const double val) { m_track_quality_high_cut = val; }
 
@@ -72,6 +85,7 @@ class PHTrackPruner : public SubsysReco
   ActsGeometry *_tGeometry{nullptr};
   int m_event = 0;
 
+  std::string _cluster_map_name = "TRKR_CLUSTER";
   std::string _tpc_seed_map_name = "TpcTrackSeedContainer";
   std::string _si_seed_map_name = "SiliconTrackSeedContainer";
   std::string _svtx_seed_map_name = "SvtxTrackSeedContainer";

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -37,9 +37,6 @@ class PHTrackPruner : public SubsysReco
   //! input cluster map name. Default is TRKR_CLUSTER
   void set_cluster_map_name(const std::string &map_name) { _cluster_map_name = map_name; }
 
-  //! input seeds map name
-  void set_svtx_seed_map_name(const std::string &map_name) { _svtx_seed_map_name = map_name; }
-
   //! input silicon seeds map name
   void set_si_seed_map_name(const std::string &map_name) { _si_seed_map_name = map_name; }
 
@@ -74,11 +71,13 @@ class PHTrackPruner : public SubsysReco
   double getBunchCrossing(unsigned int trid, double z_mismatch);
 
   TrackSeedContainer *_pruned_svtx_seed_map{nullptr};
-  TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeedContainer *_tpc_seed_map{nullptr};
   TrackSeedContainer *_si_seed_map{nullptr};
+
+  // should remove
   TrackSeed *_tpc_seed{nullptr};
   TrackSeed *_si_seed{nullptr};
+
   SvtxTrackMap *_svtx_track_map{nullptr};
   SvtxTrack *_svtx_track{nullptr};
   TrkrClusterContainer *_cluster_map{nullptr};
@@ -88,7 +87,6 @@ class PHTrackPruner : public SubsysReco
   std::string _cluster_map_name = "TRKR_CLUSTER";
   std::string _tpc_seed_map_name = "TpcTrackSeedContainer";
   std::string _si_seed_map_name = "SiliconTrackSeedContainer";
-  std::string _svtx_seed_map_name = "SvtxTrackSeedContainer";
   std::string _pruned_svtx_seed_map_name = "PrunedSvtxTrackSeedContainer";
   std::string _svtx_track_map_name = "SvtxTrackMap";
 

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -74,10 +74,6 @@ class PHTrackPruner : public SubsysReco
   TrackSeedContainer *_tpc_seed_map{nullptr};
   TrackSeedContainer *_si_seed_map{nullptr};
 
-  // should remove
-  TrackSeed *_tpc_seed{nullptr};
-  TrackSeed *_si_seed{nullptr};
-
   SvtxTrackMap *_svtx_track_map{nullptr};
   SvtxTrack *_svtx_track{nullptr};
   TrkrClusterContainer *_cluster_map{nullptr};

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -24,9 +24,10 @@ class TNtuple;
 class PHTrackPruner : public SubsysReco
 {
  public:
-  PHTrackPruner(const std::string &name = "PHTrackPruner");
 
-  ~PHTrackPruner() override;
+
+  //! constructor
+  PHTrackPruner(const std::string &name = "PHTrackPruner");
 
   int InitRun(PHCompositeNode *topNode) override;
 

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -75,10 +75,8 @@ class PHTrackPruner : public SubsysReco
   TrackSeedContainer *_si_seed_map{nullptr};
 
   SvtxTrackMap *_svtx_track_map{nullptr};
-  SvtxTrack *_svtx_track{nullptr};
   TrkrClusterContainer *_cluster_map{nullptr};
   ActsGeometry *_tGeometry{nullptr};
-  int m_event = 0;
 
   std::string _cluster_map_name = "TRKR_CLUSTER";
   std::string _tpc_seed_map_name = "TpcTrackSeedContainer";

--- a/offline/packages/trackreco/PHTrackTrackSeedSynchronization.cc
+++ b/offline/packages/trackreco/PHTrackTrackSeedSynchronization.cc
@@ -103,7 +103,7 @@ int PHTrackTrackSeedSynchronization::GetNodes(PHCompositeNode *topNode)
   _svtx_track_map = findNode::getClass<SvtxTrackMap>(topNode, _svtx_track_map_name);
   if (!_svtx_track_map)
   {
-    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name.c_str() << " not found on the node tree." << endl;
+    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name << " not found on the node tree." << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -111,7 +111,7 @@ int PHTrackTrackSeedSynchronization::GetNodes(PHCompositeNode *topNode)
   _si_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _si_seed_map_name);
   if (!_si_seed_map)
   {
-    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name.c_str() << " not found on the node tree." << endl;
+    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _si_seed_map_name << " not found on the node tree." << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -119,7 +119,7 @@ int PHTrackTrackSeedSynchronization::GetNodes(PHCompositeNode *topNode)
   _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _tpc_seed_map_name);
   if (!_tpc_seed_map)
   {
-    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name.c_str() << " not found on the node tree." << endl;
+    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _tpc_seed_map_name << " not found on the node tree." << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/trackreco/PHTrackTrackSeedSynchronization.cc
+++ b/offline/packages/trackreco/PHTrackTrackSeedSynchronization.cc
@@ -1,0 +1,168 @@
+#include "PHTrackTrackSeedSynchronization.h"
+
+/// Tracking includes
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TrackFitUtils.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterv3.h>
+#include <trackbase/TrkrDefs.h>  // for cluskey, getTrkrId, tpcId
+
+#include <trackbase_historic/SvtxTrackSeed_v2.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/TrackSeed_v2.h>
+#include <trackbase_historic/TrackSeedHelper.h>
+
+#include <trackbase_historic/SvtxTrack.h>  // for SvtxTrack
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/sphenix_constants.h>
+
+#include <TF1.h>
+#include <TFile.h>
+#include <TNtuple.h>
+
+#include <climits>   // for UINT_MAX
+#include <cmath>     // for fabs, sqrt
+#include <iostream>  // for operator<<, basic_ostream
+#include <memory>
+#include <set>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
+
+using namespace std;
+
+namespace
+{
+
+  /// find index of seed in container that matches argument seed
+  size_t find_seed_id( TrackSeedContainer* container, TrackSeed* source )
+  {
+    // perform quick search
+    const size_t index = container->find( source );
+    if( index < container->size() ) return index;
+
+    // perform deep search based on cluster keys
+    using cluster_keyset_t=std::set<TrkrDefs::cluskey>;
+
+    // get cluster key set from seed
+    auto get_cluster_keyset = []( TrackSeed* seed )
+    {
+      cluster_keyset_t ckeys;
+      std::copy( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::inserter(ckeys, ckeys.end() ) );
+      return ckeys;
+    };
+
+    const auto source_ckeys = get_cluster_keyset( source );
+
+    for( size_t i = 0; i < container->size(); ++i )
+    {
+      auto* seed = container->get(i);
+      if( !seed ) continue;
+
+      const auto ckeys = get_cluster_keyset( seed );
+      if( ckeys == source_ckeys )
+      { return i; }
+    }
+
+    // error
+    std::cout << "find_seed_id - could not find seed " << source << " in container " << container << std::endl;
+    return container->size();
+  }
+
+}
+
+//____________________________________________________________________________..
+PHTrackTrackSeedSynchronization::PHTrackTrackSeedSynchronization(const std::string &name)
+  : SubsysReco(name)
+{}
+
+//____________________________________________________________________________..
+int PHTrackTrackSeedSynchronization::InitRun(PHCompositeNode *topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHTrackTrackSeedSynchronization::process_event(PHCompositeNode * /*unused*/)
+{
+  // loop over tracks and synchronize
+  for( auto &&[key,track]:*_svtx_track_map )
+  { synchronize_track(track); }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________
+bool PHTrackTrackSeedSynchronization::synchronize_track( SvtxTrack* track ) const
+{
+  {
+    // silicon seed
+    auto* seed = track->get_silicon_seed();
+    if( seed )
+    {
+      auto index = find_seed_id( _si_seed_map, seed );
+      if( index < _si_seed_map->size() )
+      { track->set_silicon_seed( _si_seed_map->get(index)); }
+    }
+  }
+
+  {
+    // tpc seed
+    auto* seed = track->get_tpc_seed();
+    if( seed )
+    {
+      auto index = find_seed_id( _tpc_seed_map, seed );
+      if( index < _tpc_seed_map->size() )
+      { track->set_tpc_seed( _tpc_seed_map->get(index)); }
+    }
+  }
+
+  return true;
+}
+
+//__________________________________________________________________________________
+int PHTrackTrackSeedSynchronization::End(PHCompositeNode * /*unused*/)
+{ return Fun4AllReturnCodes::EVENT_OK; }
+
+//__________________________________________________________________________________
+int PHTrackTrackSeedSynchronization::GetNodes(PHCompositeNode *topNode)
+{
+
+  // tracks
+  _svtx_track_map = findNode::getClass<SvtxTrackMap>(topNode, _svtx_track_map_name);
+  if (!_svtx_track_map)
+  {
+    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name.c_str() << " not found on the node tree." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // silicon seeds
+  _si_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _si_seed_map_name);
+  if (!_si_seed_map)
+  {
+    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name.c_str() << " not found on the node tree." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // tpc seeds
+  _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _tpc_seed_map_name);
+  if (!_tpc_seed_map)
+  {
+    cerr << "PHTrackTrackSeedSynchronization::GetNodes - " << _svtx_track_map_name.c_str() << " not found on the node tree." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/offline/packages/trackreco/PHTrackTrackSeedSynchronization.cc
+++ b/offline/packages/trackreco/PHTrackTrackSeedSynchronization.cc
@@ -36,46 +36,6 @@
 
 using namespace std;
 
-namespace
-{
-
-  /// find index of seed in container that matches argument seed
-  size_t find_seed_id( TrackSeedContainer* container, TrackSeed* source )
-  {
-    // perform quick search
-    const size_t index = container->find( source );
-    if( index < container->size() ) return index;
-
-    // perform deep search based on cluster keys
-    using cluster_keyset_t=std::set<TrkrDefs::cluskey>;
-
-    // get cluster key set from seed
-    auto get_cluster_keyset = []( TrackSeed* seed )
-    {
-      cluster_keyset_t ckeys;
-      std::copy( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::inserter(ckeys, ckeys.end() ) );
-      return ckeys;
-    };
-
-    const auto source_ckeys = get_cluster_keyset( source );
-
-    for( size_t i = 0; i < container->size(); ++i )
-    {
-      auto* seed = container->get(i);
-      if( !seed ) continue;
-
-      const auto ckeys = get_cluster_keyset( seed );
-      if( ckeys == source_ckeys )
-      { return i; }
-    }
-
-    // error
-    std::cout << "find_seed_id - could not find seed " << source << " in container " << container << std::endl;
-    return container->size();
-  }
-
-}
-
 //____________________________________________________________________________..
 PHTrackTrackSeedSynchronization::PHTrackTrackSeedSynchronization(const std::string &name)
   : SubsysReco(name)
@@ -166,3 +126,47 @@ int PHTrackTrackSeedSynchronization::GetNodes(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+
+//__________________________________________________________________________________
+size_t PHTrackTrackSeedSynchronization::find_seed_id( TrackSeedContainer* container, TrackSeed* source ) const
+{
+  // perform quick search
+  const size_t index = container->find( source );
+  if( index < container->size() ) return index;
+
+  // perform deep search based on cluster keys
+  if( Verbosity() )
+  { std::cout << "PHTrackTrackSeedSynchronization::find_seed_id - performing deep search for seed " << source << " in container " << container << std::endl; }
+
+  using cluster_keyset_t=std::set<TrkrDefs::cluskey>;
+
+  // get cluster key set from seed
+  auto get_cluster_keyset = [this]( TrackSeed* seed )
+  {
+    cluster_keyset_t ckeys;
+    if( m_ignore_micromegas )
+    {
+      std::copy_if( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::inserter(ckeys, ckeys.end() ),
+        []( const TrkrDefs::cluskey& ckey ) { return TrkrDefs::getTrkrId(ckey) != TrkrDefs::micromegasId; } );
+    } else {
+      std::copy( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::inserter(ckeys, ckeys.end() ) );
+    }
+    return ckeys;
+
+  };
+
+  const auto source_ckeys = get_cluster_keyset( source );
+  for( size_t i = 0; i < container->size(); ++i )
+  {
+    auto* seed = container->get(i);
+    if( !seed ) continue;
+
+    const auto ckeys = get_cluster_keyset( seed );
+    if( ckeys == source_ckeys )
+    { return i; }
+  }
+
+  // error
+  std::cout << "PHTrackTrackSeedSynchronization::find_seed_id - could not find seed " << source << " in container " << container << std::endl;
+  return container->size();
+}

--- a/offline/packages/trackreco/PHTrackTrackSeedSynchronization.h
+++ b/offline/packages/trackreco/PHTrackTrackSeedSynchronization.h
@@ -41,12 +41,18 @@ class PHTrackTrackSeedSynchronization : public SubsysReco
   //! input track map name
   void set_svtx_track_map_name(const std::string &map_name) { _svtx_track_map_name = map_name; }
 
+  //! ignore micromegas
+  void set_ignore_micromegas( bool value ) { m_ignore_micromegas = value; }
+
   private:
 
   int GetNodes(PHCompositeNode*);
 
   /// make sure that the track seed pointers stored in track correspond to those store in the seed containers
   bool synchronize_track(SvtxTrack*) const;
+
+  /// find index of seed in container that matches argument seed
+  size_t find_seed_id( TrackSeedContainer*, TrackSeed* ) const;
 
   TrackSeedContainer *_tpc_seed_map{nullptr};
   TrackSeedContainer *_si_seed_map{nullptr};
@@ -55,6 +61,8 @@ class PHTrackTrackSeedSynchronization : public SubsysReco
   std::string _tpc_seed_map_name = "TpcTrackSeedContainer";
   std::string _si_seed_map_name = "SiliconTrackSeedContainer";
   std::string _svtx_track_map_name = "SvtxTrackMap";
+
+  bool m_ignore_micromegas = false;
 
 };
 

--- a/offline/packages/trackreco/PHTrackTrackSeedSynchronization.h
+++ b/offline/packages/trackreco/PHTrackTrackSeedSynchronization.h
@@ -1,0 +1,61 @@
+#ifndef PHTRACKTRACKSEEDSYNCHRONIZATION_H
+#define PHTRACKTRACKSEEDSYNCHRONIZATION_H
+
+#include <fun4all/SubsysReco.h>
+#include <phparameter/PHParameterInterface.h>
+#include <trackbase/ActsGeometry.h>
+
+#include <map>
+#include <string>
+
+class PHCompositeNode;
+class TrackSeedContainer;
+class TrackSeed;
+class SvtxTrackSeed;
+class SvtxTrackMap;
+class SvtxTrack;
+class TrkrClusterContainer;
+class TF1;
+class TFile;
+class TNtuple;
+
+class PHTrackTrackSeedSynchronization : public SubsysReco
+{
+ public:
+
+  //! constructor
+  PHTrackTrackSeedSynchronization(const std::string& = "PHTrackTrackSeedSynchronization");
+
+  int InitRun(PHCompositeNode *topNode) override;
+
+  int process_event(PHCompositeNode *) override;
+
+  int End(PHCompositeNode *) override;
+
+  //! input silicon seeds map name
+  void set_si_seed_map_name(const std::string &map_name) { _si_seed_map_name = map_name; }
+
+  //! input tpc seeds map name
+  void set_tpc_seed_map_name(const std::string &map_name) { _tpc_seed_map_name = map_name; }
+
+  //! input track map name
+  void set_svtx_track_map_name(const std::string &map_name) { _svtx_track_map_name = map_name; }
+
+  private:
+
+  int GetNodes(PHCompositeNode*);
+
+  /// make sure that the track seed pointers stored in track correspond to those store in the seed containers
+  bool synchronize_track(SvtxTrack*) const;
+
+  TrackSeedContainer *_tpc_seed_map{nullptr};
+  TrackSeedContainer *_si_seed_map{nullptr};
+  SvtxTrackMap *_svtx_track_map{nullptr};
+
+  std::string _tpc_seed_map_name = "TpcTrackSeedContainer";
+  std::string _si_seed_map_name = "SiliconTrackSeedContainer";
+  std::string _svtx_track_map_name = "SvtxTrackMap";
+
+};
+
+#endif  //  PHTrackTrackSeedSynchronization_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

There is a problem with our current Track DSTs. They store SvtxTrackMap as well as the TPC and silicon seed containers. However, because the tracks in the map reference seeds by pointers, and because root does not preserve pointers when writting to/reading from a rootfile, it is impossible to get the right seed in the seedcontainer from the pointer stored in the track. 

This is generally harmless, but breaks Xundons' TrackPruner, that is used in the track-based distortion workflow. 

This PR: 
- cleans up a few unnecessary members in PHTrackPruner;
- allow to specify the cluster map name in a number of modules so that they can run on TRKR_CLUSTER_SEED map instead of TRKR_CLUSTER
- adds a new subsysreco, PHTrackTrackSeedSynchronization that re-sync the seeds stored in the tracks with those stored in the Seed container, by doing a "deep" find, based on the seeds associated clusters keys. 

This allows to run the track-based distortion workflow on already produced Track DSTs. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This PR fixes a critical issue in Track DSTs where tracks store pointers to seeds that are not preserved by ROOT when writing to and reading from files. This causes incorrect seeds to be retrieved when accessing seed containers by stored pointers, breaking the track-based distortion workflow, particularly in downstream modules like TrackPruner. The PR enables track-based distortion to work on pre-existing Track DSTs with this pointer synchronization issue.

## Key Changes

- **Code Cleanup in PHTrackPruner**: Removed unnecessary class members (`svtx_seed_map`, associated seed/track pointers, `m_event` counter) and trivial destructor. Refactored seed access to use local pointers instead of persistent members, reducing memory footprint and node dependencies.

- **Cluster Map Name Configurability**: Added `set_cluster_map_name()` configuration methods to PHTrackPruner, PHTpcResiduals, and other modules to enable flexible cluster container naming. This allows modules to operate on `TRKR_CLUSTER_SEED` directly from Track DSTs without requiring separate Cluster DSTs to be loaded.

- **New PHTrackTrackSeedSynchronization Module**: Introduced a new SubsysReco module that re-synchronizes track-stored seed pointers with those in the seed containers:
  - Uses a two-stage lookup strategy: first attempts direct pointer lookup via `container->find()`, then performs a deep search based on cluster keys
  - Implements cluster key set comparison: extracts cluster keys from seeds and matches them across containers
  - Supports optional filtering of micromegas clusters during key comparison via `set_ignore_micromegas()` flag
  - Processes all tracks per event, updating both silicon and TPC seed references

## Potential Risk Areas

- **Reconstruction Behavior Changes**: The synchronization module alters how seed references are resolved in tracks, which could affect downstream reconstruction if the matching algorithm produces unexpected results (e.g., matching wrong seeds with identical cluster key sets).

- **Performance Impact**: The deep search through cluster key sets could be computationally expensive for events with many seeds. This is mitigated by attempting quick pointer lookup first, but events with pointer mismatches will incur full container scans.

- **I/O Format Implications**: While this PR doesn't change file formats, it works around an existing ROOT serialization issue. The synchronization assumes that cluster keys remain valid and consistent—invalid or inconsistent cluster information could break the matching algorithm.

- **Subtle Pointer Issues**: Error messages in `GetNodes()` contain what appears to be a copy-paste error (using `_svtx_track_map_name` for all three seed/track container messages), which could make debugging difficult if node lookups fail.

## Possible Future Improvements

- Correct error messaging in `PHTrackTrackSeedSynchronization::GetNodes()` to report the actual container name that failed to load
- Profile cluster key comparison performance on large event samples to assess whether additional optimization (e.g., caching, hashing) is needed
- Consider adding configuration option to control deep-search verbosity or logging behavior separately from module verbosity level
- Extend configurability of cluster map names to other modules that may depend on cluster containers

**Note**: AI-generated summaries can contain errors. This summary should be validated against actual code changes and tested in realistic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->