### PR TITLE
Copy data MBD PMT container for data embeding

### DIFF
--- a/offline/packages/CaloEmbedding/CopyIODataNodes.cc
+++ b/offline/packages/CaloEmbedding/CopyIODataNodes.cc
@@ -11,6 +11,9 @@
 #include <calobase/TowerInfo.h>
 
 #include <mbd/MbdOut.h>
+#include <mbd/MbdPmtContainer.h>
+#include <mbd/MbdPmtContainerV1.h>
+#include <mbd/MbdPmtHit.h>
 
 #include <ffaobjects/EventHeader.h>
 #include <ffaobjects/RunHeader.h>
@@ -56,6 +59,10 @@ int CopyIODataNodes::InitRun(PHCompositeNode *topNode)
   {
     CreateMbdOut(topNode, se->topNode());
   }
+  if (m_CopyMbdPmtContainerFlag)
+  {
+    CreateMbdPmtContainer(topNode, se->topNode());
+  }
   if (m_CopySyncObjectFlag)
   {
     CreateSyncObject(topNode, se->topNode());
@@ -91,6 +98,10 @@ int CopyIODataNodes::process_event(PHCompositeNode *topNode)
   if (m_CopyMbdOutFlag)
   {
     CopyMbdOut(topNode, se->topNode());
+  }
+  if (m_CopyMbdPmtContainerFlag)
+  {
+    CopyMbdPmtContainer(topNode, se->topNode());
   }
   if (m_CopySyncObjectFlag)
   {
@@ -364,6 +375,41 @@ void CopyIODataNodes::CreateMbdOut(PHCompositeNode *from_topNode, PHCompositeNod
 
 }
 
+void CopyIODataNodes::CreateMbdPmtContainer(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode)
+{
+  MbdPmtContainer *from_mbdpmtcontainer = findNode::getClass<MbdPmtContainer>(from_topNode, "MbdPmtContainer");
+  if (!from_mbdpmtcontainer)
+  {
+    std::cout << "Could not locate MbdPmtContainer on " << from_topNode->getName() << std::endl;
+    m_CopyMbdPmtContainerFlag = false;
+    return;
+  }
+
+  MbdPmtContainer *to_mbdpmtcontainer = findNode::getClass<MbdPmtContainer>(to_topNode, "MbdPmtContainer_data");
+  if (!to_mbdpmtcontainer)
+  {
+    PHNodeIterator iter(to_topNode);
+    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+    if (!dstNode)
+    {
+      dstNode = new PHCompositeNode("DST");
+      to_topNode->addNode(dstNode);
+    }
+
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *mbdNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "MBD"));
+    if (!mbdNode)
+    {
+      mbdNode = new PHCompositeNode("MBD");
+      dstNode->addNode(mbdNode);
+    }
+
+    to_mbdpmtcontainer = new MbdPmtContainerV1();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(to_mbdpmtcontainer, "MbdPmtContainer_data", "PHObject");
+    mbdNode->addNode(newNode);
+  }
+}
+
 void CopyIODataNodes::CreateTowerInfo(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode)
 {
   std::cout << "copying tower info" << std::endl;
@@ -407,6 +453,35 @@ void CopyIODataNodes::CopyMbdOut(PHCompositeNode *from_topNode, PHCompositeNode 
     to_mbdout->identify();
   }
   
+  return;
+}
+
+void CopyIODataNodes::CopyMbdPmtContainer(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode)
+{
+  MbdPmtContainer *from_mbdpmtcontainer = findNode::getClass<MbdPmtContainer>(from_topNode, "MbdPmtContainer");
+  MbdPmtContainer *to_mbdpmtcontainer = findNode::getClass<MbdPmtContainer>(to_topNode, "MbdPmtContainer_data");
+  if (!from_mbdpmtcontainer || !to_mbdpmtcontainer)
+  {
+    return;
+  }
+
+  to_mbdpmtcontainer->Reset();
+  const short nPMTs = from_mbdpmtcontainer->get_npmt();
+  to_mbdpmtcontainer->set_npmt(nPMTs);
+  for (short i = 0; i < nPMTs; ++i)
+  {
+    MbdPmtHit *from_mbdpmt = from_mbdpmtcontainer->get_pmt(i);
+    MbdPmtHit *to_mbdpmt = to_mbdpmtcontainer->get_pmt(i);
+    to_mbdpmt->set_pmt(from_mbdpmt->get_pmt(), from_mbdpmt->get_q(), from_mbdpmt->get_tt(), from_mbdpmt->get_tq());
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << "From MbdPmtContainer identify()" << std::endl;
+    from_mbdpmtcontainer->identify();
+    std::cout << "To MbdPmtContainer identify()" << std::endl;
+    to_mbdpmtcontainer->identify();
+  }
   return;
 }
 

--- a/offline/packages/CaloEmbedding/CopyIODataNodes.h
+++ b/offline/packages/CaloEmbedding/CopyIODataNodes.h
@@ -35,6 +35,7 @@ class CopyIODataNodes : public SubsysReco
   void CopyMbdOut(bool flag = true) { m_CopyMbdOutFlag = flag; }
   void CopyRunHeader(bool flag = true) { m_CopyRunHeaderFlag = flag; }
   void CopySyncObject(bool flag = true) { m_CopySyncObjectFlag = flag; }
+  void CopyMbdPmtContainer(bool flag = true) { m_CopyMbdPmtContainerFlag = flag; }
   void set_CopyTowerInfo(const std::string& set_from_towerInfo_name,const std::string& set_to_towerInfo_name)
   {
     from_towerInfo_name = set_from_towerInfo_name;
@@ -65,6 +66,8 @@ class CopyIODataNodes : public SubsysReco
   void CopySyncObject(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode);
   void CopyTowerInfo(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode);
   void CreateTowerInfo(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode);
+  void CreateMbdPmtContainer(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode);
+  void CopyMbdPmtContainer(PHCompositeNode *from_topNode, PHCompositeNode *to_topNode);
 
   bool m_CopyCentralityInfoFlag = true;
   bool m_CopyEventHeaderFlag = true;
@@ -74,6 +77,7 @@ class CopyIODataNodes : public SubsysReco
   bool m_CopyRunHeaderFlag = true;
   bool m_CopySyncObjectFlag = true;
   bool m_CopyTowerInfoFlag = false;
+  bool m_CopyMbdPmtContainerFlag = false;
 
   std::string from_towerInfo_name = {};
   std::string to_towerInfo_name = {};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change extends CaloEmbedding data copying to include the MBD PMT container, supporting data embedding workflows that need MBD information available in the output node tree.

Key changes:
- Added a new `CopyMbdPmtContainer()` control flag to `CopyIODataNodes`.
- During `InitRun`, the code now creates the destination `DST/MBD` MBD PMT container when enabled.
- During event processing, the source `MbdPmtContainer_data` is copied into the destination when enabled.
- Implemented helper routines to:
  - locate the source container and disable copying if it is missing,
  - create/attach an `MbdPmtContainerV1` in the output tree,
  - copy per-PMT hit content from source to destination.

Potential risk areas:
- IO/node-tree format changes if downstream code assumes the previous output structure.
- Reconstruction or embedding behavior changes if consumers rely on MBD container presence/absence.
- Performance impact from additional per-event container copying.
- Thread-safety concerns if this code is used in multi-threaded embedding contexts.

Possible future improvements:
- Add more explicit validation/logging when source/destination containers are missing.
- Expand unit/integration coverage for the new MBD copy path.
- Consider making the copy behavior more configurable for other detector containers.

AI can make mistakes, so this summary should be checked against the code with best judgment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->