### PR TITLE
fix uninitialized var use, remove not needed casts

### DIFF
--- a/offline/packages/uspin/SpinDBContentv1.cc
+++ b/offline/packages/uspin/SpinDBContentv1.cc
@@ -17,41 +17,41 @@ void SpinDBContentv1::InitializeV1()
 
   for (int icross = 0; icross < GetNCrossing(); icross++)
   {
-    bpol[icross] = (float) GetErrorValue();
-    bpolerr[icross] = (float) GetErrorValue();
-    bpolsys[icross] = (float) GetErrorValue();
-    ypol[icross] = (float) GetErrorValue();
-    ypolerr[icross] = (float) GetErrorValue();
-    ypolsys[icross] = (float) GetErrorValue();
+    bpol[icross] = GetErrorValue();
+    bpolerr[icross] = GetErrorValue();
+    bpolsys[icross] = GetErrorValue();
+    ypol[icross] = GetErrorValue();
+    ypolerr[icross] = GetErrorValue();
+    ypolsys[icross] = GetErrorValue();
     bpat[icross] = GetErrorValue();
     ypat[icross] = GetErrorValue();
-    scaler_mbd_vtxcut[icross] = (long long) GetErrorValue();
-    scaler_mbd_nocut[icross] = (long long) GetErrorValue();
-    scaler_zdc_nocut[icross] = (long long) GetErrorValue();
+    scaler_mbd_vtxcut[icross] = GetErrorValue();
+    scaler_mbd_nocut[icross] = GetErrorValue();
+    scaler_zdc_nocut[icross] = GetErrorValue();
     bad_bunch[icross] = GetErrorValue();
   }
 
-  cross_angle = (float) GetErrorValue();
-  cross_angle_std = (float) GetErrorValue();
-  cross_angle_min = (float) GetErrorValue();
-  cross_angle_max = (float) GetErrorValue();
+  cross_angle = GetErrorValue();
+  cross_angle_std = GetErrorValue();
+  cross_angle_min = GetErrorValue();
+  cross_angle_max = GetErrorValue();
 
-  asym_bf = (float) GetErrorValue();
-  asym_bb = (float) GetErrorValue();
-  asym_yf = (float) GetErrorValue();
-  asym_yb = (float) GetErrorValue();
-  asymerr_bf = (float) GetErrorValue();
-  asymerr_bb = (float) GetErrorValue();
-  asymerr_yf = (float) GetErrorValue();
-  asymerr_yb = (float) GetErrorValue();
-  phase_bf = (float) GetErrorValue();
-  phase_bb = (float) GetErrorValue();
-  phase_yf = (float) GetErrorValue();
-  phase_yb = (float) GetErrorValue();
-  phaseerr_bf = (float) GetErrorValue();
-  phaseerr_bb = (float) GetErrorValue();
-  phaseerr_yf = (float) GetErrorValue();
-  phaseerr_yb = (float) GetErrorValue();
+  asym_bf = GetErrorValue();
+  asym_bb = GetErrorValue();
+  asym_yf = GetErrorValue();
+  asym_yb = GetErrorValue();
+  asymerr_bf = GetErrorValue();
+  asymerr_bb = GetErrorValue();
+  asymerr_yf = GetErrorValue();
+  asymerr_yb = GetErrorValue();
+  phase_bf = GetErrorValue();
+  phase_bb = GetErrorValue();
+  phase_yf = GetErrorValue();
+  phase_yb = GetErrorValue();
+  phaseerr_bf = GetErrorValue();
+  phaseerr_bb = GetErrorValue();
+  phaseerr_yf = GetErrorValue();
+  phaseerr_yb = GetErrorValue();
 }
 
 /////////////////////////////////////////////////////////////////
@@ -307,6 +307,8 @@ int SpinDBContentv1::GetPolarizationBlue(int bunch, float &value, float &error) 
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
     return (GetErrorValue());
   }
   value = bpol[bunch];
@@ -320,6 +322,9 @@ int SpinDBContentv1::GetPolarizationBlue(int bunch, float &value, float &error, 
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
+    syserr = GetErrorValue();
     return (GetErrorValue());
   }
   value = bpol[bunch];
@@ -334,6 +339,8 @@ int SpinDBContentv1::GetPolarizationBlue(int bunch, double &value, double &error
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
     return (GetErrorValue());
   }
   value = (double) bpol[bunch];
@@ -347,6 +354,9 @@ int SpinDBContentv1::GetPolarizationBlue(int bunch, double &value, double &error
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
+    syserr = GetErrorValue();
     return (GetErrorValue());
   }
   value = (double) bpol[bunch];
@@ -361,6 +371,8 @@ int SpinDBContentv1::GetPolarizationYellow(int bunch, float &value, float &error
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
     return (GetErrorValue());
   }
   value = ypol[bunch];
@@ -374,6 +386,9 @@ int SpinDBContentv1::GetPolarizationYellow(int bunch, float &value, float &error
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
+    syserr = GetErrorValue();
     return (GetErrorValue());
   }
   value = ypol[bunch];
@@ -388,6 +403,8 @@ int SpinDBContentv1::GetPolarizationYellow(int bunch, double &value, double &err
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
     return (GetErrorValue());
   }
   value = (double) ypol[bunch];
@@ -401,6 +418,9 @@ int SpinDBContentv1::GetPolarizationYellow(int bunch, double &value, double &err
 {
   if (CheckBunchNumber(bunch) == GetErrorValue())
   {
+    value = GetErrorValue();
+    error = GetErrorValue();
+    syserr = GetErrorValue();
     return (GetErrorValue());
   }
   value = (double) ypol[bunch];


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
scan-build found the possible use of an uninitialized variable when copying from one spin DB to the other, this will set those values to the generic error value

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This fix addresses a scan-build warning about a possible uninitialized-variable use when copying polarization data between spin DB records. It also removes a few unnecessary casts while keeping the behavior unchanged for valid inputs.

- **Motivation / context**
  - Prevent invalid-bunch code paths from returning without initializing all output references.
  - Clean up explicit C-style casts that were not needed.

- **Key changes**
  - `SpinDBContentv1::InitializeV1` now assigns generic error values directly to the physics-related fields instead of using explicit casts.
  - `GetPolarizationBlue` / `GetPolarizationYellow` overloads now populate output parameters (`value`, `error`, and `syserr` where applicable) with `GetErrorValue()` in the invalid-bunch branch before returning.
  - No public or exported interfaces were changed.

- **Potential risk areas**
  - **IO format changes:** low risk; this appears to be an internal initialization / error-handling fix rather than a schema change.
  - **Reconstruction behavior changes:** error-path behavior changes slightly, since invalid bunch requests now return fully initialized outputs.
  - **Thread-safety:** no expected impact.
  - **Performance:** no expected impact.

- **Possible future improvements**
  - Audit similar getters/setters for the same uninitialized-output pattern.
  - Replace remaining legacy-style casts with clearer typed conversions where appropriate.

AI can make mistakes; please use best judgment when reading this summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->