### PR TITLE
Trackpruner update

### DIFF
--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -117,6 +117,9 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
 
   std::multimap<size_t, size_t> good_matches;
 
+  // increment number of processed tracks
+  m_total_tracks += _svtx_track_map->size();
+
   for (auto &iter : *_svtx_track_map)
   {
     auto* svtx_track = iter.second;
@@ -125,7 +128,9 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
     {
       continue;
     }
+
     if (Verbosity() > 1) { std::cout<<"Pass track selection"<<std::endl; }
+    ++m_accepted_tracks;
 
     auto* tpc_seed = svtx_track->get_tpc_seed();
     auto* si_seed = svtx_track->get_silicon_seed();
@@ -249,6 +254,8 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
 
 int PHTrackPruner::End(PHCompositeNode * /*unused*/)
 {
+  std::cout << "PHTrackPruner::End - m_total_tracks: " << m_total_tracks << std::endl;
+  std::cout << "PHTrackPruner::End -  m_accepted_tracks: " << m_accepted_tracks << " fraction: " << double(m_accepted_tracks)/m_total_tracks << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -108,7 +108,7 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
       << std::endl;
   }
 
-  if (_svtx_track_map->size() == 0)
+  if (_svtx_track_map->empty())
   {
     return Fun4AllReturnCodes::EVENT_OK;
   }

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -197,7 +197,7 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
   }
 
   // high pt cut
-  if( m_track_pt_high_cut>0 && track->get_pt() < m_track_pt_high_cut)
+  if( m_track_pt_high_cut>0 && track->get_pt() > m_track_pt_high_cut)
   {
     if (Verbosity() > 1) { std::cout  <<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_high_cut<<std::endl; }
     return false;

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -34,8 +34,6 @@
 #include <set>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 
-using namespace std;
-
 namespace
 {
   //! get cluster keys from a given track
@@ -104,10 +102,10 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
 
   if (Verbosity() > 0)
   {
-    cout << PHWHERE << " TPC seed map size " << _tpc_seed_map->size()
-	 << " Silicon seed map size " << _si_seed_map->size()
-	 << " Svtx track map size " << _svtx_track_map->size()
-	 << endl;
+    std::cout   << PHWHERE << " TPC seed map size " << _tpc_seed_map->size()
+      << " Silicon seed map size " << _si_seed_map->size()
+      << " Svtx track map size " << _svtx_track_map->size()
+      << std::endl;
   }
 
   if (_svtx_track_map->size() == 0)
@@ -129,26 +127,28 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
       continue;
     }
 
-    if (Verbosity() > 1) { std::cout<<"Pass track selection"<<std::endl; }
-    ++m_accepted_tracks;
+    if (Verbosity() > 1) { std::cout  <<"Pass track selection"<<std::endl; }
 
     auto* tpc_seed = svtx_track->get_tpc_seed();
     auto* si_seed = svtx_track->get_silicon_seed();
     if (tpc_seed && si_seed)
     {
-      if (Verbosity() > 1) { std::cout<<"Insert tpcid and siid into good_matches"<<std::endl; }
+      if (Verbosity() > 1) { std::cout <<"Insert tpcid and siid into good_matches"<<std::endl; }
       const size_t tpcid = _tpc_seed_map->find(tpc_seed);
       const size_t siid = _si_seed_map->find(si_seed);
 
       // check index validity
       if( tpcid < _tpc_seed_map->size() && siid < _si_seed_map->size() )
-      { good_matches.emplace(tpcid, siid); }
+      {
+        good_matches.emplace(tpcid, siid);
+        ++m_accepted_tracks;
+      }
     }
   }
 
   for (const auto& [tpcid, siid] : good_matches)
   {
-      if (Verbosity() > 1) { std::cout<<"Insert pruned svtx seed map"<<std::endl; }
+      if (Verbosity() > 1) { std::cout  <<"Insert pruned svtx seed map"<<std::endl; }
     auto _svtx_seed = std::make_unique<SvtxTrackSeed_v2>();
     _svtx_seed->set_silicon_seed_index(siid);
     _svtx_seed->set_tpc_seed_index(tpcid);
@@ -160,13 +160,13 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
 
     if (Verbosity() > 1)
     {
-      std::cout << "  combined seed id " << _pruned_svtx_seed_map->size() - 1 << " si id " << siid << " tpc id " << tpcid << " crossing estimate " << crossing_estimate << std::endl;
+      std::cout   << "  combined seed id " << _pruned_svtx_seed_map->size() - 1 << " si id " << siid << " tpc id " << tpcid << " crossing estimate " << crossing_estimate << std::endl;
     }
   }
 
   if (Verbosity() > 0)
   {
-    std::cout << "final svtx seed map size " << _pruned_svtx_seed_map->size() << std::endl;
+    std::cout   << "final svtx seed map size " << _pruned_svtx_seed_map->size() << std::endl;
   }
 
   if (Verbosity() > 1)
@@ -176,7 +176,7 @@ int PHTrackPruner::process_event(PHCompositeNode * /*unused*/)
       seed->identify();
     }
 
-    cout << "PHTrackPruner::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;
+    std::cout  << "PHTrackPruner::process_event(PHCompositeNode *topNode) Leaving process_event" << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -185,28 +185,28 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
 {
   if(!track)
   {
-    if (Verbosity() > 1) { std::cout<<"invalid track"<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"invalid track"<<std::endl; }
     return false;
   }
 
   // low pt cut
   if(track->get_pt() < m_track_pt_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_low_cut<<std::endl; }
     return false;
   }
 
   // high pt cut
   if( m_track_pt_high_cut>0 && track->get_pt() < m_track_pt_high_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_high_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_high_cut<<std::endl; }
     return false;
   }
 
   //quality cut
   if(track->get_quality() > m_track_quality_high_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"Track quality "<<track->get_quality()<<" , quality cut "<<m_track_quality_high_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"Track quality "<<track->get_quality()<<" , quality cut "<<m_track_quality_high_cut<<std::endl; }
     return false;
   }
 
@@ -214,22 +214,22 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
   const auto cluster_keys(get_cluster_keys(track));
   if (count_clusters<TrkrDefs::mvtxId>(cluster_keys) < m_nmvtx_clus_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"nmvtx "<<count_clusters<TrkrDefs::mvtxId>(cluster_keys)<<" , nmvtx cut "<<m_nmvtx_clus_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"nmvtx "<<count_clusters<TrkrDefs::mvtxId>(cluster_keys)<<" , nmvtx cut "<<m_nmvtx_clus_low_cut<<std::endl; }
     return false;
   }
   if (count_clusters<TrkrDefs::inttId>(cluster_keys) < m_nintt_clus_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"nintt "<<count_clusters<TrkrDefs::inttId>(cluster_keys)<<" , nintt cut "<<m_nintt_clus_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"nintt "<<count_clusters<TrkrDefs::inttId>(cluster_keys)<<" , nintt cut "<<m_nintt_clus_low_cut<<std::endl; }
     return false;
   }
   if (count_clusters<TrkrDefs::tpcId>(cluster_keys) < m_ntpc_clus_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"ntpc "<<count_clusters<TrkrDefs::tpcId>(cluster_keys)<<" , ntpc cut "<<m_ntpc_clus_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"ntpc "<<count_clusters<TrkrDefs::tpcId>(cluster_keys)<<" , ntpc cut "<<m_ntpc_clus_low_cut<<std::endl; }
     return false;
   }
   if (count_clusters<TrkrDefs::micromegasId>(cluster_keys) < m_ntpot_clus_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"nmicromegas "<<count_clusters<TrkrDefs::micromegasId>(cluster_keys)<<" , nmicromegas cut "<<m_ntpot_clus_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"nmicromegas "<<count_clusters<TrkrDefs::micromegasId>(cluster_keys)<<" , nmicromegas cut "<<m_ntpot_clus_low_cut<<std::endl; }
     return false;
   }
 
@@ -237,22 +237,22 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
   const auto state_keys(get_state_keys(track));
   if (count_clusters<TrkrDefs::mvtxId>(state_keys) < m_nmvtx_states_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"nmvtxstates "<<count_clusters<TrkrDefs::mvtxId>(state_keys)<<" , nmvtxstates cut "<<m_nmvtx_states_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"nmvtxstates "<<count_clusters<TrkrDefs::mvtxId>(state_keys)<<" , nmvtxstates cut "<<m_nmvtx_states_low_cut<<std::endl; }
     return false;
   }
   if (count_clusters<TrkrDefs::inttId>(state_keys) < m_nintt_states_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"ninttstates "<<count_clusters<TrkrDefs::inttId>(state_keys)<<" , ninttstates cut "<<m_nintt_states_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"ninttstates "<<count_clusters<TrkrDefs::inttId>(state_keys)<<" , ninttstates cut "<<m_nintt_states_low_cut<<std::endl; }
     return false;
   }
   if (count_clusters<TrkrDefs::tpcId>(state_keys) < m_ntpc_states_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"ntpcstates "<<count_clusters<TrkrDefs::tpcId>(state_keys)<<" , ntpcstates cut "<<m_ntpc_states_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"ntpcstates "<<count_clusters<TrkrDefs::tpcId>(state_keys)<<" , ntpcstates cut "<<m_ntpc_states_low_cut<<std::endl; }
     return false;
   }
   if (count_clusters<TrkrDefs::micromegasId>(state_keys) < m_ntpot_states_low_cut)
   {
-    if (Verbosity() > 1) { std::cout<<"nmicromegasstates "<<count_clusters<TrkrDefs::micromegasId>(state_keys)<<" , nmicromegasstates cut "<<m_ntpot_states_low_cut<<std::endl; }
+    if (Verbosity() > 1) { std::cout  <<"nmicromegasstates "<<count_clusters<TrkrDefs::micromegasId>(state_keys)<<" , nmicromegasstates cut "<<m_ntpot_states_low_cut<<std::endl; }
     return false;
   }
 
@@ -261,8 +261,8 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
 
 int PHTrackPruner::End(PHCompositeNode * /*unused*/)
 {
-  std::cout << "PHTrackPruner::End - m_total_tracks: " << m_total_tracks << std::endl;
-  std::cout << "PHTrackPruner::End -  m_accepted_tracks: " << m_accepted_tracks << " fraction: " << double(m_accepted_tracks)/m_total_tracks << std::endl;
+  std::cout   << "PHTrackPruner::End - m_total_tracks: " << m_total_tracks << std::endl;
+  std::cout   << "PHTrackPruner::End -  m_accepted_tracks: " << m_accepted_tracks << " fraction: " << double(m_accepted_tracks)/m_total_tracks << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -275,28 +275,28 @@ int PHTrackPruner::GetNodes(PHCompositeNode *topNode)
   _svtx_track_map = findNode::getClass<SvtxTrackMap>(topNode, _svtx_track_map_name);
   if (!_svtx_track_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _svtx_track_map_name  << endl;
+    std::cout   << PHWHERE << " ERROR: Can't find " << _svtx_track_map_name  << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _si_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _si_seed_map_name);
   if (!_si_seed_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _si_seed_map_name  << endl;
+    std::cout   << PHWHERE << " ERROR: Can't find " << _si_seed_map_name  << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _tpc_seed_map_name);
   if (!_tpc_seed_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _tpc_seed_map_name << endl;
+    std::cout   << PHWHERE << " ERROR: Can't find " << _tpc_seed_map_name << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _pruned_svtx_seed_map = findNode::getClass<TrackSeedContainer>(topNode, _pruned_svtx_seed_map_name);
   if (!_pruned_svtx_seed_map)
   {
-    std::cout << "Creating node " << _pruned_svtx_seed_map_name << std::endl;
+    std::cout   << "Creating node " << _pruned_svtx_seed_map_name << std::endl;
     /// Get the DST Node
     PHNodeIterator iter(topNode);
     PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
@@ -327,14 +327,14 @@ int PHTrackPruner::GetNodes(PHCompositeNode *topNode)
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, _cluster_map_name);
   if (!_cluster_map)
   {
-    std::cout << PHWHERE << " ERROR: Can't find node " << _cluster_map_name << std::endl;
+    std::cout   << PHWHERE << " ERROR: Can't find node " << _cluster_map_name << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   if (!_tGeometry)
   {
-    std::cout << PHWHERE << "Error, can't find acts tracking geometry" << std::endl;
+    std::cout   << PHWHERE << "Error, can't find acts tracking geometry" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -356,7 +356,7 @@ short int PHTrackPruner::findCrossingGeometrically(unsigned int tpcid, unsigned 
 
   if (Verbosity() > 1)
   {
-    std::cout << "findCrossing: "
+    std::cout   << "findCrossing: "
               << " tpcid " << tpcid << " si_id " << si_id << " tpc_z " << tpc_z << " si_z " << si_z << " dz " << tpc_z - si_z
               << " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
   }
@@ -398,7 +398,7 @@ double PHTrackPruner::getBunchCrossing(unsigned int trid, double z_mismatch)
 
   if (side_set.size() == 2 && Verbosity() > 1)
   {
-    std::cout << "     WARNING: tpc seed " << trid << " changed TPC sides, "
+    std::cout   << "     WARNING: tpc seed " << trid << " changed TPC sides, "
               << "  final side " << side << std::endl;
   }
 
@@ -411,7 +411,7 @@ double PHTrackPruner::getBunchCrossing(unsigned int trid, double z_mismatch)
 
   if (Verbosity() > 1)
   {
-    std::cout << "  gettrackid " << trid << " side " << side << " z_mismatch " << z_mismatch << " crossings " << crossings << std::endl;
+    std::cout   << "  gettrackid " << trid << " side " << side << " z_mismatch " << z_mismatch << " crossings " << crossings << std::endl;
   }
 
   return crossings;

--- a/offline/packages/trackreco/PHTrackPruner.cc
+++ b/offline/packages/trackreco/PHTrackPruner.cc
@@ -189,10 +189,17 @@ bool PHTrackPruner::checkTrack(SvtxTrack *track)
     return false;
   }
 
-  //pt cut
+  // low pt cut
   if(track->get_pt() < m_track_pt_low_cut)
   {
     if (Verbosity() > 1) { std::cout<<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_low_cut<<std::endl; }
+    return false;
+  }
+
+  // high pt cut
+  if( m_track_pt_high_cut>0 && track->get_pt() < m_track_pt_high_cut)
+  {
+    if (Verbosity() > 1) { std::cout<<"Track pt "<<track->get_pt()<<" , pt cut "<<m_track_pt_high_cut<<std::endl; }
     return false;
   }
 

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -97,6 +97,10 @@ class PHTrackPruner : public SubsysReco
   int m_ntpc_states_low_cut = 35;
   int m_ntpot_states_low_cut = 2;
 
+  //! keep track of track/seed statistics
+  unsigned long m_total_tracks = 0;
+  unsigned long m_accepted_tracks = 0;
+
 };
 
 #endif  //  PHTRACKPRUNER_H

--- a/offline/packages/trackreco/PHTrackPruner.h
+++ b/offline/packages/trackreco/PHTrackPruner.h
@@ -52,6 +52,11 @@ class PHTrackPruner : public SubsysReco
 
   /// low pt cut
   void set_track_pt_low_cut(const double val) { m_track_pt_low_cut = val; }
+
+  /// high pt cut.
+  /** enforced only if >0 */
+  void set_track_pt_high_cut(const double val) { m_track_pt_high_cut = val; }
+
   void set_track_quality_high_cut(const double val) { m_track_quality_high_cut = val; }
 
   void set_nmvtx_clus_low_cut(const int n) { m_nmvtx_clus_low_cut = n; }
@@ -85,7 +90,13 @@ class PHTrackPruner : public SubsysReco
   std::string _pruned_svtx_seed_map_name = "PrunedSvtxTrackSeedContainer";
   std::string _svtx_track_map_name = "SvtxTrackMap";
 
+  /// low pt cut
   double m_track_pt_low_cut = 0.5;
+
+  /// high pt cut.
+  /** enforced only if >0 */
+  double m_track_pt_high_cut = 0.;
+
   double m_track_quality_high_cut = 100;
   int m_nmvtx_clus_low_cut = 3;
   int m_nintt_clus_low_cut = 2;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Some updates to the track pruner module.
- added the possibility to have a hight pT cut
- removed using namespace std;
- add pruner statistics 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Track Pruner Module Enhancement: High‑pT Cut, Statistics, and Diagnostics

### Motivation / Context
`PHTrackPruner` is used to reduce the fitted Svtx track/seed content before downstream track-based reconstruction steps. This update adds an optional upper (high-)pT rejection capability, improves runtime visibility into pruning/selection behavior, and enhances code/diagnostic hygiene.

### Key Changes
- **High‑pT cut (opt-in)**  
  - Added `set_track_pt_high_cut(const double)` and member `m_track_pt_high_cut` (default `0.` disables).  
  - During `checkTrack`, tracks are rejected when `m_track_pt_high_cut > 0` and `track->get_pt() > m_track_pt_high_cut`.  
- **Pruner statistics**  
  - Added counters `m_total_tracks` and `m_accepted_tracks`.  
  - `process_event` increments `m_total_tracks` by `_svtx_track_map->size()` and increments `m_accepted_tracks` when a passing track has both valid TPC+silicon seeds with valid indices (the same condition used to populate `good_matches`).  
  - `End` prints total processed, accepted, and acceptance fraction.
- **Diagnostics / code quality improvements**
  - Expanded `checkTrack` verbosity-gated rejection messages for each cut stage (null track, pt low/high, quality, and per-detector cluster/state-count thresholds).
  - Improved verbosity-gated debug output in geometrical crossing helpers (`findCrossingGeometrically`, `getBunchCrossing`), including warnings and intermediate values.
  - Updated node-missing reporting in `GetNodes` to use `std::cout` for several missing required objects (event abort behavior remains).
  - Removed/avoided `using namespace std;` in the touched file(s) in favor of `std::` qualifiers.

### Potential Risk Areas
- **Logging / stdout noise:** `End` always prints statistics; additional `std::cout` in `process_event`, `checkTrack`, and crossing helpers is gated by `Verbosity()` but could still increase log volume at higher verbosity settings.
- **Reconstruction behavior change (opt-in):** enabling the high‑pT cut changes which tracks/seed pairs make it into the pruned seed map.
- **Thread-safety assumptions:** statistics counters are incremented without explicit synchronization; correctness depends on the module’s threading/execution model.

### Possible Future Improvements
- Route diagnostics through the experiment logging framework (e.g., MessageLogger) instead of direct `std::cout`.
- Provide more structured/statistics output (e.g., per-run reporting, reset hooks, or histogramming) and/or configurable verbosity for critical messages.

> ⚠️ Note: AI-generated summaries can make mistakes or miss subtle details—please cross-check against the actual code changes and review logs with best judgment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->