### PR TITLE
Fix copying sPHENIX primary particle in Fun4AllDstPileupMerger

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
@@ -274,6 +274,70 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
       }
     }
 
+    // also need to copy the sPHENIX primary particle info
+    {
+      // sPHENIX primary particles
+      const auto range = container_truth->GetSPHENIXPrimaryParticleRange();
+      for (auto iter = range.first; iter != range.second; ++iter)
+      {
+        const auto &source = iter->second;
+        if (!source) // guard
+        {
+          std::cout << __PRETTY_FUNCTION__ << " - " << __LINE__ << " - null source (sPHENIX primary) particle" << std::endl;
+          continue;
+        }
+
+        auto keyiter = trkid_map.find(source->get_track_id());
+        if (keyiter == trkid_map.end()) // guard against missing track id in map
+        {
+          std::cout << __PRETTY_FUNCTION__ << " - " << __LINE__ << " - track id " << source->get_track_id() << " not found in map" << std::endl;
+          continue;
+        }
+
+        auto *dest = new PHG4Particle_t(source);
+        dest->set_track_id(keyiter->second);
+
+        if (source->get_parent_id() == 0)
+        {
+          dest->set_parent_id(0);
+        }
+        else
+        {
+          keyiter = trkid_map.find(source->get_parent_id());
+          if (keyiter != trkid_map.end())
+          {
+            dest->set_parent_id(keyiter->second);
+          }
+          else
+          {
+            std::cout << "Fun4AllDstPileupMerger::copy_background_event - track id " << source->get_parent_id() << " not found in map" << std::endl;
+          }
+        }
+
+        keyiter = trkid_map.find(source->get_primary_id());
+        if (keyiter != trkid_map.end())
+        {
+          dest->set_primary_id(keyiter->second);
+        }
+        else
+        {
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - track id " << source->get_primary_id() << " not found in map" << std::endl;
+        }
+
+        keyiter = vtxid_map.find(source->get_vtx_id());
+        if (keyiter != vtxid_map.end())
+        {
+          dest->set_vtx_id(keyiter->second);
+        }
+        else
+        {
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+        }
+
+        m_g4truthinfo->AddsPHENIXPrimaryParticle(dest->get_track_id(), dest);
+      }
+    }
+
     // vertex embed flags
     /* embed flag is stored only for primary vertices, consistently with PHG4TruthEventAction */
     for (const auto &pair : vtxid_map)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Added copying of the sPHENIX primary particle map in `Fun4AllDstPileupMerger::copy_background_event()`

Previously it copied primary and secondary `PHG4Particle`s into the G4TruthInfo container, but did not repopulate sPHENIX primary particle from `GetSPHENIXPrimaryParticleRange()` for pileup events. As a result, sPHENIX primary particles from pileup vertices were missing for downstream analyses.
The new block clones each source sPHENIX primary particle then inserts it with `AddsPHENIXPrimaryParticle()` to the G4TruthInfo node

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

AI-generated summary — please use best judgment when reading; models can make mistakes.

**Motivation / context**
- Fixes missing sPHENIX primary particle records in pileup background events. Previously, `copy_background_event()` copied `PHG4Particle` truth objects but did not repopulate the sPHENIX primary particle map, which could impact downstream truth-based analyses.

**Key changes**
- `Fun4AllDstPileupMerger::copy_background_event()` now iterates over `GetSPHENIXPrimaryParticleRange()`.
- Each source sPHENIX primary particle is cloned and inserted into `G4TruthInfo` with `AddsPHENIXPrimaryParticle()`.
- Track, parent, primary, and vertex IDs are remapped through the existing `trkid_map` and `vtxid_map`.
- Null source entries are skipped, and missing parent/ID mappings are logged.

**Potential risk areas**
- Reconstruction/truth behavior may change for pileup events that previously lacked these primary particles.
- Additional truth copying adds a small performance cost.
- No I/O format changes are expected, but downstream consumers of `G4TruthInfo` may observe different truth content.

**Possible future improvements**
- Add validation or tests to confirm parity between copied PHG4 particles and sPHENIX primary particles.
- Consider more explicit diagnostics for unmapped parents/vertices if this becomes a frequent edge case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->