### PR TITLE
feat: evaluator branches

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -99,7 +99,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
   if (_do_vertex_eval)
   {
     _ntp_vertex = new TNtuple("ntp_vertex", "vertex => max truth",
-                              "event:seed:vertexID:vx:vy:vz:ntracks:chi2:ndof:"
+                              "event:seed:vertexID:vx:vy:vz:ntracks:chi2:ndof:crossing:"
                               "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
                               "gnembed:nfromtruth:"
                               "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
@@ -109,7 +109,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
   {
     _ntp_gpoint = new TNtuple("ntp_gpoint", "g4point => best vertex",
                               "event:seed:gvx:gvy:gvz:gvt:gntracks:gembed:"
-                              "vx:vy:vz:ntracks:"
+                              "vx:vy:vz:ntracks:crossing:"
                               "nfromtruth:"
                               "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
   }
@@ -1190,6 +1190,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           float vx = vertex->get_x();
           float vy = vertex->get_y();
           float vz = vertex->get_z();
+          float crossing = vertex->get_beam_crossing();
           float ntracks = vertex->size_tracks();
           float chi2 = vertex->get_chisq();
           float ndof = vertex->get_ndof();
@@ -1228,6 +1229,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                  ntracks,
                                  chi2,
                                  ndof,
+                                 crossing,
                                  gvx,
                                  gvy,
                                  gvz,
@@ -1373,12 +1375,13 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           float vz = std::numeric_limits<float>::quiet_NaN();
           float ntracks = std::numeric_limits<float>::quiet_NaN();
           float nfromtruth = std::numeric_limits<float>::quiet_NaN();
-
+          float crossing = std::numeric_limits<float>::quiet_NaN();
           if (vertex)
           {
             vx = vertex->get_x();
             vy = vertex->get_y();
             vz = vertex->get_z();
+            crossing = vertex->get_beam_crossing();
             ntracks = vertex->size_tracks();
             nfromtruth = vertexeval->get_ntracks_contribution(vertex, point);
           }
@@ -1394,6 +1397,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                  vy,
                                  vz,
                                  ntracks,
+                                 crossing,
                                  nfromtruth,
                                  nhit_tpc_all,
                                  nhit_tpc_in,

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -19,6 +19,8 @@
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 
+#include <phool/sphenix_constants.h>
+
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -172,7 +174,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                               "gpx:gpy:gpz:gpt:geta:gphi:"
                               "gvx:gvy:gvz:gvt:"
                               "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
-                              "gembed:gprimary:gparentflavor:gparentid:gprimaryflavor:gprimaryid:"
+                              "gembed:gprimary:gcrossing:gparentflavor:gparentid:gprimaryflavor:gprimaryid:"
                               "trackID:px:py:pz:pt:eta:phi:deltapt:deltaeta:deltaphi:"
                               "crossing:siqr:siphi:sithe:six0:siy0:tpqr:tpphi:tpthe:tpx0:tpy0:"
                               "charge:quality:chisq:ndf:nhits:layers:nmaps:nintt:ntpc:nmms:ntpc1:ntpc11:ntpc2:ntpc3:nlmaps:nlintt:nltpc:nlmms:"
@@ -192,7 +194,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                              "gpx:gpy:gpz:gpt:geta:gphi:"
                              "gvx:gvy:gvz:gvt:"
                              "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
-                             "gembed:gprimary:gparentflavor:gparentid:gprimaryflavor:gprimaryid:nfromtruth:nwrong:ntrumaps:nwrongmaps:ntruintt:nwrongintt:"
+                             "gembed:gprimary:gcrossing:gparentflavor:gparentid:gprimaryflavor:gprimaryid:nfromtruth:nwrong:ntrumaps:nwrongmaps:ntruintt:nwrongintt:"
                              "ntrutpc:nwrongtpc:ntrumms:nwrongmms:ntrutpc1:nwrongtpc1:ntrutpc11:nwrongtpc11:ntrutpc2:nwrongtpc2:ntrutpc3:nwrongtpc3:layersfromtruth:"
                              "npedge:nredge:nbig:novlp:merr:msize:"
                              "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
@@ -2858,7 +2860,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float gvy = vtx->get_y();
         float gvz = vtx->get_z();
         float gvt = vtx->get_t();
-
+        int gcrossing = std::floor(gvt / sphenix_constants::time_between_crossings);
         float gfpx = 0.;
         float gfpy = 0.;
         float gfpz = 0.;
@@ -3340,6 +3342,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                gfz,
                                gembed,
                                gprimary,
+                               (float) gcrossing,
 			       gparentflavor,
 			       gparentid,
 			       gprimaryflavor,
@@ -3812,7 +3815,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float gfz = std::numeric_limits<float>::quiet_NaN();
         float gembed = std::numeric_limits<float>::quiet_NaN();
         float gprimary = std::numeric_limits<float>::quiet_NaN();
-
+        int gcrossing = std::numeric_limits<int>::max();
         int ispure = 0;
         float nfromtruth = std::numeric_limits<float>::quiet_NaN();
         float nwrong = std::numeric_limits<float>::quiet_NaN();
@@ -3942,6 +3945,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             gvz = vtx->get_z();
             gvt = vtx->get_t();
 
+            gcrossing = std::floor(gvt / sphenix_constants::time_between_crossings);
             PHG4Hit* outerhit = nullptr;
             if (_do_eval_light == false)
             {
@@ -4090,6 +4094,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                               gfz,
 			      gembed,
                               gprimary,
+                              (float) gcrossing,
 			      gparentflavor,
 			      gparentid,
 			      gprimaryflavor,


### PR DESCRIPTION
Adds a few crossing related branches to the evaluator, useful for diagnosing streaming simulations

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Motivation / context:
- Add crossing-related evaluator branches to help diagnose streaming simulations.
- This is a new feature and is not intended as a breaking change or to require macros repo updates.
- AI-generated summaries can be imperfect; please use judgment when interpreting the details below.

Key changes:
- Added a new `crossing` value to evaluator ntuples for reconstructed vertices and best truth vertices.
- Added a new `gcrossing` truth-crossing number for both G4-track truth and reconstructed track ntuples.
- Extended the TNtuple column definitions in `SvtxEvaluator::Init()` to include the new fields.
- Updated `fillOutputNtuples()` data arrays so the new crossing values are written in the correct positions.

Potential risk areas:
- IO format changes: ntuple schemas now include additional columns, so downstream analysis code may need updates.
- Reconstruction behavior: no algorithmic changes expected, but consumers of evaluator output should verify field alignment and interpretation.
- Performance/thread-safety: low risk; changes appear limited to evaluator output bookkeeping.

Possible future improvements:
- Add explicit documentation for the new ntuple columns and their units/definitions.
- Consider validation tests to confirm column ordering and value consistency across all evaluator outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->