### PR TITLE
Waveform vector

### DIFF
--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -61,13 +61,15 @@ pkginclude_HEADERS = \
   TowerInfov4.h \
   TowerInfoSimv1.h \
   TowerInfoSimv2.h \
+  TowerInfoSimv3.h \
   TowerInfoContainer.h \
   TowerInfoContainerv1.h \
   TowerInfoContainerv2.h \
   TowerInfoContainerv3.h \
   TowerInfoContainerv4.h \
   TowerInfoContainerSimv1.h \
-  TowerInfoContainerSimv2.h
+  TowerInfoContainerSimv2.h \
+  TowerInfoContainerSimv3.h
 
 ROOTDICTS = \
   PhotonClusterv1_Dict.cc \
@@ -96,13 +98,15 @@ ROOTDICTS = \
   TowerInfov4_Dict.cc \
   TowerInfoSimv1_Dict.cc \
   TowerInfoSimv2_Dict.cc \
+  TowerInfoSimv3_Dict.cc \
   TowerInfoContainer_Dict.cc \
   TowerInfoContainerv1_Dict.cc \
   TowerInfoContainerv2_Dict.cc \
   TowerInfoContainerv3_Dict.cc \
   TowerInfoContainerv4_Dict.cc \
   TowerInfoContainerSimv1_Dict.cc \
-  TowerInfoContainerSimv2_Dict.cc
+  TowerInfoContainerSimv2_Dict.cc \
+  TowerInfoContainerSimv3_Dict.cc
 
 pcmdir = $(libdir)
 # more elegant way to create pcm files (without listing them)
@@ -135,6 +139,7 @@ libcalo_io_la_SOURCES = \
   TowerInfov4.cc \
   TowerInfoSimv1.cc \
   TowerInfoSimv2.cc \
+  TowerInfoSimv3.cc \
   TowerInfoDefs.cc \
   TowerInfoContainer.cc \
   TowerInfoContainerv1.cc \
@@ -142,7 +147,8 @@ libcalo_io_la_SOURCES = \
   TowerInfoContainerv3.cc \
   TowerInfoContainerv4.cc \
   TowerInfoContainerSimv1.cc \
-  TowerInfoContainerSimv2.cc
+  TowerInfoContainerSimv2.cc \
+  TowerInfoContainerSimv3.cc
 endif
 
 # Rule for generating table CINT dictionaries.

--- a/offline/packages/CaloBase/TowerInfo.h
+++ b/offline/packages/CaloBase/TowerInfo.h
@@ -74,6 +74,7 @@ class TowerInfo : public PHObject
   }
   virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/) { return; }
   virtual void add_shower_edep(const int /*showerid*/, const float /*edep*/) { return; }
+  virtual void set_nsample(int /*nsample*/) { return; }
 
  private:
   ClassDefOverride(TowerInfo, 1);

--- a/offline/packages/CaloBase/TowerInfo.h
+++ b/offline/packages/CaloBase/TowerInfo.h
@@ -74,10 +74,11 @@ class TowerInfo : public PHObject
   }
   virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/) { return; }
   virtual void add_shower_edep(const int /*showerid*/, const float /*edep*/) { return; }
+// methods in v5 and simv3
   virtual void set_nsample(int /*nsample*/) { return; }
 
  private:
-  ClassDefOverride(TowerInfo, 1);
+  ClassDefOverride(TowerInfo, 0);
 };
 
 #endif

--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -57,7 +57,7 @@ class TowerInfoContainer : public PHObject
   virtual DETECTOR get_detectorid() const { return DETECTOR_INVALID; }
 
  private:
-  ClassDefOverride(TowerInfoContainer, 1);
+  ClassDefOverride(TowerInfoContainer, 0);
 };
 
 #endif

--- a/offline/packages/CaloBase/TowerInfoContainerSimv3.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerSimv3.cc
@@ -1,0 +1,156 @@
+#include "TowerInfoContainerSimv3.h"
+#include "TowerInfoSimv3.h"
+
+#include <TClonesArray.h>
+
+#include <cassert>
+
+TowerInfoContainerSimv3::TowerInfoContainerSimv3(DETECTOR detec)
+  : _detector(detec)
+{
+  int nchannels = 744;
+  if (_detector == DETECTOR::SEPD)
+  {
+    nchannels = 744;
+  }
+  else if (_detector == DETECTOR::EMCAL)
+  {
+    nchannels = 24576;
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    nchannels = 1536;
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    nchannels = 256;
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    nchannels = 52;
+  }
+  _clones = new TClonesArray("TowerInfoSimv3", nchannels);
+  _clones->SetOwner();
+  _clones->SetName("TowerInfoContainerSimv3");
+  for (int i = 0; i < nchannels; ++i)
+  {
+    // as tower numbers are fixed per event
+    // construct towers once per run, and clear the towers for first use
+    _clones->ConstructedAt(i, "C");
+  }
+}
+
+TowerInfoContainerSimv3::TowerInfoContainerSimv3(const TowerInfoContainerSimv3& source)
+  : TowerInfoContainer(source)
+  , _clones(new TClonesArray("TowerInfoSimv3", (int) source.size()))
+  , _detector(source.get_detectorid())
+{
+  _clones->SetOwner();
+  _clones->SetName("TowerInfoContainerSimv3");
+  for (int i = 0; i < (int) source.size(); ++i)
+  {
+    // as tower numbers are fixed per event
+    // construct towers once per run, and clear the towers for first use
+    _clones->ConstructedAt(i, "C");
+  }
+}
+
+TowerInfoContainerSimv3::~TowerInfoContainerSimv3()
+{
+  delete _clones;
+}
+
+void TowerInfoContainerSimv3::identify(std::ostream& os) const
+{
+  os << "TowerInfoContainerSimv3 of size " << size() << std::endl;
+}
+
+void TowerInfoContainerSimv3::Reset()
+{
+  // clear content of towers in the container for the next event
+
+  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
+  {
+    TObject* obj = _clones->UncheckedAt(i);
+
+    if (obj == nullptr)
+    {
+      std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
+                << " _clones->GetSize() = " << _clones->GetSize()
+                << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
+                << " i = " << i << std::endl;
+      _clones->Print();
+    }
+
+    assert(obj);
+    // same as TClonesArray::Clear() but only clear but not to erase all towers
+    obj->Clear();
+    obj->ResetBit(kHasUUID);
+    obj->ResetBit(kIsReferenced);
+    obj->SetUniqueID(0);
+  }
+}
+
+TowerInfoSimv3* TowerInfoContainerSimv3::get_tower_at_channel(int pos)
+{
+  return (TowerInfoSimv3*) _clones->At(pos);
+}
+
+TowerInfoSimv3* TowerInfoContainerSimv3::get_tower_at_key(int pos)
+{
+  int index = (int) decode_key(pos);
+  return (TowerInfoSimv3*) _clones->At(index);
+}
+
+unsigned int TowerInfoContainerSimv3::encode_key(unsigned int towerIndex)
+{
+  unsigned int key = 0;
+  if (_detector == DETECTOR::EMCAL)
+  {
+    key = TowerInfoContainer::encode_emcal(towerIndex);
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    key = TowerInfoContainer::encode_hcal(towerIndex);
+  }
+  else if (_detector == DETECTOR::SEPD)
+  {
+    key = TowerInfoContainer::encode_epd(towerIndex);
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    key = TowerInfoContainer::encode_mbd(towerIndex);
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    key = TowerInfoContainer::encode_zdc(towerIndex);
+  }
+  return key;
+}
+
+unsigned int TowerInfoContainerSimv3::decode_key(unsigned int tower_key)
+{
+  unsigned int index = 0;
+
+  if (_detector == DETECTOR::EMCAL)
+  {
+    index = TowerInfoContainer::decode_emcal(tower_key);
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    index = TowerInfoContainer::decode_hcal(tower_key);
+  }
+  else if (_detector == DETECTOR::SEPD)
+  {
+    index = TowerInfoContainer::decode_epd(tower_key);
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    index = TowerInfoContainer::decode_mbd(tower_key);
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    index = TowerInfoContainer::decode_zdc(tower_key);
+  }
+  return index;
+}

--- a/offline/packages/CaloBase/TowerInfoContainerSimv3.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerSimv3.cc
@@ -2,6 +2,7 @@
 #include "TowerInfoSimv3.h"
 
 #include <TClonesArray.h>
+#include <TSystem.h>
 
 #include <cassert>
 
@@ -30,8 +31,6 @@ TowerInfoContainerSimv3::TowerInfoContainerSimv3(DETECTOR detec)
     nchannels = 52;
   }
   _clones = new TClonesArray("TowerInfoSimv3", nchannels);
-  _clones->SetOwner();
-  _clones->SetName("TowerInfoContainerSimv3");
   for (int i = 0; i < nchannels; ++i)
   {
     // as tower numbers are fixed per event
@@ -45,13 +44,13 @@ TowerInfoContainerSimv3::TowerInfoContainerSimv3(const TowerInfoContainerSimv3& 
   , _clones(new TClonesArray("TowerInfoSimv3", (int) source.size()))
   , _detector(source.get_detectorid())
 {
-  _clones->SetOwner();
-  _clones->SetName("TowerInfoContainerSimv3");
   for (int i = 0; i < (int) source.size(); ++i)
   {
     // as tower numbers are fixed per event
     // construct towers once per run, and clear the towers for first use
-    _clones->ConstructedAt(i, "C");
+    auto* tower = static_cast<TowerInfoSimv3*>(_clones->ConstructedAt(i, "C"));
+    auto* source_tower = static_cast<TowerInfoSimv3*>(source._clones->UncheckedAt(i));
+    tower->copy_tower(source_tower);
   }
 }
 
@@ -71,23 +70,19 @@ void TowerInfoContainerSimv3::Reset()
 
   for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
   {
-    TObject* obj = _clones->UncheckedAt(i);
+    TowerInfo *twr = (TowerInfoSimv3*) _clones->UncheckedAt(i);
 
-    if (obj == nullptr)
+    if (twr == nullptr)
     {
       std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
                 << " _clones->GetSize() = " << _clones->GetSize()
                 << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
                 << " i = " << i << std::endl;
       _clones->Print();
+      gSystem->Exit(1);
+      exit(1);
     }
-
-    assert(obj);
-    // same as TClonesArray::Clear() but only clear but not to erase all towers
-    obj->Clear();
-    obj->ResetBit(kHasUUID);
-    obj->ResetBit(kIsReferenced);
-    obj->SetUniqueID(0);
+    twr->Reset();
   }
 }
 

--- a/offline/packages/CaloBase/TowerInfoContainerSimv3.h
+++ b/offline/packages/CaloBase/TowerInfoContainerSimv3.h
@@ -17,6 +17,7 @@ class TowerInfoContainerSimv3 : public TowerInfoContainer
   TowerInfoContainerSimv3() = default;
   PHObject *CloneMe() const override { return new TowerInfoContainerSimv3(*this); }
   TowerInfoContainerSimv3(const TowerInfoContainerSimv3 &);
+  TowerInfoContainerSimv3 &operator=(const TowerInfoContainerSimv3 &) = delete;
 
   ~TowerInfoContainerSimv3() override;
 

--- a/offline/packages/CaloBase/TowerInfoContainerSimv3.h
+++ b/offline/packages/CaloBase/TowerInfoContainerSimv3.h
@@ -1,0 +1,43 @@
+#ifndef TOWERINFOCONTAINERSIMV3_H
+#define TOWERINFOCONTAINERSIMV3_H
+
+#include "TowerInfoContainer.h"
+#include "TowerInfoSimv3.h"
+
+#include <TClonesArray.h>
+
+class PHObject;
+
+class TowerInfoContainerSimv3 : public TowerInfoContainer
+{
+ public:
+  TowerInfoContainerSimv3(DETECTOR detec);
+
+  // default constructor for ROOT IO
+  TowerInfoContainerSimv3() = default;
+  PHObject *CloneMe() const override { return new TowerInfoContainerSimv3(*this); }
+  TowerInfoContainerSimv3(const TowerInfoContainerSimv3 &);
+
+  ~TowerInfoContainerSimv3() override;
+
+  void identify(std::ostream &os = std::cout) const override;
+
+  void Reset() override;
+  TowerInfoSimv3 *get_tower_at_channel(int pos) override;
+  TowerInfoSimv3 *get_tower_at_key(int pos) override;
+
+  unsigned int encode_key(unsigned int towerIndex) override;
+  unsigned int decode_key(unsigned int tower_key) override;
+
+  size_t size() const override { return _clones->GetEntries(); }
+  DETECTOR get_detectorid() const override { return _detector; }
+
+ protected:
+  TClonesArray *_clones = nullptr;
+  DETECTOR _detector = DETECTOR_INVALID;
+
+ private:
+  ClassDefOverride(TowerInfoContainerSimv3, 1);
+};
+
+#endif

--- a/offline/packages/CaloBase/TowerInfoContainerSimv3LinkDef.h
+++ b/offline/packages/CaloBase/TowerInfoContainerSimv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TowerInfoContainerSimv3 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/TowerInfoSimv3.cc
+++ b/offline/packages/CaloBase/TowerInfoSimv3.cc
@@ -1,0 +1,64 @@
+#include "TowerInfoSimv3.h"
+
+#include "TowerInfo.h"
+
+void TowerInfoSimv3::Reset()
+{
+  TowerInfoSimv1::Reset();
+  for (short& i : _waveform)
+  {
+    i = 0;
+  }
+}
+
+void TowerInfoSimv3::Clear(Option_t* /*unused*/)
+{
+  TowerInfoSimv1::Clear();
+  for (short& i : _waveform)
+  {
+    i = 0;
+  }
+}
+
+void TowerInfoSimv3::set_nsample(int nsample)
+{
+  if (nsample >= 0)
+  {
+    _waveform.resize(nsample, 0);
+  }
+}
+
+int16_t TowerInfoSimv3::get_waveform_value(int index) const
+{
+  if (index >= 0 && index < get_nsample())
+  {
+    return _waveform[index];
+  }
+  return 0;
+}
+
+void TowerInfoSimv3::set_waveform_value(int index, int16_t value)
+{
+  if (index >= 0 && index < get_nsample())
+  {
+    _waveform[index] = value;
+  }
+  return;
+}
+
+void TowerInfoSimv3::copy_tower(TowerInfo* tower)
+{
+  TowerInfoSimv1::copy_tower(tower);
+  const int nsamples = tower->get_nsample();
+  if (nsamples <= 0)
+  {
+    set_nsample(0);
+    return;
+  }
+  set_nsample(nsamples);
+  for (int i = 0; i < nsamples; ++i)
+  {
+    _waveform[i] = tower->get_waveform_value(i);
+  }
+  return;
+}

--- a/offline/packages/CaloBase/TowerInfoSimv3.cc
+++ b/offline/packages/CaloBase/TowerInfoSimv3.cc
@@ -2,30 +2,26 @@
 
 #include "TowerInfo.h"
 
+#include <phool/phool.h>
+
+#include <TSystem.h>
+
 void TowerInfoSimv3::Reset()
 {
   TowerInfoSimv1::Reset();
-  for (short& i : _waveform)
-  {
-    i = 0;
-  }
-}
-
-void TowerInfoSimv3::Clear(Option_t* /*unused*/)
-{
-  TowerInfoSimv1::Clear();
-  for (short& i : _waveform)
-  {
-    i = 0;
-  }
+  std::ranges::fill(_waveform,0);
 }
 
 void TowerInfoSimv3::set_nsample(int nsample)
 {
-  if (nsample >= 0)
+  if (nsample > 0)
   {
     _waveform.resize(nsample, 0);
+    return;
   }
+  std::cout << PHWHERE << " invalid number of samples: " << nsample << std::endl;
+  gSystem->Exit(1);
+  exit(1);
 }
 
 int16_t TowerInfoSimv3::get_waveform_value(int index) const
@@ -52,7 +48,7 @@ void TowerInfoSimv3::copy_tower(TowerInfo* tower)
   const int nsamples = tower->get_nsample();
   if (nsamples <= 0)
   {
-    set_nsample(0);
+    _waveform.clear();
     return;
   }
   set_nsample(nsamples);

--- a/offline/packages/CaloBase/TowerInfoSimv3.h
+++ b/offline/packages/CaloBase/TowerInfoSimv3.h
@@ -13,7 +13,6 @@ class TowerInfoSimv3 : public TowerInfoSimv1
   ~TowerInfoSimv3() override = default;
 
   void Reset() override;
-  void Clear(Option_t* = "") override;
 
   void copy_tower(TowerInfo* tower) override;
 
@@ -23,12 +22,9 @@ class TowerInfoSimv3 : public TowerInfoSimv1
   void set_waveform_value(int index, int16_t value) override;
 
  private:
-  EdepMap _hitedeps;
-  ShowerEdepMap _showeredeps;
   std::vector<int16_t> _waveform;
 
   ClassDefOverride(TowerInfoSimv3, 1);
-  // Inherit other methods and properties from TowerInfoSimv1
 };
 
 #endif

--- a/offline/packages/CaloBase/TowerInfoSimv3.h
+++ b/offline/packages/CaloBase/TowerInfoSimv3.h
@@ -1,0 +1,34 @@
+#ifndef TOWERINFOSIMV3_H
+#define TOWERINFOSIMV3_H
+
+#include "TowerInfoSimv1.h"
+
+#include <cstdint>  // For int16_t
+#include <vector>
+
+class TowerInfoSimv3 : public TowerInfoSimv1
+{
+ public:
+  TowerInfoSimv3() = default;
+  ~TowerInfoSimv3() override = default;
+
+  void Reset() override;
+  void Clear(Option_t* = "") override;
+
+  void copy_tower(TowerInfo* tower) override;
+
+  void set_nsample(int nsample) override;
+  int get_nsample() const override { return _waveform.size(); }
+  int16_t get_waveform_value(int index) const override;
+  void set_waveform_value(int index, int16_t value) override;
+
+ private:
+  EdepMap _hitedeps;
+  ShowerEdepMap _showeredeps;
+  std::vector<int16_t> _waveform;
+
+  ClassDefOverride(TowerInfoSimv3, 1);
+  // Inherit other methods and properties from TowerInfoSimv1
+};
+
+#endif

--- a/offline/packages/CaloBase/TowerInfoSimv3LinkDef.h
+++ b/offline/packages/CaloBase/TowerInfoSimv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TowerInfoSimv3 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/TowerInfov1.cc
+++ b/offline/packages/CaloBase/TowerInfov1.cc
@@ -11,13 +11,12 @@ TowerInfov1::TowerInfov1(TowerInfo& tower)
 void TowerInfov1::Reset()
 {
   _time = 0;
-  _energy = std::numeric_limits<float>::quiet_NaN();
+  _energy = 0;
 }
 
 void TowerInfov1::Clear(Option_t* /*unused*/)
 {
-  _time = 0;
-  _energy = 0;
+  TowerInfov1::Reset();
 }
 
 void TowerInfov1::copy_tower(TowerInfo* tower)

--- a/offline/packages/CaloBase/TowerInfov3.cc
+++ b/offline/packages/CaloBase/TowerInfov3.cc
@@ -46,3 +46,13 @@ void TowerInfov3::copy_tower(TowerInfo* tower)
   }
   return;
 }
+
+void TowerInfov3::identify(std::ostream& os) const
+{
+  os << "TowerInfov3" << std::endl;
+  for (int i = 0; i < nsample; ++i)
+  {
+    std::cout << "sample " << i << ": " << get_waveform_value(i) << std::endl;
+  }
+  return;
+}

--- a/offline/packages/CaloBase/TowerInfov3.h
+++ b/offline/packages/CaloBase/TowerInfov3.h
@@ -21,6 +21,8 @@ class TowerInfov3 : public TowerInfov2
 
   void copy_tower(TowerInfo* tower) override;
 
+  void identify(std::ostream& os) const override;
+
  private:
   static const int nsample = 31;
   int16_t _waveform[nsample] = {0};  // Initializes the entire array to zero

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -89,12 +89,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
     gSystem->Exit(1);
   }
   h_template->SetDirectory(nullptr);
-
-  m_runNumber = recoConsts::instance()->get_IntFlag("RUNNUMBER");
-  if (Verbosity() > 0)
-  {
-    std::cout << "CaloWaveformSim::InitRun Run Number: " << m_runNumber << std::endl;
-  }
+  ft->Close();
 
   // Detector-specific setup
   if (m_dettype == CaloTowerDefs::CEMC)

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -449,6 +449,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       gSystem->Exit(1);
       exit(1);
     }
+    m_PedestalContainer->identify();
   }
 
   std::vector<float> waveform_pedestal_vector(m_nsamples);
@@ -463,6 +464,11 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       {
         waveform_pedestal_vector.at(j) = (j < pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(pedestalsamples - 1);
         pedestal_mean += waveform_pedestal_vector.at(j);
+	if (pedestal_tower->get_waveform_value(j) < 100)
+	{
+	  std::cout << Name() << " channel: " << j << " too small pedestal value for index " << j << ": " << pedestal_tower->get_waveform_value(j) << std::endl;
+	  pedestal_tower->identify();
+	}
       }
       pedestal_mean /= m_nsamples;
       for (int j = 0; j < m_nsamples; j++)

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -456,32 +456,30 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     }
   }
 
+  std::vector<float> waveform_pedestal_vector(m_nsamples);
   for (int i = 0; i < m_nchannels; i++)
   {
-    std::vector<float> m_waveform_pedestal;
-    m_waveform_pedestal.resize(m_nsamples);
     if (m_noiseType == NoiseType::NOISE_TREE)
     {
       TowerInfo *pedestal_tower = m_PedestalContainer->get_tower_at_channel(i);
+      int pedestalsamples = pedestal_tower->get_nsample();
       float pedestal_mean = 0;
       for (int j = 0; j < m_nsamples; j++)
       {
-        m_waveform_pedestal.at(j) = (j < m_pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(m_pedestalsamples - 1);
-        pedestal_mean += m_waveform_pedestal.at(j);
+        waveform_pedestal_vector.at(j) = (j < pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(pedestalsamples - 1);
+        pedestal_mean += waveform_pedestal_vector.at(j);
       }
       pedestal_mean /= m_nsamples;
       for (int j = 0; j < m_nsamples; j++)
       {
-        m_waveform_pedestal.at(j) = (m_waveform_pedestal.at(j) - pedestal_mean) * m_pedestal_scale + pedestal_mean;
+        waveform_pedestal_vector.at(j) = (waveform_pedestal_vector.at(j) - pedestal_mean) * m_pedestal_scale + pedestal_mean;
       }
     }
     for (int j = 0; j < m_nsamples; j++)
     {
       if (m_noiseType == NoiseType::NOISE_TREE)
       {
-        // TowerInfo *pedestal_tower = m_PedestalContainer->get_tower_at_channel(i);
-        // m_waveforms.at(i).at(j) += (j < m_pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(m_pedestalsamples - 1);
-        m_waveforms.at(i).at(j) += m_waveform_pedestal.at(j);
+        m_waveforms.at(i).at(j) += waveform_pedestal_vector.at(j);
       }
       if (m_noiseType == NoiseType::NOISE_GAUSSIAN)
       {

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -449,7 +449,6 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       gSystem->Exit(1);
       exit(1);
     }
-    m_PedestalContainer->identify();
   }
 
   std::vector<float> waveform_pedestal_vector(m_nsamples);
@@ -464,7 +463,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       {
         waveform_pedestal_vector.at(j) = (j < pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(pedestalsamples - 1);
         pedestal_mean += waveform_pedestal_vector.at(j);
-	if (pedestal_tower->get_waveform_value(j) < 100)
+	if (Verbosity() > 2 && pedestal_tower->get_waveform_value(j) < 100)
 	{
 	  std::cout << Name() << " channel: " << j << " too small pedestal value for index " << j << ": " << pedestal_tower->get_waveform_value(j) << std::endl;
 	  pedestal_tower->identify();

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -21,7 +21,7 @@
 
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
-#include <calobase/TowerInfoContainerSimv2.h>
+#include <calobase/TowerInfoContainerSimv3.h>
 
 #include <caloreco/CaloTowerDefs.h>
 
@@ -607,8 +607,12 @@ void CaloWaveformSim::CreateNodeTree(PHCompositeNode *topNode)
     DetNode = new PHCompositeNode(DetectorNodeName);
     dstNode->addNode(DetNode);
   }
-  m_CaloWaveformContainer = new TowerInfoContainerSimv2(DetectorEnum);
-
+  m_CaloWaveformContainer = new TowerInfoContainerSimv3(DetectorEnum);
+  for (size_t index = 0; index < m_CaloWaveformContainer->size(); index++)
+  {
+    TowerInfo *twr = m_CaloWaveformContainer->get_tower_at_channel(index);
+    twr->set_nsample(m_nsamples);
+  }
   PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloWaveformContainer, "WAVEFORM_" + m_detector, "PHObject");
   DetNode->addNode(newTowerNode);
 }

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -192,8 +192,8 @@ class CaloWaveformSim : public SubsysReco
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
   int m_nsamples{12}; // number of samples for calos in our default data taking configuration
   float m_sampletime{50. / 3.};
-  int m_nchannels{24576};
-  float m_sampling_fraction{1.0f};
+  int m_nchannels{-1};
+  float m_sampling_fraction{std::numeric_limits<float>::quiet_NaN()};
 
   // Shaping & noise
   int m_fixpedestal{1500};
@@ -206,7 +206,6 @@ class CaloWaveformSim : public SubsysReco
   float m_pedestal_scale{1.};
 
   std::vector<std::vector<float>> m_waveforms;
-  int m_runNumber{0};
 
   LightCollectionModel light_collection_model;
 

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -108,7 +108,6 @@ class CaloWaveformSim : public SubsysReco
   // Waveform template & sampling
   void set_templatefile(const std::string &templatefile) { m_templatefile = templatefile; }
   void set_nsamples(int nsamples) { m_nsamples = nsamples; }
-  void set_pedestalsamples(int pedestalsamples) { m_pedestalsamples = pedestalsamples; }
   void set_sampletime(float sampletime) { m_sampletime = sampletime; }
   void set_nchannels(int nchannels) { m_nchannels = nchannels; }
   void set_sampling_fraction(float fraction) { m_sampling_fraction = fraction; }
@@ -191,8 +190,7 @@ class CaloWaveformSim : public SubsysReco
 
   // Waveform settings
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
-  int m_nsamples{31};
-  int m_pedestalsamples{31};
+  int m_nsamples{12}; // number of samples for calos in our default data taking configuration
   float m_sampletime{50. / 3.};
   int m_nchannels{24576};
   float m_sampling_fraction{1.0f};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
So far we have been using a hardcoded array[31] for the waveforms when we store them. This PR replaces this for the simulations by a vector which has by default 12 samples but can be changed with an option for the CaloWaveformSim module. This reduces the file sizes but also allow the next changes to remove all those set_nsample we have sprinkled in our macros which will bite us if inconsistent and just read the number of samples from whatever is the input. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Motivation / context  
This PR updates calorimeter simulation waveform storage from a fixed `array[31]` layout to a vector-backed implementation, configurable at runtime with a new default of 12 samples. The intent is to reduce output file sizes and move toward a cleaner configuration path (avoiding scattered `set_nsample` usage in downstream macros). AI-generated summaries can miss details—please use best judgment when reviewing the exact IO and behavior changes.

Key changes
- Added `TowerInfoSimv3` and `TowerInfoContainerSimv3` to store waveform samples in a `std::vector<int16_t>` and manage towers via `TClonesArray` (with ROOT dictionary/build support).
- Updated `CaloWaveformSim` to use `TowerInfoContainerSimv3` and set per-tower waveform length via `twr->set_nsample(m_nsamples)` during node tree creation.
- Changed `CaloWaveformSim` defaults:
  - `m_nsamples`: 31 → 12
  - `m_nchannels`: 24576 → -1
  - `m_sampling_fraction`: 1.0f → `quiet_NaN()`
- Refactored pedestal handling: removed the `set_pedestalsamples` API and compute pedestal samples on-the-fly using a per-channel `waveform_pedestal_vector` sized to `m_nsamples` (including mean/scale around the pedestal mean), then added pedestal contributions into the simulated waveforms.
- Minor simulation/ROOT housekeeping (e.g., explicit closure of the template ROOT file in `InitRun`) and related CaloBase class metadata adjustments.

Potential risk areas
- IO / data compatibility: waveform storage changes from fixed-size (31) to variable-length (vector) representation; downstream readers expecting 31 samples may break or behave differently.
- Reconstruction/simulation behavior: changing the default sample count (to 12) will affect time-sampled waveform content, pedestal application, and any algorithms downstream that assume 31 samples.
- Configuration robustness: `TowerInfoSimv3::set_nsample()` exits the process on `nsample <= 0`; setting `m_nsamples` to an invalid value would be fatal.
- Performance/memory: per-tower waveform vectors can change allocation/reset behavior; verify large runs and resets don’t introduce regressions.
- Thread-safety: container ownership and `TClonesArray` usage should be checked in any multi-threaded execution mode, even if threading behavior wasn’t intentionally changed.

Possible future improvements
- Remove remaining reliance on macro-specific manual `set_nsample` settings by standardizing configuration flow.
- Add validation/consistency checks to ensure waveform lengths are aligned across detectors and pedestal containers.
- Continue/extend Simv2/Simv3 cleanup once downstream consumers are updated for the new vector-backed waveform format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->