### PR TITLE
add truth hit interpolation in truth fitter

### DIFF
--- a/offline/packages/trackreco/PHTruthTrackFitter.cc
+++ b/offline/packages/trackreco/PHTruthTrackFitter.cc
@@ -80,23 +80,44 @@ namespace
     return trackid != std::numeric_limits<unsigned int>::max();
   }
 
-  struct InterpolationData
+  class InterpolationData
   {
-    double x = 0;
-    double y = 0;
-    double z = 0;
-    double px = 0;
-    double py = 0;
-    double pz = 0;
-    double weight = 1;
+   public:
+    InterpolationData(double x, double y, double z, double px, double py, double pz, double weight)
+      : m_x(x)
+      , m_y(y)
+      , m_z(z)
+      , m_px(px)
+      , m_py(py)
+      , m_pz(pz)
+      , m_weight(weight)
+    {
+    }
 
     double r() const
     {
-      return std::sqrt(square(x) + square(y));
+      return std::sqrt(square(m_x) + square(m_y));
     }
+
+    double x() const { return m_x; }
+    double y() const { return m_y; }
+    double z() const { return m_z; }
+    double px() const { return m_px; }
+    double py() const { return m_py; }
+    double pz() const { return m_pz; }
+    double weight() const { return m_weight; }
+
+   private:
+    double m_x = 0;
+    double m_y = 0;
+    double m_z = 0;
+    double m_px = 0;
+    double m_py = 0;
+    double m_pz = 0;
+    double m_weight = 1;
   };
 
-  template <double InterpolationData::* member>
+  template <double (InterpolationData::*accessor)() const>
   double interpolate_r(const std::vector<InterpolationData>& hits, double r_extrap, double fallback)
   {
     double sw = 0;
@@ -107,18 +128,19 @@ namespace
 
     for (const auto& hit : hits)
     {
-      const auto q = hit.*member;
+      const auto q = (hit.*accessor)();
       const auto r = hit.r();
-      if (!std::isfinite(q) || !std::isfinite(r) || !std::isfinite(hit.weight) || hit.weight <= 0)
+      const auto weight = hit.weight();
+      if (!std::isfinite(q) || !std::isfinite(r) || !std::isfinite(weight) || weight <= 0)
       {
         continue;
       }
 
-      sw += hit.weight;
-      swr += hit.weight * r;
-      swr2 += hit.weight * square(r);
-      swq += hit.weight * q;
-      swrq += hit.weight * r * q;
+      sw += weight;
+      swr += weight * r;
+      swr2 += weight * square(r);
+      swq += weight * q;
+      swrq += weight * r * q;
     }
 
     /*
@@ -570,13 +592,13 @@ bool PHTruthTrackFitter::addStateFromCluster(SvtxTrack* track,
       const auto endpoint_py = g4hit->get_py(endpoint);
       const auto endpoint_pz = g4hit->get_pz(endpoint);
 
-      interpolation_hits.push_back({endpoint_x,
-                                    endpoint_y,
-                                    endpoint_z,
-                                    is_finite(endpoint_px) ? endpoint_px : particle->get_px(),
-                                    is_finite(endpoint_py) ? endpoint_py : particle->get_py(),
-                                    is_finite(endpoint_pz) ? endpoint_pz : particle->get_pz(),
-                                    weight});
+      interpolation_hits.emplace_back(endpoint_x,
+                                      endpoint_y,
+                                      endpoint_z,
+                                      is_finite(endpoint_px) ? endpoint_px : particle->get_px(),
+                                      is_finite(endpoint_py) ? endpoint_py : particle->get_py(),
+                                      is_finite(endpoint_pz) ? endpoint_pz : particle->get_pz(),
+                                      weight);
     }
 
     weight_sum += weight;

--- a/offline/packages/trackreco/PHTruthTrackFitter.cc
+++ b/offline/packages/trackreco/PHTruthTrackFitter.cc
@@ -1,5 +1,7 @@
 #include "PHTruthTrackFitter.h"
 
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
@@ -37,6 +39,7 @@
 #include <limits>
 #include <set>
 #include <utility>
+#include <vector>
 
 namespace
 {
@@ -76,6 +79,71 @@ namespace
   {
     return trackid != std::numeric_limits<unsigned int>::max();
   }
+
+  struct InterpolationData
+  {
+    double x = 0;
+    double y = 0;
+    double z = 0;
+    double px = 0;
+    double py = 0;
+    double pz = 0;
+    double weight = 1;
+
+    double r() const
+    {
+      return std::sqrt(square(x) + square(y));
+    }
+  };
+
+  template <double InterpolationData::* member>
+  double interpolate_r(const std::vector<InterpolationData>& hits, double r_extrap, double fallback)
+  {
+    double sw = 0;
+    double swr = 0;
+    double swr2 = 0;
+    double swq = 0;
+    double swrq = 0;
+
+    for (const auto& hit : hits)
+    {
+      const auto q = hit.*member;
+      const auto r = hit.r();
+      if (!std::isfinite(q) || !std::isfinite(r) || !std::isfinite(hit.weight) || hit.weight <= 0)
+      {
+        continue;
+      }
+
+      sw += hit.weight;
+      swr += hit.weight * r;
+      swr2 += hit.weight * square(r);
+      swq += hit.weight * q;
+      swrq += hit.weight * r * q;
+    }
+
+    /*
+     * Fit q(r) = a*r + b with weighted least squares, where q is one of
+     * x/y/z/px/py/pz. The sums above form the normal equations:
+     *
+     *   a*swr2 + b*swr = swrq
+     *   a*swr  + b*sw  = swq
+     *
+     * alpha and beta are the Cramer's-rule numerators for the slope and
+     * intercept. Keeping the final division common is the same as returning
+     * slope*r_extrap + intercept, but avoids one extra division.
+     */
+    const auto denom = sw * swr2 - square(swr);
+    const auto scale = std::max(std::abs(sw * swr2), square(swr));
+    if (scale <= 0 || std::abs(denom) <= std::numeric_limits<double>::epsilon() * scale)
+    {
+      return fallback;
+    }
+
+    const auto alpha = sw * swrq - swr * swq;
+    const auto beta = swr2 * swq - swr * swrq;
+    const auto value = (alpha * r_extrap + beta) / denom;
+    return std::isfinite(value) ? value : fallback;
+  }
 }  // namespace
 
 PHTruthTrackFitter::PHTruthTrackFitter(const std::string& name)
@@ -108,7 +176,7 @@ int PHTruthTrackFitter::process_event(PHCompositeNode* /*topNode*/)
   m_trackMap->Reset();
 
   unsigned int skipped_tracks = 0;
-  for (auto *seed : *m_seedMap)
+  for (auto* seed : *m_seedMap)
   {
     if (!seed)
     {
@@ -320,6 +388,13 @@ int PHTruthTrackFitter::getNodes(PHCompositeNode* topNode)
   m_g4HitsMvtx = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
   m_g4HitsMicromegas = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MICROMEGAS");
 
+  m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (m_extrapolateToClusterRadius && !m_tGeometry)
+  {
+    std::cout << PHWHERE << "No ActsGeometry on node tree. Bailing" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -437,11 +512,13 @@ bool PHTruthTrackFitter::addStateFromCluster(SvtxTrack* track,
                                              const PHG4VtxPoint* vertex,
                                              unsigned int stateIndex) const
 {
-  if (!m_clusterMap->findCluster(cluskey))
+  auto* cluster = m_clusterMap->findCluster(cluskey);
+  if (!cluster)
   {
     return false;
   }
 
+  std::vector<InterpolationData> interpolation_hits;
   double weight_sum = 0;
   double x = 0;
   double y = 0;
@@ -479,6 +556,29 @@ bool PHTruthTrackFitter::addStateFromCluster(SvtxTrack* track,
       weight = 1;
     }
 
+    for (int endpoint = 0; endpoint < 2; ++endpoint)
+    {
+      const auto endpoint_x = g4hit->get_x(endpoint);
+      const auto endpoint_y = g4hit->get_y(endpoint);
+      const auto endpoint_z = g4hit->get_z(endpoint);
+      if (!is_finite(endpoint_x) || !is_finite(endpoint_y) || !is_finite(endpoint_z))
+      {
+        continue;
+      }
+
+      const auto endpoint_px = g4hit->get_px(endpoint);
+      const auto endpoint_py = g4hit->get_py(endpoint);
+      const auto endpoint_pz = g4hit->get_pz(endpoint);
+
+      interpolation_hits.push_back({endpoint_x,
+                                    endpoint_y,
+                                    endpoint_z,
+                                    is_finite(endpoint_px) ? endpoint_px : particle->get_px(),
+                                    is_finite(endpoint_py) ? endpoint_py : particle->get_py(),
+                                    is_finite(endpoint_pz) ? endpoint_pz : particle->get_pz(),
+                                    weight});
+    }
+
     weight_sum += weight;
     x += weight * hit_x;
     y += weight * hit_y;
@@ -503,6 +603,25 @@ bool PHTruthTrackFitter::addStateFromCluster(SvtxTrack* track,
   pz /= weight_sum;
   local_x /= weight_sum;
   local_y /= weight_sum;
+
+  if (m_extrapolateToClusterRadius && !interpolation_hits.empty())
+  {
+    const auto cluster_radius = getClusterRadius(cluskey, cluster);
+    if (std::isfinite(cluster_radius) && cluster_radius > 0)
+    {
+      x = interpolate_r<&InterpolationData::x>(interpolation_hits, cluster_radius, x);
+      y = interpolate_r<&InterpolationData::y>(interpolation_hits, cluster_radius, y);
+      z = interpolate_r<&InterpolationData::z>(interpolation_hits, cluster_radius, z);
+      px = interpolate_r<&InterpolationData::px>(interpolation_hits, cluster_radius, px);
+      py = interpolate_r<&InterpolationData::py>(interpolation_hits, cluster_radius, py);
+      pz = interpolate_r<&InterpolationData::pz>(interpolation_hits, cluster_radius, pz);
+    }
+    else if (Verbosity() > 1)
+    {
+      std::cout << "PHTruthTrackFitter::addStateFromCluster - invalid cluster radius for cluster "
+                << cluskey << ", using truth hit average" << std::endl;
+    }
+  }
 
   float pathlength = getPathLength(vertex, x, y, z, stateIndex);
   while (track->count_states(pathlength) != 0)
@@ -535,6 +654,18 @@ bool PHTruthTrackFitter::addStateFromCluster(SvtxTrack* track,
 
   track->insert_state(&state);
   return true;
+}
+
+float PHTruthTrackFitter::getClusterRadius(TrkrDefs::cluskey cluskey, TrkrCluster* cluster) const
+{
+  if (!m_tGeometry || !cluster)
+  {
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+
+  const auto global = m_tGeometry->getGlobalPosition(cluskey, cluster);
+  const auto radius = std::sqrt(square(global.x()) + square(global.y()));
+  return std::isfinite(radius) ? radius : std::numeric_limits<float>::quiet_NaN();
 }
 
 float PHTruthTrackFitter::getPathLength(const PHG4VtxPoint* vertex,

--- a/offline/packages/trackreco/PHTruthTrackFitter.h
+++ b/offline/packages/trackreco/PHTruthTrackFitter.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+class ActsGeometry;
 class PHCompositeNode;
 class PHG4Hit;
 class PHG4HitContainer;
@@ -22,6 +23,7 @@ class SvtxTrack;
 class SvtxTrackMap;
 class TrackSeed;
 class TrackSeedContainer;
+class TrkrCluster;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
@@ -42,6 +44,7 @@ class PHTruthTrackFitter : public SubsysReco
   void setDefaultCrossing(short int crossing) { m_defaultCrossing = crossing; }
   void setPositionError(float value) { m_positionError = value; }
   void setZError(float value) { m_zError = value; }
+  void setExtrapolateToClusterRadius(bool value) { m_extrapolateToClusterRadius = value; }
 
  private:
   int createNodes(PHCompositeNode* topNode);
@@ -56,6 +59,7 @@ class PHTruthTrackFitter : public SubsysReco
   bool addStateFromCluster(SvtxTrack* track, TrkrDefs::cluskey cluskey, unsigned int truthTrackId,
                            const PHG4Particle* particle, const PHG4VtxPoint* vertex,
                            unsigned int stateIndex) const;
+  float getClusterRadius(TrkrDefs::cluskey cluskey, TrkrCluster* cluster) const;
   float getPathLength(const PHG4VtxPoint* vertex, float x, float y, float z, unsigned int stateIndex) const;
   int getCharge(const PHG4Particle* particle, const TrackSeed* tpcSeed, const TrackSeed* siliconSeed) const;
   short int getCrossing(const TrackSeed* tpcSeed, const TrackSeed* siliconSeed) const;
@@ -71,6 +75,7 @@ class PHTruthTrackFitter : public SubsysReco
   TrkrClusterContainer* m_clusterMap = nullptr;
   TrkrClusterHitAssoc* m_clusterHitMap = nullptr;
   TrkrHitTruthAssoc* m_hitTruthAssoc = nullptr;
+  ActsGeometry* m_tGeometry = nullptr;
   PHG4TruthInfoContainer* m_g4TruthInfo = nullptr;
 
   PHG4HitContainer* m_g4HitsTpc = nullptr;
@@ -81,6 +86,7 @@ class PHTruthTrackFitter : public SubsysReco
   short int m_defaultCrossing = 0;
   float m_positionError = 0.005;
   float m_zError = 0.01;
+  bool m_extrapolateToClusterRadius = true;
 
   static constexpr unsigned int m_invalidTruthTrackId = std::numeric_limits<unsigned int>::max();
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Add G4hits interpolation to the same radius as clusters' based on Hugo's code. Flag is set to true by default.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

Aligning the truth-hit positions/momenta with reconstructed track-state radii (cluster transverse radius) can reduce systematic radial mismatches in truth-track fitting. This PR adds an interpolation-based mechanism to evaluate truth information at the same radius as clusters used in the truth fitter; it is enabled by default and does not change the public interface beyond an added configuration toggle. (As always, AI-generated descriptions can contain mistakes—please verify against the actual implementation and validate with tests.)

## Key Changes

- Added Acts geometry integration to compute a cluster’s transverse radius (`getClusterRadius`), returning NaN/invalid results when geometry or the cluster is unavailable.
- Introduced endpoint-based, **weighted linear** interpolation/extrapolation of truth hit state components as functions of radius (fit of the form `q(r)=a*r+b`), with numerical sanity checks.
- During `addStateFromCluster`, collected per-endpoint samples (`x/y/z` and `px/py/pz`, with weights) into an `interpolation_hits` container.
- When `m_extrapolateToClusterRadius` is enabled and geometry is available, replaced the previous averaged truth values with interpolated values evaluated at the cluster radius; otherwise preserved the prior averaged-hit behavior (including a fallback when interpolation cannot be performed).
- Added `setExtrapolateToClusterRadius(bool value)` (default `true`) to enable/disable the feature at runtime.
- Updated fitter internals to retrieve/cache `ActsGeometry` from the node tree when needed (`m_tGeometry`).

## Potential Risk Areas

- **Behavioral change by default:** truth state construction may shift (potentially improving fits, but could also affect events where truth endpoint radii poorly cover the target radius).
- **Numerical stability / fallback correctness:** interpolation sanity checks and the fallback-to-averages path should be reviewed for edge cases (e.g., sparse endpoint coverage, invalid/NaN radii).
- **Performance:** additional geometry access and interpolation computations per state/cluster may add CPU overhead.
- **Thread-safety/lifecycle:** `m_tGeometry` is stored as a member pointer and populated from the node tree; ensure the fitter is not used concurrently across threads/events in a way that could race on initialization or geometry caching.

## Possible Future Improvements

- Add unit/integration tests covering interpolation accuracy, weighted fitting behavior, and all fallback paths (missing geometry, empty/sparse endpoints, invalid radii).
- Benchmark reconstruction impact (residuals/physics performance) across representative detector regions and track topologies.
- Add optional diagnostics/logging counters for how often interpolation succeeds vs. falls back (to aid tuning and validation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->