### PR TITLE
Small fixes

### DIFF
--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -43,9 +43,9 @@ class PHHepMCGenHelper
   enum VTXFUNC
   {
     //! uniform distribution with half width set via set_vertex_distribution_width()
-    Uniform,
+    Uniform = 0,
     //! normal distribution with sigma width set via set_vertex_distribution_width()
-    Gaus
+    Gaus = 1
   };
 
   //! toss a new vertex according to a Uniform or Gaus distribution

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.cc
@@ -27,7 +27,7 @@ int G4VtxNtuple::Init(PHCompositeNode * /*unused*/)
 {
   delete hm; // make cppcheck happy
   hm = new Fun4AllHistoManager(Name());
-  ntup = new TNtuple("vtxntup", "G4Vtxs", "vx:vy:vz");
+  ntup = new TNtuple("vtxntup", "G4Vtxs", "vx:vy:vz:vt");
   hm->registerHisto(ntup);
   return 0;
 }
@@ -38,7 +38,10 @@ int G4VtxNtuple::process_event(PHCompositeNode *topNode)
   if (truthinfo)
   {
     PHG4VtxPoint *gvertex = truthinfo->GetPrimaryVtx(truthinfo->GetPrimaryVertexIndex());
-    ntup->Fill(gvertex->get_x(), gvertex->get_y(), gvertex->get_z());
+    if (gvertex)
+    {
+      ntup->Fill(gvertex->get_x(), gvertex->get_y(), gvertex->get_z(), gvertex->get_t());
+    }
   }
   return 0;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adds the collision time to the vtx ntuple, sets VTXFUNC enum values explicitly (Uniform=0, Gaus = 1)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Improve vertex ntuple completeness by recording collision time and ensure stable, explicit `VTXFUNC` enum values.

## Key changes

- Added `vt` to the `G4VtxNtuple` schema and filled it from the primary vertex time.
- Guarded vertex filling against a null primary-vertex pointer.
- Explicitly assigned `VTXFUNC::Uniform = 0` and `VTXFUNC::Gaus = 1`.

## Potential risks

- The ntuple schema change may affect downstream readers expecting three fields.
- The new null check changes behavior for events without a primary vertex, though it should prevent invalid access.
- No significant performance or thread-safety impact is expected.

## Possible future improvements

- Update and validate all downstream ntuple consumers and documentation.
- Add regression tests covering vertex time persistence and missing primary vertices.
- AI-generated summaries can contain mistakes; the implementation should be reviewed against downstream format requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->