### PR TITLE
For the INTT hit carry-over issue in streaming, deepen the m_InttRawHitMap size, and discarding non-collision crossings

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -824,7 +824,10 @@ int Fun4AllStreamingInputManager::FillIntt()
         int server = intthititer->get_packetid(); // note : the felix server ID
         int felix_ch = intthititer->get_fee(); // note : the felix channel ID 0 - 13
         
-        std::string hit_string = Form("%ld_%d_%d_%d",bco_full,FPHXbco,server,felix_ch);
+        std::string hit_string =
+          Form("%" PRIu64 "_%d_%d_%d",
+              bco_full, FPHXbco, server, felix_ch
+        );
   
         // note: "BCOFULL_FPHXBCO_FELIX_FEE"
         if (m_InttRawHitCount_FEE.find(hit_string.c_str()) == m_InttRawHitCount_FEE.end()){
@@ -883,14 +886,21 @@ int Fun4AllStreamingInputManager::FillIntt()
         int ThisStrobe_HL_server;
         int ThisStrobe_HL_felix_ch;
 
-        sscanf(
+        const int nparsed = sscanf(
             pair.first.c_str(),
-            "%ld_%d_%d_%d",
+            "%" SCNu64 "_%d_%d_%d",
             &ThisStrobe_HL_bco_full,
             &ThisStrobe_HL_FPHXBCO,
             &ThisStrobe_HL_server,
             &ThisStrobe_HL_felix_ch
         );
+
+        if (nparsed != 4)
+        {
+            std::cerr << "Fun4AllStreamingInputManager::FillIntt(), Failed to parse hit key: " << pair.first.c_str() << std::endl;
+            gSystem->Exit(1);
+            exit(1);
+        }
 
         int ThisStrobe_HL_count_perFPHXBCO = pair.second;
 
@@ -1678,4 +1688,27 @@ void Fun4AllStreamingInputManager::createQAHistos()
     h_tagBcoFelix_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCO_felix%i") % i).str()));
     h_tagBcoFelixAllFees_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCOAllFees_Felix%i") % i).str()));
   }
+}
+
+
+void Fun4AllStreamingInputManager::SetInttStreamingSignalCrossing(std::pair<int,int> input_pair) {
+
+  if (input_pair.first > input_pair.second)
+  {
+    std::cout << "In Fun4AllStreamingInputManager, Error: streaming signal crossing range is reversed: "
+              << input_pair.first << ", " << input_pair.second << std::endl;
+    std::exit(1);
+  }
+
+  m_InttStreamingSignalCrossing = input_pair;
+}
+
+void Fun4AllStreamingInputManager::InttHitCarryOverShiftMaxMultiple(const int i) { 
+  if (i < 0)
+  {
+    std::cout << "In Fun4AllStreamingInputManagerm, Error: InttHitCarryOverShiftMaxMultiple must be non-negative"
+              << std::endl;
+    std::exit(1);
+  }
+  m_InttHitCarryOverShiftMaxMultiple = i; 
 }

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -650,6 +650,28 @@ int Fun4AllStreamingInputManager::FillIntt()
     return iret;
   }
 
+  if (m_Intt_print_count == 0)
+  {
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post first FillInttPool(), m_RefBCO: "<<m_RefBCO<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post first FillInttPool(), m_intt_bco_range: "<<m_intt_bco_range<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post first FillInttPool(), m_intt_negative_bco: "<<m_intt_negative_bco<<std::endl;
+
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post first FillInttPool(), m_IsDuplicateInttFPHXBCOResetHit: "<<m_IsDuplicateInttFPHXBCOResetHit<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post first FillInttPool(), m_InttStreamingSignalCrossing: "<<m_InttStreamingSignalCrossing.first<<", "<<m_InttStreamingSignalCrossing.second<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post first FillInttPool(), m_InttResetFphxBcoVec element: ";
+    for ( auto &ele : m_InttResetFphxBcoVec){
+      std::cout<<ele<<", ";
+    }
+    std::cout<<std::endl;
+
+    std::cout<<"m_IsInttStreaming: "<<m_IsInttStreaming<<std::endl;
+    std::cout<<"m_InttHitDuplication: "<<m_InttHitDuplication<<std::endl;
+    std::cout<<"m_InttHitCarryOverShift: "<<m_InttHitCarryOverShift<<std::endl;
+    std::cout<<"m_InttHitCarryOverShiftMaxMultiple: "<<m_InttHitCarryOverShiftMaxMultiple<<std::endl;
+    std::cout<<"m_IsRejectInttNoiseCrossings: "<<m_IsRejectInttNoiseCrossings<<std::endl; 
+    m_Intt_print_count = 1;
+  }
+
   // unsigned int alldone = 0;
   //     std::cout << "stashed intt BCOs: " << m_InttRawHitMap.size() << std::endl;
   InttRawHitContainer *inttcont = findNode::getClass<InttRawHitContainer>(m_topNode, "INTTRAWHIT");
@@ -708,6 +730,14 @@ int Fun4AllStreamingInputManager::FillIntt()
     {
       return iret;
     }
+  }
+
+  if (Verbosity() > 2 && m_Intt_print_count < 10){
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post GL1BCO matching, m_RefBCO (40-bit GL1BCO): "<<m_RefBCO<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post GL1BCO matching, m_intt_bco_range: "<<m_intt_bco_range<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post GL1BCO matching, m_intt_negative_bco: "<<m_intt_negative_bco<<std::endl;
+    std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Post GL1BCO matching, m_InttRawHitMap.size(): "<<m_InttRawHitMap.size()<<std::endl;
+    std::cout<<std::endl;
   }
 
   unsigned int refbcobitshift = m_RefBCO & 0x3FU;
@@ -777,6 +807,44 @@ int Fun4AllStreamingInputManager::FillIntt()
     h_taggedAllFee_intt->Fill(refbcobitshift);
   }
 
+  if (m_InttHitDuplication){
+    m_InttRawHitCount_FEE.clear();
+
+    for (auto& [bco, hitinfo] : m_InttRawHitMap)
+    {
+      if (bco > select_crossings)
+      {
+        break;
+      }
+  
+      for (auto *intthititer : hitinfo.InttRawHitVector)
+      {
+        uint64_t bco_full = intthititer->get_bco();
+        int FPHXbco = intthititer->get_FPHX_BCO();
+        int server = intthititer->get_packetid(); // note : the felix server ID
+        int felix_ch = intthititer->get_fee(); // note : the felix channel ID 0 - 13
+        
+        std::string hit_string = Form("%ld_%d_%d_%d",bco_full,FPHXbco,server,felix_ch);
+  
+        // note: "BCOFULL_FPHXBCO_FELIX_FEE"
+        if (m_InttRawHitCount_FEE.find(hit_string.c_str()) == m_InttRawHitCount_FEE.end()){
+          m_InttRawHitCount_FEE[hit_string.c_str()] = 1;
+        }
+        else {
+          m_InttRawHitCount_FEE[hit_string.c_str()] += 1;
+        }
+      }
+    }
+
+    if (Verbosity() > 2 && m_Intt_print_count < 10){
+      for (auto &pair : m_InttRawHitCount_FEE){      
+        std::cout<<"m_InttRawHitCount_FEE key: "<<pair.first<<", count: "<<pair.second<<std::endl;
+      }
+      m_Intt_print_count += 1;
+    }
+
+  }
+
   for (auto& [bco, hitinfo] : m_InttRawHitMap)
   {
     if (bco > select_crossings)
@@ -792,9 +860,96 @@ int Fun4AllStreamingInputManager::FillIntt()
                   << intthititer->get_bco() << std::dec << std::endl;
         //        intthititer->identify();
       }
+
+      int FPHXbco = intthititer->get_FPHX_BCO();
+      if (m_IsRejectInttNoiseCrossings && m_IsInttStreaming && (FPHXbco < m_InttStreamingSignalCrossing.first || FPHXbco > m_InttStreamingSignalCrossing.second) ){
+        
+        if (Verbosity() > 10){
+          std::cout<<"Fun4AllStreamingInputManager::FillIntt(), hits with FPHX_BCO: "<<FPHXbco<<", not a signal hit, rejecting"<<std::endl;
+        }
+        
+        continue;
+      }
+
       inttcont->AddHit(intthititer);
     }
   }
+
+  if (m_InttHitDuplication){
+      for (auto pair : m_InttRawHitCount_FEE){
+
+        uint64_t ThisStrobe_HL_bco_full;
+        int ThisStrobe_HL_FPHXBCO;
+        int ThisStrobe_HL_server;
+        int ThisStrobe_HL_felix_ch;
+
+        sscanf(
+            pair.first.c_str(),
+            "%ld_%d_%d_%d",
+            &ThisStrobe_HL_bco_full,
+            &ThisStrobe_HL_FPHXBCO,
+            &ThisStrobe_HL_server,
+            &ThisStrobe_HL_felix_ch
+        );
+
+        int ThisStrobe_HL_count_perFPHXBCO = pair.second;
+
+        if (m_IsRejectInttNoiseCrossings && m_IsInttStreaming && (ThisStrobe_HL_FPHXBCO < m_InttStreamingSignalCrossing.first || ThisStrobe_HL_FPHXBCO > m_InttStreamingSignalCrossing.second) ){
+        
+          if (Verbosity() > 10){
+            std::cout<<"Fun4AllStreamingInputManager::FillIntt(), Doing hit duplication, half-ladder (BCOFULL_FPHXBCO_FELIXID_FELIXChannel): "<<pair.first<<", with FPHX_BCO: "<<ThisStrobe_HL_FPHXBCO<<", not a signal crossing, rejecting duplication for this half-ladder."<<std::endl;
+          }
+          
+          continue;
+        }
+
+        for (int search_i = 1; search_i <= m_InttHitCarryOverShiftMaxMultiple; search_i++){
+          
+          uint64_t future_strobe_bco_full = ThisStrobe_HL_bco_full + m_InttHitCarryOverShift * search_i;
+
+          auto source_iter = m_InttRawHitMap.find(future_strobe_bco_full);
+          if (source_iter == m_InttRawHitMap.end()){
+            
+            if (Verbosity()>10){
+              std::cout<<"Fun4AllStreamingInputManager::FillIntt(), don't see the future strobe, GL1_BCO: "<<m_RefBCO
+              <<", This BCOFULL: "<<ThisStrobe_HL_bco_full
+              <<", this FPHXBCO: "<<ThisStrobe_HL_FPHXBCO
+              <<", FELIXID: "<<ThisStrobe_HL_server
+              <<", FELIX_ch: "<<ThisStrobe_HL_felix_ch
+              <<", hit count: "<<ThisStrobe_HL_count_perFPHXBCO
+              <<", No hits in strobe: bco_full+120*"<<search_i
+              <<std::endl;
+            }
+
+            continue;
+          }
+
+          for (auto *source_hit : source_iter->second.InttRawHitVector)
+          {
+            int server = source_hit->get_packetid(); // note : the felix server ID
+            int felix_ch = source_hit->get_fee(); // note : the felix channel ID 0 - 13
+            int FPHXbco = source_hit->get_FPHX_BCO();
+            uint64_t bco_full = source_hit->get_bco();
+
+            if (bco_full != future_strobe_bco_full){continue;}
+            if (server != ThisStrobe_HL_server){continue;}
+            if (felix_ch != ThisStrobe_HL_felix_ch){continue;}
+
+            if (
+              FPHXbco == ThisStrobe_HL_FPHXBCO ||
+              (m_IsDuplicateInttFPHXBCOResetHit && std::find(m_InttResetFphxBcoVec.begin(),m_InttResetFphxBcoVec.end(), FPHXbco) != m_InttResetFphxBcoVec.end())
+            ){
+              auto *copied_hit = inttcont->AddHit(source_hit);
+              copied_hit->set_bco(ThisStrobe_HL_bco_full);
+              copied_hit->set_FPHX_BCO(ThisStrobe_HL_FPHXBCO);
+            }
+          }
+
+        }
+
+      }
+  }
+
   return 0;
 }
 int Fun4AllStreamingInputManager::FillMvtx()

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -45,6 +45,7 @@
 #include <cstdlib>
 #include <format>
 #include <iostream>  // for operator<<, basic_ostream, endl
+#include <sstream>
 #include <utility>   // for pair
 
 Fun4AllStreamingInputManager::Fun4AllStreamingInputManager(const std::string &name, const std::string &dstnodename, const std::string &topnodename)
@@ -824,13 +825,11 @@ int Fun4AllStreamingInputManager::FillIntt()
         int server = intthititer->get_packetid(); // note : the felix server ID
         int felix_ch = intthititer->get_fee(); // note : the felix channel ID 0 - 13
         
-        std::string hit_string =
-          Form("%" PRIu64 "_%d_%d_%d",
-              bco_full, FPHXbco, server, felix_ch
-        );
+        std::string hit_string = std::format("{}_{}_{}_{}",
+                                             bco_full, FPHXbco, server, felix_ch);
   
         // note: "BCOFULL_FPHXBCO_FELIX_FEE"
-        if (m_InttRawHitCount_FEE.find(hit_string.c_str()) == m_InttRawHitCount_FEE.end()){
+        if (!m_InttRawHitCount_FEE.contains(hit_string)){
           m_InttRawHitCount_FEE[hit_string.c_str()] = 1;
         }
         else {
@@ -879,23 +878,20 @@ int Fun4AllStreamingInputManager::FillIntt()
   }
 
   if (m_InttHitDuplication){
-      for (auto pair : m_InttRawHitCount_FEE){
+      for (const auto& pair : m_InttRawHitCount_FEE){
 
-        uint64_t ThisStrobe_HL_bco_full;
-        int ThisStrobe_HL_FPHXBCO;
-        int ThisStrobe_HL_server;
-        int ThisStrobe_HL_felix_ch;
+      uint64_t ThisStrobe_HL_bco_full = 0;
+      int ThisStrobe_HL_FPHXBCO = 0;
+      int ThisStrobe_HL_server = 0;
+      int ThisStrobe_HL_felix_ch = 0;
 
-        const int nparsed = sscanf(
-            pair.first.c_str(),
-            "%" SCNu64 "_%d_%d_%d",
-            &ThisStrobe_HL_bco_full,
-            &ThisStrobe_HL_FPHXBCO,
-            &ThisStrobe_HL_server,
-            &ThisStrobe_HL_felix_ch
-        );
+      char separator1 = 0;
+      char separator2 = 0;
+      char separator3 = 0;
 
-        if (nparsed != 4)
+      std::stringstream key_stream(pair.first);
+      if (!(key_stream >> ThisStrobe_HL_bco_full >> separator1 >> ThisStrobe_HL_FPHXBCO >> separator2 >> ThisStrobe_HL_server >> separator3 >> ThisStrobe_HL_felix_ch) ||
+        separator1 != '_' || separator2 != '_' || separator3 != '_')
         {
             std::cerr << "Fun4AllStreamingInputManager::FillIntt(), Failed to parse hit key: " << pair.first.c_str() << std::endl;
             gSystem->Exit(1);

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -76,7 +76,7 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   void SetIsRejectInttNoiseCrossings(bool b = true) {m_IsRejectInttNoiseCrossings = b;}
   void SetIsInttStreaming(bool b = true) {m_IsInttStreaming = b;}
   void SetIsDuplicateInttFPHXBCOResetHit(bool b = true) {m_IsDuplicateInttFPHXBCOResetHit = b;}
-  void SetInttResetFphxBcoVec(std::vector<int> input_vec) {m_InttResetFphxBcoVec = input_vec;}
+  void SetInttResetFphxBcoVec(const std::vector<int>& input_vec) {m_InttResetFphxBcoVec = input_vec;}
   
   void SetInttStreamingSignalCrossing(std::pair<int,int> input_pair);
   void InttHitCarryOverShiftMaxMultiple(const int i);

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 class SingleStreamingInput;
 class Gl1Packet;
@@ -68,6 +69,16 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   void Streaming(bool b = true) { m_StreamingFlag = b; }
 
   void runMvtxTriggered(bool b = true) { m_mvtx_is_triggered = b; }
+
+  // configuration for INTT hit carry-over issue mitigation (hit duplication)
+  void EnableInttHitDuplication(bool b = true) { m_InttHitDuplication = b; }
+  void InttHitCarryOverShiftMaxMultiple(const int i) { m_InttHitCarryOverShiftMaxMultiple = i; }
+  void SetIsRejectInttNoiseCrossings(bool b = true) {m_IsRejectInttNoiseCrossings = b;}
+  void SetIsInttStreaming(bool b = true) {m_IsInttStreaming = b;}
+  void SetIsDuplicateInttFPHXBCOResetHit(bool b = true) {m_IsDuplicateInttFPHXBCOResetHit = b;}
+  void SetInttResetFphxBcoVec(std::vector<int> input_vec) {m_InttResetFphxBcoVec = input_vec;}
+  void SetInttStreamingSignalCrossing(std::pair<int,int> input_pair) {m_InttStreamingSignalCrossing = input_pair;}
+
 
  private:
   struct MvtxRawHitInfo
@@ -159,6 +170,20 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   TH1 *h_taggedAllFees_intt[8]{nullptr};
   TH1 *h_gl1taggedfee_intt[8][14]{{nullptr}};
   TH2 *h_bcodiff_intt[8]{nullptr};
+
+  // for INTT hit carry-over issue mitigation (hit duplication)
+  bool m_InttHitDuplication{false}; // default to false; Should be set to true when running streaming data
+  const unsigned int m_InttHitCarryOverShift{120}; // 120 BCOs as the default shift. Fixed value 
+  int m_InttHitCarryOverShiftMaxMultiple{4}; // the max multiple of the shift. For a max multiple of M, duplicate hits from N + [1..M] * shift BCOs to N
+  bool m_IsRejectInttNoiseCrossings{false}; // not allow hits in the abort-gap crossings being saved to the INTTRawHit container
+  bool m_IsInttStreaming{true}; // is INTT in the streaming readout mode
+  bool m_IsDuplicateInttFPHXBCOResetHit{true}; // Allow duplicating hits with FPHXBCO in the range given by std::vector<int>m_InttResetFphxBcoVec
+
+  std::pair<int,int> m_InttStreamingSignalCrossing{6,116};
+  std::map<std::string, int> m_InttRawHitCount_FEE;
+  int m_Intt_print_count{0};
+  std::vector<int> m_InttResetFphxBcoVec{0,1,2,3,4,5};
+
 };
 
 #endif /* FUN4ALL_FUN4ALLSTREAMINGINPUTMANAGER_H */

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -11,6 +11,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cinttypes>
 
 class SingleStreamingInput;
 class Gl1Packet;
@@ -72,12 +73,13 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
 
   // configuration for INTT hit carry-over issue mitigation (hit duplication)
   void EnableInttHitDuplication(bool b = true) { m_InttHitDuplication = b; }
-  void InttHitCarryOverShiftMaxMultiple(const int i) { m_InttHitCarryOverShiftMaxMultiple = i; }
   void SetIsRejectInttNoiseCrossings(bool b = true) {m_IsRejectInttNoiseCrossings = b;}
   void SetIsInttStreaming(bool b = true) {m_IsInttStreaming = b;}
   void SetIsDuplicateInttFPHXBCOResetHit(bool b = true) {m_IsDuplicateInttFPHXBCOResetHit = b;}
   void SetInttResetFphxBcoVec(std::vector<int> input_vec) {m_InttResetFphxBcoVec = input_vec;}
-  void SetInttStreamingSignalCrossing(std::pair<int,int> input_pair) {m_InttStreamingSignalCrossing = input_pair;}
+  
+  void SetInttStreamingSignalCrossing(std::pair<int,int> input_pair);
+  void InttHitCarryOverShiftMaxMultiple(const int i);
 
 
  private:

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -466,7 +466,7 @@ bool SingleInttPoolInput::GetSomeMoreEvents(const uint64_t ibclk)
   std::set<int> toerase;
   for (auto bcliter : m_FEEBclkMap)
   {
-    if (bcliter.second <= localbclk)
+    if (bcliter.second <= localbclk + 120 * 40)
     {
       uint64_t highest_bclk = m_InttRawHitMap.rbegin()->first;
       if ((highest_bclk - m_InttRawHitMap.begin()->first) < MaxBclkDiff())


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

## Summary
1. The PR recovers missing hits.
2. The PR represents the ultimate way to minimize the INTT carry-over hit issue in streaming readout (Discussion in https://indico.bnl.gov/event/33369/#5-cheng-weis-update)
3. The PR has a function to remove hits from non-collision crossings. Those should be excluded from the physics analysis.


## Key Changes
### For recovering missing hits
- Deepen the size of `std::map<uint64_t, InttRawHitInfo> m_InttRawHitMap;`
  - It is found that hits are missing because the m_InttRawHitMap in the `Fun4AllStreamingInputManager` is not deep enough. 
  - The size of `m_InttRawHitMap` in `Fun4AllStreamingInputManager` is controlled by `GetSomeMoreEvents()` in `SingleInttPoolInput`.
  - The requirement is now `if (bcliter.second <= localbclk + 120 * 40)`, ensuring > 40-strobe depth in the map. 
  - The memory usage is below 2 GB for one .evt file.
  
----
### For the INTT carry-over hit issue in streaming
- Public function added in `Fun4AllStreamingInputManager`:
  - `EnableInttHitDuplication(bool)`:  Enable/disable the mitigation (defaults to disabled)
  - `InttHitCarryOverShiftMaxMultiple(int)`: Set the strobe search depth  (defaults to four future strobes)
  - `SetIsRejectInttNoiseCrossings(bool)`: Enable/disable removing INTT hits from non-collision crossings (defaults to disable)
  - `SetIsInttStreaming(bool)`: Set if INTT is in the streaming readout mode (defaults to true)
  - `SetIsDuplicateInttFPHXBCOResetHit(bool)`: enable/disable duplicating INTT hits with FPHXBCO reset to the values defined by `std::vector<int> m_InttResetFphxBcoVec` (defaults to true)
  - `SetInttResetFphxBcoVec(std::vector<int>)`: Set the `std::vector<int> m_InttResetFphxBcoVec`(default {0 to 5})
  - `SetInttStreamingSignalCrossing(std::pair<int,int>)`: Set the INTT FPHXBCO range with collision, `std::pair<int,int> m_InttStreamingSignalCrossing`. (defaults to {6, 116}). 

- Implementation in the `Fun4AllStreamingInputManager` for the INTT carry-over hit issue in the streaming readout
  - Inclusive correction following the half-ladder ordering 
    - A map, `std::map<std::string, int> m_InttRawHitCount_FEE;`, is prepared for every F4A event to count the number of hits for each half-ladder in each crossing of the five strobes in a F4A event (1 GL1BCO) 
      - The key of the map:  `BCOFULL_FPHXBCO_FELIXID_FELIXChannel`.
    - For entries in the map with FPHXBCO ranging from 6 to 116, we look for hits matched to the following text, duplicate those hits, and reset their BCOfull. For hits to be duplicated with FPHXBCO 0 to 5, we reassign their FPHXBCO. 
      - BCOfull+k*120_FELIXID_FEE_FPHXBCO
      - BCOfull+k*120_FELIXID_FEE_AAA (AAA: 0 to 5)
    - k <= N, where N is the searching depth, the `m_InttHitCarryOverShiftMaxMultiple`.
    - The demonstration of "Inclusive correction" can be found in https://indico.bnl.gov/event/33369/#5-cheng-weis-update
  - Optional: boolean variable `m_IsDuplicateInttFPHXBCOResetHit` in the `Fun4AllStreamingInputManager` to enable/disable duplicating hits with FPHXBCO reset to 0 to 5.
  - The implementation also incorporates the correction method for the triggered case to be implemented in the future.
  
----
### For discarding hits from non-collision crossings.
- Prevent hits from no-collision crossings from being saved to the INTTRawHit container
  - Only for the streaming readout (m_IsInttStreaming ==true)
  - INTT strobe is synchronized with the RHIC circulation. The RHIC bunch crossings should only happen in FPHXBCO 6 to 116. Therefore, a hit with an FPHXBCO outside the range should not be a signal hit.
  - A boolean variable `m_IsRejectInttNoiseCrossings` in `Fun4AllStreamingInputManager` to remove those hits after the carry-over hit correction.


## TODOs (if applicable)

The current implementation for hit duplication works only with the INTT streaming data. In the near future, we will implement the carry-over hit correction for the INTT-triggered data, which will be incorporated into the current implementation.

## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Motivation / context:  
This PR addresses an INTT streaming readout carry-over issue where hits can be missed across strobes. It extends the effective recovery depth by duplicating INTT raw hits across future BCOs (within a configurable carry-over window) when half-ladder/FPHX association is available. AI-generated summaries can make mistakes—please use best judgment when reading.

Key changes:
- Added new public configuration/setter APIs in `Fun4AllStreamingInputManager` to control INTT streaming behavior, including:
  - enabling/disabling INTT hit duplication (`EnableInttHitDuplication`)
  - carry-over search depth (`InttHitCarryOverShiftMaxMultiple`, with validation that it must be non-negative)
  - optional rejection of “noise crossings” during streaming save/duplication (`SetIsRejectInttNoiseCrossings`, `SetIsInttStreaming`) using a configurable signal-crossing FPHX_BCO range (`SetInttStreamingSignalCrossing`)
  - duplication rules for reset hits and their allowed FPHX_BCO values (`SetIsDuplicateInttFPHXBCOResetHit`, `SetInttResetFphxBcoVec`)
- Updated `Fun4AllStreamingInputManager::FillIntt` to implement carry-over duplication:
  - when duplication is enabled, rebuilds a per-event/per-FEE hit-count map (`m_InttRawHitCount_FEE`) keyed by `(bco, FPHX_BCO, server/packetid, fee/channel)`, limited to the active BCO selection window
  - first pass: saves original hits into `INTTRAWHIT`, optionally skipping hits whose `FPHX_BCO` lies outside the configured signal-crossing range (when noise rejection is enabled and INTT streaming is active)
  - duplication pass: for each half-ladder key, searches forward in `m_InttRawHitMap` for future strobes at `future_bco = base_bco + m_InttHitCarryOverShift * search_i` (with `search_i = 1..m_InttHitCarryOverShiftMaxMultiple`), and copies matching hits from the same server/fee/channel when:
    - `FPHX_BCO` matches the half-ladder’s `FPHX_BCO`, or
    - reset duplication is enabled and `FPHX_BCO` is contained in `m_InttResetFphxBcoVec`
  - copied hits have their `bco` and `FPHX_BCO` overwritten to the target half-ladder values; noise-crossing rejection is also applied to the half-ladder keys during this duplication pass
- Added/expanded INTT diagnostics in `FillIntt`:
  - one-time state dump (guarded by `m_Intt_print_count`)
  - additional verbose printing (e.g., after GL1 BCO matching and for the per-key hit-count map) under `Verbosity()` thresholds
- Relaxed an INTT “stuck beam clock” erasure condition in `SingleInttPoolInput` by widening the acceptable BCL gap (compare against `localbclk + 120 * 40` instead of `localbclk`).

Potential risk areas:
- Reconstruction/output behavior changes to the contents of `INTTRAWHIT` due to added hit duplication and optional exclusion of out-of-range (non-collision) crossings.
- Sensitivity to configuration correctness (signal-crossing range, shift multiple, and reset-FPHXBCO vector), which directly impacts recovered/duplicated hit counts.
- Performance impact from additional map building and forward searching across strobes (tunable via the new carry-over/max-multiple configuration).
- Thread-safety considerations: new mutable configuration/state in `Fun4AllStreamingInputManager` could be risky if the manager is accessed concurrently without external synchronization.

Possible future improvements:
- Extend and validate the same carry-over/duplication strategy for triggered (non-streaming) data as planned.
- Add targeted tests/QA for edge cases: reset-FPHXBCO duplication behavior, boundary values for the signal-crossing range, and carry-over windows where future strobes are missing.
- Consider refactoring the duplication key parsing/counting logic to reduce complexity and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->