### PR TITLE
Waveform fitting cleanup

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -73,7 +73,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   std::string templatefilename = std::string(calibroot) + "/CaloWaveSim/" + m_templatefile;
   TFile *ft = TFile::Open(templatefilename.c_str());
   assert(ft && ft->IsOpen());
-  ft->GetObject("hpwaveform",h_template);
+  ft->GetObject("hpwaveform", h_template);
 
   m_runNumber = recoConsts::instance()->get_IntFlag("RUNNUMBER");
   if (Verbosity() > 0)
@@ -138,7 +138,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
     {
       if (Verbosity() > 2)
       {
-	std::cout << PHWHERE << Name() << ": replacing calib name with " << m_calibName << std::endl;
+        std::cout << PHWHERE << Name() << ": replacing calib name with " << m_calibName << std::endl;
       }
     }
     m_directURL = CDBInterface::instance()->getUrl(m_calibName);
@@ -175,20 +175,18 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   // MC energy calibration (optional)
   if (m_directURL_MC.empty())
   {
-  if (m_MC_calibName.empty())
-  {
-    m_MC_calibName = m_detector + "_MC_RECALIB";
-  }
+    if (m_MC_calibName.empty())
+    {
+      m_MC_calibName = m_detector + "_MC_RECALIB";
+    }
     else
     {
       if (Verbosity() > 2)
       {
-	std::cout << PHWHERE << Name() << ": replacing MC calib name with " << m_MC_calibName  << std::endl;
+        std::cout << PHWHERE << Name() << ": replacing MC calib name with " << m_MC_calibName << std::endl;
       }
     }
-  std::cout << PHWHERE << Name() << ": m_MC_calibName: " << m_MC_calibName
-	    << ", m_MC_fieldname: " << m_MC_fieldname << std::endl;
-  m_directURL_MC = CDBInterface::instance()->getUrl(m_MC_calibName);
+    m_directURL_MC = CDBInterface::instance()->getUrl(m_MC_calibName);
   }
   else
   {
@@ -217,55 +215,57 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
       std::cout << PHWHERE << Name() << ": using " << m_MC_fieldname << " as MC fieldname" << std::endl;
     }
   }
-  std::string url;
+
   // Time calibration (data)
-  if (!m_overrideTimeCalibName)
-  {
-    m_calibName_time = m_detector + "_meanTime";
-  }
-  if (m_giveDirectURL_time)
-  {
-    url = m_directURL_time;
-  }
-  else
-  {
-    url = CDBInterface::instance()->getUrl(m_calibName_time);
-    if (url.empty())
-    {
-      if (m_dotimecalib)
-      {
-        std::cerr << "CaloWaveformSim::InitRun No time calibration for " << m_calibName_time << std::endl;
-        exit(1);
-      }
-    }
-  }
   if (m_dotimecalib)
   {
-    cdbttree_time = new CDBTTree(url);
-  }
-  if (Verbosity() > 0 && m_dotimecalib)
-  {
-    std::cout << "CaloWaveformSim::InitRun Time calibration from " << url << std::endl;
-  }
-
-  // Time calibration (MC)
-  if (!m_overrideMCTimeCalibName)
-  {
-    m_MC_calibName_time = m_detector + "_MC_meanTime";
-  }
-  if (m_giveDirectURL_MC_time)
-  {
-    url = m_directURL_MC_time;
-    cdbttree_MC_time = new CDBTTree(url);
-  }
-  else
-  {
-    url = CDBInterface::instance()->getUrl(m_MC_calibName_time);
-    if (!url.empty())
+    if (m_directURL_time.empty())
     {
-      cdbttree_MC_time = new CDBTTree(url);
+      if (m_calibName_time.empty())
+      {
+        m_calibName_time = m_detector + "_meanTime";
+      }
+      else
+      {
+        if (Verbosity() > 2)
+        {
+          std::cout << PHWHERE << Name() << ": replacing calib name with " << m_calibName << std::endl;
+        }
+      }
+      m_directURL_time = CDBInterface::instance()->getUrl(m_calibName_time);
     }
-    else if (m_dotimecalib)
+    else
+    {
+      if (Verbosity() > 2)
+      {
+        std::cout << PHWHERE << Name() << ": using " << m_directURL_time << " as direct time cdb file" << std::endl;
+      }
+    }
+    if (m_directURL_time.empty())
+    {
+      std::cout << "CaloWaveformSim::InitRun No time calibration for " << m_calibName_time << std::endl;
+      exit(1);
+    }
+
+    cdbttree_time = new CDBTTree(m_directURL_time);
+    if (Verbosity() > 0 && m_dotimecalib)
+    {
+      std::cout << "CaloWaveformSim::InitRun Time calibration from " << m_directURL_time << std::endl;
+    }
+    // Time calibration (MC)
+    if (m_directURL_MC_time.empty())
+    {
+      if (m_MC_calibName_time.empty())
+      {
+        m_MC_calibName_time = m_detector + "_MC_meanTime";
+      }
+      m_directURL_MC_time = CDBInterface::instance()->getUrl(m_MC_calibName_time);
+    }
+    if (!m_directURL_MC_time.empty())
+    {
+      cdbttree_MC_time = new CDBTTree(m_directURL_MC_time);
+    }
+    else
     {
       std::cerr << "CaloWaveformSim::InitRun No MC time calibration for " << m_MC_calibName_time << std::endl;
       exit(1);
@@ -346,8 +346,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     exit(1);
   }
 
-  std::map<unsigned int,float> tbt_smear;
-
+  std::map<unsigned int, float> tbt_smear;
 
   // loop over hits
   for (PHG4HitContainer::ConstIterator hititer = hits->getHits().first; hititer != hits->getHits().second; hititer++)
@@ -373,13 +372,13 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     {
       auto it = tbt_smear.find(key);
 
-      if(it != tbt_smear.end())
+      if (it != tbt_smear.end())
       {
         e_vis *= it->second;
       }
       else
       {
-        tbt_smear[key] =  1.0+ gsl_ran_gaussian(m_RandomGenerator,factor_const);
+        tbt_smear[key] = 1.0 + gsl_ran_gaussian(m_RandomGenerator, factor_const);
         e_vis *= tbt_smear[key];
       }
     }
@@ -405,7 +404,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     float t0 = hit->get_t(0) / m_sampletime;
     unsigned int tower_index = decode_tower(key);
     // here I will add the truth matching part
-    //  for the cell reco, the truth matching info relys on edep not light yield, I will be consistent here :)
+    //  for the cell reco, the truth matching info relies on edep not light yield, I will be consistent here :)
     TowerInfo *tower = m_CaloWaveformContainer->get_tower_at_channel(tower_index);
     TowerInfo::EdepMap &edepMap = tower->get_hitEdepMap();
     TowerInfo::ShowerEdepMap &showerMap = tower->get_showerEdepMap();
@@ -474,7 +473,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
         m_waveforms.at(i).at(j) += m_fixpedestal;
       }
       // saturate at 2^14 - 1 and make sure values are >= 0
-      auto& sample = m_waveforms.at(i).at(j);
+      auto &sample = m_waveforms.at(i).at(j);
       sample = std::clamp(sample, 0.F, 16383.F);
       m_CaloWaveformContainer->get_tower_at_channel(i)->set_waveform_value(j, m_waveforms.at(i).at(j));
     }
@@ -543,13 +542,6 @@ void CaloWaveformSim::maphitetaphi(PHG4Hit *g4hit, unsigned short &etabin, unsig
     gSystem->Exit(1);
     exit(1);
   }
-}
-
-//____________________________________________________________________________..
-int CaloWaveformSim::End(PHCompositeNode * /*topNode*/)
-{
-  std::cout << "CaloWaveformSim::End(PHCompositeNode *topNode) This is the End..." << std::endl;
-  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 void CaloWaveformSim::CreateNodeTree(PHCompositeNode *topNode)

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -421,10 +421,9 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       {
         m_waveforms.at(i).at(j) += m_fixpedestal;
       }
-      // saturate at 2^14 - 1
-      m_waveforms.at(i).at(j) = std::min<__gnu_cxx::__alloc_traits<class std::allocator<float> >::value_type>(m_waveforms.at(i).at(j), 16383);
-      m_waveforms.at(i).at(j) = std::max<__gnu_cxx::__alloc_traits<class std::allocator<float> >::value_type>(m_waveforms.at(i).at(j), 0);
-
+      // saturate at 2^14 - 1 and make sure values are >= 0
+      auto& sample = m_waveforms.at(i).at(j);
+      sample = std::clamp(sample, 0.F, 16383.F);
       m_CaloWaveformContainer->get_tower_at_channel(i)->set_waveform_value(j, m_waveforms.at(i).at(j));
     }
   }

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -6,39 +6,43 @@
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4HitDefs.h>  // for hit_idbits
-#include <g4main/PHG4Particle.h>
-#include <g4main/PHG4TruthInfoContainer.h>
 
 #include <cdbobjects/CDBTTree.h>  // for CDBTTree
 
 #include <ffamodules/CDBInterface.h>
 
-#include <ffaobjects/EventHeader.h>
-
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
+#include <phool/phool.h>
 #include <phool/recoConsts.h>
 
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfoContainerSimv2.h>
 
+#include <caloreco/CaloTowerDefs.h>
+
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 #include <g4detectors/PHG4CylinderCellGeom_Spacalv1.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
-#include <g4detectors/PHG4CylinderGeom_Spacalv1.h>  // for PHG4CylinderGeom_Spaca...
 #include <g4detectors/PHG4CylinderGeom_Spacalv3.h>
 
 #include <TF1.h>
 #include <TFile.h>
 #include <TProfile.h>
 #include <TSystem.h>
-#include <TTree.h>
+
+#include <gsl/gsl_randist.h>
+
 #include <algorithm>
 #include <cassert>
-#include <sstream>
-#include <string>
+#include <cstdlib>
+#include <cmath>
+#include <iostream>
+#include <map>
 
 double CaloWaveformSim::template_function(double *x, double *par)
 {

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -67,7 +67,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   const char *calibroot = getenv("CALIBRATIONROOT");
   if (!calibroot)
   {
-    std::cerr << "CaloWaveformSim::InitRun missing CALIBRATIONROOT" << std::endl;
+    std::cout << "CaloWaveformSim::InitRun missing CALIBRATIONROOT" << std::endl;
     exit(1);
   }
   std::string templatefilename = std::string(calibroot) + "/CaloWaveSim/" + m_templatefile;
@@ -82,7 +82,6 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   }
 
   // Detector-specific setup
-  std::string url;
   if (m_dettype == CaloTowerDefs::CEMC)
   {
     m_detector = "CEMC";
@@ -127,17 +126,40 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   }
 
   // Data energy calibration
-  if (m_calibName.empty())
+  // First check if the url is overridden in the macro (default is empty)
+  // Then check if the calibration name is overridden in the macro (default is empty)
+  if (m_directURL.empty())
   {
-    m_calibName = m_detector + "_calib_ADC_to_ETower";
+    if (m_calibName.empty())
+    {
+      m_calibName = m_detector + "_calib_ADC_to_ETower";
+    }
+    else
+    {
+      if (Verbosity() > 2)
+      {
+	std::cout << PHWHERE << Name() << ": using " << m_calibName << " as calib name" << std::endl;
+      }
+    }
+    m_directURL = CDBInterface::instance()->getUrl(m_calibName);
   }
   else
   {
     if (Verbosity() > 2)
     {
-      std::cout << PHWHERE << " using " << m_calibName << " as calib name" << std::endl;
+      std::cout << PHWHERE << Name() << ": using " << m_directURL << " as cdb file" << std::endl;
     }
   }
+  if (!m_directURL.empty())
+  {
+    cdbttree = new CDBTTree(m_directURL);
+  }
+  else
+  {
+    std::cout << Name() << ": CaloWaveformSim::InitRun No data calibration for " << m_calibName << std::endl;
+    exit(1);
+  }
+  // check if the fieldname was overridden in the macro (default is empty), otherwise set it
   if (m_fieldname.empty())
   {
     m_fieldname = m_detector + "_calib_ADC_to_ETower";
@@ -146,18 +168,8 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   {
     if (Verbosity() > 2)
     {
-      std::cout << PHWHERE << " using " << m_fieldname << " as fieldname" << std::endl;
+      std::cout << PHWHERE << Name() << ": using " << m_fieldname << " as fieldname" << std::endl;
     }
-  }
-  url = m_giveDirectURL ? m_directURL : CDBInterface::instance()->getUrl(m_calibName);
-  if (!url.empty())
-  {
-    cdbttree = new CDBTTree(url);
-  }
-  else
-  {
-    std::cerr << "CaloWaveformSim::InitRun No data calibration for " << m_calibName << std::endl;
-    exit(1);
   }
 
   // MC energy calibration (optional)
@@ -169,7 +181,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   {
     m_MC_fieldname = m_detector + "_calib_ADC_to_ETower";
   }
-  url = m_giveDirectURL_MC ? m_directURL_MC : CDBInterface::instance()->getUrl(m_MC_calibName);
+  std::string url = m_giveDirectURL_MC ? m_directURL_MC : CDBInterface::instance()->getUrl(m_MC_calibName);
   if (!url.empty())
   {
     cdbttree_MC = new CDBTTree(url);

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -138,7 +138,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
     {
       if (Verbosity() > 2)
       {
-	std::cout << PHWHERE << Name() << ": using " << m_calibName << " as calib name" << std::endl;
+	std::cout << PHWHERE << Name() << ": replacing calib name with " << m_calibName << std::endl;
       }
     }
     m_directURL = CDBInterface::instance()->getUrl(m_calibName);
@@ -147,7 +147,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   {
     if (Verbosity() > 2)
     {
-      std::cout << PHWHERE << Name() << ": using " << m_directURL << " as cdb file" << std::endl;
+      std::cout << PHWHERE << Name() << ": using " << m_directURL << " as direct cdb file" << std::endl;
     }
   }
   if (!m_directURL.empty())
@@ -168,29 +168,56 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   {
     if (Verbosity() > 2)
     {
-      std::cout << PHWHERE << Name() << ": using " << m_fieldname << " as fieldname" << std::endl;
+      std::cout << PHWHERE << Name() << ": replacing fieldname with " << m_fieldname << std::endl;
     }
   }
 
   // MC energy calibration (optional)
-  if (!m_overrideMCCalibName)
+  if (m_directURL_MC.empty())
+  {
+  if (m_MC_calibName.empty())
   {
     m_MC_calibName = m_detector + "_MC_RECALIB";
   }
-  if (!m_overrideMCFieldName)
-  {
-    m_MC_fieldname = m_detector + "_calib_ADC_to_ETower";
+    else
+    {
+      if (Verbosity() > 2)
+      {
+	std::cout << PHWHERE << Name() << ": replacing MC calib name with " << m_MC_calibName  << std::endl;
+      }
+    }
+  std::cout << PHWHERE << Name() << ": m_MC_calibName: " << m_MC_calibName
+	    << ", m_MC_fieldname: " << m_MC_fieldname << std::endl;
+  m_directURL_MC = CDBInterface::instance()->getUrl(m_MC_calibName);
   }
-  std::string url = m_giveDirectURL_MC ? m_directURL_MC : CDBInterface::instance()->getUrl(m_MC_calibName);
-  if (!url.empty())
+  else
   {
-    cdbttree_MC = new CDBTTree(url);
+    if (Verbosity() > 2)
+    {
+      std::cout << PHWHERE << Name() << ": using " << m_directURL_MC << " as direct MC cdb file" << std::endl;
+    }
+  }
+  if (!m_directURL_MC.empty())
+  {
+    cdbttree_MC = new CDBTTree(m_directURL_MC);
   }
   else if (Verbosity() > 0)
   {
     std::cout << "CaloWaveformSim::InitRun No MC calibration for " << m_MC_calibName << std::endl;
   }
 
+  if (m_MC_fieldname.empty())
+  {
+    m_MC_fieldname = m_detector + "_calib_ADC_to_ETower";
+  }
+  else
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << PHWHERE << Name() << ": using " << m_MC_fieldname << " as MC fieldname" << std::endl;
+    }
+  }
+  std::string url;
   // Time calibration (data)
   if (!m_overrideTimeCalibName)
   {

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -58,6 +58,11 @@ CaloWaveformSim::CaloWaveformSim(const std::string &name)
 CaloWaveformSim::~CaloWaveformSim()
 {
   gsl_rng_free(m_RandomGenerator);
+  delete cdbttree;
+  delete cdbttree_MC;
+  delete cdbttree_time;
+  delete cdbttree_MC_time;
+  delete h_template;
 }
 
 int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
@@ -78,6 +83,12 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   TFile *ft = TFile::Open(templatefilename.c_str());
   assert(ft && ft->IsOpen());
   ft->GetObject("hpwaveform", h_template);
+  if (!h_template)
+  {
+    std::cout << "Could not get hpwaveform TProfile from " << templatefilename << std::endl;
+    gSystem->Exit(1);
+  }
+  h_template->SetDirectory(nullptr);
 
   m_runNumber = recoConsts::instance()->get_IntFlag("RUNNUMBER");
   if (Verbosity() > 0)
@@ -102,7 +113,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
     m_sampling_fraction = 0.162166;
     m_nchannels = 1536;
   }
-  else  // HCALOUT
+  else  if (m_dettype == CaloTowerDefs::HCALOUT)
   {
     m_detector = "HCALOUT";
     encode_tower = TowerInfoDefs::encode_hcal;
@@ -110,7 +121,11 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
     m_sampling_fraction = 3.38021e-02;
     m_nchannels = 1536;
   }
-
+  else
+  {
+    std::cout << PHWHERE << " Invalid detector type " << m_dettype << ", must call set_dettype() first" << std::endl;
+    exit(1);
+  }
   // Gain settings
   // nobody understands this construct, please keep in mind that other
   // people have to read this and figure out what it does

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -18,6 +18,7 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
+#include <phool/recoConsts.h>
 
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
@@ -72,11 +73,9 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   std::string templatefilename = std::string(calibroot) + "/CaloWaveSim/" + m_templatefile;
   TFile *ft = TFile::Open(templatefilename.c_str());
   assert(ft && ft->IsOpen());
-  h_template = static_cast<TProfile *>(ft->Get("hpwaveform"));
+  ft->GetObject("hpwaveform",h_template);
 
-  // Determine run number
-  EventHeader *evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader");
-  m_runNumber = evtHeader ? evtHeader->get_RunNumber() : -1;
+  m_runNumber = recoConsts::instance()->get_IntFlag("RUNNUMBER");
   if (Verbosity() > 0)
   {
     std::cout << "CaloWaveformSim::InitRun Run Number: " << m_runNumber << std::endl;
@@ -128,13 +127,27 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
   }
 
   // Data energy calibration
-  if (!m_overrideCalibName)
+  if (m_calibName.empty())
   {
     m_calibName = m_detector + "_calib_ADC_to_ETower";
   }
-  if (!m_overrideFieldName)
+  else
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << PHWHERE << " using " << m_calibName << " as calib name" << std::endl;
+    }
+  }
+  if (m_fieldname.empty())
   {
     m_fieldname = m_detector + "_calib_ADC_to_ETower";
+  }
+  else
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << PHWHERE << " using " << m_fieldname << " as fieldname" << std::endl;
+    }
   }
   url = m_giveDirectURL ? m_directURL : CDBInterface::instance()->getUrl(m_calibName);
   if (!url.empty())

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -10,12 +10,16 @@
 #ifndef G4WAVEFORMSIM_CALOWAVEFORMSIM_H
 #define G4WAVEFORMSIM_CALOWAVEFORMSIM_H
 
+#include <fun4all/SubsysReco.h>
+
 #include <calobase/TowerInfoDefs.h>
 #include <caloreco/CaloTowerDefs.h>
-#include <fun4all/SubsysReco.h>
+
 #include <g4detectors/LightCollectionModel.h>
+
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
+
 #include <string>
 #include <vector>
 
@@ -46,20 +50,16 @@ class CaloWaveformSim : public SubsysReco
   void set_fieldname(const std::string &fieldname)
   {
     m_fieldname = fieldname;
-    m_overrideFieldName = true;
   }
   void set_calibName(const std::string &calibName)
   {
     m_calibName = calibName;
-    m_overrideCalibName = true;
   }
   void set_directURL_calib(const std::string &url)
   {
     m_giveDirectURL = true;
     m_directURL = url;
   }
-  void set_overrideCalibName(bool overrideCalib) { m_overrideCalibName = overrideCalib; }
-  void set_overrideFieldName(bool overrideField) { m_overrideFieldName = overrideField; }
 
   // Calibration settings (MC energy)
   void set_MC_fieldname(const std::string &MC_fieldname)
@@ -159,19 +159,17 @@ class CaloWaveformSim : public SubsysReco
   std::string m_detector{"CEMC"};
 
   // Data energy calibration
-  std::string m_fieldname{"Femc_datadriven_qm1_correction"};
-  std::string m_calibName{"cemc_pi0_twrSlope_v1"};
-  bool m_overrideCalibName{false};
-  bool m_overrideFieldName{false};
+  std::string m_fieldname;
+  std::string m_calibName;
   bool m_giveDirectURL{false};
-  std::string m_directURL{""};
+  std::string m_directURL;
   // MC energy calibration
   std::string m_MC_fieldname{"Femc_datadriven_qm1_correction"};
   std::string m_MC_calibName{"cemc_pi0_twrSlope_v1"};
   bool m_overrideMCFieldName{false};
   bool m_overrideMCCalibName{false};
   bool m_giveDirectURL_MC{false};
-  std::string m_directURL_MC{""};
+  std::string m_directURL_MC;
 
   bool m_smear_const{false};
   float factor_const{0.};
@@ -183,14 +181,14 @@ class CaloWaveformSim : public SubsysReco
   bool m_overrideTimeCalibName{false};
   bool m_dotimecalib{true};
   bool m_giveDirectURL_time{false};
-  std::string m_directURL_time{""};
+  std::string m_directURL_time;
   // MC time calibration
   std::string m_MC_fieldname_time{"time"};
   std::string m_MC_calibName_time{"CEMC_meanTime"};
   bool m_overrideMCTimeFieldName{false};
   bool m_overrideMCTimeCalibName{false};
   bool m_giveDirectURL_MC_time{false};
-  std::string m_directURL_MC_time{""};
+  std::string m_directURL_MC_time;
 
   // Waveform settings
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
@@ -223,8 +221,10 @@ class CaloWaveformSim : public SubsysReco
   unsigned int (*encode_tower)(unsigned int, unsigned int){TowerInfoDefs::encode_emcal};
   unsigned int (*decode_tower)(unsigned int){TowerInfoDefs::decode_emcal};
 
-  CDBTTree *cdbttree{nullptr}, *cdbttree_MC{nullptr};
-  CDBTTree *cdbttree_time{nullptr}, *cdbttree_MC_time{nullptr};
+  CDBTTree *cdbttree{nullptr};
+  CDBTTree *cdbttree_MC{nullptr};
+  CDBTTree *cdbttree_time{nullptr};
+  CDBTTree *cdbttree_MC_time{nullptr};
   TProfile *h_template{nullptr};
   LightCollectionModel light_collection_model;
 

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -17,7 +17,6 @@
 
 #include <g4detectors/LightCollectionModel.h>
 
-#include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
 
 #include <string>
@@ -28,7 +27,6 @@ class TProfile;
 class PHG4Hit;
 class PHG4CylinderCellGeom_Spacalv1;
 class PHG4CylinderGeom_Spacalv3;
-class TTree;
 class CDBTTree;
 class TowerInfoContainer;
 
@@ -77,7 +75,6 @@ class CaloWaveformSim : public SubsysReco
   void set_fieldname_time(const std::string &fieldname_time)
   {
     m_fieldname_time = fieldname_time;
-    m_overrideTimeFieldName = true;
   }
   void set_calibName_time(const std::string &calibName_time)
   {
@@ -85,7 +82,6 @@ class CaloWaveformSim : public SubsysReco
   }
   void set_directURL_timecalib(const std::string &url)
   {
-    m_giveDirectURL_time = true;
     m_directURL_time = url;
   }
   void set_dotimecalib(bool dotimecalib) { m_dotimecalib = dotimecalib; }
@@ -151,7 +147,22 @@ class CaloWaveformSim : public SubsysReco
   unsigned int (*encode_tower)(unsigned int, unsigned int){TowerInfoDefs::encode_emcal};
   unsigned int (*decode_tower)(unsigned int){TowerInfoDefs::decode_emcal};
 
+  // containers
+  TowerInfoContainer *m_CaloWaveformContainer{nullptr};
+  TowerInfoContainer *m_PedestalContainer{nullptr};
+
+  CDBTTree *cdbttree{nullptr};
+  CDBTTree *cdbttree_MC{nullptr};
+  CDBTTree *cdbttree_time{nullptr};
+  CDBTTree *cdbttree_MC_time{nullptr};
+  TProfile *h_template{nullptr};
+
+  gsl_rng *m_RandomGenerator{nullptr};
+  PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};
+  const PHG4CylinderGeom_Spacalv3 *layergeom{nullptr};
+
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
+
   std::string m_detector;
 
   // Data energy calibration
@@ -170,14 +181,13 @@ class CaloWaveformSim : public SubsysReco
   // Data time calibration
   std::string m_fieldname_time{"time"};
   std::string m_calibName_time;
-  bool m_overrideTimeFieldName{false};
-  bool m_dotimecalib{true};
-  bool m_giveDirectURL_time{false};
   std::string m_directURL_time;
   // MC time calibration
   std::string m_MC_fieldname_time{"time"};
   std::string m_MC_calibName_time;
   std::string m_directURL_MC_time;
+
+  bool m_dotimecalib{true};
 
   // Waveform settings
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
@@ -186,10 +196,6 @@ class CaloWaveformSim : public SubsysReco
   float m_sampletime{50. / 3.};
   int m_nchannels{24576};
   float m_sampling_fraction{1.0f};
-
-  // containers
-  TowerInfoContainer *m_CaloWaveformContainer{nullptr};
-  TowerInfoContainer *m_PedestalContainer{nullptr};
 
   // Shaping & noise
   int m_fixpedestal{1500};
@@ -201,17 +207,9 @@ class CaloWaveformSim : public SubsysReco
   float m_peakpos{6.};
   float m_pedestal_scale{1.};
 
-  gsl_rng *m_RandomGenerator{nullptr};
-  PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};
-  const PHG4CylinderGeom_Spacalv3 *layergeom{nullptr};
   std::vector<std::vector<float>> m_waveforms;
   int m_runNumber{0};
 
-  CDBTTree *cdbttree{nullptr};
-  CDBTTree *cdbttree_MC{nullptr};
-  CDBTTree *cdbttree_time{nullptr};
-  CDBTTree *cdbttree_MC_time{nullptr};
-  TProfile *h_template{nullptr};
   LightCollectionModel light_collection_model;
 
   NoiseType m_noiseType{NOISE_TREE};

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -64,20 +64,15 @@ class CaloWaveformSim : public SubsysReco
   void set_MC_fieldname(const std::string &MC_fieldname)
   {
     m_MC_fieldname = MC_fieldname;
-    m_overrideMCFieldName = true;
   }
   void set_MC_calibName(const std::string &MC_calibName)
   {
     m_MC_calibName = MC_calibName;
-    m_overrideMCCalibName = true;
   }
   void set_directURL_MCcalib(const std::string &url)
   {
-    m_giveDirectURL_MC = true;
     m_directURL_MC = url;
   }
-  void set_overrideMCFieldName(bool overrideField) { m_overrideMCFieldName = overrideField; }
-  void set_overrideMCCalibName(bool overrideCalib) { m_overrideMCCalibName = overrideCalib; }
 
   // Time calibration (data)
   void set_fieldname_time(const std::string &fieldname_time)
@@ -165,9 +160,6 @@ class CaloWaveformSim : public SubsysReco
   // MC energy calibration
   std::string m_MC_fieldname;
   std::string m_MC_calibName;
-  bool m_overrideMCFieldName{false};
-  bool m_overrideMCCalibName{false};
-  bool m_giveDirectURL_MC{false};
   std::string m_directURL_MC;
 
   bool m_smear_const{false};

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -40,7 +40,6 @@ class CaloWaveformSim : public SubsysReco
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  int End(PHCompositeNode *topNode) override;
 
   // Detector configuration
   void set_detector_type(CaloTowerDefs::DetectorSystem dettype) { m_dettype = dettype; }
@@ -83,7 +82,6 @@ class CaloWaveformSim : public SubsysReco
   void set_calibName_time(const std::string &calibName_time)
   {
     m_calibName_time = calibName_time;
-    m_overrideTimeCalibName = true;
   }
   void set_directURL_timecalib(const std::string &url)
   {
@@ -91,23 +89,18 @@ class CaloWaveformSim : public SubsysReco
     m_directURL_time = url;
   }
   void set_dotimecalib(bool dotimecalib) { m_dotimecalib = dotimecalib; }
-  void set_overrideTimeFieldName(bool overrideField) { m_overrideTimeFieldName = overrideField; }
-  void set_overrideTimeCalibName(bool overrideCalib) { m_overrideTimeCalibName = overrideCalib; }
 
   // Time calibration (MC)
   void set_MC_fieldname_time(const std::string &MC_fieldname_time)
   {
     m_MC_fieldname_time = MC_fieldname_time;
-    m_overrideMCTimeFieldName = true;
   }
   void set_MC_calibName_time(const std::string &MC_calibName_time)
   {
     m_MC_calibName_time = MC_calibName_time;
-    m_overrideMCTimeCalibName = true;
   }
   void set_directURL_MCtimecalib(const std::string &url)
   {
-    m_giveDirectURL_MC_time = true;
     m_directURL_MC_time = url;
   }
   void set_smear_const(float val)
@@ -115,8 +108,6 @@ class CaloWaveformSim : public SubsysReco
     m_smear_const = true;
     factor_const = val;
   }
-  void set_overrideMCTimeFieldName(bool overrideField) { m_overrideMCTimeFieldName = overrideField; }
-  void set_overrideMCTimeCalibName(bool overrideCalib) { m_overrideMCTimeCalibName = overrideCalib; }
 
   // Waveform template & sampling
   void set_templatefile(const std::string &templatefile) { m_templatefile = templatefile; }
@@ -149,6 +140,17 @@ class CaloWaveformSim : public SubsysReco
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
  private:
+  void CreateNodeTree(PHCompositeNode *topNode);
+  void maphitetaphi(PHG4Hit *g4hit,
+                    unsigned short &etabin,
+                    unsigned short &phibin,
+                    float &correction);
+  double template_function(double *x, double *par);
+
+  // function pointers for use different decoders for hcals and cemc
+  unsigned int (*encode_tower)(unsigned int, unsigned int){TowerInfoDefs::encode_emcal};
+  unsigned int (*decode_tower)(unsigned int){TowerInfoDefs::decode_emcal};
+
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
   std::string m_detector;
 
@@ -167,18 +169,14 @@ class CaloWaveformSim : public SubsysReco
 
   // Data time calibration
   std::string m_fieldname_time{"time"};
-  std::string m_calibName_time{"CEMC_meanTime"};
+  std::string m_calibName_time;
   bool m_overrideTimeFieldName{false};
-  bool m_overrideTimeCalibName{false};
   bool m_dotimecalib{true};
   bool m_giveDirectURL_time{false};
   std::string m_directURL_time;
   // MC time calibration
   std::string m_MC_fieldname_time{"time"};
-  std::string m_MC_calibName_time{"CEMC_meanTime"};
-  bool m_overrideMCTimeFieldName{false};
-  bool m_overrideMCTimeCalibName{false};
-  bool m_giveDirectURL_MC_time{false};
+  std::string m_MC_calibName_time;
   std::string m_directURL_MC_time;
 
   // Waveform settings
@@ -209,9 +207,6 @@ class CaloWaveformSim : public SubsysReco
   std::vector<std::vector<float>> m_waveforms;
   int m_runNumber{0};
 
-  unsigned int (*encode_tower)(unsigned int, unsigned int){TowerInfoDefs::encode_emcal};
-  unsigned int (*decode_tower)(unsigned int){TowerInfoDefs::decode_emcal};
-
   CDBTTree *cdbttree{nullptr};
   CDBTTree *cdbttree_MC{nullptr};
   CDBTTree *cdbttree_time{nullptr};
@@ -220,13 +215,6 @@ class CaloWaveformSim : public SubsysReco
   LightCollectionModel light_collection_model;
 
   NoiseType m_noiseType{NOISE_TREE};
-
-  void CreateNodeTree(PHCompositeNode *topNode);
-  void maphitetaphi(PHG4Hit *g4hit,
-                    unsigned short &etabin,
-                    unsigned short &phibin,
-                    float &correction);
-  double template_function(double *x, double *par);
 };
 
 #endif  // G4WAVEFORMSIM_CALOWAVEFORMSIM_H

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -57,7 +57,6 @@ class CaloWaveformSim : public SubsysReco
   }
   void set_directURL_calib(const std::string &url)
   {
-    m_giveDirectURL = true;
     m_directURL = url;
   }
 
@@ -155,17 +154,17 @@ class CaloWaveformSim : public SubsysReco
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
  private:
-  CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::CEMC};
-  std::string m_detector{"CEMC"};
+  CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
+  std::string m_detector;
 
   // Data energy calibration
   std::string m_fieldname;
   std::string m_calibName;
-  bool m_giveDirectURL{false};
   std::string m_directURL;
+
   // MC energy calibration
-  std::string m_MC_fieldname{"Femc_datadriven_qm1_correction"};
-  std::string m_MC_calibName{"cemc_pi0_twrSlope_v1"};
+  std::string m_MC_fieldname;
+  std::string m_MC_calibName;
   bool m_overrideMCFieldName{false};
   bool m_overrideMCCalibName{false};
   bool m_giveDirectURL_MC{false};

--- a/simulation/g4simulation/g4waveformsim/Makefile.am
+++ b/simulation/g4simulation/g4waveformsim/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
@@ -20,15 +20,12 @@ libCaloWaveformSim_la_SOURCES = \
   CaloWaveformSim.cc
 
 libCaloWaveformSim_la_LIBADD = \
-  -lphool \
-  -lSubsysReco \
-  -lcalo_io \
-  -lfun4all \
-  -lg4detectors \
-  -lg4detectors_io \
   -lcalo_io \
   -lcdbobjects \
-  -lphg4hit
+  -lg4detectors \
+  -lg4detectors_io \
+  -lphg4hit \
+  -lSubsysReco
 
 BUILT_SOURCES = testexternals.cc
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR is a cleanup of the g4waveformsim package, no functionality changes

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context
This PR is a maintenance/refactoring cleanup of **g4waveformsim** driven by Valgrind-detected memory leak issues and “code quality/memory safety” improvements. The stated goal is **no intended physics/reconstruction behavior change**, but several internal refactors do touch waveform/calibration setup paths.

## Key changes
- **Memory/resource cleanup**
  - Updated `CaloWaveformSim` destructor to additionally delete calibration-related `CDBTTree` pointers and the waveform template (`h_template`), not just the RNG.
- **`InitRun` refactor (calibration + setup)**
  - Waveform template loading refactored to `TFile::Open()` + `GetObject("hpwaveform", h_template)`.
  - `m_runNumber` now comes from `recoConsts::instance()->get_IntFlag("RUNNUMBER")` instead of reading the `EventHeader`.
  - Detector initialization now includes an explicit **`HCALOUT`** branch and improved invalid-detector error handling.
  - Calibration resolution rewritten:
    - Direct URLs resolved via `CDBInterface::instance()->getUrl(...)`.
    - Conditionally constructs `CDBTTree` objects for **data**, optional **MC energy**, and optional **time** calibrations.
    - Adds verbosity-controlled logging for selected calibration selections.
    - Exits early when required calibrations are unavailable (notably when data/time calibration is enabled but missing).
- **Event processing refactors**
  - Introduced/used a per-tower memoization cache (`tbt_smear`) for Gaussian smearing factors keyed by an encoded identifier.
  - Waveform saturation after noise/pedestal injection now uses `std::clamp` to enforce samples in **[0, 16383]**.
- **API/build system cleanup**
  - Removed `CaloWaveformSim::End(PHCompositeNode*)`.
  - Header/build dependency cleanup (include reorganization; Makefile uses `-isystem` for an offline include path; link list reordered/trimmed).

## Potential risk areas
- **Reconstruction/calibration behavior**: The calibration setup logic was substantially rewritten (direct-URL handling, early-exit conditions, selection of data/MC/time trees). Even if intended to be equivalent, it should be validated for common run configurations.
- **Waveform output differences**: Switching saturation logic to `std::clamp` and changing template loading method can lead to subtle differences at boundaries/edge cases.
- **Data products / IO shape**: Adding an explicit `HCALOUT` branch may affect downstream consumers expecting specific branch sets.
- **Thread-safety / performance**: The new `tbt_smear` memoization cache could have implications if instances are used in multithreaded contexts (ensure it’s per-instance and not shared unsafely). Performance should generally improve (less repeated sampling), but verify under realistic workloads.
- **Memory correctness**: Destructor changes are intended to eliminate leaks, but ownership/double-free risks should be checked if any of those pointers are also owned elsewhere.

## Possible future improvements
- Factor calibration selection (data vs MC energy vs time, directURL vs CDB name) into a small helper/config struct to reduce conditional complexity.
- Add targeted integration tests covering:
  - direct-URL calibration vs CDB-name calibration,
  - “missing calibration” early-exit behavior,
  - waveform saturation boundary conditions.
- Add explicit notes/assertions for multithreading assumptions and cache lifetime.

**Note:** AI-generated summaries can miss nuances—please use best judgment and verify behavior against your expected physics/reconstruction workflows before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->