### PR TITLE
Local alignment params file

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -77,11 +77,17 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 
   // load alignment constants file
   std::ifstream datafile;
-  datafile.open(alignmentParamsFile);  //  looks for default file name on disk
+  if( !alignmentParamsFile.empty() )
+  {
+    //  looks for default file name on disk
+    datafile.open(alignmentParamsFile);
+  }
+
   if (datafile.is_open())
   {
-    std::cout << "AlignmentTransformation: Reading alignment parameters from disk file: "
-              << alignmentParamsFile << " localVerbosity = " << localVerbosity << std::endl;
+    std::cout
+      << "AlignmentTransformation: Reading alignment parameters from disk file: "
+      << alignmentParamsFile << " localVerbosity = " << localVerbosity << std::endl;
   }
   else
   {
@@ -165,7 +171,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	std::cout  <<  hitsetkey << "  " << alpha  << "  " << beta  << "  " << gamma  << "  " << dx  << "  " << dy << "  " << dz
 		   << "  " << dgrx << "  " << dgry << "  " << dgrz << std::endl;
       }
-    
+
     // Perturbation translations and angles for stave and sensor
     Eigen::Vector3d sensorAngles(alpha, beta, gamma);
     Eigen::Vector3d millepedeTranslation(dx, dy, dz);
@@ -285,7 +291,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		zcenter *= -1;
 	      }
 	    Acts::Vector3 env_pos(radius*std::cos(phis), radius * std::sin(phis), zcenter);
-	    Acts::Vector3 world_pos = m_tGeometry->transformTpcEnvelopeToWorld(env_pos);	    
+	    Acts::Vector3 world_pos = m_tGeometry->transformTpcEnvelopeToWorld(env_pos);
 	    unsigned short  sskey = 999;
 	    Surface this_surf = m_tGeometry->get_tpc_surface_from_coords(this_hitsetkey, world_pos, sskey);
 	    if(sskey == 999 || !this_surf)
@@ -299,7 +305,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		      <<"  world_radius " << sqrt(world_pos.x() * world_pos.x() + world_pos.y() * world_pos.y())
 		      << " sskey " << sskey << std::endl;
 	    */
-	    
+
 	    Eigen::Vector3d localFrameTranslation(0, 0, 0);
 	    use_module_tilt = false;
 	    if (test_layer < 4 || use_module_tilt_always)
@@ -312,18 +318,18 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		double this_radius = std::sqrt(this_center_envelope[0] * this_center_envelope[0] + this_center_envelope[1] * this_center_envelope[1]);
 		float moduleRadius = TpcModuleRadii[side][sector][this_region];                                     // radius of the center of the module in cm
 		localFrameTranslation = getTpcLocalFrameTranslation(moduleRadius, this_radius, sensorAngles) * 10;  // cm to mm
-		
-		// set this flag for later use 
+
+		// set this flag for later use
 		use_module_tilt = true;
 	      }
 
 	    Acts::Transform3 transform;
 	    transform = newMakeTransform(this_surf, millepedeTranslation, sensorAngles, localFrameTranslation, sensorAnglesGlobal, trkrId, false);
 	    Acts::GeometryIdentifier id = this_surf->geometryId();
-	    
+
 	    if (localVerbosity)
 	      {
-		std::cout << "    Add transform for TPC with surface GeometryIdentifier " << id 
+		std::cout << "    Add transform for TPC with surface GeometryIdentifier " << id
 			  << " trkrid " << trkrId << " hitsetkey " << this_hitsetkey << " layer " << this_layer << " sector " << sector
 			  << " side " << side << std::endl;
 		if(localVerbosity > 1)
@@ -339,10 +345,10 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	    transformMapTransient->addTransform(id, transform);
 	  }
       }
-      
+
       break;
     }
-    
+
     case TrkrDefs::micromegasId:
     {
       if (perturbMM)
@@ -464,7 +470,7 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(const Surface& surf, 
 	{
 	  if(use_module_tilt)
 	    {
-	      // use module tilt transforms with local rotation followed by local translation 
+	      // use module tilt transforms with local rotation followed by local translation
 	      transform = mpGlobalTranslationAffine * mpGlobalRotationAffine * actsTranslationAffine * actsRotationAffine * mpLocalTranslationAffine * mpLocalRotationAffine;
 	    }
 	  else
@@ -475,7 +481,7 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(const Surface& surf, 
 	}
       else
 	{
-	  // silicon and TPOT	  
+	  // silicon and TPOT
 	  if(use_new_silicon_rotation_order)
 	    {
 	      // use new transform order for silicon as well as TPC
@@ -488,11 +494,11 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(const Surface& surf, 
 	    }
 	}
     }
-  
+
   if (localVerbosity > 1)
     {
       Acts::Transform3 actstransform = actsTranslationAffine * actsRotationAffine;
-      
+
       std::cout << "newMakeTransform" << std::endl;
       std::cout << "Input sensorAngles: " << std::endl
 		<< sensorAngles << std::endl;
@@ -526,7 +532,7 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(const Surface& surf, 
 	  std::cout << std::endl;
 	}
     }
-  
+
   return transform;
 }
 
@@ -582,7 +588,7 @@ int AlignmentTransformation::getNodes(PHCompositeNode* topNode)
     std::cout << PHWHERE << " unable to find DST node TPCGEOMCONTAINER" << std::endl;
     exit(1);
   }
-  
+
   return 0;
 }
 
@@ -685,7 +691,7 @@ void AlignmentTransformation::extractModuleCenterPositions()
 
         TrkrDefs::hitsetkey hitsetkey_out = TpcDefs::genHitSetKey(lout, isector, iside);
 	double surf_rad_out = extractModuleCenter(hitsetkey_out, sectorphi);
-	
+
         double mod_radius = (surf_rad_in + surf_rad_out) / 2.0;
         TpcModuleRadii[iside][isector][iregion] = mod_radius;
 
@@ -714,7 +720,7 @@ double AlignmentTransformation::extractModuleCenter(TrkrDefs::hitsetkey hitsetke
   TrkrDefs::subsurfkey subsurfkey = 0;
 
   //   std::cout << "extractModuleCenter: sectorphi " << sectorphi << " world " << world(0) << "  " << world(1) << "  " << world(2) << std::endl;
-    
+
   // Note: the "world" position here is in pre-tilt tpc envelope coordinates, not global coordinates
   // But, get_tpc_surface_from_coords() expects a global position as input, so we convert to world coordinates
   Acts::Vector3 world_envelope = m_tGeometry->transformTpcEnvelopeToWorld(world);

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -17,9 +17,12 @@ class ActsGeometry;
 class AlignmentTransformation
 {
  public:
+
+  /// constructor
   AlignmentTransformation() = default;
 
-  ~AlignmentTransformation() {}
+  /// destructor
+  ~AlignmentTransformation() = default;
 
   void createMap(PHCompositeNode* topNode);
   void createAlignmentTransformContainer(PHCompositeNode* topNode);
@@ -33,6 +36,9 @@ class AlignmentTransformation
   Eigen::Vector3d perturbationAngles = Eigen::Vector3d(0.0, 0.0, 0.0);
   Eigen::Vector3d perturbationAnglesGlobal = Eigen::Vector3d(0.0, 0.0, 0.0);
   Eigen::Vector3d perturbationTranslation = Eigen::Vector3d(0.0, 0.0, 0.0);
+
+  /// assign local alignment parameter file to be used instead of CDB, if found
+  void setAlignmentParamsFile(const std::string& value ) { alignmentParamsFile = value; }
 
   void setMVTXParams(double mvtxDevs[6])
   {
@@ -129,14 +135,14 @@ private:
   bool use_new_silicon_rotation_order = false;
   bool use_module_tilt_always = false;
   bool use_module_tilt = false;   // starts at false in all cases
-  
+
   bool use_intt_survey_geometry = false;
-  
+
   Acts::Transform3 newMakeTransform(const Surface& surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, Eigen::Vector3d& localFrameTranslation, Eigen::Vector3d& sensorAnglesGlobal, unsigned int trkrid, bool survey);
 
-  Eigen::Vector3d getTpcLocalFrameTranslation(float moduleRadius, float layerRadius, Eigen::Vector3d& localRotation) const; 
+  Eigen::Vector3d getTpcLocalFrameTranslation(float moduleRadius, float layerRadius, Eigen::Vector3d& localRotation) const;
   void extractModuleCenterPositions();
-  double extractModuleCenter(TrkrDefs::hitsetkey hitsetkey, double sectorphi);  
+  double extractModuleCenter(TrkrDefs::hitsetkey hitsetkey, double sectorphi);
 
   alignmentTransformationContainer* transformMap = NULL;
   alignmentTransformationContainer* transformMapTransient = NULL;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -175,12 +175,11 @@ int MakeActsGeometry::Init(PHCompositeNode * /*topNode*/)
 
 int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
 {
-  m_geomContainerTpc =
-      findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  m_geomContainerTpc = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
 
   PHG4TpcGeom *layergeom = m_geomContainerTpc->GetLayerCellGeom(20);  // z geometry is the same for all layers
   m_max_driftlength = layergeom->get_max_driftlength();
-  m_CM_halfwidth = layergeom->get_CM_halfwidth();  
+  m_CM_halfwidth = layergeom->get_CM_halfwidth();
   m_maxSurfZ = m_max_driftlength - 0.0001; // add clearance from physical TPC gas volume length to avoid overlaps
 
     // Make the transform from TPC envelope to global coordinates
@@ -203,7 +202,7 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_tpc_envelope_world_transform.translation() = trans;
   // and the inverse
   m_tpc_world_envelope_transform = m_tpc_envelope_world_transform.inverse();
-  
+
   // test
   Acts::Vector3 test_env(10.0, 40.0, 80.0);
   std::cout << "MakeActsGeometry::InitRun transform tests north" << std::endl;
@@ -211,7 +210,7 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   Acts::Vector3 test_glob =  m_tpc_envelope_world_transform * test_env;
   std::cout << " test_glob " << test_glob.x() << "  " << test_glob.y() << "  " << test_glob.z() << std::endl;
   Acts::Vector3 test_env_check =  m_tpc_world_envelope_transform * test_glob;
-  std::cout << " test_env_check " << test_env_check.x() << "  " << test_env_check.y() << "  " << test_env_check.z() << std::endl;  
+  std::cout << " test_env_check " << test_env_check.x() << "  " << test_env_check.y() << "  " << test_env_check.z() << std::endl;
 
   Acts::Vector3 test_envs(10.0, 40.0, -80.0);
   std::cout << "MakeActsGeometry::InitRun transform tests south" << std::endl;
@@ -219,10 +218,11 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   Acts::Vector3 test_globs =  m_tpc_envelope_world_transform * test_envs;
   std::cout << " test_glob " << test_globs.x() << "  " << test_globs.y() << "  " << test_globs.z() << std::endl;
   Acts::Vector3 test_env_checks =  m_tpc_world_envelope_transform * test_globs;
-  std::cout << " test_env_check " << test_env_checks.x() << "  " << test_env_checks.y() << "  " << test_env_checks.z() << std::endl;  
+  std::cout << " test_env_check " << test_env_checks.x() << "  " << test_env_checks.y() << "  " << test_env_checks.z() << std::endl;
 
   // Alignment Transformation declaration of instance - must be here to set initial alignment flag
   AlignmentTransformation alignment_transformation;
+  alignment_transformation.setAlignmentParamsFile(m_alignmentParamsFile);
   alignment_transformation.createAlignmentTransformContainer(topNode);
 
   // set parameter for sampling probability distribution
@@ -245,8 +245,8 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
 
   alignment_transformation.setUseNewSiliconRotationOrder(m_use_new_silicon_rotation_order);
   alignment_transformation.setUseModuleTiltAlways(m_use_module_tilt_always);
-  
-  
+
+
   if (buildAllGeometry(topNode) != Fun4AllReturnCodes::EVENT_OK)
   {
     return Fun4AllReturnCodes::ABORTEVENT;
@@ -784,7 +784,7 @@ void MakeActsGeometry::makeGeometry(int argc, char *argv[], const std::string& r
     matDeco = std::make_shared<Acts::MaterialWiper>();
   }
   config.materialDecorator = matDeco;
-  // this does the building now. The TGeoDetector owns the 
+  // this does the building now. The TGeoDetector owns the
   // tracking geometry
   m_TGeoDetector = std::make_unique<ActsExamples::TGeoDetectorWithOptions>(config);
 
@@ -892,7 +892,7 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
       auto vec3d = surf->center(m_geoCtxt);
       vec3d /= 10.0;
       auto vec3d_envelope = m_tpc_world_envelope_transform * vec3d;  // needs to be in TPC envelope coordinates due to tilt in sims
-      
+
       std::vector<double> world_center = {vec3d_envelope(0),
                                           vec3d_envelope(1),
                                           vec3d_envelope(2)};
@@ -910,13 +910,13 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
 
       if (mapIter != m_clusterSurfaceMapTpcEdit.end())
       {
-	//std::cout << "  Adding surface to map with layer " << layer << " side " << side << " sector " << sector << std::endl; 
+	//std::cout << "  Adding surface to map with layer " << layer << " side " << side << " sector " << sector << std::endl;
         mapIter->second.push_back(surf);
       }
       else
       {
         // Otherwise make a new map entry
-	//	std::cout << "Starting new surfvec for layer " << layer << " side " << side << " sector " << sector << std::endl; 
+	//	std::cout << "Starting new surfvec for layer " << layer << " side " << side << " sector " << sector << std::endl;
         std::vector<Surface> dumvec;
         dumvec.push_back(surf);
         std::pair<unsigned int, std::vector<Surface>> tmp =
@@ -1270,7 +1270,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getTpcHitSetKeyFromCoords(std::vector<doub
         m_layerRadius[ilayer] - m_layerThickness[ilayer] / 2.0;
     double tpc_ref_radius_high =
         m_layerRadius[ilayer] + m_layerThickness[ilayer] / 2.0;
-	  
+
     if (layer_rad >= tpc_ref_radius_low && layer_rad < tpc_ref_radius_high)
     {
       layer = ilayer;
@@ -1299,7 +1299,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getTpcHitSetKeyFromCoords(std::vector<doub
   {
     side = 1;
   }
-  
+
   // readout module
   unsigned int readout_mod = 999;
   double phi_world = atan2(world[1], world[0]);
@@ -1318,7 +1318,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getTpcHitSetKeyFromCoords(std::vector<doub
   {
       std::cout << " layer_rad " << layer_rad << " m_layerRadius[layer] " << m_layerRadius[layer-7] << " found layer " << layer << " side " << side << " world " << world[0] << "  " << world[1] << "  " << world[2] << " phi_world " << phi_world << " readout_mod " << readout_mod << std::endl;
     }
-  
+
   if (readout_mod >= m_nTpcModulesPerLayer)
   {
     std::cout << PHWHERE

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -137,17 +137,22 @@ class MakeActsGeometry : public SubsysReco
   double getSurfStepPhi() { return m_surfStepPhi; }
   double getSurfStepZ() { return m_surfStepZ; }
 
+  /// assign local alignment parameter file to be used instead of CDB, if found
+  void set_alignmentParamsFile(const std::string& value ) { m_alignmentParamsFile = value; }
+
+  /// assign TPC drift velocity
   void set_drift_velocity(double vd) { m_drift_velocity = vd; }
+
+  /// assign TPC T0
   void set_tpc_tzero(double tz) { m_tpc_tzero = tz; }
   void set_sampa_tzero_bias(double tzb) { m_sampa_tzero_bias = tzb; }
   void set_apply_tpc_tzero_correction(bool flag) { m_apply_tpc_tzero_correction = flag; }
-  
+
   void set_nSurfPhi(unsigned int value)
   {
     m_nSurfPhi = value;
   }
-  //  void set_maxSurfZ(double value) {m_maxSurfZ = value;}  // set to TPC gas volume length
-    
+
   void set_mvtx_applymisalign(bool b) { m_mvtxapplymisalign = b; }
   void set_intt_survey(bool surv) { m_inttSurvey = surv; }
 
@@ -275,18 +280,28 @@ private:
 
   std::map<unsigned int, unsigned int> base_layer_map = {{10, 0}, {12, 3}, {14, 7}, {16, 55}};
   unsigned int mvtx_chips_per_stave = 9;
-  
+
   /// Verbosity value handed from PHActsSourceLinks
   //  int m_verbosity = 0;
 
-  double m_drift_velocity = 0.;  // cm/ns, override from macro
-  double m_max_driftlength = 0.;  // override from macro
-  double m_CM_halfwidth = 0.;  // central membrane half width in cm
+  /// local alignment parameter file
+  /** this is passed to Alignment Transformation and used instead of CDB if found */
+  std::string m_alignmentParamsFile = "./localAlignmentParamsFile.txt";
 
+  /// TPC drift velocity overriden from macro (cm/ns)
+  double m_drift_velocity = 0.;
+
+  /// maximum drift length, overriden from macro (cm)
+  double m_max_driftlength = 0.;
+
+  /// central membrane half width (cm) overriden from macro
+  double m_CM_halfwidth = 0.;
+
+  /// T0 correction
   bool m_apply_tpc_tzero_correction = false;
   double m_tpc_tzero = 0.0;  // ns, override from macro
   double m_sampa_tzero_bias = 0.0;  // ns, override from macro
-  
+
   /// Magnetic field components to set Acts magnetic field
   std::string m_magField = "1.4";
   double m_magFieldRescale = -1.;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR allows to specify a local alignment parameter text file, instead of the default "./localAlignmentParamsFile.txt"
If said local file is found, then it is used, if not, the code falls back to CDB.
Too many times have I realised that some of my reconstruction was "broken" because I had a local ocalAlignmentParamsFile.txt file remaining from an earlier test. Having the ability to specify the file at runtime, in the steering macro, would address this.

Note that the default behavior (loading ./localAlignmentParamsFile.txt if found, CDB otherwise) is unchanged, so this is transparent to users. 

To @osbornjd: once this goes in, there is also a change needed to the macros directory. Essentially one needs a global variable for this filename, that is then passed to MakeActsGeom. Do you have any preference for the global variable namespace ? 
For instance, we can have "G4TRACKING::alignmentParamsFile" in /macros/common/G4_TrkrVariables.C
or "TRACKING::alignmentParamsFile:" in /macros/common/GlobalVariables.C
or any other suggestion. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

AI can make mistakes, so please use best judgment when reading this summary.

Motivation / context
- Allow runtime steering to choose a local alignment-parameter text file instead of being limited to the default `./localAlignmentParamsFile.txt`.
- Reduce failures caused by leftover local files from earlier tests by falling back cleanly to the CDB when the requested file is unavailable.

Key changes
- Added configurable alignment-parameter file paths in both alignment and geometry setup code.
- `MakeActsGeometry` now has a new setter and a new `m_alignmentParamsFile` member, defaulting to `./localAlignmentParamsFile.txt`.
- `AlignmentTransformation` now exposes a setter for the alignment file path and uses it only when the path is non-empty.
- File-opening logic now prefers the local file when provided and present; otherwise it falls back to the `TRACKINGALIGNMENT` CDB resource.
- `AlignmentTransformation` destructor was simplified to `= default`.
- `MakeActsGeometry::InitRun` includes additional debug/validation output for the TPC envelope/world transforms.
- Remaining diffs are largely formatting/whitespace cleanup.

Potential risk areas
- IO behavior changes around local-file vs CDB fallback may affect jobs that implicitly relied on the old default file search order.
- Additional debug stdout in `InitRun` may be noisy in production logs.
- Reconstruction behavior should be unchanged for the default case, but steering-dependent paths need validation.

Possible future improvements
- Add explicit user-facing documentation for the new alignment file steering option.
- Consider tightening validation/logging when the local file is missing or malformed.
- Reduce or guard the new transform debug output behind a verbosity flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->