### PR TITLE
Fix combiner crash

### DIFF
--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1105,7 +1105,14 @@ int Fun4AllServer::EndRun(const int runno)
 int Fun4AllServer::End()
 {
   recoConsts *rc = recoConsts::instance();
-  EndRun(rc->get_IntFlag("RUNNUMBER"));  // call SubsysReco EndRun methods for current run
+  if (rc->FlagExist("RUNNUMBER"))
+  {
+    EndRun(rc->get_IntFlag("RUNNUMBER"));  // call SubsysReco EndRun methods for current run
+  }
+  else
+  {
+    std::cout << PHWHERE << " No RUNNUMBER Int Flag set, not calling EndRun() for registered modules" << std::endl;
+  }
   int i = 0;
   std::vector<std::pair<SubsysReco *, PHCompositeNode *>>::iterator iter;
   gROOT->cd(default_Tdirectory.c_str());

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -66,7 +66,6 @@ libfun4all_la_SOURCES = \
 libfun4all_la_LIBADD = \
   libSubsysReco.la \
   libTDirectoryHelper.la \
-  -lboost_filesystem \
   -lFROG \
   -lffaobjects \
   -lphool \

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -729,6 +729,15 @@ void SingleTriggeredInput::FillPool()
   if (!FilesDone())
   {
     int eventvectorsize = FillEventVector();
+    // this seems a unique signature for raw data files which only contain the
+    // begin and end run event but no data events. FillEventVector() returns -1
+    // and since no events were read the m_PacketEventDeque is empty
+    if (eventvectorsize < 0 && m_PacketEventDeque.empty())
+    {
+      std::cout << Name() << ": No data Events in input file " << FileName() << std::endl;
+      AllDone(1);
+      return;
+    }
     if (eventvectorsize != 0)
     {
       if (Gl1Input()->m_bclkdiffarray_map.empty())
@@ -1226,7 +1235,6 @@ int SingleTriggeredInput::ReadEvent()
     size_t size = m_PacketEventDeque.begin()->second.size();
     std::cout << "deque size: " << size << std::endl;
   }
-
   auto* ref_evt = m_PacketEventDeque.begin()->second.front();
   RunNumber(ref_evt->getRunNumber());
 

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -36,7 +36,6 @@ libg4testbench_la_LDFLAGS = \
 
 libg4testbench_la_LIBADD = \
   libphg4hit.la \
-  -lboost_filesystem \
   -lffamodules \
   -lfun4all \
   -lg4decayer \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
We have a few raw data files which do not contain data events (daq problem), only the begin and end run event. The event combiner did not expect this and segfaulted somewhere deep in its guts. This PR catches this particular failure and quits gracefully with an error.
A consequence of this is that the runnumber rc flag is not set which triggers a warning and stacktrace when Fun4All calls the EndRun with the runnumber rc flag. Now Fun4All checks if this flag exists and - if not - will not call EndRun for registered modules. This should take care of misleading printouts in some of our logfiles

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a crash in the raw-data event combiner (`coresoftware`) that occurred when an input file contains only begin/end run events (no data events), caused by a DAQ issue. It also prevents follow-on noise where the `RUNNUMBER` rc flag was not set, which could lead `Fun4All` to attempt `EndRun` in an invalid state.

Key changes:
- `SingleTriggeredInput::FillPool`: added an early guard to detect “begin/end-only” raw files (no data packets), log the condition, call `AllDone(1)`, and exit cleanly instead of continuing into a failing combiner path.
- `Fun4AllServer::End`: added a guard so `EndRun()` is called only if `recoConsts` contains the `RUNNUMBER` integer flag; if missing, it skips `EndRun()` for registered modules to reduce misleading warnings/stack traces.
- Build/link cleanup: removed `-lboost_filesystem` from `offline/framework/fun4all/Makefile.am` and `simulation/g4simulation/g4main/Makefile.am` library link lists.

Potential risk areas:
- Behavior/logging changes in the failure path for malformed/incomplete raw files (different exit timing and error messaging).
- Potential build/link behavior changes from removing `boost_filesystem` linkage (should be harmless if no longer required, but verify in your build environment).

Possible future improvements:
- Add a targeted regression test for begin/end-only raw inputs to ensure graceful termination and correct end-of-run handling.
- Improve diagnostics to surface why the raw input produced zero data events (e.g., upstream DAQ metadata or packet counters).
- Audit other end-of-run/teardown paths for similar “missing rc flag” assumptions.

AI can make mistakes—please use best judgment when reading this summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->