### PR TITLE
fix: hide verbosity

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -835,7 +835,9 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
            * 1/ drphi and dz are actually calculated in Tile's local reference frame, not in world coordinates
            * 2/ drphi also includes SC distortion correction, which the world coordinates don't
           */
-	  std::cout
+         if(Verbosity() > 1)
+         {
+	          std::cout
             << "  Try_mms: " << (int) layer
             << " drphi " << drphi
             << " dz " << dz
@@ -844,6 +846,7 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
             << " pt " << tracklet_tpc->get_pt()
             << " charge " << tracklet_tpc->get_charge()
             << std::endl;		 
+         }
         }
       }  // end loop over clusters
 


### PR DESCRIPTION
Hides some verbosity that snuck into the tpc tpot matching module

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Motivation / context:
- Reduce unintended verbosity in the TPC-TPOT matching module by suppressing debug output unless higher verbosity is explicitly requested.

Key changes:
- Added an additional `Verbosity() > 1` guard around the Micromegas candidate/diagnostic `std::cout` block in `PHMicromegasTpcTrackMatching::process_event`.
- The debug print now only appears for more verbose runs, instead of triggering whenever the `_test_windows` condition is met.
- No public or exported interfaces were changed.

Potential risk areas:
- IO/output format changes: less console output may affect log-based workflows or debugging scripts.
- Reconstruction behavior: no intended physics or matching logic changes, but log suppression should be checked for any downstream dependence on stdout.
- Performance: likely slightly improved due to reduced printing; no threading-related changes observed.

Possible future improvements:
- Consider routing diagnostic output through the framework logging system instead of `std::cout`.
- Audit similar debug prints in related matching modules to ensure consistent verbosity handling.

AI-generated summaries can be imperfect; please use best judgment when reviewing the wording and the interpretation of the code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->