### PR TITLE
Input gl1rawhitdst for luminosity calculation instead of gl1 raw data…

### DIFF
--- a/offline/packages/bcolumicount/StreamingBcoReco.cc
+++ b/offline/packages/bcolumicount/StreamingBcoReco.cc
@@ -43,13 +43,13 @@ int StreamingBcoReco::Init(PHCompositeNode *topNode)
 {
   int iret = CreateNodeTree(topNode);
   h_bco_diff = new TH1I("h_bco_diff", ";bco diff;", 3500, 0, 3500);
-  std::string hist_name = "h_bco_diff_bit";
-  for (int bit=0; bit<trigbits; ++bit)
-  {
-    hist_name += std::to_string(bit);
-    h_bco_diff_trigbits[bit] = new TH1I(hist_name.c_str(), ";bco diff;", 3500, 0, 3500);
-    hm->registerHisto(h_bco_diff_trigbits[bit]);
-  }
+  //std::string hist_name = "h_bco_diff_bit";
+  //for (int bit=0; bit<trigbits; ++bit)
+  //{
+  //  hist_name += std::to_string(bit);
+  //  h_bco_diff_trigbits[bit] = new TH1I(hist_name.c_str(), ";bco diff;", 3500, 0, 3500);
+  //  hm->registerHisto(h_bco_diff_trigbits[bit]);
+  //}
   h_bco_tag = new TH1I("h_bco_tag", ";usable bco tag;", 2, -0.5, 1.5);
   hm->registerHisto(h_bco_diff);
   hm->registerHisto(h_bco_tag);
@@ -81,123 +81,81 @@ int StreamingBcoReco::process_event(PHCompositeNode *topNode)
 {
   BcoInfo *bcoinfo = findNode::getClass<BcoInfo>(topNode, "BCOINFO");
   SyncObject *syncobject = findNode::getClass<SyncObject>(topNode, syncdefs::SYNCNODENAME);
-  //Gl1Packet *gl1packet = findNode::getClass<Gl1Packet>(topNode, 14001);
-  Event *evt = findNode::getClass<Event>(topNode, "PRDF");
-  if (evt)
+  if (Verbosity() > 2)
+  {
+    if (!syncobject)
+    {
+      std::cout << PHWHERE << " SyncObject missing" << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+    std::cout << "Event No: " << syncobject->EventNumber() << std::endl;
+  }
+  if (bcoinfo)
   {
     if (Verbosity() > 2)
     {
-      evt->identify();
+      std::cout << "prev event: " << bcoinfo->get_previous_evtno() /*<< std::hex*/
+                << " bco: " << bcoinfo->get_previous_bco() << std::dec << std::endl;
+      std::cout << "curr event: " << bcoinfo->get_current_evtno() /*<< std::hex*/
+                << " bco: " << bcoinfo->get_current_bco() << std::dec << std::endl;
+      std::cout << "futu event: " << bcoinfo->get_future_evtno() /*<< std::hex*/
+                << " bco: " << bcoinfo->get_future_bco() << std::dec << std::endl;
     }
-    if (evt->getEvtType() != DATAEVENT)
+    StreamingBcoInfo *streaming_bco_info = findNode::getClass<StreamingBcoInfo>(topNode, "STREAMINGBCOINFO");
+    if (!streaming_bco_info)
     {
+      std::cout << PHWHERE << " STREAMINGBCOINFO node missing" << std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
-    Packet *packet = evt->getPacket(14001);
-    if (!packet)
+    m_bco = bcoinfo->get_current_bco();
+    // No longer reading in the raw data for this check, but it should not be necessary
+    //if (gtm_bco != m_bco) { std::cout << "BCO MISMATCH!!! : gtm_bco : " << gtm_bco << " m_bco " << m_bco << std::endl;}
+    uint64_t bco_prev = bcoinfo->get_previous_bco();
+    uint64_t bco_futu = bcoinfo->get_future_bco();
+    uint64_t bco_diff_prev = m_bco - bco_prev;
+    uint64_t bco_diff_futu = bco_futu - m_bco;
+
+    // special case if BCO is within 20 of previous BCO?
+    if (bco_diff_prev < m_default_positive_window_length)
     {
-      if (Verbosity() > 0)
-      {
-        std::cout << "no gl1 packet 14001" << std::endl;
-        evt->identify();
-      }
-      return Fun4AllReturnCodes::ABORTEVENT;
+      m_usable_bco_tag = true;
     }
-    uint64_t gtm_bco = packet->lValue(0, "BCO");
-    uint64_t gl1_scaledvec = packet->lValue(0, "ScaledVector");
-    //uint64_t gl1_livevec = packet->lValue(0, "TriggerVector");   
-
-    int bunchno = packet->lValue(0,"BunchNumber");
-    if (bunchno < 0 || bunchno >= m_bunches)
+    else
     {
-      if (Verbosity() > 0)
-      {
-        std::cout << PHWHERE << " invalid bunch number: " << bunchno << std::endl;
-      }
-      delete packet;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      m_usable_bco_tag = false;
     }
-
-    delete packet;
-
+    if (bco_diff_futu < m_default_positive_window_length)
+    {
+      // double check boundaries for overlap!!
+      m_bco_streaming_window = std::make_pair(get_bco() - m_default_negative_window_length, bco_futu - m_default_negative_window_length + 1);
+    }
+    else
+    {
+      m_bco_streaming_window = std::make_pair(get_bco() - m_default_negative_window_length, get_bco() + m_default_positive_window_length);
+    }
     if (Verbosity() > 2)
     {
-      if (!syncobject)
-      {
-        std::cout << PHWHERE << " SyncObject missing" << std::endl;
-        return Fun4AllReturnCodes::ABORTEVENT;
-      }
-      std::cout << "Event No: " << syncobject->EventNumber() /*<< std::hex*/
-                << " gl1  bco: " << gtm_bco <<std::dec << std::endl;
+      std::cout << "bco_diff_prev : " << bco_diff_prev << std::endl;
+      std::cout << "bco_diff_futu : " << bco_diff_futu << std::endl;
     }
-    if (bcoinfo)
+    h_bco_diff->Fill(bco_diff_prev);
+    h_bco_tag->Fill(m_usable_bco_tag);
+    // There is no longer a need to read in the .evt file here, so we won't have access to this info. If we wish to access it we can in a different module
+    //for (int bit=0; bit<trigbits; ++bit)
+    //{
+    //  bool trigger_fired = ((gl1_scaledvec >> static_cast<uint64_t>(bit)) & 0x1U) == 0x1U;
+    //  if (trigger_fired)
+    //  {
+    //    h_bco_diff_trigbits[bit]->Fill(bco_diff_prev);
+    //  }
+    //}
+
+    streaming_bco_info->set_bco(get_bco());
+    streaming_bco_info->set_usable_bco_tag(get_usable_bco_tag());
+    streaming_bco_info->set_bco_streaming_window(get_bco_streaming_window());
+    if (syncobject)
     {
-      if (Verbosity() > 2)
-      {
-        std::cout << "prev event: " << bcoinfo->get_previous_evtno() /*<< std::hex*/
-                  << " bco: " << bcoinfo->get_previous_bco() << std::dec << std::endl;
-        std::cout << "curr event: " << bcoinfo->get_current_evtno() /*<< std::hex*/
-                  << " bco: " << bcoinfo->get_current_bco() << std::dec << std::endl;
-        std::cout << "futu event: " << bcoinfo->get_future_evtno() /*<< std::hex*/
-                  << " bco: " << bcoinfo->get_future_bco() << std::dec << std::endl;
-      }
-
-      StreamingBcoInfo *streaming_bco_info = findNode::getClass<StreamingBcoInfo>(topNode, "STREAMINGBCOINFO");
-      if (!streaming_bco_info)
-      {
-        std::cout << PHWHERE << " STREAMINGBCOINFO node missing" << std::endl;
-        return Fun4AllReturnCodes::ABORTEVENT;
-      }
-      m_bco = bcoinfo->get_current_bco();
-      if (gtm_bco != m_bco) { std::cout << "BCO MISMATCH!!! : gtm_bco : " << gtm_bco << " m_bco " << m_bco << std::endl;}
-      uint64_t bco_prev = bcoinfo->get_previous_bco();
-      uint64_t bco_futu = bcoinfo->get_future_bco();
-      uint64_t bco_diff_prev = m_bco - bco_prev;
-      uint64_t bco_diff_futu = bco_futu - m_bco;
-
-      // special case if BCO is within 20 of previous BCO?
-      if (bco_diff_prev < m_default_positive_window_length)
-      {
-        m_usable_bco_tag = true;
-      }
-      else
-      {
-        m_usable_bco_tag = false;
-      }
-      if (bco_diff_futu < m_default_positive_window_length)
-      {
-        // double check boundaries for overlap!!
-        m_bco_streaming_window = std::make_pair(get_bco() - m_default_negative_window_length, bco_futu - m_default_negative_window_length + 1);
-      }
-      else
-      {
-        m_bco_streaming_window = std::make_pair(get_bco() - m_default_negative_window_length, get_bco() + m_default_positive_window_length);
-      }
-      if (Verbosity() > 2)
-      {
-        std::cout << "bco_diff_prev : " << bco_diff_prev << std::endl;
-        std::cout << "bco_diff_futu : " << bco_diff_futu << std::endl; 
-      }
-      h_bco_diff->Fill(bco_diff_prev);
-      h_bco_tag->Fill(m_usable_bco_tag);
-      for (int bit=0; bit<trigbits; ++bit)
-      {
-        bool trigger_fired = ((gl1_scaledvec >> static_cast<uint64_t>(bit)) & 0x1U) == 0x1U;
-        //bool scaled_trigger_fired = ((gl1_scaledvec >> bit) & 0x1U) == 0x1U;
-
-        if (trigger_fired) 
-        {
-          h_bco_diff_trigbits[bit]->Fill(bco_diff_prev);
-        }
-      }
-
-      streaming_bco_info->set_bco(get_bco());
-      streaming_bco_info->set_usable_bco_tag(get_usable_bco_tag());
-      streaming_bco_info->set_bco_streaming_window(get_bco_streaming_window());
-      if (syncobject)
-      {
-        streaming_bco_info->set_evtno(syncobject->EventNumber());
-      }
+      streaming_bco_info->set_evtno(syncobject->EventNumber());
     }
   }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/bcolumicount/StreamingBcoReco.h
+++ b/offline/packages/bcolumicount/StreamingBcoReco.h
@@ -34,14 +34,13 @@ class StreamingBcoReco : public SubsysReco
 
  private:
   static int CreateNodeTree(PHCompositeNode *topNode);
-  const int trigbits = 40;
+  //const int trigbits = 40;
   Fun4AllHistoManager *hm = nullptr; 
   TH1 *h_bco_diff = nullptr;
   //TH1 *h_bco_diff_trigbits[40] = {nullptr};
   TH1 *h_bco_tag = nullptr;
 
   uint64_t m_bco{0};
-  int m_bunches = 120;
   int m_evtno{0};
   bool m_usable_bco_tag = false;
   std::pair<uint64_t, uint64_t> m_bco_streaming_window;

--- a/offline/packages/bcolumicount/StreamingBcoReco.h
+++ b/offline/packages/bcolumicount/StreamingBcoReco.h
@@ -37,7 +37,7 @@ class StreamingBcoReco : public SubsysReco
   const int trigbits = 40;
   Fun4AllHistoManager *hm = nullptr; 
   TH1 *h_bco_diff = nullptr;
-  TH1 *h_bco_diff_trigbits[40] = {nullptr};
+  //TH1 *h_bco_diff_trigbits[40] = {nullptr};
   TH1 *h_bco_tag = nullptr;
 
   uint64_t m_bco{0};

--- a/offline/packages/bcolumicount/StreamingLumiReco.cc
+++ b/offline/packages/bcolumicount/StreamingLumiReco.cc
@@ -23,11 +23,6 @@
 #include <phool/phool.h>  // for PHWHERE
 #include <phool/sphenix_constants.h> // for MDB_NS_xsec
 
-
-#include <Event/Event.h>
-#include <Event/EventTypes.h>
-#include <Event/packet.h>  // for Packet
-
 #include <TH1.h>
 
 #include <iostream>
@@ -80,83 +75,63 @@ int StreamingLumiReco::CreateNodeTree(PHCompositeNode *topNode)
 int StreamingLumiReco::process_event(PHCompositeNode *topNode)
 {
   StreamingBcoInfo *streaming_bcoinfo = findNode::getClass<StreamingBcoInfo>(topNode, "STREAMINGBCOINFO");
-  Event *evt = findNode::getClass<Event>(topNode, "PRDF");
-  if (evt)
+  Gl1Packet *gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
+  if (!gl1packet)
   {
-    if (Verbosity() > 2)
+    if (Verbosity() > 0)
     {
-      evt->identify();
+      std::cout << "no gl1 packet 14001" << std::endl;
     }
-    if (evt->getEvtType() != DATAEVENT)
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  uint64_t gtm_bco = gl1packet->lValue(0, "BCO");
+
+  int bunchno = gl1packet->lValue(0,"BunchNumber");
+  if (bunchno < 0 || bunchno >= m_bunches)
+  {
+    if (Verbosity() > 0)
     {
-      return Fun4AllReturnCodes::ABORTEVENT;
+      std::cout << PHWHERE << " invalid bunch number: " << bunchno << std::endl;
     }
-    Packet *packet = evt->getPacket(14001);
-    if (!packet)
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // SYNTAX TAKEN FROM ZHIWANS CODE, why = and not +=? If this is correct it seems like a waste to call it for every event (would just need it for the last event in a particular crossing?)
+  m_bunchnumber_MBDNS_raw[bunchno] = gl1packet->lValue(0, "GL1PRAW");
+  m_bunchnumber_MBDNS_live[bunchno] = gl1packet->lValue(0, "GL1PLIVE");
+  m_bunchnumber_MBDNS_scaled[bunchno] = gl1packet->lValue(0, "GL1PSCALED");
+
+
+  if(gl1packet->lValue(0, 0))
+  {
+    m_rawgl1scaler = gl1packet->lValue(0, 0);
+  }
+
+  if (streaming_bcoinfo)
+  {
+    if (gtm_bco != streaming_bcoinfo->get_bco()) { std::cout << "BCO MISMATCH!!! : gtm_bco : " << gtm_bco << " bco " << streaming_bcoinfo->get_bco() << std::endl;}
+
+    // Double check Zhiwan's logic for assigning the adjusted bunch!
+    int lower = streaming_bcoinfo->get_bco_streaming_window().first - streaming_bcoinfo->get_bco();
+    int upper = streaming_bcoinfo->get_bco_streaming_window().second - streaming_bcoinfo->get_bco();
+    for(int i = lower; i< upper;i++)
     {
-      if (Verbosity() > 0)
+      int adjusted_bunch = bunchno + i;
+      while (adjusted_bunch < 0)
       {
-        std::cout << "no gl1 packet 14001" << std::endl;
-        evt->identify();
+          adjusted_bunch += 120;
       }
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-    uint64_t gtm_bco = packet->lValue(0, "BCO"); 
-
-    int bunchno = packet->lValue(0,"BunchNumber");
-    if (bunchno < 0 || bunchno >= m_bunches)
-    {
-      if (Verbosity() > 0)
+      while (adjusted_bunch > 119)
       {
-        std::cout << PHWHERE << " invalid bunch number: " << bunchno << std::endl;
+          adjusted_bunch -= 120;
       }
-      delete packet;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+      // ABORT GAP!
+      if (adjusted_bunch>110) { continue; }
 
-    // SYNTAX TAKEN FROM ZHIWANS CODE, why = and not +=? If this is correct it seems like a waste to call it for every event (would just need it for the last event in a particular crossing?)
-    m_bunchnumber_MBDNS_raw[bunchno] = packet->lValue(0, "GL1PRAW");
-    m_bunchnumber_MBDNS_live[bunchno] = packet->lValue(0, "GL1PLIVE");
-    m_bunchnumber_MBDNS_scaled[bunchno] = packet->lValue(0, "GL1PSCALED");
-
-
-    if(packet->lValue(0, 0))
-    {
-      m_rawgl1scaler = packet->lValue(0, 0);
-    }
-
-    delete packet;
-
-    if (streaming_bcoinfo)
-    {
-      if (gtm_bco != streaming_bcoinfo->get_bco()) { std::cout << "BCO MISMATCH!!! : gtm_bco : " << gtm_bco << " bco " << streaming_bcoinfo->get_bco() << std::endl;}
-
-      // Double check Zhiwan's logic for assigning the adjusted bunch!
-      int lower = streaming_bcoinfo->get_bco_streaming_window().first - streaming_bcoinfo->get_bco();
-      int upper = streaming_bcoinfo->get_bco_streaming_window().second - streaming_bcoinfo->get_bco();
-      for(int i = lower; i< upper;i++)
+      // Make sure this is the correct way to count crossings! Need to zero out for each run!
+      if(i!=0 || streaming_bcoinfo->get_usable_bco_tag())
       {
-        int adjusted_bunch = bunchno + i;
-          while (adjusted_bunch < 0)
-          {
-              adjusted_bunch += 120;
-          }
-          while (adjusted_bunch > 119)
-          {
-              adjusted_bunch -= 120;
-          }
-          // ABORT GAP!
-          if (adjusted_bunch>110) { continue; }
-
-          // Make sure this is the correct way to count crossings! Need to zero out for each run!
-          if(i!=0 || streaming_bcoinfo->get_usable_bco_tag())
-          {
-            m_bunchnumber_crossings[adjusted_bunch] += 1;
-          }
-          //else if (m_usable_bco_tag)
-          //{
-          //  m_bunchnumber_crossings[adjusted_bunch] += 1;
-          //}
+        m_bunchnumber_crossings[adjusted_bunch] += 1;
       }
     }
   }


### PR DESCRIPTION
… (PRDF) and remove unnecessary inputs from StreamingBcoReco.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR is a step towards making the luminosity calculation user facing by extracting necessary info from GL1RAWHITNODE DSTs instead of the PRDFs. See https://github.com/sPHENIX-Collaboration/coresoftware/pull/4317#discussion_r3483510570 for reference. 


[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This is following work from https://github.com/sPHENIX-Collaboration/coresoftware/pull/4269 and https://github.com/sPHENIX-Collaboration/coresoftware/pull/4317.

## TODOs (if applicable)

- [ ]  Validation check to ensure the same luminosity is obtained over a full run as when reading in PRDFs. The number of input files increases dramatically when switching to DSTs, so this check will require scripting some condor jobs (WIP).

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/macros/pull/1358



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context

Enable user-facing luminosity calculations by switching luminosity input from GL1 raw PRDF packet data to the `GL1RAWHITNODE` / `gl1rawhitdst` DST stream, while simplifying `StreamingBcoReco` to consume already-produced node-tree BCO information. A remaining validation ensures luminosity equivalence over a full run; related macros updates are required.

## Key changes

- **`StreamingLumiReco`**
  - Switched GL1 input source from PRDF `Event`/packet (14001) to the `GL1RAWHIT` node (`Gl1Packet` / `gl1rawhitdst`).
  - Added **early abort** if `GL1RAWHIT` is missing and **validation** for extracted bunch number.
  - Filled per-bunch scaler arrays (`GL1PRAW`, `GL1PLIVE`, `GL1PSCALED`) directly from the `Gl1Packet`, preserving existing streaming-window crossing / adjusted-bunch counting logic.

- **`StreamingBcoReco`**
  - Removed PRDF event/packet handling for BCO/trigger vector extraction; now computes BCO quantities from `BcoInfo` + `StreamingBcoInfo` in the node tree.
  - Simplified sync handling: validates/aborts on `syncobject` only under higher verbosity, and aborts when required BCO node information is missing.
  - Removed trigger-bit-specific histogram initialization/filling (`h_bco_diff_trigbits`) and corresponding histogram declarations.

- **Macros**
  - Requires companion updates in the macros repository (as referenced by the macros PR linkage).

## Potential risk areas

- **IO/input compatibility:** DST/node availability and field semantics may differ from the prior PRDF path.
- **Reconstruction behavior:** Changed BCO derivation and missing-node abort logic may affect event acceptance, timing, and luminosity results.
- **Monitoring/histograms:** Removal of trigger-bit BCO differential histogram content could affect downstream monitoring or analysis expectations.
- **Synchronization edge cases:** Conditional `syncobject` validation behavior could mask or expose issues depending on verbosity and run conditions.

## Possible future improvements

- Complete and document **full-run physics validation** confirming luminosity equivalence vs. the prior PRDF-based approach.
- If needed, **restore or replace** trigger-bit monitoring in a DST/node-driven way.
- Add targeted checks/tests for:
  - missing `GL1RAWHIT` / `StreamingBCOINFO`
  - invalid bunch numbers
  - DST compatibility across typical workflows.
- Coordinate the **macros** changes to ensure end-to-end user workflows work unchanged.

*AI-generated summaries can contain mistakes—use best judgment and confirm against the actual implementation and validation results.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->