### PR TITLE
update PHTruthTrackSeeding & MakeActsGeometry

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -91,6 +91,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -646,10 +647,17 @@ void MakeActsGeometry::buildActsSurfaces()
   std::vector<std::string> argstr =
   {
     "-n1",
-    "--geo-tgeo-jsonconfig", responseFile,
-    "--mat-input-type", "file",
-    "--mat-input-file", materialFile
+    "--geo-tgeo-jsonconfig", responseFile
   };
+
+  if (m_useActsMaterialMap)
+  {
+    argstr.insert(argstr.end(),
+    {
+      "--mat-input-type", "file",
+      "--mat-input-file", materialFile
+    });
+  }
 
   double fieldstrength = std::numeric_limits<double>::quiet_NaN();
   if( isConstantField( m_magField, fieldstrength ) )
@@ -723,12 +731,9 @@ void MakeActsGeometry::setMaterialResponseFile(std::string &responseFile,
                                                std::string &materialFile)
 {
   responseFile = "tgeo-sphenix-mms.json";
-  materialFile = "sphenix-mm-material.json";
-  // Check to see if files exist locally - if not, use defaults
-  std::ifstream file;
-
-  file.open(responseFile);
-  if (!file.is_open())
+  // Check to see if the geometry response file exists locally. If not, use CDB.
+  std::ifstream responseStream(responseFile);
+  if (!responseStream.is_open())
   {
     std::cout << responseFile
               << " not found locally, use CDB version"
@@ -736,19 +741,29 @@ void MakeActsGeometry::setMaterialResponseFile(std::string &responseFile,
     responseFile = CDBInterface::instance()->getUrl("ACTSGEOMETRYCONFIG");
   }
 
-  file.open(materialFile);
-  if (!file.is_open())
+  if (m_useActsMaterialMap)
   {
-    std::cout << materialFile
-              << " not found locally, use CDB version"
+    materialFile = "sphenix-mm-material.json";
+    std::ifstream materialStream(materialFile);
+    if (!materialStream.is_open())
+    {
+      std::cout << materialFile
+                << " not found locally, use CDB version"
+                << std::endl;
+      materialFile = CDBInterface::instance()->getUrl("ACTSMATERIALMAP");
+    }
+
+    std::cout << "Using Acts material file : " << materialFile
               << std::endl;
-    materialFile = CDBInterface::instance()->getUrl("ACTSMATERIALMAP");
+  }
+  else
+  {
+    materialFile.clear();
+    std::cout << "Using empty Acts material map" << std::endl;
   }
 
-    std::cout << "using Acts material file : " << materialFile
-              << std::endl;
-    std::cout << "Using Acts TGeoResponse file : " << responseFile
-              << std::endl;
+  std::cout << "Using Acts TGeoResponse file : " << responseFile
+            << std::endl;
 
   return;
 }
@@ -770,9 +785,16 @@ void MakeActsGeometry::makeGeometry(int argc, char *argv[], const std::string& r
   config.readJson(responseFile);
 
   std::shared_ptr<Acts::IMaterialDecorator> matDeco = nullptr;
-  if (materialFile.find(".json") != std::string::npos ||
-      materialFile.find(".cbor") != std::string::npos)
+  if (m_useActsMaterialMap)
   {
+    if (materialFile.find(".json") == std::string::npos &&
+        materialFile.find(".cbor") == std::string::npos)
+    {
+      std::cout << "Unsupported Acts material map format: " << materialFile
+                << std::endl;
+      exit(1);
+    }
+
     // Set up the converter first
     Acts::MaterialMapJsonConverter::Config jsonGeoConvConfig;
     // Set up the json-based decorator

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -728,7 +728,7 @@ void MakeActsGeometry::buildActsSurfaces()
 
 
 void MakeActsGeometry::setMaterialResponseFile(std::string &responseFile,
-                                               std::string &materialFile)
+                                               std::string &materialFile) const
 {
   responseFile = "tgeo-sphenix-mms.json";
   // Check to see if the geometry response file exists locally. If not, use CDB.

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -77,6 +77,12 @@ class MakeActsGeometry : public SubsysReco
     m_magFieldRescale = magFieldRescale;
   }
 
+  /// enable or disable the ACTS surface and volume material map
+  void setUseActsMaterialMap(bool value)
+  {
+    m_useActsMaterialMap = value;
+  }
+
   // void useInttSurveyGeom(const bool useSurveyGeom) { m_useInttSurveyGeom = useSurveyGeom; }
 
   void setMvtxDev(double array[6])
@@ -231,6 +237,7 @@ private:
   std::vector<double> v_globaldisplacement = {0., 0., 0.};
 
   bool m_useField = true;
+  bool m_useActsMaterialMap = true;
   std::map<uint8_t, double> m_misalignmentFactor;
 
   /// Several maps that connect Acts world to sPHENIX G4 world

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -188,7 +188,7 @@ private:
   void makeGeometry(int argc, char *argv[], const std::string& responseFile, const std::string& materialFile);
 
   void setMaterialResponseFile(std::string &responseFile,
-                               std::string &materialFile);
+                               std::string &materialFile) const;
 
   /// Get hitsetkey from TGeoNode for each detector geometry
   void getInttKeyFromNode(TGeoNode *gnode);

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -120,7 +120,10 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
   std::vector<TrkrDefs::cluskey> ClusterKeyListSilicon;
   std::vector<TrkrDefs::cluskey> ClusterKeyListTpc;
 
-  PHG4TruthInfoContainer::ConstRange range = m_g4truth_container->GetPrimaryParticleRange();
+  PHG4TruthInfoContainer::ConstRange range =
+      m_include_secondaries
+          ? m_g4truth_container->GetParticleRange()
+          : m_g4truth_container->GetPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
        iter != range.second;
        ++iter)

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -60,6 +60,12 @@ class PHTruthTrackSeeding : public PHTrackSeeding
     _max_layer = maxLayer;
   }
 
+  //! include Geant4 secondary particles when building truth seeds
+  void set_include_secondaries(bool includeSecondaries)
+  {
+    m_include_secondaries = includeSecondaries;
+  }
+
   //! minimal truth momentum cut
   double get_min_momentum() const
   {
@@ -105,6 +111,9 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   unsigned int _min_clusters_per_track = 3;
   unsigned int _min_layer = 0;
   unsigned int _max_layer = 60;
+
+  //! include Geant4 secondary particles in addition to primaries
+  bool m_include_secondaries = false;
 
   //! minimal truth momentum cut (GeV)
   double _min_momentum = 50e-3;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Two changes: 
1. Add a flag in PHTruthTrackSeeding to decide whether using all particles or only primary particles. Run with primary particles by default.
2. Update MakeActsGeometry to be able set material map empty.
Should be transparent to other users.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context
This PR adds two transparent, opt-in controls for reconstruction inputs: (1) truth track seeding can optionally include Geant4 secondary particles, and (2) ACTS geometry construction can proceed using an intentionally empty material-map configuration (e.g., for workflows that don’t require surface/volume material effects).

## Key Changes
- **`PHTruthTrackSeeding`**
  - Added `set_include_secondaries(bool)` and `m_include_secondaries` (default **false**).
  - Updated `Process` to iterate over `GetPrimaryParticleRange()` by default, or `GetParticleRange()` when secondaries inclusion is enabled.
- **`MakeActsGeometry`**
  - Added `setUseActsMaterialMap(bool)` and `m_useActsMaterialMap` (default **true**).
  - Refactored local file detection to use `std::ifstream` open checks for:
    - `tgeo-sphenix-mms.json` (fallback to `ACTSGEOMETRYCONFIG` CDB URL if missing),
    - `sphenix-mm-material.json` (fallback to `ACTSMATERIALMAP` CDB URL if missing) when material maps are enabled.
  - When `setUseActsMaterialMap(false)`, the code clears the material file and uses `Acts::MaterialWiper` (“empty Acts material map”).
  - When material maps are enabled, added validation that the material map format contains **`.json`** or **`.cbor`**; otherwise the job terminates (`exit(1)`).

## Potential Risk Areas
- **Reconstruction / physics behavior**
  - Enabling secondary-particle seeding can change seed multiplicity and downstream track reconstruction results (default remains primary-only).
- **Geometry initialization / I/O**
  - Material-map and response-file selection now depends on local open-check behavior and CDB fallback paths.
  - Unsupported material-map formats now trigger a hard failure during geometry building (`exit(1)`), which may surface misconfiguration sooner than before.
- **Performance**
  - Secondary seeding may increase truth-iteration workload and seed building cost.
- **Thread-safety**
  - No explicit thread-safety changes are indicated, but reviewers should confirm these setters/config pathways are used consistently per job/config instance.

## Possible Future Improvements
- Add regression tests for:
  - primary-only vs. include-secondaries truth seeding behavior,
  - material-map enabled vs. disabled (empty map) geometry build,
  - supported (`.json`, `.cbor`) vs. unsupported material-map extensions and the resulting failure mode.
- Consider replacing `exit(1)` on unsupported material-map formats with a recoverable error/reporting mechanism consistent with collaboration run practices.

*AI can make mistakes—please verify defaults, failure modes, and call paths during review against the actual runtime configuration.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->