### PR TITLE
Track based distortions update

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -128,6 +128,8 @@ namespace
 PHTpcResiduals::PHTpcResiduals(const std::string& name)
   : SubsysReco(name)
   , m_matrix_container(new TpcSpaceChargeMatrixContainerv2)
+  , m_matrix_container_pos(new TpcSpaceChargeMatrixContainerv2)
+  , m_matrix_container_neg(new TpcSpaceChargeMatrixContainerv2)
 {
 }
 
@@ -186,11 +188,13 @@ int PHTpcResiduals::End(PHCompositeNode* /*topNode*/)
   std::cout << "PHTpcResiduals::End - writing matrices to " << m_outputfile << std::endl;
 
   // save matrix container in output file
-  if (m_matrix_container)
+  if (m_matrix_container || m_matrix_container_pos || m_matrix_container_neg)
   {
     std::unique_ptr<TFile> outputfile(TFile::Open(m_outputfile.c_str(), "RECREATE"));
     outputfile->cd();
-    m_matrix_container->Write("TpcSpaceChargeMatrixContainer");
+    if( m_matrix_container ) { m_matrix_container->Write("TpcSpaceChargeMatrixContainer"); }
+    if( m_matrix_container_pos ) { m_matrix_container_pos->Write("TpcSpaceChargeMatrixContainer_pos"); }
+    if( m_matrix_container_neg ) { m_matrix_container_neg->Write("TpcSpaceChargeMatrixContainer_neg"); }
   }
 
   // print counters
@@ -650,43 +654,58 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
       continue;
     }
 
-    // Fill distortion matrices
-    m_matrix_container->add_to_lhs(index, 0, 0, square(clusR) / erp);
-    m_matrix_container->add_to_lhs(index, 0, 1, 0);
-    m_matrix_container->add_to_lhs(index, 0, 2, clusR * trackAlpha / erp);
+    std::vector<TpcSpaceChargeMatrixContainer*> containers;
+    containers.emplace_back( m_matrix_container.get() );
+    if( track->get_positive_charge() ) {
+      containers.emplace_back( m_matrix_container_pos.get() );
+    } else {
+      containers.emplace_back( m_matrix_container_neg.get() );
+    }
 
-    m_matrix_container->add_to_lhs(index, 1, 0, 0);
-    m_matrix_container->add_to_lhs(index, 1, 1, 1. / ez);
-    m_matrix_container->add_to_lhs(index, 1, 2, trackBeta / ez);
 
-    m_matrix_container->add_to_lhs(index, 2, 0, clusR * trackAlpha / erp);
-    m_matrix_container->add_to_lhs(index, 2, 1, trackBeta / ez);
-    m_matrix_container->add_to_lhs(index, 2, 2, square(trackAlpha) / erp + square(trackBeta) / ez);
+    for( auto& container:containers )
+    {
 
-    m_matrix_container->add_to_rhs(index, 0, clusR * drphi / erp);
-    m_matrix_container->add_to_rhs(index, 1, dz / ez);
-    m_matrix_container->add_to_rhs(index, 2, trackAlpha * drphi / erp + trackBeta * dz / ez);
+      if( !container ) continue;
 
-    // also update rphi reduced matrices
-    m_matrix_container->add_to_lhs_rphi(index, 0, 0, square(clusR) / erp);
-    m_matrix_container->add_to_lhs_rphi(index, 0, 1, clusR * trackAlpha / erp);
-    m_matrix_container->add_to_lhs_rphi(index, 1, 0, clusR * trackAlpha / erp);
-    m_matrix_container->add_to_lhs_rphi(index, 1, 1, square(trackAlpha) / erp);
+      // Fill distortion matrices
+      container->add_to_lhs(index, 0, 0, square(clusR) / erp);
+      container->add_to_lhs(index, 0, 1, 0);
+      container->add_to_lhs(index, 0, 2, clusR * trackAlpha / erp);
 
-    m_matrix_container->add_to_rhs_rphi(index, 0, clusR * drphi / erp);
-    m_matrix_container->add_to_rhs_rphi(index, 1, trackAlpha * drphi / erp);
+      container->add_to_lhs(index, 1, 0, 0);
+      container->add_to_lhs(index, 1, 1, 1. / ez);
+      container->add_to_lhs(index, 1, 2, trackBeta / ez);
 
-    // also update z reduced matrices
-    m_matrix_container->add_to_lhs_z(index, 0, 0, 1. / ez);
-    m_matrix_container->add_to_lhs_z(index, 0, 1, trackBeta / ez);
-    m_matrix_container->add_to_lhs_z(index, 1, 0, trackBeta / ez);
-    m_matrix_container->add_to_lhs_z(index, 1, 1, square(trackBeta) / ez);
+      container->add_to_lhs(index, 2, 0, clusR * trackAlpha / erp);
+      container->add_to_lhs(index, 2, 1, trackBeta / ez);
+      container->add_to_lhs(index, 2, 2, square(trackAlpha) / erp + square(trackBeta) / ez);
 
-    m_matrix_container->add_to_rhs_z(index, 0, dz / ez);
-    m_matrix_container->add_to_rhs_z(index, 1, trackBeta * dz / ez);
+      container->add_to_rhs(index, 0, clusR * drphi / erp);
+      container->add_to_rhs(index, 1, dz / ez);
+      container->add_to_rhs(index, 2, trackAlpha * drphi / erp + trackBeta * dz / ez);
 
-    // update entries in cell
-    m_matrix_container->add_to_entries(index);
+      // also update rphi reduced matrices
+      container->add_to_lhs_rphi(index, 0, 0, square(clusR) / erp);
+      container->add_to_lhs_rphi(index, 0, 1, clusR * trackAlpha / erp);
+      container->add_to_lhs_rphi(index, 1, 0, clusR * trackAlpha / erp);
+      container->add_to_lhs_rphi(index, 1, 1, square(trackAlpha) / erp);
+
+      container->add_to_rhs_rphi(index, 0, clusR * drphi / erp);
+      container->add_to_rhs_rphi(index, 1, trackAlpha * drphi / erp);
+
+      // also update z reduced matrices
+      container->add_to_lhs_z(index, 0, 0, 1. / ez);
+      container->add_to_lhs_z(index, 0, 1, trackBeta / ez);
+      container->add_to_lhs_z(index, 1, 0, trackBeta / ez);
+      container->add_to_lhs_z(index, 1, 1, square(trackBeta) / ez);
+
+      container->add_to_rhs_z(index, 0, dz / ez);
+      container->add_to_rhs_z(index, 1, trackBeta * dz / ez);
+
+      // update entries in cell
+      container->add_to_entries(index);
+    }
 
     // increment number of accepted clusters
     ++m_accepted_clusters;

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -192,9 +192,21 @@ int PHTpcResiduals::End(PHCompositeNode* /*topNode*/)
   {
     std::unique_ptr<TFile> outputfile(TFile::Open(m_outputfile.c_str(), "RECREATE"));
     outputfile->cd();
-    if( m_matrix_container ) { m_matrix_container->Write("TpcSpaceChargeMatrixContainer"); }
-    if( m_matrix_container_pos ) { m_matrix_container_pos->Write("TpcSpaceChargeMatrixContainer_pos"); }
-    if( m_matrix_container_neg ) { m_matrix_container_neg->Write("TpcSpaceChargeMatrixContainer_neg"); }
+
+    if( m_matrix_container ) {
+      std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer_all object. entries: " << m_matrix_container->get_entries() << std::endl;
+      m_matrix_container->Write("TpcSpaceChargeMatrixContainer_all");
+    }
+
+    if( m_matrix_container_pos ) {
+      std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer_pos object. entries: " << m_matrix_container_pos->get_entries() << std::endl;
+      m_matrix_container->Write("TpcSpaceChargeMatrixContainer_pos");
+    }
+
+    if( m_matrix_container_neg ) {
+      std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer_neg object. entries: " << m_matrix_container_neg->get_entries() << std::endl;
+      m_matrix_container->Write("TpcSpaceChargeMatrixContainer_neg");
+    }
   }
 
   // print counters
@@ -795,5 +807,7 @@ int PHTpcResiduals::getNodes(PHCompositeNode* topNode)
 //____________________________________________________________________________
 void PHTpcResiduals::setGridDimensions(const int phiBins, const int rBins, const int zBins)
 {
-  m_matrix_container->set_grid_dimensions(phiBins, rBins, zBins);
+  if( m_matrix_container ) { m_matrix_container->set_grid_dimensions(phiBins, rBins, zBins); }
+  if( m_matrix_container_pos ) { m_matrix_container_pos->set_grid_dimensions(phiBins, rBins, zBins); }
+  if( m_matrix_container_neg ) { m_matrix_container_neg->set_grid_dimensions(phiBins, rBins, zBins); }
 }

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -194,8 +194,8 @@ int PHTpcResiduals::End(PHCompositeNode* /*topNode*/)
     outputfile->cd();
 
     if( m_matrix_container ) {
-      std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer_all object. entries: " << m_matrix_container->get_entries() << std::endl;
-      m_matrix_container->Write("TpcSpaceChargeMatrixContainer_all");
+      std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer object. entries: " << m_matrix_container->get_entries() << std::endl;
+      m_matrix_container->Write("TpcSpaceChargeMatrixContainer");
     }
 
     if( m_matrix_container_pos ) {

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -141,6 +141,7 @@ int PHTpcResiduals::Init(PHCompositeNode* /*topNode*/)
   std::cout << "PHTpcResiduals::Init - m_maxTBeta: " << m_maxTBeta << std::endl;
   std::cout << "PHTpcResiduals::Init - m_maxResidualDrphi: " << m_maxResidualDrphi << " cm" << std::endl;
   std::cout << "PHTpcResiduals::Init - m_maxResidualDz: " << m_maxResidualDz << " cm" << std::endl;
+  std::cout << "PHTpcResiduals::Init - m_ignoreEdgeClusters: " << m_ignoreEdgeClusters << std::endl;
   std::cout << "PHTpcResiduals::Init - m_minRPhiErr: " << m_minRPhiErr << " cm" << std::endl;
   std::cout << "PHTpcResiduals::Init - m_minZErr: " << m_minZErr << " cm" << std::endl;
   std::cout << "PHTpcResiduals::Init - m_minPt: " << m_minPt << " GeV/c" << std::endl;
@@ -472,8 +473,6 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
 
   for (const auto& cluskey : get_cluster_keys(track))
   {
-    // increment counter
-    ++m_total_clusters;
 
     // make sure cluster is from TPC
     const auto detId = TrkrDefs::getTrkrId(cluskey);
@@ -481,6 +480,10 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     {
       continue;
     }
+
+    // increment counter
+    /* only counts TPC clusters */
+    ++m_total_clusters;
 
     // find matching track state
     const auto stateiter = std::find_if( track->begin_states(), track->end_states(), [&cluskey]( const auto& state_pair )
@@ -494,6 +497,14 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
 
     // calculate residuals with respect to cluster
     auto* const cluster = m_clusterContainer->findCluster(cluskey);
+
+    // check cluster
+    if( !cluster ) { continue; }
+
+    // check if cluster is an edge
+    if( m_ignoreEdgeClusters && cluster->getEdge() > 0 && cluster->getEdge() < std::numeric_limits<char>::max() )
+    { continue; }
+
     const auto globClusPos = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(cluskey, cluster, crossing);
     const double clusR = get_r(globClusPos(0), globClusPos(1));
     const double clusPhi = std::atan2(globClusPos(1), globClusPos(0));

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -200,12 +200,12 @@ int PHTpcResiduals::End(PHCompositeNode* /*topNode*/)
 
     if( m_matrix_container_pos ) {
       std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer_pos object. entries: " << m_matrix_container_pos->get_entries() << std::endl;
-      m_matrix_container->Write("TpcSpaceChargeMatrixContainer_pos");
+      m_matrix_container_pos->Write("TpcSpaceChargeMatrixContainer_pos");
     }
 
     if( m_matrix_container_neg ) {
       std::cout << "PHTpcResiduals::End - writing TpcSpaceChargeMatrixContainer_neg object. entries: " << m_matrix_container_neg->get_entries() << std::endl;
-      m_matrix_container->Write("TpcSpaceChargeMatrixContainer_neg");
+      m_matrix_container_neg->Write("TpcSpaceChargeMatrixContainer_neg");
     }
   }
 

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -689,7 +689,7 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     for( auto& container:containers )
     {
 
-      if( !container ) continue;
+      if( !container ) { continue; }
 
       // Fill distortion matrices
       container->add_to_lhs(index, 0, 0, square(clusR) / erp);

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -63,11 +63,20 @@ class PHTpcResiduals : public SubsysReco
   }
   //@}
 
+  /// true to remove "edge" clusters
+  /** these are clusters that touch the edge of a detector and are considered pathological */
+  void setIgnoreEdgeClusters( bool value )
+  { m_ignoreEdgeClusters = value; }
+
+  /// minimum value for RPhi error.
+  /** a too small rphi error is usually a sign of pathological TPC cluster */
   void setMinRPhiErr(float minRPhiErr)
   {
     m_minRPhiErr = minRPhiErr;
   }
 
+  /// minimum value for z error.
+  /** a too small z error is usually a sign of pathological TPC cluster */
   void setMinZErr(float minZErr)
   {
     m_minZErr = minZErr;
@@ -170,6 +179,9 @@ class PHTpcResiduals : public SubsysReco
   float m_maxResidualDrphi = 0.5;  // cm
   float m_maxTBeta = 1.5;
   float m_maxResidualDz = 0.5;  // cm
+
+  /// ignore edge clusters
+  bool m_ignoreEdgeClusters = false;
 
   float m_minRPhiErr = 0.005;  // 0.005cm -- 50um
   float m_minZErr = 0.01;      // 0.01cm -- 100um

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -193,6 +193,12 @@ class PHTpcResiduals : public SubsysReco
   /// matrix container
   std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
 
+  /// matrix container positive charges only
+  std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container_pos;
+
+  /// matrix container negative charges only
+  std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container_neg;
+
   // TODO: check if needed
   int m_event = 0;
 

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainer.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainer.h
@@ -45,6 +45,10 @@ class TpcSpaceChargeMatrixContainer : public PHObject
   virtual int get_cell_index( int /*iphibin*/, int /*irbin*/, int /*izbin*/ ) const
   { return -1; }
 
+  /// get all entries
+  virtual int get_entries() const
+  { return 0; }
+
   /// get entries for a given cell
   virtual int get_entries( int /*cell_index*/ ) const
   { return 0; }

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
@@ -8,6 +8,8 @@
 
 #include "TpcSpaceChargeMatrixContainerv2.h"
 
+#include <numeric>
+
 //___________________________________________________________
 TpcSpaceChargeMatrixContainerv2::TpcSpaceChargeMatrixContainerv2()
 {
@@ -55,6 +57,10 @@ int TpcSpaceChargeMatrixContainerv2::get_cell_index(int iphi, int ir, int iz) co
   }
   return iz + m_zbins * (ir + m_rbins * iphi);
 }
+
+//___________________________________________________________
+int TpcSpaceChargeMatrixContainerv2::get_entries() const
+{ return std::accumulate( m_entries.begin(), m_entries.end(), (int)0); }
 
 //___________________________________________________________
 int TpcSpaceChargeMatrixContainerv2::get_entries(int cell_index) const

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
@@ -60,7 +60,7 @@ int TpcSpaceChargeMatrixContainerv2::get_cell_index(int iphi, int ir, int iz) co
 
 //___________________________________________________________
 int TpcSpaceChargeMatrixContainerv2::get_entries() const
-{ return std::accumulate( m_entries.begin(), m_entries.end(), (int)0); }
+{ return std::accumulate( m_entries.begin(), m_entries.end(), 0); }
 
 //___________________________________________________________
 int TpcSpaceChargeMatrixContainerv2::get_entries(int cell_index) const

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.h
@@ -39,6 +39,9 @@ class TpcSpaceChargeMatrixContainerv2 : public TpcSpaceChargeMatrixContainer
   /// get grid index for given sub-indexes
   int get_cell_index(int iphibin, int irbin, int izbin) const override;
 
+  /// get all entries
+  int get_entries() const override;
+
   /// get entries for a given cell
   int get_entries(int cell_index) const override;
 

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -163,6 +163,12 @@ bool TpcSpaceChargeMatrixInversion::add_from_file(const std::string& shortfilena
   {
     std::cout << "TpcSpaceChargeMatrixInversion::add_from_file - could not find object name " << objectname << " in file " << filename << std::endl;
     return false;
+  } else if( Verbosity() ) {
+    std::cout << "TpcSpaceChargeMatrixInversion::add_from_file -"
+      << " file: " << filename
+      << " objectname: " << objectname
+      << " entries: " << source->get_entries()
+      << std::endl;
   }
 
   // add object
@@ -199,6 +205,8 @@ void TpcSpaceChargeMatrixInversion::calculate_distortion_corrections(const Inver
     std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - no distortion matrices loaded. Aborting" << std::endl;
     exit(1);
   }
+
+  std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - entries: " <<  m_matrix_container->get_entries() << std::endl;
 
   // get grid dimensions from matrix container
   int phibins = 0;

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -163,7 +163,9 @@ bool TpcSpaceChargeMatrixInversion::add_from_file(const std::string& shortfilena
   {
     std::cout << "TpcSpaceChargeMatrixInversion::add_from_file - could not find object name " << objectname << " in file " << filename << std::endl;
     return false;
-  } else if( Verbosity() ) {
+  }
+
+  if( Verbosity() ) {
     std::cout << "TpcSpaceChargeMatrixInversion::add_from_file -"
       << " file: " << filename
       << " objectname: " << objectname

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -48,7 +48,7 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode*) override;
   int End(PHCompositeNode*) override;
-  
+
   // deprecated calls
   inline void set_sc_calib_mode(const bool) {}
   inline void set_collision_rate(const double) {}
@@ -77,7 +77,7 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   unsigned int _max_tpc_layer = 55;
 
   // pt cut for field-on data
-  float _pt_cut = 0.5;
+  float _pt_cut = 0.2;
 
   // delta_phi window between the last cluster in the tracklet and the projection
   float _dphi_cut = 0.9;
@@ -90,7 +90,7 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   TrackSeedContainer* _si_track_map{nullptr};
 
   std::string _clustermap_name = "TRKR_CLUSTER";
-  
+
   //! default rphi search window for each layer
   std::array<double, _n_mm_layers> _rphi_search_win{0.25, 13.0};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR adds a number of functionalities to further test the Matrix inversion method for track-based distortion corrections.
Namely:
- the possibility to remove Edge clustesr
- the possibility to store charge-dependent matrix containers in addition to the default charge-inclusive container.
In addition the default minimum PT cut for the Micromegas-TPC matching module is moved back to 0.2 GeV. 
It can be set manually in the steering macro (@pedroanietom used to have it at 0.5)
This increases by about x2 the number of TPC tracks correctly matched to TPOT. (TPOT clusters being later ignored in the track fit anyway). 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR extends the TPC distortion-correction workflow to further test the matrix inversion approach on TPOT-related studies, improving track/cluster handling and enabling charge-dependent matrix storage. It also restores the Micromegas–TPC matching module’s default minimum pT cut to 0.2 GeV to increase the number of matched TPC tracks (while still ignoring TPOT clusters later in the track fit).

Key changes:
- **PHTpcResiduals**
  - Added an **`ignoreEdgeClusters`** option (`setIgnoreEdgeClusters(bool)`) to optionally skip edge TPC clusters.
  - Added **charge-separated space-charge matrix containers**:
    - `m_matrix_container_pos`
    - `m_matrix_container_neg`
  - Updated track processing to tighten cluster accounting:
    - Increment total-cluster count only for **TPC clusters**
    - **Skip missing clusters**
    - **Skip edge clusters** when enabled
    - Fill matrices for accepted clusters via a loop over the container set determined by **track charge** (default/inclusive container is still updated, plus the sign-specific one).
  - Extended grid-dimension configuration so it applies to the inclusive, **pos**, and **neg** containers.
  - Updated output behavior to **conditionally create/write the ROOT output file** and to write whichever matrix containers exist.
  - Added initialization/diagnostic printout for `m_ignoreEdgeClusters`.
- **Matrix container introspection for inversion**
  - Added `virtual int get_entries() const` to `TpcSpaceChargeMatrixContainer` (default 0).
  - Implemented `get_entries()` in `TpcSpaceChargeMatrixContainerv2` to return the total entries across `m_entries` (via `std::accumulate`).
  - Enhanced `TpcSpaceChargeMatrixInversion` verbose logging to print loaded filenames/object names and **entry counts** (including via `m_matrix_container->get_entries()` after load/guard).
- **Micromegas–TPC matching default pT**
  - Restored default `_pt_cut` to **0.2 GeV** (still overrideable via the existing steering setter).

Potential risk areas:
- **ROOT I/O / object layout changes**: additional `_pos` and `_neg` matrix containers may affect downstream code expecting only the original inclusive container names.
- **Reconstruction behavior changes**: enabling edge-cluster rejection and restoring the lower default pT cut can alter which tracks/clusters contribute to the residuals and thus the produced correction matrices.
- **Interface compatibility**: downstream consumers of matrix containers may need to accommodate the new `get_entries()` virtual method if they use custom container subclasses.
- **Performance**: extra bookkeeping and writing additional containers (pos/neg) may slightly impact runtime and output size.

Possible future improvements:
- Add validation/monitoring comparing inclusive vs. charge-separated matrices (and quantifying differences in inversion/corrections).
- Document the edge-cluster option and default pT behavior more explicitly in steering examples.
- Add regression tests that exercise both (i) edge-cluster removal enabled/disabled and (ii) inclusive-only vs. inclusive+charge-separated outputs.

AI can make mistakes—please use best judgment when reviewing the implementation details and assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->