### PR TITLE
Fix valgrind

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -13,9 +13,12 @@
 #include <ffarawobjects/CaloPacket.h>
 #include <ffarawobjects/CaloPacketContainer.h>
 
+#include <cdbobjects/CDBTTree.h>  // for CDBTTree
+
+#include <ffamodules/CDBInterface.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
-#include <phool/recoConsts.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode
@@ -23,10 +26,7 @@
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
-
-#include <cdbobjects/CDBTTree.h>  // for CDBTTree
-
-#include <ffamodules/CDBInterface.h>
+#include <phool/recoConsts.h>
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
@@ -58,6 +58,7 @@ CaloTowerBuilder::~CaloTowerBuilder()
 {
   delete cdbttree;
   delete cdbttree_tbt_zs;
+  delete cdbttree_sepd_map;
   delete WaveformProcessing;
 }
 

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -7,12 +7,14 @@
 #include <TFile.h>
 #include <TGraphErrors.h>
 #include <TRatioPlot.h>
+#include <TH1.h>
 #include <TH2.h>
 #include <TMath.h>
 #include <TPad.h>
 #include <TSpectrum.h>
 #include <TSpline.h>
 #include <TTree.h>
+#include <TVirtualFitter.h>
 
 #include <algorithm>
 #include <fstream>
@@ -140,6 +142,8 @@ MbdSig::~MbdSig()
   {
     _pileupfile->close();
   }
+  // ROOT keeps the current fitter as a process-wide cache after Fit().
+  TVirtualFitter::SetFitter(nullptr, 0);
   delete hRawPulse;
   delete hSubPulse;
   delete gRawPulse;

--- a/offline/packages/mbd/MbdSig.h
+++ b/offline/packages/mbd/MbdSig.h
@@ -3,13 +3,16 @@
 
 #include "MbdRunningStats.h"
 
-#include <TH1.h>
+#include <Rtypes.h>
 
 #include <fstream>
+#include <limits>
 #include <vector>
 
 class TTree;
+class TF1;
 class TGraphErrors;
+class TH1;
 class TH2;
 class MbdCalib;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This should fix the valgrind errors from the CaloFitting test 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR addresses valgrind failures in the CaloFitting test by tightening memory cleanup in a couple of reconstruction components. Please use best judgment when reviewing this summary, as AI-generated summaries can make mistakes.

**Motivation / context**
- Fix leaks and stale ROOT fitter state reported by valgrind in calorimeter-related tests.
- Improve destructor cleanup for objects created during run initialization.

**Key changes**
- `CaloTowerBuilder`:
  - Deletes `cdbttree_sepd_map` in the destructor to release the SEPD-specific CDB tree allocated during `InitRun`.
  - Minor include reordering only; no functional change.
- `MbdSig`:
  - Adds ROOT header dependencies needed for fitter-related cleanup.
  - Resets the global ROOT fitter cache with `TVirtualFitter::SetFitter(nullptr, 0)` in the destructor before deleting member objects.
- `MbdSig.h`:
  - Reworks ROOT type usage with forward declarations and header cleanup to reduce coupling.

**Potential risk areas**
- ROOT/global state cleanup may affect shared fitter behavior if other code assumes the cached fitter persists.
- Destructor changes could subtly alter reconstruction lifecycle behavior or memory ownership assumptions.
- Header dependency changes should be checked for build consistency and any downstream compile impacts.
- No IO format changes are expected, but reconstruction outputs should still be validated.

**Possible future improvements**
- Audit similar reconstruction classes for missing destructor cleanup and global ROOT state handling.
- Add targeted regression tests or valgrind-focused checks for these components.
- Review ownership patterns around CDB trees and fitter objects to make cleanup more explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->