### PR TITLE
Fixed the nedge logic.

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -224,12 +224,22 @@ namespace
       if (tbin + tup >= NTBinsMax)
       {
         tup = NTBinsMax - tbin - 1;
-        counts.nedge++;
+	if (!ttop_edge)
+	{
+          counts.nedge++;
+	  counts.tredge = 1;
+	  ttop_edge = true;
+	}
       }
       if ((tbin - tdown) <= 0)
       {
         tdown = tbin;
-        counts.nedge++;
+	if (!tbottom_edge)
+	{
+          counts.nedge++;
+	  counts.tledge = 1;
+	  tbottom_edge = true;
+	}
       }
       return;
     }
@@ -331,12 +341,22 @@ namespace
       if (phibin + phiup >= NPhiBinsMax)
       {
         phiup = NPhiBinsMax - phibin - 1;
-        counts.nedge++;
+	if (!phitop_edge)
+	{
+          counts.nedge++;
+	  counts.sredge = 1;
+	  phitop_edge = true;
+	}
       }
       if (phibin - phidown <= 0)
       {
         phidown = phibin;
-        counts.nedge++;
+	if (!phibottom_edge)
+	{
+          counts.nedge++;
+	  counts.sledge = 1;
+	  phibottom_edge = true;
+	}
       }
       return;
     }
@@ -913,11 +933,11 @@ namespace
 
       if (my_data.debug)
       {
-	      clus = new TrkrClusterv6;
+	clus = new TrkrClusterv6;
       }
       else
       {
-	      clus = new TrkrClusterv5;
+	clus = new TrkrClusterv5;
       }
 
       clus_base = clus;


### PR DESCRIPTION
[comment]: <> (Fixed the edge counter logic without messing up fixed window.)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

AI-generated summaries can be wrong; please use best judgment when reviewing the change.

**Motivation / context**
- Fix the edge-counter logic in the clusterizer while preserving the existing fixed-window reconstruction behavior.

**Key changes**
- In `TpcClusterizer.cc`, FixedWindow handling in `find_t_range` and `find_phi_range` now:
  - sets the appropriate edge flags (`tredge`/`tledge`, `sredge`/`sledge`) when truncation occurs
  - increments `counts.nedge` only once per affected edge
  - uses edge guards (`ttop_edge`/`ttbottom_edge`, `phitop_edge`/`phibottom_edge`) to avoid double counting
- No functional changes were reported in `calc_cluster_parameter`; the `TrkrClusterv5`/`TrkrClusterv6` selection remains unchanged.

**Potential risk areas**
- Reconstruction behavior changes at FixedWindow boundaries
- Downstream code that depends on `ClusterCounters` edge flags or `counts.nedge`
- Any implicit IO/format expectations tied to cluster counter semantics
- Performance impact appears likely minimal, but boundary bookkeeping should be checked in validation

**Possible future improvements**
- Add targeted regression tests for fixed-window boundary cases
- Validate edge counts against representative data samples
- Consider documenting the intended `nedge`/flag semantics more explicitly for future maintenance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->