### PR TITLE
CaloTowerStatus: Z-Score Patch

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -154,9 +154,6 @@ void CaloTowerStatus::LoadCalib(CDBTTree *cdbttree_chi2, CDBTTree *cdbttree_hotM
   unsigned int ntowers = m_raw_towers->size();
   m_cdbInfo_vec.resize(ntowers);
 
-  // Check if we actually need to evaluate the z_score
-  bool need_z_score = (z_score_threshold != z_score_threshold_default);
-
   for (unsigned int channel = 0; channel < ntowers; channel++)
   {
     unsigned int key = m_raw_towers->encode_key(channel);
@@ -170,7 +167,7 @@ void CaloTowerStatus::LoadCalib(CDBTTree *cdbttree_chi2, CDBTTree *cdbttree_hotM
       m_cdbInfo_vec[channel].hotMap_val = cdbttree_hotMap->GetIntValue(key, m_fieldname_hotMap);
 
       // Only fetch the z_score field if the custom threshold requires it
-      if (need_z_score)
+      if (z_score_threshold != z_score_threshold_default)
       {
         m_cdbInfo_vec[channel].z_score = cdbttree_hotMap->GetFloatValue(key, m_fieldname_z_score);
       }

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -154,6 +154,9 @@ void CaloTowerStatus::LoadCalib(CDBTTree *cdbttree_chi2, CDBTTree *cdbttree_hotM
   unsigned int ntowers = m_raw_towers->size();
   m_cdbInfo_vec.resize(ntowers);
 
+  // Check if we actually need to evaluate the z_score
+  bool need_z_score = (z_score_threshold != z_score_threshold_default);
+
   for (unsigned int channel = 0; channel < ntowers; channel++)
   {
     unsigned int key = m_raw_towers->encode_key(channel);
@@ -165,7 +168,12 @@ void CaloTowerStatus::LoadCalib(CDBTTree *cdbttree_chi2, CDBTTree *cdbttree_hotM
     if (m_doHotMap && cdbttree_hotMap)
     {
       m_cdbInfo_vec[channel].hotMap_val = cdbttree_hotMap->GetIntValue(key, m_fieldname_hotMap);
-      m_cdbInfo_vec[channel].z_score = cdbttree_hotMap->GetFloatValue(key, m_fieldname_z_score);
+
+      // Only fetch the z_score field if the custom threshold requires it
+      if (need_z_score)
+      {
+        m_cdbInfo_vec[channel].z_score = cdbttree_hotMap->GetFloatValue(key, m_fieldname_z_score);
+      }
     }
   }
 }


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

- Modified `CaloTowerStatus::LoadCalib` to calculate `need_z_score` based on whether `z_score_threshold` deviates from its default.
- Wrapped the `GetFloatValue` call for the z_score field in a conditional check, eliminating the slowdowns for EMCal Hot Map CDB TTree that do not have the "CEMC_sigma" field.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves the robustness and performance of `CaloTowerStatus::LoadCalib` for EMCal hot-tower CDB TTrees, particularly when the tree schema does not include the `CEMC_sigma` (z-score) field.

**Key changes**
- `need_z_score` behavior is replaced by a direct condition: z-score (`GetFloatValue` of the sigma field) is fetched only when `z_score_threshold` differs from `z_score_threshold_default`.
- The z-score field lookup from `cdbttree_hotMap` is now guarded, avoiding repeated access to a potentially missing CDB field for every tower.
- Default hot-tower classification continues to rely solely on the hot-map `status` codes when `z_score_threshold == z_score_threshold_default`.

**Potential risk areas**
- **Reconstruction/calibration behavior:** hot-tower decisions now more explicitly depend on whether `z_score_threshold` equals the configured default; unusual configurations should be checked for intended behavior.
- **CDB schema variability:** while the guard avoids reads when the default threshold is used, a run with a non-default threshold will still expect the sigma field to exist.
- **Performance:** intended improvement in load time/I/O overhead; should be validated on representative hot-map datasets.

**Possible future improvements**
- Add tests for both CDB hot-map formats (with and without the sigma field) under default and non-default `z_score_threshold` settings.
- Improve defensive handling (or clearer logging) when `z_score_threshold` is non-default but the sigma field is absent.

AI can make mistakes—please use best judgment when reviewing the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->