### PR TITLE
EMCal SiPM Occupancy

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -366,6 +366,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
   }
 
   std::map<unsigned int, float> tbt_smear;
+  std::map<unsigned int, double> tower_photon_count_mean;
 
   // loop over hits
   for (PHG4HitContainer::ConstIterator hititer = hits->getHits().first; hititer != hits->getHits().second; hititer++)
@@ -384,6 +385,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     float correction = 1.;
     maphitetaphi(hit, etabin, phibin, correction);
     unsigned int key = encode_tower(etabin, phibin);
+    unsigned int tower_index = decode_tower(key);
     float calibconst = cdbttree->GetFloatValue(key, m_fieldname);
     float e_vis = hit->get_light_yield();
     e_vis *= correction;
@@ -397,10 +399,26 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       }
       else
       {
-        tbt_smear[key] = 1.0 + gsl_ran_gaussian(m_RandomGenerator, factor_const);
+        float val =  1.0+ gsl_ran_gaussian(m_RandomGenerator,factor_const);
+        if(val < 0.0f)
+        {
+          val = 0;
+        }
+        tbt_smear[key] = val; 
         e_vis *= tbt_smear[key];
       }
     }
+
+    if (m_use_sipm_occupancy && m_dettype == CaloTowerDefs::CEMC)
+    {
+      double kPhotonElecYieldVisibleGeV = kPhotoelectronsPerGeV / kSamplingFraction;
+      const double photon_count_mean = static_cast<double>(e_vis) * kPhotonElecYieldVisibleGeV;
+      if (photon_count_mean > 0.)
+      {
+        tower_photon_count_mean[tower_index] += photon_count_mean;
+      }
+    }
+
     float e_dep = e_vis / m_sampling_fraction;
     float ADC = (calibconst != 0) ? e_dep / calibconst : 0.;
     ADC *= m_gain;
@@ -421,7 +439,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     }
 
     float t0 = hit->get_t(0) / m_sampletime;
-    unsigned int tower_index = decode_tower(key);
+
     // here I will add the truth matching part
     //  for the cell reco, the truth matching info relies on edep not light yield, I will be consistent here :)
     TowerInfo *tower = m_CaloWaveformContainer->get_tower_at_channel(tower_index);
@@ -440,6 +458,31 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       m_waveforms.at(tower_index).at(i) += f_fit->Eval(i);
     }
   }
+
+  if (m_use_sipm_occupancy && m_dettype == CaloTowerDefs::CEMC)
+  {
+    for (const auto &entry : tower_photon_count_mean)
+    {
+      const unsigned int tower_index = entry.first;
+      const double photon_count_mean = entry.second;
+      if (photon_count_mean <= 0. || tower_index >= m_waveforms.size())
+      {
+        continue;
+      }
+
+      const double poisson_param_per_pixel = photon_count_mean / kSiPMEffectivePixel;
+      const double expected_active_pixels =
+          kSiPMEffectivePixel * (1. - std::exp(-poisson_param_per_pixel));
+      const double occupancy_ratio =
+          std::max(0., std::min(1., expected_active_pixels / photon_count_mean));
+      //std::cout << "occupancy_ratio: " << occupancy_ratio << std::endl;
+      for (int isample = 0; isample < m_nsamples; ++isample)
+      {
+        m_waveforms.at(tower_index).at(isample) *= occupancy_ratio;
+      }
+    }
+  }
+
 
   // do noise here and add to waveform
 

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -400,7 +400,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       else
       {
         float val =  1.0+ gsl_ran_gaussian(m_RandomGenerator,factor_const);
-        if(val < 0.0f)
+        if(val < 0.0F)
         {
           val = 0;
         }

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -465,20 +465,28 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     {
       const unsigned int tower_index = entry.first;
       const double photon_count_mean = entry.second;
-      if (photon_count_mean <= 0. || tower_index >= m_waveforms.size())
+      
+      double photon_count = photon_count_mean;
+      if (m_use_photon_statistics)
+      {
+        const double sigma = std::sqrt(std::max(0., photon_count_mean));
+        photon_count = std::max(0., photon_count + gsl_ran_gaussian(m_RandomGenerator, sigma));
+      }
+
+      if (photon_count_mean <= 0. || photon_count <= 0. || tower_index >= m_waveforms.size())
       {
         continue;
       }
 
-      const double poisson_param_per_pixel = photon_count_mean / kSiPMEffectivePixel;
+      const double poisson_param_per_pixel = photon_count / kSiPMEffectivePixel;
       const double expected_active_pixels =
           kSiPMEffectivePixel * (1. - std::exp(-poisson_param_per_pixel));
       const double occupancy_ratio =
-          std::max(0., std::min(1., expected_active_pixels / photon_count_mean));
-      //std::cout << "occupancy_ratio: " << occupancy_ratio << std::endl;
+          std::max(0., std::min(1., expected_active_pixels / photon_count));
+      const double photon_stat_fac = photon_count / photon_count_mean;
       for (int isample = 0; isample < m_nsamples; ++isample)
       {
-        m_waveforms.at(tower_index).at(isample) *= occupancy_ratio;
+        m_waveforms.at(tower_index).at(isample) *= occupancy_ratio * photon_stat_fac;
       }
     }
   }

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -76,6 +76,11 @@ class CaloWaveformSim : public SubsysReco
     m_use_sipm_occupancy = use_sipm_occupancy;
   }
 
+  void set_use_photon_statistics( bool state=true )
+  {
+    m_use_photon_statistics = state;
+  }
+
   // Time calibration (data)
   void set_fieldname_time(const std::string &fieldname_time)
   {
@@ -230,6 +235,7 @@ class CaloWaveformSim : public SubsysReco
 
   LightCollectionModel light_collection_model;
 
+  bool m_use_photon_statistics{false};
   bool m_use_sipm_occupancy{false};
   double kSamplingFraction     = 2e-2;
   double kPhotoelectronsPerGeV = 500.;

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -71,6 +71,11 @@ class CaloWaveformSim : public SubsysReco
     m_directURL_MC = url;
   }
 
+  void set_use_sipm_occupancy(bool use_sipm_occupancy = true)
+  {
+    m_use_sipm_occupancy = use_sipm_occupancy;
+  }
+
   // Time calibration (data)
   void set_fieldname_time(const std::string &fieldname_time)
   {
@@ -103,6 +108,19 @@ class CaloWaveformSim : public SubsysReco
   {
     m_smear_const = true;
     factor_const = val;
+  }
+
+  void set_kSamplingFraction(double val)
+  {
+    kSamplingFraction     = val;
+  }
+  void set_kPhotoelectronsPerGeV(double val)
+  {
+    kPhotoelectronsPerGeV = val;
+  }
+  void set_kSiPMEffectivePixel(double val)
+  {
+    kSiPMEffectivePixel   = val;
   }
 
   // Waveform template & sampling
@@ -211,6 +229,11 @@ class CaloWaveformSim : public SubsysReco
   int m_runNumber{0};
 
   LightCollectionModel light_collection_model;
+
+  bool m_use_sipm_occupancy{false};
+  double kSamplingFraction     = 2e-2;
+  double kPhotoelectronsPerGeV = 500.;
+  double kSiPMEffectivePixel   = 40000 * 4.;
 
   NoiseType m_noiseType{NOISE_TREE};
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
AI can make mistakes, so please use best judgment when reviewing.

**Motivation / context**
- Improve EMCal (CEMC) waveform simulation realism by adding an SiPM occupancy and photon-statistics response model to better represent sensor saturation/active-pixel effects.

**Key changes**
- `simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc`
  - In `CaloWaveformSim::process_event`, for the CEMC path, accumulates per-tower mean visible photon counts when SiPM occupancy is enabled.
  - When applying `tbt_smear`, clamps the sampled smear multiplier to be non-negative before scaling `e_vis`.
  - After processing hits (and before adding noise), iterates over accumulated per-tower photon-count means to:
    - optionally add photon-count fluctuations when `m_use_photon_statistics` is enabled,
    - compute an expected active-pixel count using a Poisson “effective pixel” model (`kSiPMEffectivePixel`),
    - derive an `occupancy_ratio` and scale every waveform sample for that tower by `occupancy_ratio * photon_stat_fac`,
    - include guards to skip non-positive photon-count means and invalid tower indices.
  - Decodes `tower_index` once and reuses it to remove a redundant later decode.
- `simulation/g4simulation/g4waveformsim/CaloWaveformSim.h`
  - Adds runtime configuration setters:
    - `set_use_sipm_occupancy(bool)`
    - `set_use_photon_statistics(bool)`
    - calibration/response setters: `set_kSamplingFraction(double)`, `set_kPhotoelectronsPerGeV(double)`, `set_kSiPMEffectivePixel(double)`

**Potential risk areas**
- **Physics/simulation behavior change:** tower-wise waveform amplitude scaling and optional photon-statistics fluctuations can shift waveform shapes and downstream reconstruction outputs.
- **Parameter sensitivity/tuning:** new constants (`kSamplingFraction`, `kPhotoelectronsPerGeV`, `kSiPMEffectivePixel`) likely require validation/retuning to match reference observables.
- **Edge cases/correctness:** the new skips/guards for non-positive photon means and tower index handling may affect rare event topologies; confirm assumptions about tower indexing and expected photon-mean ranges.
- **Performance:** additional per-tower accumulation and a post-hit per-tower scaling loop may increase runtime.

**Possible future improvements**
- Add validation/benchmarking (plots/tests) comparing key CEMC observables (occupancy dependence, waveform shape metrics, derived hit/energy resolution) against trusted reference simulation/data.
- Document recommended parameter ranges/defaults and add regression tests covering SiPM occupancy and photon-statistics on/off combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->