### PR TITLE
promote NoRunTTree() method to input mgr base class

### DIFF
--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -50,8 +50,9 @@ class Fun4AllInputManager : public Fun4AllBase, public InputFileHandler
   void InputNode(const std::string &innode) { m_InputNode = innode; }
   const std::string &TopNodeName() const { return m_TopNodeName; }
   void Verbosity(const uint64_t ival) override;
-  
- protected:
+  virtual int NoRunTTree() {return -1;}
+
+protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
   Fun4AllSyncManager *MySyncManager() { return m_MySyncManager; }
   void DisableReadCache() { m_disable_read_cache_flag = true; }

--- a/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
@@ -28,7 +28,7 @@ class Fun4AllNoSyncDstInputManager : public Fun4AllDstInputManager
   int setSyncBranches(PHNodeIOManager* /*IManager*/) override { return 0; }
 
   // turn off reading of the runwise TTree to make run mixing for embedding possible
-  int NoRunTTree();
+  int NoRunTTree() override;
 
   int SkipForThisManager(const int nevents) override { return PushBackEvents(nevents); }
   int HasSyncObject() const override { return 0; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
When reading DSTs which do not contain the run wise nodes (stored in the T1 TTree), one gets a misleading warning. The Fun4AllDstNoSyncManager can suppress this but this method wasn't propagated to the Fun4AllInputManager base class. This PR adds this method - so this error message can be suppressed when reading DSTs without a T1 TTree

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

