### PR TITLE
set waveform to zero if pedestal is zero (dead channel)

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -525,7 +525,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       {
         // only modify the waveform_pedestal_vector if it is > 0, otherwise there is something wrong with the pedestal
         // (for dead channels all samples of the waveform are zero). Doing it this way will also catch single zero samples
-        if (waveform_pedestal_vector.at(j) == 0)
+        if (waveform_pedestal_vector.at(j) != 0)
         {
           waveform_pedestal_vector.at(j) = (waveform_pedestal_vector.at(j) - pedestal_mean) * m_pedestal_scale + pedestal_mean;
         }

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -535,6 +535,9 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     {
       if (m_noiseType == NoiseType::NOISE_TREE)
       {
+	// set samples which have zero pedestal (dead channels in real data) to zero
+	// they are supposed to be masked out later, so this is just a safeguard in case
+	// that changes or doesn't work
         if (waveform_pedestal_vector.at(j) == 0)
         {
           m_waveforms.at(i).at(j) = 0;

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -39,8 +39,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 
@@ -108,7 +108,7 @@ int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
     m_sampling_fraction = 0.162166;
     m_nchannels = 1536;
   }
-  else  if (m_dettype == CaloTowerDefs::HCALOUT)
+  else if (m_dettype == CaloTowerDefs::HCALOUT)
   {
     m_detector = "HCALOUT";
     encode_tower = TowerInfoDefs::encode_hcal;
@@ -394,12 +394,12 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       }
       else
       {
-        float val =  1.0+ gsl_ran_gaussian(m_RandomGenerator,factor_const);
-        if(val < 0.0F)
+        float val = 1.0 + gsl_ran_gaussian(m_RandomGenerator, factor_const);
+        if (val < 0.0F)
         {
           val = 0;
         }
-        tbt_smear[key] = val; 
+        tbt_smear[key] = val;
         e_vis *= tbt_smear[key];
       }
     }
@@ -460,7 +460,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     {
       const unsigned int tower_index = entry.first;
       const double photon_count_mean = entry.second;
-      
+
       double photon_count = photon_count_mean;
       if (m_use_photon_statistics)
       {
@@ -485,7 +485,6 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       }
     }
   }
-
 
   // do noise here and add to waveform
 
@@ -514,30 +513,36 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       {
         waveform_pedestal_vector.at(j) = (j < pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(pedestalsamples - 1);
         pedestal_mean += waveform_pedestal_vector.at(j);
-	if (Verbosity() > 1 && pedestal_tower->get_waveform_value(j) == 0)
-	{
-	  std::cout << Name() << " channel: " << j << " too small pedestal value for index " << j << ": " << pedestal_tower->get_waveform_value(j) << std::endl;
-	  pedestal_tower->identify();
-	}
+        // it should be around 5000+, dead channels have zero's but who knows what else is out there in the future
+        if (Verbosity() > 1 && pedestal_tower->get_waveform_value(j) < 1000)
+        {
+          std::cout << Name() << " channel: " << j << " too small pedestal value for index " << j << ": " << pedestal_tower->get_waveform_value(j) << std::endl;
+          pedestal_tower->identify();
+        }
       }
       pedestal_mean /= m_nsamples;
       for (int j = 0; j < m_nsamples; j++)
       {
-        waveform_pedestal_vector.at(j) = (waveform_pedestal_vector.at(j) - pedestal_mean) * m_pedestal_scale + pedestal_mean;
+        // only modify the waveform_pedestal_vector if it is > 0, otherwise there is something wrong with the pedestal
+        // (for dead channels all samples of the waveform are zero). Doing it this way will also catch single zero samples
+        if (waveform_pedestal_vector.at(j) == 0)
+        {
+          waveform_pedestal_vector.at(j) = (waveform_pedestal_vector.at(j) - pedestal_mean) * m_pedestal_scale + pedestal_mean;
+        }
       }
     }
     for (int j = 0; j < m_nsamples; j++)
     {
       if (m_noiseType == NoiseType::NOISE_TREE)
       {
-	if (waveform_pedestal_vector.at(j) == 0)
-	{
-	  m_waveforms.at(i).at(j) = 0;
-	}
-	else
-	{
+        if (waveform_pedestal_vector.at(j) == 0)
+        {
+          m_waveforms.at(i).at(j) = 0;
+        }
+        else
+        {
           m_waveforms.at(i).at(j) += waveform_pedestal_vector.at(j);
-	}
+        }
       }
       if (m_noiseType == NoiseType::NOISE_GAUSSIAN)
       {

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -514,7 +514,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
       {
         waveform_pedestal_vector.at(j) = (j < pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(pedestalsamples - 1);
         pedestal_mean += waveform_pedestal_vector.at(j);
-	if (Verbosity() > 2 && pedestal_tower->get_waveform_value(j) < 100)
+	if (Verbosity() > 1 && pedestal_tower->get_waveform_value(j) == 0)
 	{
 	  std::cout << Name() << " channel: " << j << " too small pedestal value for index " << j << ": " << pedestal_tower->get_waveform_value(j) << std::endl;
 	  pedestal_tower->identify();
@@ -530,7 +530,14 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     {
       if (m_noiseType == NoiseType::NOISE_TREE)
       {
-        m_waveforms.at(i).at(j) += waveform_pedestal_vector.at(j);
+	if (waveform_pedestal_vector.at(j) == 0)
+	{
+	  m_waveforms.at(i).at(j) = 0;
+	}
+	else
+	{
+          m_waveforms.at(i).at(j) += waveform_pedestal_vector.at(j);
+	}
       }
       if (m_noiseType == NoiseType::NOISE_GAUSSIAN)
       {

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -77,7 +77,7 @@ class CaloWaveformSim : public SubsysReco
     m_use_sipm_occupancy = use_sipm_occupancy;
   }
 
-  void set_use_photon_statistics( bool state=true )
+  void set_use_photon_statistics(bool state = true)
   {
     m_use_photon_statistics = state;
   }
@@ -118,7 +118,7 @@ class CaloWaveformSim : public SubsysReco
 
   void set_kSamplingFraction(double val)
   {
-    kSamplingFraction     = val;
+    kSamplingFraction = val;
   }
   void set_kPhotoelectronsPerGeV(double val)
   {
@@ -126,7 +126,7 @@ class CaloWaveformSim : public SubsysReco
   }
   void set_kSiPMEffectivePixel(double val)
   {
-    kSiPMEffectivePixel   = val;
+    kSiPMEffectivePixel = val;
   }
 
   // Waveform template & sampling
@@ -214,7 +214,7 @@ class CaloWaveformSim : public SubsysReco
 
   // Waveform settings
   std::string m_templatefile{"waveformtemptempohcalcosmic.root"};
-  int m_nsamples{12}; // number of samples for calos in our default data taking configuration
+  int m_nsamples{12};  // number of samples for calos in our default data taking configuration
   float m_sampletime{50. / 3.};
   int m_nchannels{-1};
   float m_sampling_fraction{std::numeric_limits<float>::quiet_NaN()};
@@ -235,9 +235,9 @@ class CaloWaveformSim : public SubsysReco
 
   bool m_use_photon_statistics{false};
   bool m_use_sipm_occupancy{false};
-  double kSamplingFraction     = 2e-2;
+  double kSamplingFraction = 2e-2;
   double kPhotoelectronsPerGeV = 500.;
-  double kSiPMEffectivePixel   = 40000 * 4.;
+  double kSiPMEffectivePixel = 40000 * 4.;
 
   NoiseType m_noiseType{NOISE_TREE};
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR sets calo channels to zero if the corresponding pedestal is zero 
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context

A calorimeter “dead” channel is indicated when the measured pedestal is exactly zero. The simulated waveform for such channels should therefore be suppressed (forced to zero) rather than filled with pedestal-subtracted noise/signal contributions.

## Key changes

- In `CaloWaveformSim::process_event`, updated the “too small pedestal value” diagnostic:
  - Threshold changed from `< 100` with `Verbosity() > 2` to `< 1000` with `Verbosity() > 1`.
- When constructing `waveform_pedestal_vector`, the pedestal mean/scale correction is now applied **only to samples whose raw pedestal value is non-zero**; **raw `== 0` samples are left unchanged**.
- When applying `waveform_pedestal_vector` to `m_waveforms`, each waveform sample is explicitly set to **0** if the corresponding pedestal-processed value is **exactly `0`**; otherwise the pedestal-removed contribution is added as before.
- Minor non-functional formatting/whitespace adjustments in the implementation and header.

## Potential risk areas

- Logic depends on **exact floating-point equality to 0**; pedestals that are “effectively zero” but not exactly zero will not be treated as dead.
- Because the correction is conditioned on the (post-raw) `waveform_pedestal_vector == 0` value, any upstream change to how pedestal samples are stored/scaled could alter which channels get forced to zero.
- No direct I/O format changes; impact is through modified simulated waveform content for dead-channel conditions.

## Possible future improvements

- Replace exact `== 0` with a scientifically motivated **tolerance-based dead-channel criterion**, if appropriate.
- Add regression tests covering:
  - all-zero pedestals,
  - single-sample zero pedestals,
  - near-zero (tolerance) pedestals,
  - sensitivity to pedestal scaling (`m_pedestal_scale`).
- Add monitoring to quantify how many channels are classified as dead under the exact-zero rule.

*As always, AI-generated summaries can be wrong—please use domain expertise to verify the intended dead-channel definition and the exact-zero logic against the scientific requirements.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->