### PR TITLE
feat: zero field projections in silicon seeding

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -54,6 +54,28 @@ namespace
   {
     return x * x;
   }
+
+  Acts::Vector3 get_line_surface_intersection(const Surface& surf,
+                                              const std::vector<float>& fitpars,
+                                              const Acts::Vector3& global,
+                                              ActsGeometry* tGeometry)
+  {
+    Acts::Vector3 const sensorCenter = surf->center(tGeometry->geometry().getGeoContext()) * 0.1;
+    Acts::Vector3 sensorNormal = -surf->normal(tGeometry->geometry().getGeoContext(), Acts::Vector3(1, 1, 1), Acts::Vector3(1, 1, 1));
+    sensorNormal /= sensorNormal.norm();
+
+    Acts::Vector3 const linePoint(0., fitpars[1], fitpars[3]);
+    Acts::Vector3 tangent(1., fitpars[0], fitpars[2]);
+    tangent /= tangent.norm();
+
+    // Keep the line direction consistent with the measured cluster direction when possible.
+    if ((global - linePoint).dot(tangent) < 0)
+    {
+      tangent = -1. * tangent;
+    }
+
+    return TrackFitUtils::get_line_plane_intersection(linePoint, tangent, sensorCenter, sensorNormal);
+  }
 }  // namespace
 
 PHActsSiliconSeeding::PHActsSiliconSeeding(const std::string& name)
@@ -807,7 +829,8 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
     std::vector<TrkrDefs::cluskey>& keys,
     TrackSeed& seed)
 {
-  auto fitpars = TrackFitUtils::fitClusters(clusters, keys, true);
+  auto fitpars = m_zeroField ? TrackFitUtils::fitClustersZeroField(clusters, keys, true)
+                             : TrackFitUtils::fitClusters(clusters, keys, true);
   float avgtripletx = 0;
   float avgtriplety = 0;
   for (auto& pos : clusters)
@@ -934,7 +957,8 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
         /// If we added a cluster, refit the track to get a better projection
         if (dummyclusters.size() > clusters.size())
         {
-          dummypars = TrackFitUtils::fitClusters(dummyclusters, dummykeys, false);
+          dummypars = m_zeroField ? TrackFitUtils::fitClustersZeroField(dummyclusters, dummykeys, false)
+                                  : TrackFitUtils::fitClusters(dummyclusters, dummykeys, false);
         }
         auto range = m_clusterMap->getClusters(hitsetkey);
         for (auto clusIter = range.first; clusIter != range.second; ++clusIter)
@@ -951,10 +975,12 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
           auto* const cluster = clusIter->second;
           auto glob = m_tGeometry->getGlobalPosition(
               cluskey, cluster);
-          auto intersection = TrackFitUtils::get_helix_surface_intersection(surf, fitpars, glob, m_tGeometry);
+          auto intersection = m_zeroField ? get_line_surface_intersection(surf, fitpars, glob, m_tGeometry)
+                                          : TrackFitUtils::get_helix_surface_intersection(surf, fitpars, glob, m_tGeometry);
           if (!dummypars.empty())
           {
-            intersection = TrackFitUtils::get_helix_surface_intersection(surf, dummypars, glob, m_tGeometry);
+            intersection = m_zeroField ? get_line_surface_intersection(surf, dummypars, glob, m_tGeometry)
+                                       : TrackFitUtils::get_helix_surface_intersection(surf, dummypars, glob, m_tGeometry);
           }
           auto local = (surf->localToGlobalTransform(m_tGeometry->geometry().getGeoContext())).inverse() * (intersection * Acts::UnitConstants::cm);
           local /= Acts::UnitConstants::cm;
@@ -1145,7 +1171,8 @@ std::vector<std::vector<TrkrDefs::cluskey>> PHActsSiliconSeeding::iterateLayers(
 {
   std::vector<std::vector<TrkrDefs::cluskey>> inttMatches;
   auto dummypos = positions;
-  auto fitpars = TrackFitUtils::fitClusters(dummypos, keys, true);
+  auto fitpars = m_zeroField ? TrackFitUtils::fitClustersZeroField(dummypos, keys, true)
+                             : TrackFitUtils::fitClusters(dummypos, keys, true);
   float avgtripletx = 0;
   float avgtriplety = 0;
   for (const auto& pos : positions)
@@ -1258,7 +1285,8 @@ std::vector<std::vector<TrkrDefs::cluskey>> PHActsSiliconSeeding::iterateLayers(
         auto* const cluster = clusIter->second;
         auto glob = m_tGeometry->getGlobalPosition(
             cluskey, cluster);
-        auto intersection = TrackFitUtils::get_helix_surface_intersection(surf, fitpars, glob, m_tGeometry);
+        auto intersection = m_zeroField ? get_line_surface_intersection(surf, fitpars, glob, m_tGeometry)
+                : TrackFitUtils::get_helix_surface_intersection(surf, fitpars, glob, m_tGeometry);
         auto local = (surf->localToGlobalTransform(m_tGeometry->geometry().getGeoContext())).inverse() * (intersection * Acts::UnitConstants::cm);
         local /= Acts::UnitConstants::cm;
         m_projgx = intersection.x();

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -176,6 +176,10 @@ class PHActsSiliconSeeding : public SubsysReco
   {
     m_bField = field;
   }
+  void zeroField(const bool flag = true)
+  {
+    m_zeroField = flag;
+  }
   void minpt(const float pt)
   {
     m_minSeedPt = pt;
@@ -353,6 +357,7 @@ class PHActsSiliconSeeding : public SubsysReco
   /// B field value in z direction
   /// bfield for space point grid neds to be in kiloTesla
   float m_bField = 1.4 * Acts::UnitConstants::T;
+  bool m_zeroField = false;
   std::vector<std::pair<int, int>> zBinNeighborsTop;
   std::vector<std::pair<int, int>> zBinNeighborsBottom;
   int nphineighbors = 1;


### PR DESCRIPTION
This adds a flag to perform the projection in the silicon seeder with line fit parameters instead of helical fit parameters, for zero field. Improves the number of associated INTT measurements slightly and is in any case more correct for zero field data processing.

Developed in conjunction with codex

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change adds a zero-field option to silicon seeding so projections can use line-fit parameters instead of helical-fit parameters when processing zero-field data. This is intended to make the reconstruction more appropriate for the field-free case and may slightly improve INTT association.

- **Motivation / context**
  - Zero-field tracks are better described by straight-line motion than helices.
  - The new flag enables a non-breaking switch in the silicon seeder to use the more appropriate projection model.

- **Key changes**
  - Added a public `zeroField(true)` configuration setter and internal state to `PHActsSiliconSeeding`.
  - Added a line/surface intersection helper for zero-field projection.
  - Updated `findMatches` and `iterateLayers` to:
    - use `fitClustersZeroField(...)` when zero-field mode is enabled,
    - use line-based intersections for projection in zero-field mode,
    - retain existing helix-based behavior otherwise.
  - Applied the same zero-field logic to both initial projections and refit projections.

- **Potential risk areas**
  - Reconstruction behavior changes in zero-field runs, especially around cluster association decisions.
  - Any downstream code relying on the previous projection behavior may see different matching results.
  - No obvious IO format changes, but validation is still important since this affects core tracking logic.
  - Thread-safety appears unchanged, but the new mutable configuration state should be reviewed in the context of how the tool is shared.
  - Minor performance impact is possible due to the added conditional logic and extra geometry calculations.

- **Possible future improvements**
  - Add dedicated validation/benchmarking for zero-field tracking efficiency and fake rates.
  - Consider making the projection strategy explicit via a shared policy/helper to reduce branching duplication.
  - Add tests covering both zero-field and standard-field seeding paths.

AI can make mistakes; please use best judgment when reading this summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->