### PR TITLE
fix another source of uninit vars

### DIFF
--- a/offline/packages/uspin/SpinDBContent.cc
+++ b/offline/packages/uspin/SpinDBContent.cc
@@ -2,7 +2,66 @@
 
 #include <iostream>
 
-void SpinDBContent::identify(std::ostream& os) const
+void SpinDBContent::identify(std::ostream &os) const
 {
   os << "virtual SpinDBContent object" << std::endl;
+}
+
+int SpinDBContent::GetPolarizationBlue(int /*bunch*/, float &value, float &error) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  return -1;
+}
+
+int SpinDBContent::GetPolarizationBlue(int /*bunch*/, float &value, float &error, float &syserr) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  syserr = GetErrorValue();
+  return -1;
+}
+
+int SpinDBContent::GetPolarizationBlue(int /*bunch*/, double &value, double &error) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  return -1;
+}
+
+int SpinDBContent::GetPolarizationBlue(int /*bunch*/, double &value, double &error, double &syserr) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  syserr = GetErrorValue();
+  return -1;
+}
+
+int SpinDBContent::GetPolarizationYellow(int /*bunch*/, float &value, float &error) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  return -1;
+}
+int SpinDBContent::GetPolarizationYellow(int /*bunch*/, float &value, float &error, float &syserr) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  syserr = GetErrorValue();
+  return -1;
+}
+
+int SpinDBContent::GetPolarizationYellow(int /*bunch*/, double &value, double &error) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  return -1;
+}
+
+int SpinDBContent::GetPolarizationYellow(int /*bunch*/, double &value, double &error, double &syserr) const
+{
+  value = GetErrorValue();
+  error = GetErrorValue();
+  syserr = GetErrorValue();
+  return -1;
 }

--- a/offline/packages/uspin/SpinDBContent.h
+++ b/offline/packages/uspin/SpinDBContent.h
@@ -71,14 +71,14 @@ class SpinDBContent : public PHObject
   virtual int GetBadRunFlag() const = 0;
   virtual int GetCrossingShift() const = 0;
 
-  virtual int GetPolarizationBlue(int, float&, float&) const { return -1; }
-  virtual int GetPolarizationBlue(int, float&, float&, float&) const { return -1; }
-  virtual int GetPolarizationBlue(int, double&, double&) const { return -1; }
-  virtual int GetPolarizationBlue(int, double&, double&, double&) const { return -1; }
-  virtual int GetPolarizationYellow(int, float&, float&) const { return -1; }
-  virtual int GetPolarizationYellow(int, float&, float&, float&) const { return -1; }
-  virtual int GetPolarizationYellow(int, double&, double&) const { return -1; }
-  virtual int GetPolarizationYellow(int, double&, double&, double&) const { return -1; }
+  virtual int GetPolarizationBlue(int, float&, float&) const;
+  virtual int GetPolarizationBlue(int, float&, float&, float&) const;
+  virtual int GetPolarizationBlue(int, double&, double&) const;
+  virtual int GetPolarizationBlue(int, double&, double&, double&) const;
+  virtual int GetPolarizationYellow(int, float&, float&) const;
+  virtual int GetPolarizationYellow(int, float&, float&, float&) const;
+  virtual int GetPolarizationYellow(int, double&, double&) const;
+  virtual int GetPolarizationYellow(int, double&, double&, double&) const;
 
   virtual int GetSpinPatternBlue(int) const { return -1; }
   virtual int GetSpinPatternYellow(int) const { return -1; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Set passed down variables also in base class - let's see about the scan-build error

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Fixes a scan-build finding involving potentially uninitialized variables by ensuring polarization output parameters receive defined values in the `SpinDBContent` base implementation. This is intended as a non-breaking bug fix.

## Key changes

- Moved polarization getter implementations from inline header bodies into `SpinDBContent.cc`.
- Added blue and yellow polarization getter overloads for `float` and `double`, with optional systematic-error outputs.
- Initialize output values from `GetErrorValue()` and return `-1` to preserve the unavailable-data sentinel behavior.
- Retained `identify` behavior while standardizing its stream parameter formatting.

## Potential risk areas

- No I/O format, reconstruction algorithm, threading, or performance changes are expected.
- Derived classes lacking definitions for these virtual methods may encounter linkage issues if they previously depended on the inline implementations.
- The initialized fallback values should be checked for consistency with downstream handling of the `-1` return code.

## Possible future improvements

- Add focused tests verifying all getter overloads initialize value, statistical error, and systematic error outputs.
- Document the meaning and expected use of `GetErrorValue()` and the `-1` return status.

*AI-generated summaries can contain mistakes; review the implementation and surrounding APIs before relying on these conclusions.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->