### PR TITLE
Micromegas and Silicon side drift calibration QA modules

### DIFF
--- a/offline/QA/Tracking/Makefile.am
+++ b/offline/QA/Tracking/Makefile.am
@@ -21,7 +21,9 @@ pkginclude_HEADERS = \
   MicromegasClusterQA.h \
   CosmicTrackQA.h \
   TrackFittingQA.h \
-  VertexQA.h
+  VertexQA.h \
+  SiliconDriftQA.h \
+  MicromegasDriftQA.h
 
 lib_LTLIBRARIES = \
   libtrackingqa.la
@@ -37,7 +39,9 @@ libtrackingqa_la_SOURCES = \
   MicromegasClusterQA.cc \
   CosmicTrackQA.cc \
   TrackFittingQA.cc \
-  VertexQA.cc
+  VertexQA.cc \
+  SiliconDriftQA.cc \
+  MicromegasDriftQA.cc
 
 libtrackingqa_la_LIBADD = \
   -lphool \
@@ -49,6 +53,7 @@ libtrackingqa_la_LIBADD = \
   -lmvtx_io \
   -lintt_io \
   -ltrack_io \
+  -ltrack  \
   -ltrackbase_historic_io \
   -ltrack_reco \
   -lqautils

--- a/offline/QA/Tracking/MicromegasDriftQA.cc
+++ b/offline/QA/Tracking/MicromegasDriftQA.cc
@@ -164,12 +164,12 @@ namespace
 
     // the helix-plane equation can have more than one solution:
     // look for a solution within the tile acceptance from three different phi seeds
-    std::vector<double> t_seeds;
+    std::vector<double> t_seeds(3);
     const double t_center = 0.5 * (t_min + t_max);
     const double delta = 2.0 * M_PI / 3.0;
     for (int i = 0; i < 3; ++i)
     {
-      t_seeds.push_back(wrap(t_center + i * delta));
+      t_seeds[i]=wrap(t_center + i * delta);
     }
 
     for (const double t_seed : t_seeds)

--- a/offline/QA/Tracking/MicromegasDriftQA.cc
+++ b/offline/QA/Tracking/MicromegasDriftQA.cc
@@ -1,0 +1,618 @@
+#include "MicromegasDriftQA.h"
+
+#include <qautils/QAHistManagerDef.h>
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
+
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <micromegas/CylinderGeomMicromegas.h>
+#include <micromegas/MicromegasDefs.h>
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrackFitUtils.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <TDirectory.h>
+#include <TF1.h>
+#include <TF2.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TVector3.h>
+
+#include <array>
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <format>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+  template <class T>
+  class range_adaptor
+  {
+   public:
+    explicit range_adaptor(const T& range)
+      : m_range(range)
+    {
+    }
+    const typename T::first_type& begin() { return m_range.first; }
+    const typename T::second_type& end() { return m_range.second; }
+
+   private:
+    T m_range;
+  };
+
+  double normalize_angle(double phi)
+  {
+    while (phi < 0)
+    {
+      phi += 2 * M_PI;
+    }
+    while (phi >= 2 * M_PI)
+    {
+      phi -= 2 * M_PI;
+    }
+    return phi;
+  }
+
+  bool phi_in_range(double phi, double min, double max)
+  {
+    phi = normalize_angle(phi);
+    min = normalize_angle(min);
+    max = normalize_angle(max);
+    return (min < max) ? (phi >= min && phi <= max)
+                       : (phi >= min || phi <= max);
+  }
+
+  //! helix-plane intersection via Newton-Raphson
+  //  identical to the version in MicromegasTrackEvaluator_hp.cc
+  bool helix_plane_intersection(
+      double t_min,
+      double t_max,
+      double zmin,
+      double zmax,
+      double R,
+      double X0,
+      double Y0,
+      double intersect_rz,
+      double slope_rz,
+      const TVector3& ptile,
+      const TVector3& ntile,
+      TVector3& intersect)
+  {
+    // number of iterations and tolerance for Newton-Raphson method
+    const int max_iter = 10;
+    const double tol = 1e-6;
+
+    // define C
+    const double C = ntile.X() * (X0 - ptile.X()) + ntile.Y() * (Y0 - ptile.Y()) + ntile.Z() * (intersect_rz - ptile.Z());
+
+    // define the function and the corresponding derivative used in the Newton-Raphson method
+    auto f = [&](double t)
+    {
+      const double xt = X0 + R * std::cos(t);
+      const double yt = Y0 + R * std::sin(t);
+      const double Rt = std::sqrt(xt * xt + yt * yt);
+      return ntile.X() * R * std::cos(t) + ntile.Y() * R * std::sin(t) + ntile.Z() * slope_rz * Rt + C;
+    };
+
+    auto df = [&](double t)
+    {
+      const double xt = X0 + R * std::cos(t);
+      const double yt = Y0 + R * std::sin(t);
+      const double Rt = std::sqrt(xt * xt + yt * yt);
+      return -ntile.X() * R * std::sin(t) + ntile.Y() * R * std::cos(t) + ntile.Z() * R * slope_rz * (Y0 * std::cos(t) - X0 * std::sin(t)) / Rt;
+    };
+
+    auto solve_from = [&](double t_seed, TVector3& result) -> bool
+    {
+      double t = t_seed;
+      for (int i = 0; i < max_iter; ++i)
+      {
+        const double ft = f(t);
+        const double dft = df(t);
+        if (std::abs(dft) < 1e-8)
+        {
+          return false;
+        }
+        const double t_new = t - ft / dft;
+
+        const double x = X0 + R * std::cos(t_new);
+        const double y = Y0 + R * std::sin(t_new);
+        const double Rt_n = std::sqrt(x * x + y * y);
+        const double z = slope_rz * Rt_n + intersect_rz;
+        const double phi = std::atan2(y, x);
+
+        const TVector3 cand(x, y, z);
+        const bool phi_ok = phi_in_range(phi, t_min - 1e-4, t_max + 1e-4);
+        const bool z_ok = (z >= zmin - 1e-4 && z <= zmax + 1e-4);
+        const bool proj_ok = (std::abs(ntile.Dot(cand - ptile)) <= 0.05);
+
+        if (std::abs(t_new - t) < tol && proj_ok && phi_ok && z_ok)
+        {
+          result = cand;
+          return true;
+        }
+        t = t_new;
+      }
+      return false;
+    };
+
+    auto wrap = [&](double t)
+    {
+      while (t > t_max)
+      {
+        t -= 2 * M_PI;
+      }
+      while (t < t_min)
+      {
+        t += 2 * M_PI;
+      }
+      return t;
+    };
+
+    // the helix-plane equation can have more than one solution:
+    // look for a solution within the tile acceptance from three different phi seeds
+    std::vector<double> t_seeds;
+    const double t_center = 0.5 * (t_min + t_max);
+    const double delta = 2.0 * M_PI / 3.0;
+    for (int i = 0; i < 3; ++i)
+    {
+      t_seeds.push_back(wrap(t_center + i * delta));
+    }
+
+    for (const double t_seed : t_seeds)
+    {
+      if (solve_from(t_seed, intersect))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  //! piecewise fit function used for the drift velocity extraction
+  //  par[0] = constrained slope, par[1..8] = per-tile offsets
+  double fit_function_2d(double* x, double* par)
+  {
+    const int itile = static_cast<int>(std::floor(x[0]));
+    const double z = x[1];
+    if (itile < 0 || itile >= 8)
+    {
+      TF2::RejectPoint();
+      return 0.;
+    }
+    return par[itile + 1] + par[0] * z;
+  }
+
+  //! z-view tile names
+  const std::array<const char*, 8> k_tile_names =
+      {"SCOZ", "SCIZ", "NCIZ", "NCOZ", "SEZ", "NEZ", "SWZ", "NWZ"};
+
+  //! number of z bins of the dz vs z histograms
+  constexpr int k_nzbins = 220;
+
+  //! z_track range (cm)
+  constexpr double k_max_z = 110;
+
+  //! dz range (cm)
+  constexpr double k_max_dz = 10;
+
+}  // namespace
+
+//____________________________________________________________________________..
+MicromegasDriftQA::MicromegasDriftQA(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+int MicromegasDriftQA::InitRun(PHCompositeNode* topNode)
+{
+  if (Verbosity())
+  {
+    std::cout << Name() << "::InitRun"
+              << " drift_velocity=" << m_drift_velocity << " cm/ns"
+              << " min_tpc_layer=" << m_min_tpc_layer
+              << " max_tpc_layer=" << m_max_tpc_layer
+              << std::endl;
+  }
+
+  const auto res = load_nodes(topNode);
+  if (res != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return res;
+  }
+
+  createHistos();
+
+  // reference histograms initialized in header file to histos in HistoManager
+  auto* hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  for (int itile = 0; itile < 8; itile++)
+  {
+    h_ztrk_dz[itile] = dynamic_cast<TH2*>(hm->getHisto(std::format("{}ztrk_dz_{}", getHistoPrefix(), k_tile_names[itile])));
+  }
+  h_dz = dynamic_cast<TH1*>(hm->getHisto(std::format("{}dz", getHistoPrefix())));
+  h_tile = dynamic_cast<TH1*>(hm->getHisto(std::format("{}tile", getHistoPrefix())));
+  h_ylocal = dynamic_cast<TH1*>(hm->getHisto(std::format("{}ylocal", getHistoPrefix())));
+  h_ntracks = dynamic_cast<TH1*>(hm->getHisto(std::format("{}ntracks", getHistoPrefix())));
+  h_driftSummary = dynamic_cast<TH1*>(hm->getHisto(std::format("{}driftSummary", getHistoPrefix())));
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int MicromegasDriftQA::process_event(PHCompositeNode* topNode)
+{
+  const auto res = load_nodes(topNode);
+  if (res != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return res;
+  }
+
+  int nmatched = 0;
+
+  for (const auto& [track_id, track] : *m_track_map)
+  {
+    // require valid beam-crossing
+    const auto crossing = track->get_crossing();
+    if (crossing == SHRT_MAX)
+    {
+      continue;
+    }
+
+    // collect distortion-corrected TPC cluster positions in the selected layer range
+    std::vector<Acts::Vector3> tpc_positions;
+    for (const auto* seed : {track->get_silicon_seed(), track->get_tpc_seed()})
+    {
+      if (!seed)
+      {
+        continue;
+      }
+      for (auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys(); ++it)
+      {
+        const auto ckey = *it;
+        if (TrkrDefs::getTrkrId(ckey) != TrkrDefs::tpcId)
+        {
+          continue;
+        }
+        const auto layer = TrkrDefs::getLayer(ckey);
+        if (layer < m_min_tpc_layer || layer >= m_max_tpc_layer)
+        {
+          continue;
+        }
+        auto* cl = m_cluster_map->findCluster(ckey);
+        if (cl)
+        {
+          tpc_positions.push_back(
+              m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cl, crossing));
+        }
+      }
+    }
+
+    // need at least 3 TPC clusters in range
+    if (tpc_positions.size() < 3)
+    {
+      continue;
+    }
+
+    // helix fit: straight line in r-z, circle in x-y
+    const auto [slope_rz, intersect_rz] = TrackFitUtils::line_fit(tpc_positions);
+    const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin(tpc_positions);
+
+    // reject badly reconstructed / low-pT tracks
+    if (R < 40.0)
+    {
+      continue;
+    }
+
+    // extrapolate to the TPOT z-view modules
+    const auto mm_range = m_micromegas_geomcontainer->get_begin_end();
+    for (const auto& [mm_layer, base_layergeom] : range_adaptor(mm_range))
+    {
+      const auto* layergeom = static_cast<const CylinderGeomMicromegas*>(base_layergeom);
+      assert(layergeom);
+
+      // skip the phi layer; only the z-view layer matters here
+      if (layergeom->get_segmentation_type() != MicromegasDefs::SegmentationType::SEGMENTATION_Z)
+      {
+        continue;
+      }
+
+      const double layer_radius = layergeom->get_radius();
+      auto [xplus, yplus, xminus, yminus] =
+          TrackFitUtils::circle_circle_intersection(layer_radius, R, X0, Y0);
+
+      if (!std::isfinite(xplus))
+      {
+        continue;
+      }
+
+      // pick the solution closest in phi to the last TPC cluster
+      const double last_phi = std::atan2(tpc_positions.back().y(), tpc_positions.back().x());
+      const double phi_plus = std::atan2(yplus, xplus);
+      const double phi_minus = std::atan2(yminus, xminus);
+      const double phi = (std::abs(last_phi - phi_plus) < std::abs(last_phi - phi_minus)) ? phi_plus : phi_minus;
+
+      const double r_cyl = layer_radius;
+      const double z_cyl = intersect_rz + slope_rz * r_cyl;
+      const TVector3 world_cyl(r_cyl * std::cos(phi), r_cyl * std::sin(phi), z_cyl);
+
+      const int tileid = layergeom->find_tile_cylindrical(world_cyl);
+      if (tileid < 0)
+      {
+        continue;
+      }
+
+      const auto tile_center = layergeom->get_world_from_local_coords(tileid, m_tGeometry, {0, 0});
+      const TVector3 ptile(tile_center.x(), tile_center.y(), tile_center.z());
+
+      const auto tile_norm = layergeom->get_world_from_local_vect(tileid, m_tGeometry, {0, 0, 1});
+      const TVector3 ntile(tile_norm.x(), tile_norm.y(), tile_norm.z());
+
+      const auto phi_range = layergeom->get_phi_range(tileid, m_tGeometry);
+      const double zmin = layergeom->get_zmin();
+      const double zmax = layergeom->get_zmax();
+
+      TVector3 intersection;
+      if (!helix_plane_intersection(phi_range.first, phi_range.second, zmin, zmax,
+                                    R, X0, Y0, intersect_rz, slope_rz, ptile, ntile, intersection))
+      {
+        continue;
+      }
+
+      const auto local_intersection = layergeom->get_local_from_world_coords(
+          tileid, m_tGeometry, {intersection.x(), intersection.y(), intersection.z()});
+      const double y_local = local_intersection.y();
+
+      // reject track states near the tile edge
+      if (std::abs(y_local) > m_y_local_cut)
+      {
+        continue;
+      }
+
+      // find the nearest TPOT cluster on this tile
+      const auto hitsetkey = MicromegasDefs::genHitSetKey(mm_layer, MicromegasDefs::SegmentationType::SEGMENTATION_Z, tileid);
+      const auto clusrange = m_cluster_map->getClusters(hitsetkey);
+
+      double dmin = -1;
+      double z_cluster = 0;
+      for (const auto& [ckey, cl] : range_adaptor(clusrange))
+      {
+        const double cl_y_local = cl->getLocalY();
+        const double d = std::abs(y_local - cl_y_local);
+        if (dmin < 0 || d < dmin)
+        {
+          dmin = d;
+          const auto gpos = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cl, crossing);
+          z_cluster = gpos.z();
+        }
+      }
+
+      // require cluster within the z search window
+      if (dmin < 0 || dmin > m_z_search_win)
+      {
+        continue;
+      }
+
+      // fill histograms
+      const double z_track = intersection.z();
+      const double dz = z_track - z_cluster;
+
+      h_ztrk_dz[tileid]->Fill(z_track, dz);
+      h_dz->Fill(dz);
+      h_tile->Fill(tileid);
+      h_ylocal->Fill(y_local);
+
+      ++nmatched;
+      break;
+    }
+  }
+
+  h_ntracks->Fill(nmatched);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int MicromegasDriftQA::End(PHCompositeNode* /*topNode*/)
+{
+  if (!(h_ztrk_dz[0] && h_driftSummary))
+  {
+    std::cout << PHWHERE << " histograms not found, skipping drift velocity fit." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  int nEntries = 0;
+  for (const auto* h : h_ztrk_dz)
+  {
+    nEntries += static_cast<int>(h->GetEntries());
+  }
+  if (Verbosity())
+  {
+    std::cout << Name() << "::End - fitting " << nEntries << " entries" << std::endl;
+  }
+
+  // record input drift velocity even if the fit is skipped
+  h_driftSummary->SetBinContent(3, m_drift_velocity);
+
+  if (nEntries < 8 * m_min_slice_entries)
+  {
+    std::cout << Name() << "::End - not enough entries (" << nEntries << "), skipping drift velocity fit." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  // build mean-dz TH2 via FitSlicesY, one tile at a time
+  // x = tile [0,8), y = z_track (cm), content = mean dz (cm)
+  auto* h_fit = new TH2F("h_fit_micromegas", "", 8, 0, 8, k_nzbins, -k_max_z, k_max_z);
+  h_fit->SetDirectory(nullptr);
+
+  for (int itile = 0; itile < 8; ++itile)
+  {
+    auto* h2d = h_ztrk_dz[itile];
+
+    // fit vertical slices; require a minimum of m_min_slice_entries per slice
+    TObjArray slices;
+    slices.SetOwner(kTRUE);
+    h2d->FitSlicesY(nullptr, 0, -1, m_min_slice_entries, "QNR", &slices);
+    auto* h_mean = dynamic_cast<TH1*>(slices.At(1));
+    if (!h_mean)
+    {
+      continue;
+    }
+
+    for (int iz = 1; iz <= h_mean->GetNbinsX(); ++iz)
+    {
+      const double entries = h2d->Integral(iz, iz, 1, h2d->GetNbinsY());
+      if (entries > 0)
+      {
+        h_fit->SetBinContent(itile + 1, iz, h_mean->GetBinContent(iz));
+      }
+    }
+  }
+
+  // 2D piecewise fit: the eight tiles are fitted simultaneously with a shared
+  // slope and per-tile offsets. This eliminates the need for perfect
+  // translational TPOT alignment.
+  auto* fit2d = new TF2("fit2d_micromegas", fit_function_2d, 0, 8, -k_max_z, k_max_z, 9);
+  for (int i = 0; i < 9; ++i)
+  {
+    fit2d->SetParameter(i, 0.0);
+  }
+  h_fit->Fit(fit2d, "0RQ");
+
+  const double slope = fit2d->GetParameter(0);
+  const double slope_err = fit2d->GetParError(0);
+  const double new_drift = m_drift_velocity / (1.0 + slope);
+  const double drift_err = m_drift_velocity / std::pow(1.0 + slope, 2) * slope_err;
+
+  std::cout << Name() << "::End"
+            << " slope=" << slope
+            << " input_drift=" << m_drift_velocity << " cm/ns"
+            << " new_drift=" << new_drift << " cm/ns +/- " << drift_err << " cm/ns"
+            << std::endl;
+
+  // store fit results in the summary histogram
+  h_driftSummary->SetBinContent(1, slope);
+  h_driftSummary->SetBinContent(2, slope_err);
+  h_driftSummary->SetBinContent(4, new_drift);
+  h_driftSummary->SetBinContent(5, drift_err);
+
+  delete fit2d;
+  delete h_fit;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int MicromegasDriftQA::load_nodes(PHCompositeNode* topNode)
+{
+  m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!m_tGeometry)
+  {
+    std::cout << PHWHERE << " ActsGeometry node missing, abort." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_micromegas_geomcontainer = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
+  if (!m_micromegas_geomcontainer)
+  {
+    std::cout << PHWHERE << " CYLINDERGEOM_MICROMEGAS_FULL node missing, abort." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_track_map = findNode::getClass<SvtxTrackMap>(topNode, m_trackmapname);
+  if (!m_track_map)
+  {
+    std::cout << PHWHERE << " " << m_trackmapname << " node missing, abort." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!m_cluster_map)
+  {
+    std::cout << PHWHERE << " TRKR_CLUSTER node missing, abort." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_globalPositionWrapper.loadNodes(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+std::string MicromegasDriftQA::getHistoPrefix() const
+{
+  // define prefix to all histos in HistoManager
+  return std::string("h_") + Name() + std::string("_");
+}
+
+//____________________________________________________________________________..
+void MicromegasDriftQA::createHistos()
+{
+  // initialize HistoManager
+  auto* hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  // create and register histos in HistoManager
+  for (int itile = 0; itile < 8; itile++)
+  {
+    auto* h = new TH2F(std::format("{}ztrk_dz_{}", getHistoPrefix(), k_tile_names[itile]).c_str(),
+                       std::format("{};z_{{track}} (cm);#Deltaz (track#minuscluster) (cm)", k_tile_names[itile]).c_str(),
+                       k_nzbins, -k_max_z, k_max_z, 100, -k_max_dz, k_max_dz);
+    hm->registerHisto(h);
+  }
+
+  {
+    auto* h = new TH1F(std::format("{}dz", getHistoPrefix()).c_str(),
+                       ";#Deltaz (track#minuscluster) (cm);track states", 100, -k_max_dz, k_max_dz);
+    hm->registerHisto(h);
+  }
+
+  {
+    auto* h = new TH1F(std::format("{}tile", getHistoPrefix()).c_str(),
+                       ";tile;track states", 8, -0.5, 7.5);
+    for (int itile = 0; itile < 8; itile++)
+    {
+      h->GetXaxis()->SetBinLabel(itile + 1, k_tile_names[itile]);
+    }
+    hm->registerHisto(h);
+  }
+
+  {
+    auto* h = new TH1F(std::format("{}ylocal", getHistoPrefix()).c_str(),
+                       ";y_{local} (cm);track states", 100, -30, 30);
+    hm->registerHisto(h);
+  }
+
+  {
+    auto* h = new TH1F(std::format("{}ntracks", getHistoPrefix()).c_str(),
+                       ";matched track states per event;events", 20, -0.5, 19.5);
+    hm->registerHisto(h);
+  }
+
+  {
+    // summary of the drift velocity fit performed in End()
+    auto* h = new TH1F(std::format("{}driftSummary", getHistoPrefix()).c_str(),
+                       "drift velocity fit summary", 5, 0.5, 5.5);
+    h->GetXaxis()->SetBinLabel(1, "slope");
+    h->GetXaxis()->SetBinLabel(2, "slope_err");
+    h->GetXaxis()->SetBinLabel(3, "v_{in} (cm/ns)");
+    h->GetXaxis()->SetBinLabel(4, "v_{new} (cm/ns)");
+    h->GetXaxis()->SetBinLabel(5, "v_{new} err (cm/ns)");
+    hm->registerHisto(h);
+  }
+}

--- a/offline/QA/Tracking/MicromegasDriftQA.h
+++ b/offline/QA/Tracking/MicromegasDriftQA.h
@@ -1,0 +1,118 @@
+#ifndef QA_TRACKING_MICROMEGASDRIFTQA_H
+#define QA_TRACKING_MICROMEGASDRIFTQA_H
+
+/*
+ * Bade Sayki June 10th, 2026 -- LANL
+ * This QA module is created to monitor the calibration of the drift velocity in the TPC by fitting a helix to the clusters within a certain layer range, and projecting it to the TPOT z view module plane. The default layers in the TPC are set to be 39-55, which correspond to R3.
+ * This is heavily inspired by and distilled from Dr. Hugo Pereira Da Costa's MicromegasTrackEvaluator_hp module. It is meant to be a more lightweight and specialized version.
+ * If you have any questions, please feel free to message me on mattermost.
+ * Claude Code tool was used to format and debug this module
+ */
+
+#include <fun4all/SubsysReco.h>
+#include <tpc/TpcGlobalPositionWrapper.h>
+
+#include <string>
+
+class ActsGeometry;
+class PHCompositeNode;
+class PHG4CylinderGeomContainer;
+class SvtxTrackMap;
+class TrkrClusterContainer;
+class TH1;
+class TH2;
+
+class MicromegasDriftQA : public SubsysReco
+{
+ public:
+  explicit MicromegasDriftQA(const std::string& name = "MicromegasDriftQA");
+
+  ~MicromegasDriftQA() override = default;
+
+  //! run initialization: load nodes, create and register histograms
+  int InitRun(PHCompositeNode* topNode) override;
+
+  //! event processing: fill histograms
+  int process_event(PHCompositeNode* topNode) override;
+
+  //! end of processing: fit accumulated distributions, fill summary histogram
+  int End(PHCompositeNode* topNode) override;
+
+  //! track map name
+  void set_trackmapname(const std::string& value) { m_trackmapname = value; }
+
+  //! initial drift velocity (cm/ns); starting point for the fit. Use the drift velocity used at reconstruction.
+  void set_drift_velocity(double value) { m_drift_velocity = value; }
+
+  //! TPC layer range used for the helix fit (default: R3)
+  void set_min_tpc_layer(unsigned int value) { m_min_tpc_layer = value; }
+  void set_max_tpc_layer(unsigned int value) { m_max_tpc_layer = value; }
+
+  //! reject track states near the tile edge (cm, local y)
+  void set_y_local_cut(double value) { m_y_local_cut = value; }
+
+  //! search window to match a Micromegas cluster to the prediction (cm)
+  void set_z_search_window(double value) { m_z_search_win = value; }
+
+  //! minimum entries per z slice required by FitSlicesY
+  void set_min_slice_entries(int value) { m_min_slice_entries = value; }
+
+ private:
+  int load_nodes(PHCompositeNode* topNode);
+
+  void createHistos();
+  std::string getHistoPrefix() const;
+
+  //!@name histograms (owned by the QA histogram manager)
+  //@{
+
+  //! z_track vs dz, one per z-view tile
+  TH2* h_ztrk_dz[8]{nullptr};
+
+  //! dz = z_track - z_cluster, all tiles
+  TH1* h_dz{nullptr};
+
+  //! matched track states per tile
+  TH1* h_tile{nullptr};
+
+  //! local y of the track state on the tile
+  TH1* h_ylocal{nullptr};
+
+  //! number of matched track states per event
+  TH1* h_ntracks{nullptr};
+
+  //! drift velocity fit summary, filled in End()
+  TH1* h_driftSummary{nullptr};
+
+  //@}
+
+  //!@name nodes
+  //@{
+  ActsGeometry* m_tGeometry{nullptr};
+  TpcGlobalPositionWrapper m_globalPositionWrapper;
+  PHG4CylinderGeomContainer* m_micromegas_geomcontainer{nullptr};
+  TrkrClusterContainer* m_cluster_map{nullptr};
+  SvtxTrackMap* m_track_map{nullptr};
+  //@}
+
+  //! track map name
+  std::string m_trackmapname{"SvtxTrackMap"};
+
+  //! initial drift velocity (cm/ns)
+  double m_drift_velocity{0.00745};
+
+  //! TPC layer range used for the helix fit
+  unsigned int m_min_tpc_layer{39};
+  unsigned int m_max_tpc_layer{55};
+
+  //! reject track states near the tile edge (cm)
+  double m_y_local_cut{22.0};
+
+  //! search window to match a Micromegas cluster to the prediction (cm)
+  double m_z_search_win{3.0};
+
+  //! minimum entries per z slice for FitSlicesY
+  int m_min_slice_entries{10};
+};
+
+#endif  // QA_TRACKING_MICROMEGASDRIFTQA_H

--- a/offline/QA/Tracking/SiliconDriftQA.cc
+++ b/offline/QA/Tracking/SiliconDriftQA.cc
@@ -1,0 +1,338 @@
+#include "SiliconDriftQA.h"
+
+#include <qautils/QAHistManagerDef.h>
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
+
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/TrackSeedHelper.h>
+
+#include <TDirectory.h>
+#include <TF1.h>
+#include <TF2.h>
+#include <TH1.h>
+#include <TH2.h>
+
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <format>
+#include <iostream>
+#include <string>
+
+namespace
+{
+  //! pt
+  template <class T>
+  T get_pt(const T& px, const T& py)
+  {
+    return std::sqrt(px * px + py * py);
+  }
+
+  //! piecewise fit function used for the drift velocity extraction
+  //  par[0] = constrained slope
+  //  par[1] = offset for eta < 0
+  //  par[2] = offset for eta >= 0
+  double fit_function_2d(double* x, double* par)
+  {
+    const int ieta = static_cast<int>(std::floor(x[0]));
+    const double z = x[1];
+    if (ieta < 0 || ieta > 1)
+    {
+      TF2::RejectPoint();
+      return 0.;
+    }
+    return par[ieta + 1] + par[0] * z;
+  }
+
+  //! suffixes used in histogram names for the two eta bins
+  const char* k_eta_suffix[2] = {"negeta", "poseta"};
+
+  //! number of z bins of the dz vs z histograms
+  constexpr int k_nzbins = 200;
+
+}  // namespace
+
+//____________________________________________________________________________..
+SiliconDriftQA::SiliconDriftQA(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+int SiliconDriftQA::InitRun(PHCompositeNode* /*topNode*/)
+{
+  createHistos();
+
+  // reference histograms initialized in header file to histos in HistoManager
+  auto* hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  for (int ieta = 0; ieta < 2; ieta++)
+  {
+    h_zsi_dz[ieta] = dynamic_cast<TH2*>(hm->getHisto(std::format("{}zsi_dz_{}", getHistoPrefix(), k_eta_suffix[ieta])));
+  }
+  h_dz = dynamic_cast<TH1*>(hm->getHisto(std::format("{}dz", getHistoPrefix())));
+  h_ntracks = dynamic_cast<TH1*>(hm->getHisto(std::format("{}ntracks", getHistoPrefix())));
+  h_driftSummary = dynamic_cast<TH1*>(hm->getHisto(std::format("{}driftSummary", getHistoPrefix())));
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SiliconDriftQA::process_event(PHCompositeNode* topNode)
+{
+  auto* track_map = findNode::getClass<SvtxTrackMap>(topNode, m_trackmapname);
+  if (!track_map)
+  {
+    std::cout << PHWHERE << " " << m_trackmapname << " node missing, abort." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  int naccepted = 0;
+
+  for (const auto& [track_id, track] : *track_map)
+  {
+    // require valid beam-crossing
+    const auto crossing = track->get_crossing();
+    if (crossing == SHRT_MAX)
+    {
+      if (Verbosity())
+      {
+        std::cout << PHWHERE << " invalid crossing, track ignored." << std::endl;
+      }
+      continue;
+    }
+
+    // require both seeds
+    const auto* si_seed = track->get_silicon_seed();
+    const auto* tpc_seed = track->get_tpc_seed();
+    if (!si_seed || !tpc_seed)
+    {
+      continue;
+    }
+
+    // count clusters per subsystem
+    unsigned int n_tpc = 0;
+    unsigned int n_mvtx = 0;
+    unsigned int n_intt = 0;
+
+    for (const auto* seed : {si_seed, tpc_seed})
+    {
+      for (auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys(); ++it)
+      {
+        switch (TrkrDefs::getTrkrId(*it))
+        {
+        case TrkrDefs::tpcId:
+          ++n_tpc;
+          break;
+        case TrkrDefs::mvtxId:
+          ++n_mvtx;
+          break;
+        case TrkrDefs::inttId:
+          ++n_intt;
+          break;
+        default:
+          break;
+        }
+      }
+    }
+
+    // apply selection cuts
+    if (n_tpc < m_min_nclusters_tpc)
+    {
+      continue;
+    }
+    if (n_mvtx < m_min_nclusters_mvtx)
+    {
+      continue;
+    }
+    if (n_intt < m_min_nclusters_intt)
+    {
+      continue;
+    }
+
+    const float eta = tpc_seed->get_eta();
+    if (std::abs(eta) > m_max_eta)
+    {
+      continue;
+    }
+
+    const float pt = get_pt(track->get_px(), track->get_py());
+    if (pt < m_min_pt)
+    {
+      continue;
+    }
+
+    // get seed z positions at POCA
+    const auto si_pos = TrackSeedHelper::get_xyz(si_seed);
+    const auto tpc_pos = TrackSeedHelper::get_xyz(tpc_seed);
+
+    const float z_si = si_pos.z();
+    const float z_tpc = tpc_pos.z();
+
+    // dz = (z_tpc + sign(eta)*crossing*crossing_interval*dv) - z_si
+    const double sign_eta = (eta >= 0) ? 1.0 : -1.0;
+    const float z_tpc_corr = z_tpc + sign_eta * crossing * m_crossing_interval * m_drift_velocity;
+    const float dz = z_tpc_corr - z_si;
+
+    // fill histograms
+    const int ieta = (eta >= 0) ? 1 : 0;
+    h_zsi_dz[ieta]->Fill(z_si, dz);
+    h_dz->Fill(dz);
+
+    ++naccepted;
+  }
+
+  h_ntracks->Fill(naccepted);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SiliconDriftQA::End(PHCompositeNode* /*topNode*/)
+{
+  if (!(h_zsi_dz[0] && h_zsi_dz[1] && h_driftSummary))
+  {
+    std::cout << PHWHERE << " histograms not found, skipping drift velocity fit." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  const int nEntries = static_cast<int>(h_zsi_dz[0]->GetEntries() + h_zsi_dz[1]->GetEntries());
+  if (Verbosity())
+  {
+    std::cout << Name() << "::End - fitting " << nEntries << " entries" << std::endl;
+  }
+
+  // record input drift velocity even if the fit is skipped
+  h_driftSummary->SetBinContent(3, m_drift_velocity);
+
+  if (nEntries < 2 * m_min_slice_entries)
+  {
+    std::cout << Name() << "::End - not enough entries (" << nEntries << "), skipping drift velocity fit." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  // build mean-dz TH2 via FitSlicesY, one eta bin at a time
+  // x = eta bin [0,2), y = z_si (cm), content = mean dz (cm)
+  auto* h_fit = new TH2F("h_fit_silicon", "", 2, 0, 2, k_nzbins, -m_max_z, m_max_z);
+  h_fit->SetDirectory(nullptr);
+
+  for (int ieta = 0; ieta < 2; ++ieta)
+  {
+    auto* h2d = h_zsi_dz[ieta];
+
+    // fit vertical slices; require a minimum of m_min_slice_entries per slice
+    TObjArray slices;
+    slices.SetOwner(kTRUE);
+    h2d->FitSlicesY(nullptr, 0, -1, m_min_slice_entries, "QNR", &slices);
+    auto* h_mean = dynamic_cast<TH1*>(slices.At(1));
+    if (!h_mean)
+    {
+      continue;
+    }
+
+    for (int iz = 1; iz <= h_mean->GetNbinsX(); ++iz)
+    {
+      const double entries = h2d->Integral(iz, iz, 1, h2d->GetNbinsY());
+      if (entries > 0)
+      {
+        h_fit->SetBinContent(ieta + 1, iz, h_mean->GetBinContent(iz));
+      }
+    }
+  }
+
+  // 2D piecewise fit: shared slope + per-eta offset
+  auto* fit2d = new TF2("fit2d_silicon", fit_function_2d, 0, 2, -m_max_z, m_max_z, 3);
+  for (int i = 0; i < 3; ++i)
+  {
+    fit2d->SetParameter(i, 0.0);
+  }
+  h_fit->Fit(fit2d, "0RQ");
+
+  const double slope = fit2d->GetParameter(0);
+  const double slope_err = fit2d->GetParError(0);
+  const double off_neg = fit2d->GetParameter(1);  // ieta=0, eta<0
+  const double off_pos = fit2d->GetParameter(2);  // ieta=1, eta>=0
+
+  const double dv_new = m_drift_velocity / (1.0 + slope);
+  const double dv_err = m_drift_velocity / std::pow(1.0 + slope, 2) * slope_err;
+  const double t0_new = (off_pos - off_neg) / (2.0 * dv_new);
+
+  std::cout << Name() << "::End"
+            << " slope=" << slope
+            << " dv_in=" << m_drift_velocity << " cm/ns"
+            << " dv_new=" << dv_new << " +/- " << dv_err << " cm/ns"
+            << " t0_new=" << t0_new << " ns"
+            << std::endl;
+
+  // store fit results in the summary histogram
+  h_driftSummary->SetBinContent(1, slope);
+  h_driftSummary->SetBinContent(2, slope_err);
+  h_driftSummary->SetBinContent(4, dv_new);
+  h_driftSummary->SetBinContent(5, dv_err);
+  h_driftSummary->SetBinContent(6, t0_new);
+
+  delete fit2d;
+  delete h_fit;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+std::string SiliconDriftQA::getHistoPrefix() const
+{
+  // define prefix to all histos in HistoManager
+  return std::string("h_") + Name() + std::string("_");
+}
+
+//____________________________________________________________________________..
+void SiliconDriftQA::createHistos()
+{
+  // initialize HistoManager
+  auto* hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  // create and register histos in HistoManager
+  for (int ieta = 0; ieta < 2; ieta++)
+  {
+    auto* h = new TH2F(std::format("{}zsi_dz_{}", getHistoPrefix(), k_eta_suffix[ieta]).c_str(),
+                       std::format("{};z_{{silicon}} (cm);#Deltaz_{{TPC-silicon}} (cm)",
+                                   (ieta == 0 ? "#eta_{TPC} < 0" : "#eta_{TPC} #geq 0"))
+                           .c_str(),
+                       k_nzbins, -m_max_z, m_max_z, 200, -m_max_dz, m_max_dz);
+    hm->registerHisto(h);
+  }
+
+  {
+    auto* h = new TH1F(std::format("{}dz", getHistoPrefix()).c_str(),
+                       ";#Deltaz_{TPC-silicon} (cm);tracks", 200, -m_max_dz, m_max_dz);
+    hm->registerHisto(h);
+  }
+
+  {
+    auto* h = new TH1F(std::format("{}ntracks", getHistoPrefix()).c_str(),
+                       ";accepted tracks per event;events", 50, -0.5, 49.5);
+    hm->registerHisto(h);
+  }
+
+  {
+    // summary of the drift velocity fit performed in End()
+    auto* h = new TH1F(std::format("{}driftSummary", getHistoPrefix()).c_str(),
+                       "drift velocity fit summary", 6, 0.5, 6.5);
+    h->GetXaxis()->SetBinLabel(1, "slope");
+    h->GetXaxis()->SetBinLabel(2, "slope_err");
+    h->GetXaxis()->SetBinLabel(3, "v_{in} (cm/ns)");
+    h->GetXaxis()->SetBinLabel(4, "v_{new} (cm/ns)");
+    h->GetXaxis()->SetBinLabel(5, "v_{new} err (cm/ns)");
+    h->GetXaxis()->SetBinLabel(6, "t_{0} (ns)");
+    hm->registerHisto(h);
+  }
+}

--- a/offline/QA/Tracking/SiliconDriftQA.h
+++ b/offline/QA/Tracking/SiliconDriftQA.h
@@ -1,0 +1,119 @@
+#ifndef QA_TRACKING_SILICONDRIFTQA_H
+#define QA_TRACKING_SILICONDRIFTQA_H
+
+/*
+ * QA version of SiliconDriftEvaluator (B. Sayki, LANL).
+ *
+ * Monitors the TPC drift velocity calibration by comparing the z position of
+ * the TPC seed and the silicon seed at the beam line, following the standard
+ * sPHENIX QA module conventions
+ * Claude code was used in formatting and debugging of this module
+ * v_new = v_in / (1 + slope)
+ * t0    = (offset_pos - offset_neg) / (2 v_new)
+ */
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+class TH1;
+class TH2;
+
+class SiliconDriftQA : public SubsysReco
+{
+ public:
+  explicit SiliconDriftQA(const std::string& name = "SiliconDriftQA");
+
+  ~SiliconDriftQA() override = default;
+
+  //! run initialization: create and register histograms
+  int InitRun(PHCompositeNode* topNode) override;
+
+  //! event processing: fill histograms
+  int process_event(PHCompositeNode* topNode) override;
+
+  //! end of processing: fit accumulated distributions, fill summary histogram
+  int End(PHCompositeNode* topNode) override;
+
+  //! track map name
+  void set_trackmapname(const std::string& value) { m_trackmapname = value; }
+
+  //! initial drift velocity (cm/ns); starting point for the fit and used in the crossing correction
+  void set_drift_velocity(double value) { m_drift_velocity = value; }
+
+  //! bunch-crossing interval in ns (default: 106.65237 ns)
+  void set_crossing_interval(double value) { m_crossing_interval = value; }
+
+  //! minimum pT cut on tracks (GeV)
+  void set_min_pt(double value) { m_min_pt = value; }
+
+  //! minimum number of TPC clusters required
+  void set_min_nclusters_tpc(unsigned int value) { m_min_nclusters_tpc = value; }
+
+  //! minimum number of MVTX clusters required
+  void set_min_nclusters_mvtx(unsigned int value) { m_min_nclusters_mvtx = value; }
+
+  //! minimum number of INTT clusters required
+  void set_min_nclusters_intt(unsigned int value) { m_min_nclusters_intt = value; }
+
+  //! maximum abs(eta) of TPC seed accepted
+  void set_max_eta(double value) { m_max_eta = value; }
+
+  //! half-range of the z_si histogram axis (cm)
+  void set_max_z(double value) { m_max_z = value; }
+
+  //! half-range of the dz histogram axis (cm)
+  void set_max_dz(double value) { m_max_dz = value; }
+
+  //! minimum entries per z slice required by FitSlicesY
+  void set_min_slice_entries(int value) { m_min_slice_entries = value; }
+
+ private:
+  void createHistos();
+  std::string getHistoPrefix() const;
+
+  //!@name histograms (owned by the QA histogram manager)
+  //@{
+
+  //! z_si vs dz, one per eta bin (0: eta<0, 1: eta>=0)
+  TH2* h_zsi_dz[2]{nullptr, nullptr};
+
+  //! crossing-corrected dz = z_tpc_corr - z_si (cm)
+  TH1* h_dz{nullptr};
+
+  //! number of accepted tracks per event
+  TH1* h_ntracks{nullptr};
+
+  //! drift velocity fit summary, filled in End()
+  TH1* h_driftSummary{nullptr};
+
+  //@}
+
+  //! track map name
+  std::string m_trackmapname{"SvtxTrackMap"};
+
+  //! initial drift velocity (cm/ns)
+  double m_drift_velocity{0.00749};
+
+  //! bunch-crossing interval (ns)
+  double m_crossing_interval{106.65237};
+
+  //!@name track selection cuts
+  //@{
+  double m_min_pt{0.5};
+  unsigned int m_min_nclusters_tpc{20};
+  unsigned int m_min_nclusters_mvtx{3};
+  unsigned int m_min_nclusters_intt{2};
+  double m_max_eta{0.9};
+  //@}
+
+  //! histogram ranges
+  double m_max_z{20.0};
+  double m_max_dz{10.0};
+
+  //! minimum entries per z slice for FitSlicesY
+  int m_min_slice_entries{10};
+};
+
+#endif  // QA_TRACKING_SILICONDRIFTQA_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <Drift Velocity QA modules> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <More histograms to add for silicon, and switch to matched seeds instead of full tracks need to be implemented> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation
Add tracking QA modules to validate **Silicon** and **Micromegas drift calibration** by extracting drift-related **dz** residuals from reconstructed tracks/clusters and producing summary fits that can be used to monitor/update drift velocity behavior.

## Key changes
- **Build/registration**
  - Installed new headers **`SiliconDriftQA.h`** and **`MicromegasDriftQA.h`**.
  - Added **`SiliconDriftQA.cc`** and **`MicromegasDriftQA.cc`** to `libtrackingqa.la` sources.
  - Updated `libtrackingqa.la` link inputs to include **`-ltrack`** (in addition to the QA/library deps already listed).

- **`SiliconDriftQA`**
  - Selects tracks from the configured `SvtxTrackMap`, requires silicon + TPC seeds, applies configurable **pT/|η|** and **minimum cluster count** thresholds (TPC/MVTX/INTT across the two seed types).
  - Computes crossing-corrected **dz** using silicon vs TPC POCA z positions and the configured **crossing interval** and **drift-velocity correction** sign handling tied to η.
  - Fills an **η-binned** histogram of **zsi vs dz** (`zsi_dz`) plus inclusive **dz** and track count histograms.
  - In `End()`, if histograms and entry counts are sufficient, runs `FitSlicesY` per η bin and then a shared-slope **piecewise `TF2`** fit to extract slope/drift-velocity update and **t0**; it **always records the input drift velocity** in the drift summary bin even when the fit is skipped due to insufficient statistics.

- **`MicromegasDriftQA`**
  - Fits **helix geometry** from TPC clusters within configured **TPC layer range** (r–z line + x–y circle approach).
  - Extrapolates the helix to the Micromegas **z-view tiles** using a **Newton–Raphson helix–plane intersection** helper, including tile acceptance handling via multiple φ seeds and a local edge-proximity rejection.
  - Matches the nearest **TPOT** Micromegas cluster on the selected tile within a configurable **z search window**, fills per-tile **z_track vs dz** (`ztrk_dz`) and global `dz`/tile/count histograms.
  - In `End()`, if enough entries exist, uses `FitSlicesY` tile-by-tile and then a simultaneous shared-slope, per-tile-offset **piecewise `TF2`** fit to extract slope and compute updated drift velocity/uncertainty; it also **always records the input drift velocity** in the drift summary bin even when the fit is skipped.

## Potential risk areas
- **Reconstruction/QA behavior sensitivity**
  - Results depend on configured node names (e.g., track map), geometry containers, beam crossing validity handling, silicon/TPC seed requirements, and the various cut thresholds (cluster counts, |η|, pT, tile edge rejection, z matching window).
  - If upstream required nodes (e.g., `SvtxTrackMap`) are missing, the subsystem may abort/reject processing as coded (QA-run fragility).
- **Fit stability / numerical edge cases**
  - Newton–Raphson helix–tile intersection convergence and tile-acceptance constraints can be sensitive for tracks near tile boundaries or with atypical fit parameters.
  - `FitSlicesY` and shared-slope `TF2` fits can be biased or fail gracefully when slice/tile statistics are low or distributions are non-ideal.
- **Performance**
  - Additional per-event histogram filling plus end-of-run slicing and multi-parameter fits (especially the multi-tile/shared-slope fit) may increase CPU time.
- **Thread-safety**
  - The code primarily operates within per-event loops and end-of-run fit steps; if the surrounding framework is multithreaded, histogram objects and any shared state should be reviewed for framework-specific thread guarantees.
- No external **IO format changes** are indicated by the build wiring; changes are mainly in QA computations and histogram registration.

## Possible future improvements
- Add the planned **additional Silicon histograms**.
- Implement the TODO: **switch from full tracks to matched seeds** where appropriate.
- Add regression/validation for boundary conditions (tile edge rejection, Newton iteration behavior, and sparse-slice fit stability) to ensure drift extraction remains robust.

*As with any AI-assisted change, AI can make mistakes—please validate the details against collaboration conventions and the actual runtime behavior/logs before relying on the extracted drift results.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->