### PR TITLE
Update CaloStatusSkimmer.cc

### DIFF
--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -177,7 +177,8 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       {
         std::cout << PHWHERE << "CaloStatusSkimmer::process_event: missing TOWERS_SEPD" << std::endl;
       }
-      return Fun4AllReturnCodes::ABORTEVENT;
+      //Temporarily turned off the event abort because the sEPD towers were removed from calofitting dsts. 
+      //return Fun4AllReturnCodes::ABORTEVENT;
     }
     const uint32_t ntowers = sepd_towers->size();
     for (uint32_t ch = 0; ch < ntowers; ++ch)

--- a/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
+++ b/offline/packages/Skimmers/CaloStatusSkimmer/CaloStatusSkimmer.cc
@@ -1,7 +1,7 @@
 #include "CaloStatusSkimmer.h"
 
-#include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
@@ -20,11 +20,10 @@
 
 //____________________________________________________________________________..
 CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name)
-    : SubsysReco(name)
+  : SubsysReco(name)
 {
-  //std::cout << "CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name) ""Calling ctor" << std::endl;
+  // std::cout << "CaloStatusSkimmer::CaloStatusSkimmer(const std::string &name) ""Calling ctor" << std::endl;
 }
-
 
 //____________________________________________________________________________..
 int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
@@ -33,7 +32,7 @@ int CaloStatusSkimmer::Init([[maybe_unused]] PHCompositeNode *topNode)
 
   if (b_produce_QA_histograms)
   {
-    auto* hm = QAHistManagerDef::getHistoManager();
+    auto *hm = QAHistManagerDef::getHistoManager();
     assert(hm);
 
     h_EMC_nTowers_notinstr = new TH1F("h_EMC_nTowers_notinstr", "Number of not-instrumented(empty/missing pckt) towers in EMCal; nNotInstrTowers; Counts", 24577, -0.5, 24576.5);
@@ -177,32 +176,35 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       {
         std::cout << PHWHERE << "CaloStatusSkimmer::process_event: missing TOWERS_SEPD" << std::endl;
       }
-      //Temporarily turned off the event abort because the sEPD towers were removed from calofitting dsts. 
-      //return Fun4AllReturnCodes::ABORTEVENT;
+      // Temporarily turned off the event abort because the sEPD towers were removed from calofitting dsts.
+      // return Fun4AllReturnCodes::ABORTEVENT;
     }
-    const uint32_t ntowers = sepd_towers->size();
-    for (uint32_t ch = 0; ch < ntowers; ++ch)
+    if (sepd_towers)
     {
-      TowerInfo *tower = sepd_towers->get_tower_at_channel(ch);
-      if (tower->get_isNotInstr())
+      const uint32_t ntowers = sepd_towers->size();
+      for (uint32_t ch = 0; ch < ntowers; ++ch)
       {
-        ++notinstr_sEPD;
+        TowerInfo *tower = sepd_towers->get_tower_at_channel(ch);
+        if (tower->get_isNotInstr())
+        {
+          ++notinstr_sEPD;
+        }
       }
-    }
 
-    if (Verbosity() > 9)
-    {
-      std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in sEPD = " << ntowers << ", not-instrumented(empty/missing pckt) towers in sEPD = " << notinstr_sEPD << std::endl;
-    }
+      if (Verbosity() > 9)
+      {
+        std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in sEPD = " << ntowers << ", not-instrumented(empty/missing pckt) towers in sEPD = " << notinstr_sEPD << std::endl;
+      }
 
-    if(b_produce_QA_histograms)
-    {
-      h_sEPD_nTowers_notinstr->Fill(notinstr_sEPD);
-    }
+      if (b_produce_QA_histograms)
+      {
+        h_sEPD_nTowers_notinstr->Fill(notinstr_sEPD);
+      }
 
-    if (notinstr_sEPD >= m_sEPD_skim_threshold)
-    {
-      sEPD_skim_count++;
+      if (notinstr_sEPD >= m_sEPD_skim_threshold)
+      {
+        sEPD_skim_count++;
+      }
     }
   }
 
@@ -234,7 +236,7 @@ int CaloStatusSkimmer::process_event(PHCompositeNode *topNode)
       std::cout << "CaloStatusSkimmer::process_event: event " << n_eventcounter << ", ntowers in ZDC = " << ntowers << ", not-instrumented(empty/missing pckt) towers in ZDC = " << notinstr_ZDC << std::endl;
     }
 
-    if(b_produce_QA_histograms)
+    if (b_produce_QA_histograms)
     {
       h_ZDC_nTowers_notinstr->Fill(notinstr_ZDC);
     }


### PR DESCRIPTION
[comment]: Turned off abort for missing sEPD towers node. 
See this thread: https://chat.sdcc.bnl.gov/sphenix/pl/t6espj4y1brwtgpcqkora3bfty

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Comments out event abort from sEPD towers node missing. Potentially dangerous, but currently all events are aborted if you only use calofitting dsts, which no longer have the node in question.
I added a check if sepd_towers is a nullptr before running the sEPD sections.

## TODOs (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change is a workaround for calofitting DSTs that no longer include the `TOWERS_SEPD` node. Previously, `CaloStatusSkimmer::process_event` aborted every event when that node was missing, causing valid events to be dropped.

- Stops immediately aborting the event when `TOWERS_SEPD` is not found
- Leaves the missing-node check in place, but disables the `ABORTEVENT` path so processing can continue
- Targets the current DST format gap rather than changing the broader skimmer behavior

Potential risk areas:
- Reconstruction behavior may change because events with missing inputs are now allowed to pass this check
- This workaround could mask genuine data-quality or I/O format issues
- Future threading/performance impact appears minimal, but downstream assumptions about the node’s presence should be reviewed

Possible future improvements:
- Replace the workaround with a format-aware, explicit fallback path for calofitting DSTs
- Add clearer diagnostics or validation so missing-node cases are tracked without aborting good events
- Revisit whether the skimmer should distinguish between expected and unexpected missing inputs

AI-generated summaries can be wrong; please use best judgment when reviewing the code and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->