### PR TITLE
added method to dump mbd calibs to disk

### DIFF
--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -973,6 +973,12 @@ int MbdCalib::Download_Shapes(const std::string& dbase_location)
   return 1;
 }
 
+void MbdCalib::get_tcorr_range(const int ifeech, int& min, int& max, int& step)
+{
+    min = _tcorr_minrange[ifeech];
+    max = _tcorr_maxrange[ifeech];
+    step = (_tcorr_maxrange[ifeech] - _tcorr_minrange[ifeech]) / (_tcorr_npts[ifeech]-1);
+}
 
 int MbdCalib::Download_TimeCorr(const std::string& dbase_location)
 {
@@ -2426,9 +2432,42 @@ int MbdCalib::Write_Thresholds(const std::string& dbfile)
 #ifndef ONLINE
 int MbdCalib::Write_CDB_All()
 {
+  Write_CDB_Shapes("mbd_shape.root");
+  Write_CDB_TimeCorr("mbd_t0orr.root");
+  Write_CDB_SlewCorr("mbd_slewcorr.root");
+  Write_CDB_Pileup("mbd_pileup.root");
+  Write_CDB_SampMax("mbd_sampmax.root");
+  Write_CDB_Ped("mbd_ped.root");
+  Write_CDB_Status("mbd_status.root");
+  Write_CDB_TTT0("mbd_tt_t0.root");
+  Write_CDB_TQT0("mbd_tq_t0.root");
+  Write_CDB_T0Corr("mbd_t0corr.root");
+  Write_CDB_Gains("mbd_qfit.root");
+  Write_CDB_TimeRMS("mbd_trms.root");
+  Write_CDB_Thresholds("mbd_thresh.root");
+
   return 1;
 }
 #endif
+
+int MbdCalib::Write_All()
+{
+  //Write_Shapes("mbd_shape.calib");
+  Write_TimeCorr("mbd_t0corr.calib");
+  Write_SlewCorr("mbd_slewcorr.calib");
+  Write_Pileup("mbd_pileup.calib");
+  Write_SampMax("mbd_sampmax.calib");
+  Write_Ped("mbd_ped.calib");
+  Write_Status("mbd_status.calib");
+  Write_TTT0("mbd_tt_t0.calib");
+  Write_TQT0("mbd_tq_t0.calib");
+  Write_T0Corr("mbd_t0corr.calib");
+  Write_Gains("mbd_qfit.calib");
+  //Write_TimeRMS("mbd_trms.calib");
+  //Write_Thresholds("mbd_thresh.calib");
+
+  return 1;
+}
 
 // dz is what we need to move the MBD z by
 // dt is what we change the MBD t0 by

--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -2439,6 +2439,8 @@ int MbdCalib::Write_Thresholds(const std::string& dbfile)
 #ifndef ONLINE
 int MbdCalib::Write_CDB_All()
 {
+  int status = 1;
+
   if ( Write_CDB_Shapes("mbd_shape.root") != 1 )
   {
     status = 0;
@@ -2493,10 +2495,12 @@ int MbdCalib::Write_CDB_All()
 int MbdCalib::Write_All()
 {
   int status = 1;
+  /*
   if ( Write_Shapes("mbd_shape.calib") != 1 )
   {
     status = 0;
   }
+  */
   if ( Write_TimeCorr("mbd_timecorr.calib") != 1 )
   {
     status = 0;

--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -975,9 +975,16 @@ int MbdCalib::Download_Shapes(const std::string& dbase_location)
 
 void MbdCalib::get_tcorr_range(const int ifeech, int& min, int& max, int& step)
 {
-    min = _tcorr_minrange[ifeech];
-    max = _tcorr_maxrange[ifeech];
-    step = (_tcorr_maxrange[ifeech] - _tcorr_minrange[ifeech]) / (_tcorr_npts[ifeech]-1);
+    min = static_cast<int>( _tcorr_minrange[ifeech] );
+    max = static_cast<int>( _tcorr_maxrange[ifeech] );
+    if ( _tcorr_npts[ifeech] > 1 )
+    {
+      step = (_tcorr_maxrange[ifeech] - _tcorr_minrange[ifeech]) / (_tcorr_npts[ifeech]-1);
+    }
+    else
+    {
+      step = 0;
+    }
 }
 
 int MbdCalib::Download_TimeCorr(const std::string& dbase_location)
@@ -2432,41 +2439,108 @@ int MbdCalib::Write_Thresholds(const std::string& dbfile)
 #ifndef ONLINE
 int MbdCalib::Write_CDB_All()
 {
-  Write_CDB_Shapes("mbd_shape.root");
-  Write_CDB_TimeCorr("mbd_t0orr.root");
-  Write_CDB_SlewCorr("mbd_slewcorr.root");
-  Write_CDB_Pileup("mbd_pileup.root");
-  Write_CDB_SampMax("mbd_sampmax.root");
-  Write_CDB_Ped("mbd_ped.root");
-  Write_CDB_Status("mbd_status.root");
-  Write_CDB_TTT0("mbd_tt_t0.root");
-  Write_CDB_TQT0("mbd_tq_t0.root");
-  Write_CDB_T0Corr("mbd_t0corr.root");
-  Write_CDB_Gains("mbd_qfit.root");
-  Write_CDB_TimeRMS("mbd_trms.root");
-  Write_CDB_Thresholds("mbd_thresh.root");
+  if ( Write_CDB_Shapes("mbd_shape.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_TimeCorr("mbd_timecorr.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_SlewCorr("mbd_slewcorr.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_Pileup("mbd_pileup.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_SampMax("mbd_sampmax.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_Ped("mbd_ped.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_Status("mbd_status.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_TTT0("mbd_tt_t0.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_TQT0("mbd_tq_t0.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_T0Corr("mbd_t0corr.root") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_CDB_Gains("mbd_qfit.root") != 1 )
+  {
+    status = 0;
+  }
+  //Write_CDB_TimeRMS("mbd_trms.root");
+  //Write_CDB_Thresholds("mbd_thresh.root");
 
-  return 1;
+  return status;
 }
 #endif
 
 int MbdCalib::Write_All()
 {
-  //Write_Shapes("mbd_shape.calib");
-  Write_TimeCorr("mbd_t0corr.calib");
-  Write_SlewCorr("mbd_slewcorr.calib");
-  Write_Pileup("mbd_pileup.calib");
-  Write_SampMax("mbd_sampmax.calib");
-  Write_Ped("mbd_ped.calib");
-  Write_Status("mbd_status.calib");
-  Write_TTT0("mbd_tt_t0.calib");
-  Write_TQT0("mbd_tq_t0.calib");
-  Write_T0Corr("mbd_t0corr.calib");
-  Write_Gains("mbd_qfit.calib");
+  int status = 1;
+  if ( Write_Shapes("mbd_shape.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_TimeCorr("mbd_timecorr.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_SlewCorr("mbd_slewcorr.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_Pileup("mbd_pileup.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_SampMax("mbd_sampmax.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_Ped("mbd_ped.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_Status("mbd_status.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_TTT0("mbd_tt_t0.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_TQT0("mbd_tq_t0.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_T0Corr("mbd_t0corr.calib") != 1 )
+  {
+    status = 0;
+  }
+  if ( Write_Gains("mbd_qfit.calib") != 1 )
+  {
+    status = 0;
+  }
   //Write_TimeRMS("mbd_trms.calib");
   //Write_Thresholds("mbd_thresh.calib");
 
-  return 1;
+  return status;
 }
 
 // dz is what we need to move the MBD z by

--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -71,6 +71,7 @@ class MbdCalib
     return std::numeric_limits<float>::quiet_NaN();
   }
 
+  void get_tcorr_range(const int ifeech, int& min, int& max, int& step);
 
   float get_tcorr(const int ifeech, const int tdc) const {
     if (tdc<0)
@@ -160,7 +161,7 @@ class MbdCalib
   int Write_CDB_Gains(const std::string& dbfile);
   int Write_CDB_Pileup(const std::string& dbfile);
   int Write_CDB_Thresholds(const std::string& dbfile);
-  static int Write_CDB_All();
+  int Write_CDB_All();
 #endif
 
   int Write_SampMax(const std::string& dbfile);
@@ -174,6 +175,7 @@ class MbdCalib
   int Write_Gains(const std::string& dbfile);
   int Write_Pileup(const std::string& dbfile);
   int Write_Thresholds(const std::string& dbfile);
+  int Write_All();
 
   void Reset_TQT0();
   void Reset_TTT0();

--- a/offline/packages/mbd/MbdReco.h
+++ b/offline/packages/mbd/MbdReco.h
@@ -36,7 +36,7 @@ class MbdReco : public SubsysReco
 
   void DoOnlyFits()                  { _fitsonly = 1; }
   void DoFitEval(const int s)        { _fiteval = s; }
-  void SetCalPass(const int calpass) { _calpass = calpass; }
+  void SetCalPass(const int calpass) { _calpass = calpass; if (calpass==1) DoOnlyFits(); }
   void SetProcChargeCh(const bool s) { _always_process_charge = s; }
   void SetMbdTrigOnly(const int m)   { _mbdonly = m; }
 


### PR DESCRIPTION
[comment]: minor update to be able to dump calibs to disk for investigation

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves support for offline MBD calibration inspection by adding/expanding the ability to dump calibration constants to disk (text “.calib” files and ROOT/CDB-style “.root” outputs), so calibration contents can be reviewed and cross-checked outside the normal workflow. AI-generated summaries can make mistakes—please verify details against the implementation.

**Key changes**
- Added `MbdCalib::get_tcorr_range(ifeech, min, max, step)` to return the per-channel `_tcorr_minrange/_tcorr_maxrange` (cast to `int`) and compute `step` from the configured number of TCorr points (`step=range_span/(npts-1)`, or `0` when `npts<=1`).
- Extended `MbdCalib::Write_CDB_All()` (now a non-`static` member) to sequentially run the available CDB writers: shapes, timecorr, slewcorr, pileup, sampmax, ped, status, tt/t0, tq/t0, t0corr, and gains; it marks failure by setting `status = 0` if any writer returns `!= 1` and returns the final `status`. (TimeRMS/thresholds calls remain commented.)
- Implemented `MbdCalib::Write_All()` to write the corresponding offline text calibration files (`mbd_*.calib`), with `status` initialized to `1` and set to `0` upon any per-product writer failure. (TimeRMS/thresholds calls remain commented.)
- Updated `MbdReco::SetCalPass(calpass)` so that when `calpass == 1` it also calls `DoOnlyFits()` after updating `_calpass`.

**Potential risk areas**
- **Calibration dump/IO behavior:** new output file generation and naming/formatting (`mbd_*.calib` and `mbd_*.root`), plus continued omission of TimeRMS/threshold outputs (commented).
- **Correctness of return status:** `Write_CDB_All()` uses a `status` variable without local initialization in the shown block—ensure it’s properly set before use elsewhere.
- **Reconstruction behavior:** `SetCalPass(1)` now changes control flow by enabling “fits-only” mode via `DoOnlyFits()`.
- **Thread-safety:** calibration write/dump methods appear to mutate calibration state/produce files; concurrent calls could race.
- **Performance:** additional disk IO when using the new “dump all” entry points.

**Possible future improvements**
- Add/confirm explicit initialization and robustness checks for `Write_CDB_All()`’s `status` handling.
- Re-enable and/or document the commented TimeRMS/threshold outputs, or ensure downstream tooling doesn’t assume they exist.
- Add validation (schema/format checks) for the written calibration files and targeted tests covering `get_tcorr_range`, `Write_All`, `Write_CDB_All`, and the `SetCalPass(1)` behavioral change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->