### PR TITLE
Laser cluster hit storage

### DIFF
--- a/offline/QA/Tpc/Makefile.am
+++ b/offline/QA/Tpc/Makefile.am
@@ -28,6 +28,7 @@ libtpcqa_la_SOURCES = \
 libtpcqa_la_LIBADD = \
   -lphool \
   -lSubsysReco \
+  -lg4detectors_io \
   -lg4tpc \
   -ltrack_io \
   -ltrackbase_historic_io \

--- a/offline/QA/Tpc/TpcLaserQA.cc
+++ b/offline/QA/Tpc/TpcLaserQA.cc
@@ -54,18 +54,6 @@ int TpcLaserQA::InitRun(PHCompositeNode* topNode)
     }
   }
 
-  m_tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
-  if(!m_tGeometry)
-  {
-      std::cout << "LaserClusterHelper::loadNodes - ActsGeometry not found on node tree" << std::endl;
-  }
-
-  m_geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
-  if(!m_geom_container)
-  {
-      std::cout << "LaserClusterHelper::loadNodes - TPCGEOMCONTAINER not found on node tree" << std::endl;
-  }
-
   m_laserClusterHelper.set_useZ(m_useZ);
   m_laserClusterHelper.loadNodes(topNode);
 

--- a/offline/QA/Tpc/TpcLaserQA.cc
+++ b/offline/QA/Tpc/TpcLaserQA.cc
@@ -30,7 +30,7 @@ TpcLaserQA::TpcLaserQA(const std::string &name)
 {
 }
 
-int TpcLaserQA::InitRun(PHCompositeNode * /*topNode*/)
+int TpcLaserQA::InitRun(PHCompositeNode* topNode)
 {
   createHistos();
 
@@ -53,6 +53,21 @@ int TpcLaserQA::InitRun(PHCompositeNode * /*topNode*/)
       m_sample_R3[side][sec] = dynamic_cast<TH1 *>(hm->getHisto(std::format("{}sample_R3_{}_{}", getHistoPrefix(), (side == 1 ? "North" : "South"), sec)));
     }
   }
+
+  m_tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
+  if(!m_tGeometry)
+  {
+      std::cout << "LaserClusterHelper::loadNodes - ActsGeometry not found on node tree" << std::endl;
+  }
+
+  m_geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  if(!m_geom_container)
+  {
+      std::cout << "LaserClusterHelper::loadNodes - TPCGEOMCONTAINER not found on node tree" << std::endl;
+  }
+
+  m_laserClusterHelper.set_useZ(m_useZ);
+  m_laserClusterHelper.loadNodes(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -111,11 +126,24 @@ int TpcLaserQA::process_event(PHCompositeNode *topNode)
     const unsigned int nhits = cmclus->getNhits();
     for (unsigned int i = 0; i < nhits; i++)
     {
-      float layer = cmclus->getHitLayer(i);
-      float hitAdc = cmclus->getHitAdc(i);
-      float hitIT = cmclus->getHitIT(i);
+      Acts::Vector3 global = m_laserClusterHelper.getClusterCentroid(cmclus);
 
-      double phi = std::atan2(cmclus->getHitY(i), cmclus->getHitX(i));
+      if(global.hasNaN())
+      {
+        continue;
+      }
+
+      LaserClusterHitInfo LCHI = cmclus->getHit(i);
+
+      float layer = 1.0*TrkrDefs::getLayer(LCHI.hitsetkey);
+      float hitAdc = 1.0*LCHI.adc;
+      float hitIT = 1.0*TpcDefs::getTBin(LCHI.hitkey);
+
+      //float layer = cmclus->getHitLayer(i);
+      //float hitAdc = cmclus->getHitAdc(i);
+      //float hitIT = cmclus->getHitIT(i);
+
+      double phi = std::atan2(global(1), global(0));
       if (phi < -M_PI / 12.) { phi += 2 * M_PI;
 }
 

--- a/offline/QA/Tpc/TpcLaserQA.cc
+++ b/offline/QA/Tpc/TpcLaserQA.cc
@@ -123,17 +123,17 @@ int TpcLaserQA::process_event(PHCompositeNode *topNode)
       nS++;
     }
 
+
     const unsigned int nhits = cmclus->getNhits();
     for (unsigned int i = 0; i < nhits; i++)
-    {
-      Acts::Vector3 global = m_laserClusterHelper.getClusterCentroid(cmclus);
+    {        
+      LaserClusterHitInfo LCHI = cmclus->getHit(i);
 
-      if(global.hasNaN())
+      Acts::Vector3 hitGlobal = m_laserClusterHelper.getHitGlobalPosition(LCHI.hitsetkey, LCHI.hitkey);
+      if(hitGlobal.hasNaN())
       {
         continue;
-      }
-
-      LaserClusterHitInfo LCHI = cmclus->getHit(i);
+      }    
 
       float layer = 1.0*TrkrDefs::getLayer(LCHI.hitsetkey);
       float hitAdc = 1.0*LCHI.adc;
@@ -143,7 +143,7 @@ int TpcLaserQA::process_event(PHCompositeNode *topNode)
       //float hitAdc = cmclus->getHitAdc(i);
       //float hitIT = cmclus->getHitIT(i);
 
-      double phi = std::atan2(global(1), global(0));
+      double phi = std::atan2(hitGlobal(1), hitGlobal(0));
       if (phi < -M_PI / 12.) { phi += 2 * M_PI;
 }
 

--- a/offline/QA/Tpc/TpcLaserQA.h
+++ b/offline/QA/Tpc/TpcLaserQA.h
@@ -3,6 +3,11 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <tpc/LaserClusterHelper.h>
+
+#include <g4detectors/PHG4TpcGeom.h>
+#include <g4detectors/PHG4TpcGeomContainer.h>
+
 #include <string>
 
 class PHCompositeNode;
@@ -19,6 +24,8 @@ class TpcLaserQA : public SubsysReco
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
 
+  void set_useZ(bool use) { m_useZ = use; }
+
  private:
   void createHistos();
   std::string getHistoPrefix() const;
@@ -34,6 +41,12 @@ class TpcLaserQA : public SubsysReco
   TH1* m_sample_R1[2][12]{{nullptr}};
   TH1* m_sample_R2[2][12]{{nullptr}};
   TH1* m_sample_R3[2][12]{{nullptr}};
+
+  ActsGeometry *m_tGeometry{nullptr};
+  PHG4TpcGeomContainer *m_geom_container{nullptr};
+
+  LaserClusterHelper m_laserClusterHelper;
+  bool m_useZ{false};
 };
 
 #endif

--- a/offline/QA/Tpc/TpcLaserQA.h
+++ b/offline/QA/Tpc/TpcLaserQA.h
@@ -5,9 +5,6 @@
 
 #include <tpc/LaserClusterHelper.h>
 
-#include <g4detectors/PHG4TpcGeom.h>
-#include <g4detectors/PHG4TpcGeomContainer.h>
-
 #include <string>
 
 class PHCompositeNode;
@@ -41,9 +38,6 @@ class TpcLaserQA : public SubsysReco
   TH1* m_sample_R1[2][12]{{nullptr}};
   TH1* m_sample_R2[2][12]{{nullptr}};
   TH1* m_sample_R3[2][12]{{nullptr}};
-
-  ActsGeometry *m_tGeometry{nullptr};
-  PHG4TpcGeomContainer *m_geom_container{nullptr};
 
   LaserClusterHelper m_laserClusterHelper;
   bool m_useZ{false};

--- a/offline/packages/tpc/LaserClusterHelper.cc
+++ b/offline/packages/tpc/LaserClusterHelper.cc
@@ -1,0 +1,117 @@
+#include "LaserClusterHelper.h"
+ 
+#include <trackbase/LaserCluster.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrDefs.h>
+ 
+#include <g4detectors/PHG4TpcGeom.h>
+#include <g4detectors/PHG4TpcGeomContainer.h>
+ 
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+ 
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+//____________________________________________________________________________
+void LaserClusterHelper::loadNodes(PHCompositeNode* topNode)
+{
+    m_tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
+    if(!m_tGeometry)
+    {
+        std::cout << "LaserClusterHelper::loadNodes - ActsGeometry not found on node tree" << std::endl;
+    }
+
+    m_geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+    if(!m_geom_container)
+    {
+        std::cout << "LaserClusterHelper::loadNodes - TPCGEOMCONTAINER not found on node tree" << std::endl;
+    }
+}
+
+//____________________________________________________________________________
+Acts::Vector3 LaserClusterHelper::getHitGlobalPosition(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::hitkey hitkey) const
+{
+    const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN());
+
+    if(!m_tGeometry || !m_geom_container)
+    {
+        return invalid;
+    }
+
+    const int layer = TrkrDefs::getLayer(hitsetkey);
+    const int side = TpcDefs::getSide(hitsetkey);
+
+    PHG4TpcGeom *layer_geom = m_geom_container->GetLayerCellGeom(layer);
+    if(!layer_geom)
+    {
+        return invalid;
+    }
+
+    const int iphi = TpcDefs::getPad(hitkey);
+    const int it = TpcDefs::getTBin(hitkey);
+
+    const double radius = layer_geom->get_radius();
+    const double phi = layer_geom->get_phi(iphi, side);
+    
+    const double env_x = radius * cos(phi);
+    const double env_y = radius * sin(phi);
+    double env_z = 0.0;
+    //hard code at 0 until better z coordinate calibration is determined
+    if(m_useZ)
+    {
+        double vdrift = m_tGeometry->get_drift_velocity();
+        double tdriftmax = layer_geom->get_max_driftlength() / vdrift;
+
+        double zdriftlength = layer_geom->get_zcenter(it) * vdrift;
+        // convert z drift length to z position in the TPC
+        env_z = tdriftmax * vdrift - zdriftlength;
+        if (side == 0)
+        {
+            env_z = -env_z;
+        }
+    }
+
+    Acts::Vector3 env_global(env_x, env_y, env_z);
+    return m_tGeometry->transformTpcEnvelopeToWorld(env_global);
+}
+
+//____________________________________________________________________________
+Acts::Vector3 LaserClusterHelper::getClusterCentroid(LaserCluster* cluster) const
+{
+    const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN());
+    
+    if(!cluster)
+    {
+        return invalid;
+    }
+
+    Acts::Vector3 weightedSum(0.0, 0.0, 0.0);
+    double adcSum = 0.0;
+
+    const unsigned int nhits = cluster->getNhits();
+    for(unsigned int i=0; i<nhits; ++i)
+    {
+        const LaserClusterHitInfo hit= cluster->getHit(i);
+        const Acts::Vector3 global = getHitGlobalPosition(hit.hitsetkey, hit.hitkey);
+        if(global.hasNaN())
+        {
+            continue;
+        }
+
+        weightedSum += hit.adc * global;
+        adcSum += hit.adc;
+    }
+
+    if(adcSum <= 0.0)
+    {
+        return invalid;
+    }
+
+    return weightedSum / adcSum;
+}

--- a/offline/packages/tpc/LaserClusterHelper.cc
+++ b/offline/packages/tpc/LaserClusterHelper.cc
@@ -14,6 +14,13 @@
 #include <iostream>
 #include <limits>
 
+namespace
+{
+  Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN());
+}
+
 //____________________________________________________________________________
 void LaserClusterHelper::loadNodes(PHCompositeNode* topNode)
 {
@@ -33,9 +40,9 @@ void LaserClusterHelper::loadNodes(PHCompositeNode* topNode)
 //____________________________________________________________________________
 Acts::Vector3 LaserClusterHelper::getHitGlobalPosition(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::hitkey hitkey) const
 {
-    const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
-                                std::numeric_limits<double>::quiet_NaN(),
-                                std::numeric_limits<double>::quiet_NaN());
+    //const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
+    //                            std::numeric_limits<double>::quiet_NaN(),
+    //                            std::numeric_limits<double>::quiet_NaN());
 
     if(!m_tGeometry || !m_geom_container)
     {
@@ -82,9 +89,9 @@ Acts::Vector3 LaserClusterHelper::getHitGlobalPosition(TrkrDefs::hitsetkey hitse
 //____________________________________________________________________________
 Acts::Vector3 LaserClusterHelper::getClusterCentroid(LaserCluster* cluster) const
 {
-    const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
-                                std::numeric_limits<double>::quiet_NaN(),
-                                std::numeric_limits<double>::quiet_NaN());
+    //const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
+    //                            std::numeric_limits<double>::quiet_NaN(),
+    //                            std::numeric_limits<double>::quiet_NaN());
     
     if(!cluster)
     {

--- a/offline/packages/tpc/LaserClusterHelper.h
+++ b/offline/packages/tpc/LaserClusterHelper.h
@@ -1,0 +1,32 @@
+#ifndef TPC_LASERCLUSTERHELPER_H
+#define TPC_LASERCLUSTERHELPER_H
+
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrDefs.h>
+
+class ActsGeometry;
+class LaserCluster;
+class PHCompositeNode;
+class PHG4TpcGeomContainer;
+
+class LaserClusterHelper
+{
+  public:
+    LaserClusterHelper () = default;
+
+    void loadNodes(PHCompositeNode *topNode);
+  
+    Acts::Vector3 getHitGlobalPosition(TrkrDefs::hitsetkey, TrkrDefs::hitkey) const;
+    Acts::Vector3 getClusterCentroid(LaserCluster*) const;
+
+    void set_useZ(bool use) { m_useZ = use; }
+  private:
+
+    ActsGeometry *m_tGeometry{nullptr};
+    PHG4TpcGeomContainer *m_geom_container{nullptr};
+
+    bool m_useZ{false};
+
+};
+
+#endif

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -77,13 +77,13 @@ namespace
   {
     PHG4TpcGeomContainer *geom_container = nullptr;
     ActsGeometry *tGeometry = nullptr;
-    std::vector<TrkrHitSet *> hitsets;
-    std::vector<unsigned int> layers;
+    std::vector<TrkrHitSet *> hitsets = {};
+    std::vector<unsigned int> layers = {};
     bool side = false;
     unsigned int sector = 0;
     unsigned int module = 0;
-    std::vector<LaserCluster *> cluster_vector;
-    std::vector<TrkrDefs::cluskey> cluster_key_vector;
+    std::vector<LaserCluster *> cluster_vector = {};
+    std::vector<TrkrDefs::cluskey> cluster_key_vector = {};
     double adc_threshold = 74.4;
     int peakTimeBin = 325;
     int layerMin = 1;
@@ -433,7 +433,10 @@ namespace
     findConnectedRegions3(clusHits, maxADCKey, my_data.Verbosity);
     
     unsigned int nHits = clusHits.size();
-    if(nHits == 0) return;
+    if(nHits == 0)
+    {
+      return;
+    }
 
     double layerSum = 0.0;
     double iphiSum = 0.0;

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -431,7 +431,9 @@ namespace
   void calc_cluster_parameter(std::vector<hitData> &clusHits, thread_data &my_data, std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> maxADCKey)
   {
     findConnectedRegions3(clusHits, maxADCKey, my_data.Verbosity);
-
+    
+    unsigned int nHits = clusHits.size();
+    if(nHits == 0) return;
 
     double layerSum = 0.0;
     double iphiSum = 0.0;
@@ -443,8 +445,6 @@ namespace
     TrkrDefs::hitsetkey maxKey = 0;
     //double secondmaxAdc = 0.0;
     //TrkrDefs::hitsetkey secondmaxKey = 0;
-
-    unsigned int nHits = clusHits.size();
 
     auto *clus = new LaserClusterv3;
 
@@ -550,6 +550,7 @@ namespace
 
     if (nHits == 0 || clus->getNhits() == 0)
     {
+      delete clus;
       return;
     }
 

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -5,7 +5,7 @@
 #include <trackbase/LaserCluster.h>
 #include <trackbase/LaserClusterContainer.h>
 #include <trackbase/LaserClusterContainerv1.h>
-#include <trackbase/LaserClusterv2.h>
+#include <trackbase/LaserClusterv3.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHit.h>
@@ -432,9 +432,6 @@ namespace
   {
     findConnectedRegions3(clusHits, maxADCKey, my_data.Verbosity);
 
-    double rSum = 0.0;
-    double phiSum = 0.0;
-    double tSum = 0.0;
 
     double layerSum = 0.0;
     double iphiSum = 0.0;
@@ -444,28 +441,28 @@ namespace
 
     double maxAdc = 0.0;
     TrkrDefs::hitsetkey maxKey = 0;
-    double secondmaxAdc = 0.0;
-    TrkrDefs::hitsetkey secondmaxKey = 0;
+    //double secondmaxAdc = 0.0;
+    //TrkrDefs::hitsetkey secondmaxKey = 0;
 
     unsigned int nHits = clusHits.size();
 
-    auto *clus = new LaserClusterv2;
+    auto *clus = new LaserClusterv3;
 
     int meanSide = 0;
 
-    std::vector<double> usedLayer;
-    std::vector<double> usedIPhi;
-    std::vector<double> usedIT;
+    std::vector<int> usedLayer;
+    std::vector<int> usedIPhi;
+    std::vector<int> usedIT;
 
-    double meanLayer = 0.0;
-    double meanIPhi = 0.0;
-    double meanIT = 0.0;
+    float meanLayer = 0.0;
+    float meanIPhi = 0.0;
+    float meanIT = 0.0;
 
     for (auto &clusHit : clusHits)
     {
-      double coords[3] = {clusHit.first.get<0>(), clusHit.first.get<1>(), clusHit.first.get<2>()};
+      int coords[3] = {(int)clusHit.first.get<0>(), (int)clusHit.first.get<1>(), (int)clusHit.first.get<2>()};
       std::pair<TrkrDefs::hitkey, TrkrDefs::hitsetkey> spechitkey = clusHit.second.second;
-      unsigned int adc = clusHit.second.first;
+      uint16_t adc = clusHit.second.first;
 
       int side = TpcDefs::getSide(spechitkey.second);
 
@@ -478,17 +475,8 @@ namespace
         meanSide--;
       }
 
-      PHG4TpcGeom *layergeom = my_data.geom_container->GetLayerCellGeom((int) coords[0]);
-
-      double r = layergeom->get_radius();
-      double phi = layergeom->get_phi(coords[1], side);
-      double t = layergeom->get_zcenter(fabs(coords[2]));
-
-      double hitzdriftlength = t * my_data.tGeometry->get_drift_velocity();
-      double hitZ = my_data.tdriftmax * my_data.tGeometry->get_drift_velocity() - hitzdriftlength;
-
       bool foundLayer = false;
-      for (double i : usedLayer)
+      for (int i : usedLayer)
       {
         if (coords[0] == i)
         {
@@ -503,7 +491,7 @@ namespace
       }
 
       bool foundIPhi = false;
-      for (double i : usedIPhi)
+      for (int i : usedIPhi)
       {
         if (coords[1] == i)
         {
@@ -518,7 +506,7 @@ namespace
       }
 
       bool foundIT = false;
-      for (double i : usedIT)
+      for (int i : usedIT)
       {
         if (coords[2] == i)
         {
@@ -532,65 +520,37 @@ namespace
         usedIT.push_back(coords[2]);
       }
 
-      clus->addHit();
-      clus->setHitLayer(clus->getNhits() - 1, coords[0]);
-      clus->setHitIPhi(clus->getNhits() - 1, coords[1]);
-      clus->setHitIT(clus->getNhits() - 1, coords[2]);
-      clus->setHitX(clus->getNhits() - 1, r * cos(phi));
-      clus->setHitY(clus->getNhits() - 1, r * sin(phi));
-      clus->setHitZ(clus->getNhits() - 1, hitZ);
-      clus->setHitAdc(clus->getNhits() - 1, (double) adc);
+      clus->addHit(spechitkey.second, spechitkey.first, adc);
 
-      rSum += r * adc;
-      phiSum += phi * adc;
-      tSum += t * adc;
+      layerSum += 1.0 * coords[0] * adc;
+      iphiSum += 1.0 * coords[1] * adc;
+      itSum += 1.0 * coords[2] * adc;
 
-      layerSum += coords[0] * adc;
-      iphiSum += coords[1] * adc;
-      itSum += coords[2] * adc;
+      meanLayer += 1.0 * coords[0];
+      meanIPhi += 1.0 * coords[1];
+      meanIT += 1.0 * coords[2];
 
-      meanLayer += coords[0];
-      meanIPhi += coords[1];
-      meanIT += coords[2];
+      adcSum += 1.0*adc;
 
-      adcSum += adc;
-
-      if (adc > maxAdc)
+      if (1.0*adc > maxAdc)
       {
-        secondmaxAdc = maxAdc;
-        secondmaxKey = maxKey;
+        //secondmaxAdc = maxAdc;
+        //secondmaxKey = maxKey;
         maxAdc = adc;
         maxKey = spechitkey.second;
       }
-      else if (adc > secondmaxAdc)
+      //else if (1.0*adc > secondmaxAdc)
       {
-        secondmaxAdc = adc;
-        secondmaxKey = spechitkey.second;
+        //secondmaxAdc = adc;
+        //secondmaxKey = spechitkey.second;
       }
 
 
     }
 
-    if (nHits == 0)
+    if (nHits == 0 || clus->getNhits() == 0)
     {
       return;
-    }
-
-    double clusR = rSum / adcSum;
-    double clusPhi = phiSum / adcSum;
-    double clusT = tSum / adcSum;
-    double zdriftlength = clusT * my_data.tGeometry->get_drift_velocity();
-
-    double clusX = clusR * cos(clusPhi);
-    double clusY = clusR * sin(clusPhi);
-    double clusZ = my_data.tdriftmax * my_data.tGeometry->get_drift_velocity() - zdriftlength;
-    if (meanSide < 0)
-    {
-      clusZ = -clusZ;
-      for (int i = 0; i < (int) clus->getNhits(); i++)
-      {
-        clus->setHitZ(i, -1 * clus->getHitZ(i));
-      }
     }
 
     std::sort(usedLayer.begin(), usedLayer.end());
@@ -609,29 +569,54 @@ namespace
     double sigmaWeightedIPhi = 0.0;
     double sigmaWeightedIT = 0.0;
 
-    pthread_mutex_lock(&mythreadlock);
-    my_data.hitHist = new TH3D(std::format("hitHist_event{}_side{}_sector{}_module{}_cluster{}", my_data.eventNum, (int) my_data.side, (int) my_data.sector, (int) my_data.module, (int) my_data.cluster_vector.size()).c_str(), ";layer;iphi;it", usedLayer.size() + 2, usedLayer[0] - 1.5, *usedLayer.rbegin() + 1.5, usedIPhi.size() + 2, usedIPhi[0] - 1.5, *usedIPhi.rbegin() + 1.5, usedIT.size() + 2, usedIT[0] - 1.5, *usedIT.rbegin() + 1.5);
-
-    // TH3D *hitHist = new TH3D(Form("hitHist_event%d_side%d_sector%d_module%d_cluster%d",my_data.eventNum,(int)my_data.side,(int)my_data.sector,(int)my_data.module,(int)my_data.cluster_vector.size()),";layer;iphi;it",usedLayer.size()+2,usedLayer[0]-1.5,*usedLayer.rbegin()+1.5,usedIPhi.size()+2,usedIPhi[0]-1.5,*usedIPhi.rbegin()+1.5,usedIT.size()+2,usedIT[0]-1.5,*usedIT.rbegin()+1.5);
-
     for (int i = 0; i < (int) clus->getNhits(); i++)
     {
-      my_data.hitHist->Fill(clus->getHitLayer(i), clus->getHitIPhi(i), clus->getHitIT(i), clus->getHitAdc(i));
+      LaserClusterHitInfo LCHI = clus->getHit(i);
+      uint8_t layer = TrkrDefs::getLayer(LCHI.hitsetkey);
+      uint16_t iphi = TpcDefs::getPad(LCHI.hitkey);
+      uint16_t it = TpcDefs::getTBin(LCHI.hitkey);
 
-      sigmaLayer += pow(clus->getHitLayer(i) - meanLayer, 2);
-      sigmaIPhi += pow(clus->getHitIPhi(i) - meanIPhi, 2);
-      sigmaIT += pow(clus->getHitIT(i) - meanIT, 2);
+      sigmaLayer += pow(layer - meanLayer, 2);
+      sigmaIPhi += pow(iphi - meanIPhi, 2);
+      sigmaIT += pow(it - meanIT, 2);
 
-      sigmaWeightedLayer += clus->getHitAdc(i) * pow(clus->getHitLayer(i) - (layerSum / adcSum), 2);
-      sigmaWeightedIPhi += clus->getHitAdc(i) * pow(clus->getHitIPhi(i) - (iphiSum / adcSum), 2);
-      sigmaWeightedIT += clus->getHitAdc(i) * pow(clus->getHitIT(i) - (itSum / adcSum), 2);
+      sigmaWeightedLayer += LCHI.adc * pow(layer - (layerSum / adcSum), 2);
+      sigmaWeightedIPhi += LCHI.adc * pow(iphi - (iphiSum / adcSum), 2);
+      sigmaWeightedIT += LCHI.adc * pow(it - (itSum / adcSum), 2);
     }
 
-    bool fitSuccess = false;
-    ROOT::Fit::Fitter *fit3D = new ROOT::Fit::Fitter;
+    clus->setNLayers(usedLayer.size());
+    clus->setNIPhi(usedIPhi.size());
+    clus->setNIT(usedIT.size());
+    clus->setLayer(layerSum / adcSum);
+    clus->setIPhi(iphiSum / adcSum);
+    clus->setIT(itSum / adcSum);
+    clus->setSDLayer(sqrt(sigmaLayer / nHits));
+    clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
+    clus->setSDIT(sqrt(sigmaIT / nHits));
+    clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
+    clus->setSDWeightedIPhi(sqrt(sigmaWeightedIPhi / adcSum));
+    clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
 
     if (my_data.doFitting)
     {
+      pthread_mutex_lock(&mythreadlock);
+      my_data.hitHist = new TH3D(std::format("hitHist_event{}_side{}_sector{}_module{}_cluster{}", my_data.eventNum, (int) my_data.side, (int) my_data.sector, (int) my_data.module, (int) my_data.cluster_vector.size()).c_str(), ";layer;iphi;it", usedLayer.size() + 2, usedLayer[0] - 1.5, *usedLayer.rbegin() + 1.5, usedIPhi.size() + 2, usedIPhi[0] - 1.5, *usedIPhi.rbegin() + 1.5, usedIT.size() + 2, usedIT[0] - 1.5, *usedIT.rbegin() + 1.5);
+
+      // TH3D *hitHist = new TH3D(Form("hitHist_event%d_side%d_sector%d_module%d_cluster%d",my_data.eventNum,(int)my_data.side,(int)my_data.sector,(int)my_data.module,(int)my_data.cluster_vector.size()),";layer;iphi;it",usedLayer.size()+2,usedLayer[0]-1.5,*usedLayer.rbegin()+1.5,usedIPhi.size()+2,usedIPhi[0]-1.5,*usedIPhi.rbegin()+1.5,usedIT.size()+2,usedIT[0]-1.5,*usedIT.rbegin()+1.5);
+
+      for (int i = 0; i < (int) clus->getNhits(); i++)
+      {
+        LaserClusterHitInfo LCHI = clus->getHit(i);
+        uint8_t layer = TrkrDefs::getLayer(LCHI.hitsetkey);
+        uint16_t iphi = TpcDefs::getPad(LCHI.hitkey);
+        uint16_t it = TpcDefs::getTBin(LCHI.hitkey);
+        my_data.hitHist->Fill(layer, iphi, it, LCHI.adc);
+      }
+
+      bool fitSuccess = false;
+      ROOT::Fit::Fitter *fit3D = new ROOT::Fit::Fitter;
+
       double par_init[7] = {
           maxAdc,
           meanLayer,
@@ -726,179 +711,62 @@ namespace
       {
         std::cout << "fit success: " << fitSuccess << std::endl;
       }
+    
+      if (fitSuccess)
+      {
+        const ROOT::Fit::FitResult &result = fit3D->Result();
+
+        PHG4TpcGeom *layergeomLow = my_data.geom_container->GetLayerCellGeom((int) floor(result.Parameter(1)));
+        PHG4TpcGeom *layergeomHigh = my_data.geom_container->GetLayerCellGeom((int) ceil(result.Parameter(1)));
+
+        //double RLow = layergeomLow->get_radius();
+        //double RHigh = layergeomHigh->get_radius();
+
+        double phiHigh_RLow = -999.0;
+        if (ceil(result.Parameter(2)) < layergeomLow->get_phibins())
+        {
+          phiHigh_RLow = layergeomLow->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+        }
+        double phiHigh_RHigh = -999.0;
+        if (ceil(result.Parameter(2)) < layergeomHigh->get_phibins())
+        {
+          phiHigh_RHigh = layergeomHigh->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+        }
+
+        //double phiLow_RLow = layergeomLow->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+        //double phiLow_RHigh = layergeomHigh->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
+
+        if (phiHigh_RLow == -999.0 && phiHigh_RHigh == -999.0)
+        {
+          clus->setFitMode(false);
+        }
+        else
+        {
+          clus->setFitMode(true);
+          clus->setLayer(result.Parameter(1));
+          clus->setIPhi(result.Parameter(2));
+          clus->setIT(result.Parameter(4));
+          clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
+          clus->setSDWeightedIPhi(result.Parameter(3));
+          clus->setSDWeightedIT(result.Parameter(5));
+        }
+      }
+      
+      delete fit3D;
+      if (my_data.hitHist)
+      {
+        delete my_data.hitHist;
+        my_data.hitHist = nullptr;
+      }
+      pthread_mutex_unlock(&mythreadlock);
     }
-    pthread_mutex_unlock(&mythreadlock);
-
-    if (my_data.doFitting && fitSuccess)
-    {
-      const ROOT::Fit::FitResult &result = fit3D->Result();
-
-      PHG4TpcGeom *layergeomLow = my_data.geom_container->GetLayerCellGeom((int) floor(result.Parameter(1)));
-      PHG4TpcGeom *layergeomHigh = my_data.geom_container->GetLayerCellGeom((int) ceil(result.Parameter(1)));
-
-      double RLow = layergeomLow->get_radius();
-      double RHigh = layergeomHigh->get_radius();
-
-      double phiHigh_RLow = -999.0;
-      if (ceil(result.Parameter(2)) < layergeomLow->get_phibins())
-      {
-        phiHigh_RLow = layergeomLow->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
-      }
-      double phiHigh_RHigh = -999.0;
-      if (ceil(result.Parameter(2)) < layergeomHigh->get_phibins())
-      {
-        phiHigh_RHigh = layergeomHigh->get_phi(ceil(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
-      }
-
-      double phiLow_RLow = layergeomLow->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
-      double phiLow_RHigh = layergeomHigh->get_phi(floor(result.Parameter(2)), (meanSide < 0 ? 0 : 1));
-
-      double meanR = (result.Parameter(1) - floor(result.Parameter(1))) * (RHigh - RLow) + RLow;
-
-      double meanPhi_RLow = ((result.Parameter(2) - floor(result.Parameter(2)))) * (phiHigh_RLow - phiLow_RLow) + phiLow_RLow;
-      double meanPhi_RHigh = ((result.Parameter(2) - floor(result.Parameter(2)))) * (phiHigh_RHigh - phiLow_RHigh) + phiLow_RHigh;
-
-      double meanPhi = 0.5 * (meanPhi_RLow + meanPhi_RHigh);
-      if (phiHigh_RLow == -999.0 && phiHigh_RHigh != -999.0)
-      {
-        meanPhi = meanPhi_RHigh;
-      }
-      else if (phiHigh_RLow != -999.0 && phiHigh_RHigh == -999.0)
-      {
-        meanPhi = meanPhi_RLow;
-      }
-
-      if (phiHigh_RLow == -999.0 && phiHigh_RHigh == -999.0)
-      {
-        clus->setAdc(adcSum);
-        clus->setX(clusX);
-        clus->setY(clusY);
-        clus->setZ(clusZ);
-        clus->setFitMode(false);
-        clus->setLayer(layerSum / adcSum);
-        clus->setIPhi(iphiSum / adcSum);
-        clus->setIT(itSum / adcSum);
-        clus->setNLayers(usedLayer.size());
-        clus->setNIPhi(usedIPhi.size());
-        clus->setNIT(usedIT.size());
-        clus->setSDLayer(sqrt(sigmaLayer / nHits));
-        clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
-        clus->setSDIT(sqrt(sigmaIT / nHits));
-        clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
-        clus->setSDWeightedIPhi(sqrt(sigmaWeightedIPhi / adcSum));
-        clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
-      }
-      else
-      {
-        clus->setAdc(adcSum);
-        clus->setX(meanR * cos(meanPhi));
-        clus->setY(meanR * sin(meanPhi));
-        clus->setZ(clusZ);
-        clus->setFitMode(true);
-        clus->setLayer(result.Parameter(1));
-        clus->setIPhi(result.Parameter(2));
-        clus->setIT(result.Parameter(4));
-        clus->setNLayers(usedLayer.size());
-        clus->setNIPhi(usedIPhi.size());
-        clus->setNIT(usedIT.size());
-        clus->setSDLayer(sqrt(sigmaLayer / nHits));
-        clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
-        clus->setSDIT(sqrt(sigmaIT / nHits));
-        clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
-        clus->setSDWeightedIPhi(result.Parameter(3));
-        clus->setSDWeightedIT(result.Parameter(5));
-      }
-    }
-    else
-    {
-      clus->setAdc(adcSum);
-      clus->setX(clusX);
-      clus->setY(clusY);
-      clus->setZ(clusZ);
-      clus->setFitMode(false);
-      clus->setLayer(layerSum / adcSum);
-      clus->setIPhi(iphiSum / adcSum);
-      clus->setIT(itSum / adcSum);
-      clus->setNLayers(usedLayer.size());
-      clus->setNIPhi(usedIPhi.size());
-      clus->setNIT(usedIT.size());
-      clus->setSDLayer(sqrt(sigmaLayer / nHits));
-      clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
-      clus->setSDIT(sqrt(sigmaIT / nHits));
-      clus->setSDWeightedLayer(sqrt(sigmaWeightedLayer / adcSum));
-      clus->setSDWeightedIPhi(sqrt(sigmaWeightedIPhi / adcSum));
-      clus->setSDWeightedIT(sqrt(sigmaWeightedIT / adcSum));
-    }
-
 
     pthread_mutex_lock(&mythreadlock);
-    // Get surface of max ADC hit
-    bool alignmentflag = alignmentTransformationContainer::use_alignment;
-    alignmentTransformationContainer::use_alignment = false;
-    Acts::Vector3 ideal(clus->getX(), clus->getY(), clus->getZ());
-    TrkrDefs::subsurfkey subsurfkey = 0;
-
-    Surface surface = my_data.tGeometry->get_tpc_surface_from_coords(
-        maxKey,
-        ideal,
-        subsurfkey);
-
-    if (!surface)
-    {
-      // try second maximum ADC hit
-      if (secondmaxKey != 0)
-      {
-        surface = my_data.tGeometry->get_tpc_surface_from_coords(
-            secondmaxKey,
-            ideal,
-            subsurfkey);
-      }
-
-      // if still no surface, skip this cluster
-      if (!surface)
-      {
-        // clean up
-        alignmentTransformationContainer::use_alignment = alignmentflag;
-        delete clus;
-        delete fit3D;
-        if (my_data.hitHist)
-        {
-          delete my_data.hitHist;
-          my_data.hitHist = nullptr;
-        }
-        pthread_mutex_unlock(&mythreadlock);
-        return;
-      }
-    }
-
-    // Convert from ideal TPC coordinates to surface coordinates 
-    Acts::Vector3 local = surface->localToGlobalTransform(my_data.tGeometry->geometry().getGeoContext()).inverse() * (ideal * Acts::UnitConstants::cm);
-    local /= Acts::UnitConstants::cm;
-
-    // Convert back to TPC coordinates with alignment applied 
-    alignmentTransformationContainer::use_alignment = true;
-    Acts::Vector3 global = surface->localToGlobalTransform(my_data.tGeometry->geometry().getGeoContext()) * (local * Acts::UnitConstants::cm);
-    global /= Acts::UnitConstants::cm;
-    clus->setX(global(0));
-    clus->setY(global(1));
-    clus->setZ(global(2));
-
-    alignmentTransformationContainer::use_alignment = alignmentflag;
-    pthread_mutex_unlock(&mythreadlock);
-
-
-    const auto ckey = TrkrDefs::genClusKey(maxKey, my_data.cluster_vector.size());
+    const auto ckey = TrkrDefs::genClusKey(maxKey, my_data.cluster_vector.size());    
     my_data.cluster_vector.push_back(clus);
     my_data.cluster_key_vector.push_back(ckey);
+    pthread_mutex_unlock(&mythreadlock);
 
-    
-    delete fit3D;
-
-    if (my_data.hitHist)
-    {
-      delete my_data.hitHist;
-      my_data.hitHist = nullptr;
-    }
   }
 
   void ProcessModuleData(thread_data *my_data)

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -77,13 +77,13 @@ namespace
   {
     PHG4TpcGeomContainer *geom_container = nullptr;
     ActsGeometry *tGeometry = nullptr;
-    std::vector<TrkrHitSet *> hitsets = {};
-    std::vector<unsigned int> layers = {};
+    std::vector<TrkrHitSet *> hitsets;
+    std::vector<unsigned int> layers;
     bool side = false;
     unsigned int sector = 0;
     unsigned int module = 0;
-    std::vector<LaserCluster *> cluster_vector = {};
-    std::vector<TrkrDefs::cluskey> cluster_key_vector = {};
+    std::vector<LaserCluster *> cluster_vector;
+    std::vector<TrkrDefs::cluskey> cluster_key_vector;
     double adc_threshold = 74.4;
     int peakTimeBin = 325;
     int layerMin = 1;

--- a/offline/packages/tpc/Makefile.am
+++ b/offline/packages/tpc/Makefile.am
@@ -35,6 +35,7 @@ lib_LTLIBRARIES = \
   libtpc.la
 
 pkginclude_HEADERS = \
+  LaserClusterHelper.h \
   LaserClusterizer.h \
   LaserEventInfo.h \
   LaserEventInfov1.h \
@@ -76,6 +77,7 @@ dist_mydata_DATA = \
 
 # sources for tpc library
 libtpc_la_SOURCES = \
+  LaserClusterHelper.cc \
   LaserClusterizer.cc \
   LaserEventInfov1.cc \
   LaserEventInfov2.cc \

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
@@ -1494,7 +1494,8 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
     // Do the static + average distortion corrections if the container was found
     // since incorrect z values are in cluster do to wrong t0 of laser flash, fixing based on the side for now
     // Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), cmclus->getZ());
-    Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), (side ? 1.0 : -1.0));
+    Acts::Vector3 pos = m_laserClusterHelper.getClusterCentroid(cmclus);
+    //Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), (side ? 1.0 : -1.0));
     TVector3 tmp_raw(pos[0], pos[1], pos[2]);
     if (m_dcc_in_module_edge)
     {
@@ -1579,12 +1580,12 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
 
     if (Verbosity() > 2)
     {
-      double raw_rad = std::sqrt(cmclus->getX() * cmclus->getX() + cmclus->getY() * cmclus->getY());
+      double raw_rad = std::sqrt(tmp_raw.X() * tmp_raw.X() + tmp_raw.Y() * tmp_raw.Y());
       double static_rad = sqrt(tmp_static.X() * tmp_static.X() + tmp_static.Y() * tmp_static.Y());
       double corr_rad = sqrt(tmp_pos.X() * tmp_pos.X() + tmp_pos.Y() * tmp_pos.Y());
       std::cout << "cluster " << clusterIndex << std::endl;
       clusterIndex++;
-      std::cout << "found raw cluster " << cmkey << " side " << side << " with x " << cmclus->getX() << " y " << cmclus->getY() << " z " << cmclus->getZ() << " radius " << raw_rad << std::endl;
+      std::cout << "found raw cluster " << cmkey << " side " << side << " with x " << tmp_raw.X() << " y " << tmp_raw.Y() << " z " << tmp_raw.Z() << " radius " << raw_rad << std::endl;
       std::cout << "        --- static corrected positions: " << tmp_static.X() << "  " << tmp_static.Y() << "  " << tmp_static.Z() << " radius " << static_rad << std::endl;
       std::cout << "                --- corrected positions: " << tmp_pos.X() << "  " << tmp_pos.Y() << "  " << tmp_pos.Z() << " radius " << corr_rad << std::endl;
     }
@@ -2786,6 +2787,9 @@ int TpcCentralMembraneMatching::GetNodes(PHCompositeNode* topNode)
     std::cout << PHWHERE << "CORRECTED_CM_CLUSTER Node missing, abort." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
+
+  m_laserClusterHelper.set_useZ(m_useZ);
+  m_laserClusterHelper.loadNodes(topNode);
 
   // input tpc distortion correction module edge
   m_dcc_in_module_edge = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerModuleEdge");

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
@@ -1495,6 +1495,10 @@ int TpcCentralMembraneMatching::process_event(PHCompositeNode* topNode)
     // since incorrect z values are in cluster do to wrong t0 of laser flash, fixing based on the side for now
     // Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), cmclus->getZ());
     Acts::Vector3 pos = m_laserClusterHelper.getClusterCentroid(cmclus);
+    if(pos.hasNaN())
+    {
+      continue;
+    }
     //Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), (side ? 1.0 : -1.0));
     TVector3 tmp_raw(pos[0], pos[1], pos[2]);
     if (m_dcc_in_module_edge)

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.h
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.h
@@ -9,6 +9,7 @@
  * \author Tony Frawley <frawley@fsunuc.physics.fsu.edu>, Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 
+#include <tpc/LaserClusterHelper.h>
 #include <tpc/TpcDistortionCorrection.h>
 #include <tpc/TpcDistortionCorrectionContainer.h>
 
@@ -126,6 +127,7 @@ class TpcCentralMembraneMatching : public SubsysReco
 
   void set_phiHistInRad(bool rad){ m_phiHist_in_rad = rad; }
 
+  void set_useZ(bool use) { m_useZ = use; }
 
   // void set_laminationFile(const std::string& filename)
   //{
@@ -423,6 +425,9 @@ class TpcCentralMembraneMatching : public SubsysReco
   std::vector<int> m_reco_RMatches[2];
 
   double m_recoRotation[2][3]{{-999, -999, -999}, {-999, -999, -999}};
+
+  LaserClusterHelper m_laserClusterHelper;
+  bool m_useZ{false};
 };
 
 #endif  // PHTPCCENTRALMEMBRANEMATCHER_H

--- a/offline/packages/tpccalib/TpcLaminationFitting.cc
+++ b/offline/packages/tpccalib/TpcLaminationFitting.cc
@@ -316,7 +316,10 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
     const auto &[cmkey, cmclus_orig] = *cmitr;
     LaserCluster *cmclus = cmclus_orig;
 
-    if(cmclus->getNLayers() <= m_nLayerCut) continue;
+    if(cmclus->getNLayers() <= m_nLayerCut)
+    {
+      continue;
+    }
 
     bool side = (bool) TpcDefs::getSide(cmkey);
     double weight = 1.0;

--- a/offline/packages/tpccalib/TpcLaminationFitting.cc
+++ b/offline/packages/tpccalib/TpcLaminationFitting.cc
@@ -3,7 +3,7 @@
 #include <trackbase/CMFlashDifferenceContainerv1.h>
 #include <trackbase/CMFlashDifferencev1.h>
 #include <trackbase/LaserClusterContainerv1.h>
-#include <trackbase/LaserClusterv1.h>
+#include <trackbase/LaserClusterv3.h>
 #include <trackbase/TpcDefs.h>
 
 #include <ffaobjects/EventHeader.h>
@@ -120,82 +120,6 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
     }
   }
 
-  /*
-  //Make map for run and ZDC rate for pp mode
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(49709, 555.0));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(52077, 0.0));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(52078, 0.0));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53534, 3013.5));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53630, 6849.3));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53631, 5577.8));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53632, 5151.2));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53652, 4600.0));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53687, 3967.2));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53716, 3070.1));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53738, 4510.7));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53739, 4165.0));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53741, 3738.1));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53742, 3721.4));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53743, 3693.4));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53744, 3581.9));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53756, 4471.4));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53783, 4825.7));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53871, 6871.5));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53876, 5082.3));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53877, 4758.5));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53879, 4315.0));
-
-  //beam off go into pp
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53098, 0.0));
-  m_run_ZDC_map_pp.insert(std::pair<int, float>(53271, 0.0));
-
-  m_run_ZDC_map_auau.insert(std::pair<int, float>(54966, 12400.));
-  m_run_ZDC_map_auau.insert(std::pair<int, float>(54967, 11600.));
-  m_run_ZDC_map_auau.insert(std::pair<int, float>(54968, 10500.));
-  m_run_ZDC_map_auau.insert(std::pair<int, float>(54969, 9680.));
-  */
-
-  /*
-  for(int module=0; module<4; module++)
-  {
-    double spacing[nRadii];
-    for(int j=0; j<nRadii; j++)
-    {
-      spacing[j] = 2.0 * ((dw_mult * diffwidth / RValues[module][j]) + (pr_mult * phi_petal / nPads[module]));
-    }
-    double phiTmp = 0.0;
-    for(int j=0; j<nRadii; j++)
-    {
-      for(int k=keepThisAndAfter[j]; k<keepUntil[module][j]; k++)
-      {
-        if(j % 2 == 0)
-        {
-          phiTmp = k * spacing[j] + (spacing[j] / 2.0) - adjust;
-        }
-        else
-        {
-          phiTmp = (k + 1) * spacing[j] - adjust;
-        }
-
-        double phi[2] = {phiTmp - (M_PI / 18), acos(-cos(phiTmp))};
-        for(int s=0; s<2; s++)
-        {
-          while(phi[s] < m_phiModMin[s])
-          {
-            phi[s] += M_PI / 9;
-          }
-          while(phi[s] > m_phiModMax[s])
-          {
-            phi[s] -= M_PI / 9;
-          }
-          m_truthR[s].push_back(RValues[module][j]);
-          m_truthPhi[s].push_back(phi[s]);
-        }
-
-      }
-    }
-  }
-  */
   CDBTTree *cdbttree = new CDBTTree(m_stripePatternFile);
   cdbttree->LoadCalibrations();
   auto cdbMap = cdbttree->GetDoubleEntryMap();
@@ -217,32 +141,6 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
     std::cerr << "stripe pattern file passed has no stripes on one side. Exiting" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  /*
-  for(int i=0; i<32; i++)
-  {
-    for(int j=0; j<11; j++)
-    {
-      int index0 = 18 + i*100 + j;
-      int index1 = i*100 + j;
-
-      double R0 = cdbttree->GetDoubleValue(index0, "truthR");
-      double Phi0 = cdbttree->GetDoubleValue(index0, "truthPhi");
-      if(!std::isnan(R0) && !std::isnan(Phi0))
-      {
-        m_truthR[0].push_back(R0);
-        m_truthPhi[0].push_back(Phi0);
-      }
-
-      double R1 = cdbttree->GetDoubleValue(index1, "truthR");
-      double Phi1 = cdbttree->GetDoubleValue(index1, "truthPhi");
-      if(!std::isnan(R1) && !std::isnan(Phi1))
-      {
-        m_truthR[1].push_back(R1);
-        m_truthPhi[1].push_back(Phi1);
-      }
-    }
-  }
-  */
 
   int ret = GetNodes(topNode);
   return ret;
@@ -251,13 +149,31 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
 //______________________________________
 int TpcLaminationFitting::GetNodes(PHCompositeNode *topNode)
 {
-  //m_correctedCMcluster_map = findNode::getClass<LaserClusterContainer>(topNode, "LAMINATION_CLUSTER");
   m_correctedCMcluster_map = findNode::getClass<LaserClusterContainer>(topNode, "LASER_CLUSTER");
   if (!m_correctedCMcluster_map)
   {
     std::cout << PHWHERE << "CORRECTED_CM_CLUSTER Node missing, abort." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
+
+  /*
+  m_geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  if (!m_geom_container)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node TPCGEOMCONTAINER" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!m_tGeometry)
+  {
+    std::cout << PHWHERE << "ActsGeometry not found on node tree. Exiting" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  */
+
+  m_laserClusterHelper.set_useZ(m_useZ);
+  m_laserClusterHelper.loadNodes(topNode);
 
   m_dcc_in_module_edge = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerModuleEdge");
   if (m_dcc_in_module_edge)
@@ -399,7 +315,16 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
   {
     const auto &[cmkey, cmclus_orig] = *cmitr;
     LaserCluster *cmclus = cmclus_orig;
+
+    bool side = (bool) TpcDefs::getSide(cmkey);
+    double weight = 1.0;
+    if(m_adcWeight)
+    {
+      weight = 1.0*cmclus->getAdc();
+    }
+
     //const unsigned int adc = cmclus->getAdc();
+    /*
     bool side = (bool) TpcDefs::getSide(cmkey);
     if (cmclus->getNLayers() < m_nLayerCut)
     {
@@ -412,9 +337,65 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
       weight = 1.0*cmclus->getAdc();
     }
 
+    double meanR = 0.0;
+    double meanPhi = 0.0;
+    double meanZ = 0.0;
+    double meanAdc = 0.0;
+    for(int i=0; i<(int)cmclus->getNhits(); i++)
+    {
+      LaserClusterHitInfo LCHI = cmclus->getHit(i);
+      int layer = TrkrDefs::getLayer(LCHI.hitsetkey);
+      PHG4TpcGeom *layer_geom = m_geom_container->GetLayerCellGeom(layer);
+      double radius = layer_geom->get_radius();
+      double phi = layer_geom->get_phi(TpcDefs::getTBin(LCHI.hitkey), TpcDefs::getSide(LCHI.hitsetkey));
+
+      double tdriftmax = layer_geom->get_max_driftlength() / m_tGeometry->get_drift_velocity();
+
+      double zdriftlength = layer_geom->get_zcenter(TpcDefs::getPad(LCHI.hitkey)) * m_tGeometry->get_drift_velocity();
+      // convert z drift length to z position in the TPC
+      double env_z = tdriftmax * m_tGeometry->get_drift_velocity() - zdriftlength;
+      if (TpcDefs::getSide(LCHI.hitsetkey) == 0)
+      {
+        env_z = -env_z;
+      }
+
+      double env_x = radius * cos(phi);
+      double env_y = radius * sin(phi);
+
+      //hard code at 0 until better z coordinate calibration is determined
+      env_z = 0.0;
+
+      Acts::Vector3 env_global(env_x, env_y, env_z);
+      Acts::Vector3 global = m_tGeometry->transformTpcEnvelopeToWorld(env_global);
+
+      double global_x = global.x();
+      double global_y = global.y();
+      double global_z = global.z();
+
+      double global_R = sqrt(global_x*global_x + global_y*global_y);
+      double global_phi = atan2(global_y, global_x);
+
+      meanR += global_R * LCHI.adc;
+      meanPhi += global_phi * LCHI.adc;
+      meanZ += global_z * LCHI.adc;
+      meanAdc += LCHI.adc;
+    }
+    
+    meanR /= meanAdc;
+    meanPhi /= meanAdc;
+    meanZ /= meanAdc;
     
     //Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), cmclus->getZ());
-    Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), (side ? 1.0 : -1.0));
+    //Acts::Vector3 pos(cmclus->getX(), cmclus->getY(), (side ? 1.0 : -1.0));
+    Acts::Vector3 pos(meanR * cos(meanPhi), meanR * sin(meanPhi), meanZ);
+    */
+
+    Acts::Vector3 pos = m_laserClusterHelper.getClusterCentroid(cmclus);
+    if(pos.hasNaN())
+    {
+      continue;
+    }
+
     if (m_dcc_in_module_edge)
     {
       pos = m_distortionCorrection.get_corrected_position(pos, m_dcc_in_module_edge);

--- a/offline/packages/tpccalib/TpcLaminationFitting.cc
+++ b/offline/packages/tpccalib/TpcLaminationFitting.cc
@@ -75,6 +75,9 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
     //m_parameterScan[s] = new TH2D((boost::format("parameterScan_%s") %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("TPC %s Lamination Parameter Scan;m;B") %(s == 1 ? "North" : "South")).str().c_str(), 101, -0.101, 0.101, 101, -10.1, 10.1);
     //m_parameterScan[s] = new TH2D((boost::format("parameterScan_%s") %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("TPC %s Lamination Parameter Scan;A (asymptote);C (decay constant)") %(s == 1 ? "North" : "South")).str().c_str(), 101, -1.005, 0.005, 101, -0.0025, 0.5025);
 
+
+    clusterMap[s] = new TH2D((boost::format("clusterMap_%s") %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("TPC %s;#phi;R [cm]") %(s == 1 ? "North" : "South")).str().c_str(), 2000, 0.0, 2*TMath::Pi(), 2000, 28, 80);
+
     for (int l = 0; l < 18; l++)
     {
       double shift = (l * M_PI / 9);
@@ -422,8 +425,10 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
     }
 
     TVector3 tmp_pos(pos[0], pos[1], pos[2]);
+
     if(cmclus->getNLayers() > m_nLayerCut && (!m_useSDLayerCut || cmclus->getSDWeightedLayer() > 0.5))
     {
+      clusterMap[side]->Fill(tmp_pos.Phi(), tmp_pos.Perp(), weight);
       for (int l = 0; l < 18; l++)
       {
 	      double shift = m_laminationIdeal[l][side];
@@ -1175,6 +1180,7 @@ int TpcLaminationFitting::End(PHCompositeNode * /*topNode*/)
   
   for(int s=0; s<2; s++)
   {
+    clusterMap[s]->Write();
     for(int l=0; l<18; l++)
     {
       m_side = s;

--- a/offline/packages/tpccalib/TpcLaminationFitting.cc
+++ b/offline/packages/tpccalib/TpcLaminationFitting.cc
@@ -76,7 +76,7 @@ int TpcLaminationFitting::InitRun(PHCompositeNode *topNode)
     //m_parameterScan[s] = new TH2D((boost::format("parameterScan_%s") %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("TPC %s Lamination Parameter Scan;A (asymptote);C (decay constant)") %(s == 1 ? "North" : "South")).str().c_str(), 101, -1.005, 0.005, 101, -0.0025, 0.5025);
 
 
-    clusterMap[s] = new TH2D((boost::format("clusterMap_%s") %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("TPC %s;#phi;R [cm]") %(s == 1 ? "North" : "South")).str().c_str(), 2000, 0.0, 2*TMath::Pi(), 2000, 28, 80);
+    clusterMap[s] = new TH2D((boost::format("clusterMap_%s") %(s == 1 ? "North" : "South")).str().c_str(), (boost::format("TPC %s;#phi;R [cm]") %(s == 1 ? "North" : "South")).str().c_str(), 20000, 0.0, 2*TMath::Pi(), 2000, 28, 80);
 
     for (int l = 0; l < 18; l++)
     {
@@ -316,6 +316,8 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
     const auto &[cmkey, cmclus_orig] = *cmitr;
     LaserCluster *cmclus = cmclus_orig;
 
+    if(cmclus->getNLayers() <= m_nLayerCut) continue;
+
     bool side = (bool) TpcDefs::getSide(cmkey);
     double weight = 1.0;
     if(m_adcWeight)
@@ -409,7 +411,6 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
 
     if(cmclus->getNLayers() > m_nLayerCut && (!m_useSDLayerCut || cmclus->getSDWeightedLayer() > 0.5))
     {
-      clusterMap[side]->Fill(tmp_pos.Phi(), tmp_pos.Perp(), weight);
       for (int l = 0; l < 18; l++)
       {
 	      double shift = m_laminationIdeal[l][side];
@@ -435,12 +436,15 @@ int TpcLaminationFitting::process_event(PHCompositeNode *topNode)
     {
       continue;
     }
-    
+
     double phi2pimod = tmp_pos.Phi();
     if (phi2pimod < 0.0)
     {
       phi2pimod += 2 * M_PI;
     }
+
+    clusterMap[side]->Fill(phi2pimod, tmp_pos.Perp(), weight);    
+
     while(side && phi2pimod > M_PI / 9)
     {
       phi2pimod -= M_PI / 9;
@@ -1161,7 +1165,6 @@ int TpcLaminationFitting::End(PHCompositeNode * /*topNode*/)
   
   for(int s=0; s<2; s++)
   {
-    clusterMap[s]->Write();
     for(int l=0; l<18; l++)
     {
       m_side = s;
@@ -1198,6 +1201,7 @@ int TpcLaminationFitting::End(PHCompositeNode * /*topNode*/)
   outputfile->cd();
   for (int s = 0; s < 2; s++)
   {
+    clusterMap[s]->Write();
     for (const auto &h : {m_dcc_out->m_hDRint[s], m_dcc_out->m_hDPint[s], m_dcc_out->m_hDZint[s], m_dcc_out->m_hentries[s]})
     {
       if (h)

--- a/offline/packages/tpccalib/TpcLaminationFitting.h
+++ b/offline/packages/tpccalib/TpcLaminationFitting.h
@@ -2,14 +2,14 @@
 #define TPCCALIB_TPCLAMINATIONFITTING_H
 
 
-#include <g4detectors/PHG4TpcGeom.h>
-#include <g4detectors/PHG4TpcGeomContainer.h>
+//#include <g4detectors/PHG4TpcGeom.h>
+//#include <g4detectors/PHG4TpcGeomContainer.h>
 
 #include <tpc/LaserClusterHelper.h>
 #include <tpc/TpcDistortionCorrection.h>
 #include <tpc/TpcDistortionCorrectionContainer.h>
 
-#include <trackbase/ActsGeometry.h>
+//#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
 
@@ -197,14 +197,11 @@ class TpcLaminationFitting : public SubsysReco
   const double adjust = 0.015;
   */
 
-  std::vector<double> m_truthR[2];
-  std::vector<double> m_truthPhi[2];
+  std::vector<double> m_truthR[2]{};
+  std::vector<double> m_truthPhi[2]{};
 
   double m_phiModMin[2]{-M_PI/18, 0.0};
   double m_phiModMax[2]{M_PI/18, M_PI/9};
-
-  ActsGeometry *m_tGeometry {nullptr};
-  PHG4TpcGeomContainer *m_geom_container {nullptr};
 
   LaserClusterHelper m_laserClusterHelper;
   bool m_useZ{false};

--- a/offline/packages/tpccalib/TpcLaminationFitting.h
+++ b/offline/packages/tpccalib/TpcLaminationFitting.h
@@ -115,6 +115,8 @@ class TpcLaminationFitting : public SubsysReco
   TH2 *phiDistortionLamination[2]{nullptr};
   //TH2 *scaleFactorMap[2]{nullptr};
 
+  TH2 *clusterMap[2]{nullptr};
+
   unsigned int m_nLayerCut{1};
   bool m_useSDLayerCut{true};
   bool m_adcWeight{false};

--- a/offline/packages/tpccalib/TpcLaminationFitting.h
+++ b/offline/packages/tpccalib/TpcLaminationFitting.h
@@ -1,9 +1,15 @@
 #ifndef TPCCALIB_TPCLAMINATIONFITTING_H
 #define TPCCALIB_TPCLAMINATIONFITTING_H
 
+
+#include <g4detectors/PHG4TpcGeom.h>
+#include <g4detectors/PHG4TpcGeomContainer.h>
+
+#include <tpc/LaserClusterHelper.h>
 #include <tpc/TpcDistortionCorrection.h>
 #include <tpc/TpcDistortionCorrectionContainer.h>
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
 
@@ -65,6 +71,8 @@ class TpcLaminationFitting : public SubsysReco
   void set_adcWeight(bool useADC) { m_adcWeight = useADC; }
 
   void set_lam_grid_dimensions(int phibins, int rbins);
+
+  void set_useZ(bool use) { m_useZ = use; }
 
   int InitRun(PHCompositeNode *topNode) override;
 
@@ -194,6 +202,12 @@ class TpcLaminationFitting : public SubsysReco
 
   double m_phiModMin[2]{-M_PI/18, 0.0};
   double m_phiModMax[2]{M_PI/18, M_PI/9};
+
+  ActsGeometry *m_tGeometry {nullptr};
+  PHG4TpcGeomContainer *m_geom_container {nullptr};
+
+  LaserClusterHelper m_laserClusterHelper;
+  bool m_useZ{false};
 };
 
 #endif

--- a/offline/packages/trackbase/LaserCluster.h
+++ b/offline/packages/trackbase/LaserCluster.h
@@ -7,9 +7,11 @@
 #ifndef TRACKBASE_LASERCLUSTER_H
 #define TRACKBASE_LASERCLUSTER_H
 
+#include "TpcDefs.h"
+
 #include <phool/PHObject.h>
 
-#include <trackbase/TpcDefs.h>
+
 
 #include <iostream>
 #include <limits>

--- a/offline/packages/trackbase/LaserCluster.h
+++ b/offline/packages/trackbase/LaserCluster.h
@@ -9,8 +9,17 @@
 
 #include <phool/PHObject.h>
 
+#include <trackbase/TpcDefs.h>
+
 #include <iostream>
 #include <limits>
+
+struct LaserClusterHitInfo
+{
+  TrkrDefs::hitsetkey hitsetkey = 0;
+  TrkrDefs::hitkey hitkey = 0;
+  uint16_t adc    = 0;
+};
 
 /**
  * @brief Base class for laser cluster object
@@ -59,6 +68,13 @@ class LaserCluster : public PHObject
   virtual void setIPhi(float) {}
   virtual float getIT() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setIT(float) {}
+
+  virtual unsigned int getLayerInt() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual void setLayerInt(unsigned int) {}
+  virtual unsigned int getIPhiInt() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual void setIPhiInt(unsigned int) {}
+  virtual unsigned int getITInt() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual void setITInt(unsigned int) {}
 
   //
   // cluster info
@@ -121,6 +137,8 @@ class LaserCluster : public PHObject
   virtual void setHitAdc(int, float) {}
   virtual float getHitAdc(int) const { return std::numeric_limits<float>::quiet_NaN(); }
 
+  virtual void addHit(TrkrDefs::hitsetkey, TrkrDefs::hitkey, uint16_t) {}
+  virtual LaserClusterHitInfo getHit(int) const { return LaserClusterHitInfo(std::numeric_limits<TrkrDefs::hitsetkey>::max(), std::numeric_limits<TrkrDefs::hitkey>::max(), std::numeric_limits<uint16_t>::max()); }
 
  protected:
   LaserCluster() = default;

--- a/offline/packages/trackbase/LaserCluster.h
+++ b/offline/packages/trackbase/LaserCluster.h
@@ -69,11 +69,11 @@ class LaserCluster : public PHObject
   virtual float getIT() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void setIT(float) {}
 
-  virtual unsigned int getLayerInt() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual unsigned int getLayerInt() const { return std::numeric_limits<unsigned int>::max(); }
   virtual void setLayerInt(unsigned int) {}
-  virtual unsigned int getIPhiInt() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual unsigned int getIPhiInt() const { return std::numeric_limits<unsigned int>::max(); }
   virtual void setIPhiInt(unsigned int) {}
-  virtual unsigned int getITInt() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual unsigned int getITInt() const { return std::numeric_limits<unsigned int>::max(); }
   virtual void setITInt(unsigned int) {}
 
   //

--- a/offline/packages/trackbase/LaserClusterLinkDef.h
+++ b/offline/packages/trackbase/LaserClusterLinkDef.h
@@ -1,5 +1,7 @@
 #ifdef __CINT__
 
 #pragma link C++ class LaserCluster+;
+#pragma link C++ struct LaserClusterHitInfo+;
+#pragma link C++ class std::vector<LaserClusterHitInfo>+;
 
 #endif

--- a/offline/packages/trackbase/LaserClusterv3.cc
+++ b/offline/packages/trackbase/LaserClusterv3.cc
@@ -1,0 +1,78 @@
+/**
+ * @file trackbase/LaserClusterv3.cc
+ * @author Ben Kimelman
+ * @date July 2026
+ * @brief Implementation of LaserClusterv3
+ */
+#include "LaserClusterv3.h"
+
+#include <cmath>
+#include <utility>          // for swap
+
+void LaserClusterv3::identify(std::ostream& os) const
+{
+  os << "---LaserClusterv3--------------------" << std::endl;
+
+  os << " " << m_hits.size() << " hits";
+  os << " fit? " << m_fitMode;
+  os << " (layer, iphi, it) =  (" << m_posHardware[0];
+  os << ", " << m_posHardware[1] << ", ";
+  os << m_posHardware[2] << ")";
+  os << " adc = " << getAdc() << std::endl;
+
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
+
+  return;
+}
+
+int LaserClusterv3::isValid() const
+{
+  if(getNhits() == 0)
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+unsigned int LaserClusterv3::getAdc() const
+{
+  unsigned int adc = 0;
+  for(const auto &LCHI : m_hits)
+  {
+    adc += (unsigned int) LCHI.adc;
+  }
+  return adc;
+}
+
+void LaserClusterv3::CopyFrom( const LaserCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source )
+    {
+      return;
+    }
+ 
+  // parent class method
+  LaserCluster::CopyFrom( source );
+  setLayerInt( source.getLayerInt() );
+  setIPhiInt( source.getIPhiInt() );
+  setITInt( source.getITInt() );
+  setNLayers( source.getNLayers() );
+  setNIPhi( source.getNIPhi() );
+  setNIT( source.getNIT() );
+  setSDLayer( source.getSDLayer() );
+  setSDIPhi( source.getSDIPhi() );
+  setSDIT( source.getSDIT() );
+  setSDWeightedLayer( source.getSDWeightedLayer() );
+  setSDWeightedIPhi( source.getSDWeightedIPhi() );
+  setSDWeightedIT( source.getSDWeightedIT() );
+
+
+  for(int i=0; i<(int)source.getNhits(); i++){
+    LaserClusterHitInfo LCHI = source.getHit(i);
+    addHit(LCHI.hitsetkey, LCHI.hitkey, LCHI.adc);
+  }
+}
+

--- a/offline/packages/trackbase/LaserClusterv3.h
+++ b/offline/packages/trackbase/LaserClusterv3.h
@@ -1,0 +1,116 @@
+/**
+ * @file trackbase/LaserClusterv3.h
+ * @author Ben Kimelman
+ * @date July 2026
+ * @brief Version 3 of CMFLashCluster
+ */
+#ifndef TRACKBASE_LASERCLUSTERV3_H
+#define TRACKBASE_LASERCLUSTERV3_H
+
+#include "LaserCluster.h"
+
+#include <iostream>
+#include <vector>
+
+class PHObject;
+
+/**
+ * @brief Version 3 of LaserCluster
+ *
+ * Note - D. McGlinchey June 2018:
+ *   CINT does not like "override", so ignore where CINT
+ *   complains. Should be checked with ROOT 6 once
+ *   migration occurs.
+ */
+
+
+class LaserClusterv3 : public LaserCluster
+{
+ public:
+  //! ctor
+  LaserClusterv3() = default;
+
+  // PHObject virtual overloads
+  void Reset() override {}
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new LaserClusterv3(*this); }
+ 
+  //! copy content from base class
+  void CopyFrom( const LaserCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( LaserCluster* source ) override
+  { CopyFrom( *source ); }
+
+  bool getFitMode() const override { return m_fitMode; }
+  void setFitMode(bool fitMode) override { m_fitMode = fitMode; }
+
+  unsigned int getLayerInt() const override { return m_posHardware[0]; }
+  void setLayerInt(unsigned int layer) override { m_posHardware[0] = layer; }
+  unsigned int getIPhiInt() const override { return m_posHardware[1]; }
+  void setIPhiInt(unsigned int iphi) override { m_posHardware[1] = iphi; }
+  unsigned int getITInt() const override { return m_posHardware[2]; }
+  void setITInt(unsigned int it) override { m_posHardware[2] = it; }
+
+  unsigned int getNhits() const override {return (unsigned int)m_hits.size();}
+
+  //
+  // cluster info
+  //
+  unsigned int getAdc() const override;
+
+  void setNLayers(unsigned int nLayers) override { m_nLayers = nLayers; }
+  unsigned int getNLayers() const override { return m_nLayers; }
+
+  void setNIPhi(unsigned int nIPhi) override { m_nIPhi = nIPhi; }
+  unsigned int getNIPhi() const override { return m_nIPhi; }
+
+  void setNIT(unsigned int nIT) override { m_nIT = nIT; }
+  unsigned int getNIT() const override { return m_nIT; }
+
+  void setSDLayer(float SDLayer) override { m_SDLayer = SDLayer; }
+  float getSDLayer() const override { return m_SDLayer; }
+
+  void setSDIPhi(float SDIPhi) override { m_SDIPhi = SDIPhi; }
+  float getSDIPhi() const override { return m_SDIPhi; }
+
+  void setSDIT(float SDIT) override { m_SDIT = SDIT; }
+  float getSDIT() const override { return m_SDIT; }
+
+  void setSDWeightedLayer(float SDLayer) override { m_SDWeightedLayer = SDLayer; }
+  float getSDWeightedLayer() const override { return m_SDWeightedLayer; }
+
+  void setSDWeightedIPhi(float SDIPhi) override { m_SDWeightedIPhi = SDIPhi; }
+  float getSDWeightedIPhi() const override { return m_SDWeightedIPhi; }
+
+  void setSDWeightedIT(float SDIT) override { m_SDWeightedIT = SDIT; }
+  float getSDWeightedIT() const override { return m_SDWeightedIT; }
+
+  void addHit(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::hitkey hitkey, uint16_t adc) override { m_hits.push_back(LaserClusterHitInfo(hitsetkey, hitkey, adc)); };
+  LaserClusterHitInfo getHit(int hitIndex) const override { return m_hits[hitIndex]; };
+
+  void identify(std::ostream& os = std::cout) const override;
+
+ protected:
+
+  std::vector<LaserClusterHitInfo> m_hits;
+  
+  unsigned int m_posHardware[3] = {std::numeric_limits<unsigned int>::max(), std::numeric_limits<unsigned int>::max(), std::numeric_limits<unsigned int>::max()};
+  bool m_fitMode{false};
+
+  /// number of TPC clusters used to create this central mebrane cluster
+  unsigned int m_nhits = std::numeric_limits<unsigned int>::max();
+  unsigned int m_nLayers = std::numeric_limits<unsigned int>::max();
+  unsigned int m_nIPhi = std::numeric_limits<unsigned int>::max();
+  unsigned int m_nIT = std::numeric_limits<unsigned int>::max();
+  float m_SDLayer = std::numeric_limits<float>::quiet_NaN();
+  float m_SDIPhi = std::numeric_limits<float>::quiet_NaN();
+  float m_SDIT = std::numeric_limits<float>::quiet_NaN();
+  float m_SDWeightedLayer = std::numeric_limits<float>::quiet_NaN();
+  float m_SDWeightedIPhi = std::numeric_limits<float>::quiet_NaN();
+  float m_SDWeightedIT = std::numeric_limits<float>::quiet_NaN();
+
+  ClassDefOverride(LaserClusterv3, 1)
+};
+
+#endif //TRACKBASE_LASERCLUSTERV3_H

--- a/offline/packages/trackbase/LaserClusterv3LinkDef.h
+++ b/offline/packages/trackbase/LaserClusterv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class LaserClusterv3+;
+
+#endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -69,6 +69,7 @@ pkginclude_HEADERS = \
   LaserClusterContainerv1.h \
   LaserClusterv1.h \
   LaserClusterv2.h \
+  LaserClusterv3.h \
   MaterialWiper.h \
   MagneticFieldOptions.h \
   MvtxDefs.h \
@@ -151,6 +152,7 @@ ROOTDICTS = \
   LaserCluster_Dict.cc \
   LaserClusterv1_Dict.cc \
   LaserClusterv2_Dict.cc \
+  LaserClusterv3_Dict.cc \
   MvtxEventInfo_Dict.cc \
   MvtxEventInfov1_Dict.cc \
   MvtxEventInfov2_Dict.cc \
@@ -239,6 +241,7 @@ libtrack_io_la_SOURCES = \
   LaserClusterContainerv1.cc \
   LaserClusterv1.cc \
   LaserClusterv2.cc \
+  LaserClusterv3.cc \
   MvtxDefs.cc \
   MvtxEventInfo.cc \
   MvtxEventInfov1.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Makes new version of laser clusters that do not store cluster coordinates or hit coordinates, instead store hitsetkey, hitkey, and adc of each hit. This allows cluster to have alignment applied (done in new helper class) by applying transformations to each hit, then calculating the cluster centroid from the transformed hits. All pieces of code that use the laser clusters have been updated to use this change.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context
Update the laser-cluster data model and downstream QA/calibration/fitting so alignment/geometry-corrected **cluster centroids are derived from per-hit identifiers and ADC**, with geometry-aware hit transforms centralized in a helper. This improves consistency of coordinate construction across producers/consumers.

## Key Changes
- **New laser-cluster v3 hit-based payload**
  - Added `LaserClusterHitInfo { hitsetkey, hitkey, adc }` and ROOT/CINT dictionary support.
  - Extended `LaserCluster` with integer `layer/IPhi/IT` accessors and a new `addHit(hitsetkey, hitkey, adc)` / `getHit(i)` API (base returns NaN/“max” sentinels).
  - Introduced **`LaserClusterv3`** implementing per-hit storage, `getAdc()` (ADC sum), and copying/fit/metadata behavior.

- **Geometry-aware transformations + centroid calculation helper**
  - Added **`LaserClusterHelper`** with:
    - `loadNodes(PHCompositeNode*)`: grabs `ActsGeometry` and `PHG4TpcGeomContainer` from the node tree.
    - `set_useZ(bool)`: controls whether a Z estimate is computed; otherwise Z stays at **0** (commented as a temporary “hard code”).
    - `getHitGlobalPosition(hitsetkey, hitkey)`: builds an envelope position from geometry (`radius`, `phi`, and optional drift-based `env_z`), transforms it to world coordinates; returns an all-NaN vector if required geometry/data is missing.
    - `getClusterCentroid(LaserCluster*)`: computes an **ADC-weighted centroid**; skips hits with NaN global positions; returns NaN if the input cluster is null or if the ADC sum is `<= 0`.

- **Consumers updated to use helper-derived centroids / hit metadata**
  - **`TpcLaserQA`**:
    - Initializes helper via `set_useZ(m_useZ)` + `loadNodes(topNode)`.
    - For each hit: computes `hitGlobal` with `getHitGlobalPosition(...)`, skips NaN hits, derives `phi` from global `(x,y)` and sets `layer`, `hitAdc`, `hitIT` directly from hit keys/ADC (no longer from legacy per-hit coordinate getters).
  - **`TpcCentralMembraneMatching`**:
    - Uses `m_laserClusterHelper.getClusterCentroid(cmclus)` and skips clusters when centroid has NaNs.
    - Configures helper with `set_useZ(m_useZ)` + `loadNodes(topNode)`.
  - **`TpcLaminationFitting`**:
    - Uses `getClusterCentroid(cmclus)` and skips clusters with NaN centroids.
    - Adds/records a new `(phi, R)` **`clusterMap[side]`** histogram filled from centroid-derived `tmp_pos` and guarded by existing selection logic.
    - Configures helper with `set_useZ(m_useZ)` + `loadNodes(topNode)`.

- **Laser clustering producer switched to v3**
  - **`LaserClusterizer`**:
    - Switches to **`LaserClusterv3`** and rewrites `calc_cluster_parameter`.
    - Adds early exits for empty hit inputs and for clusters with `getNhits()==0`.
    - Populates clusters by calling `LaserClusterv3::addHit(hitsetkey, hitkey, adc)` and derives `(layer, iphi, it)` from hit keys via `TrkrDefs/TpcDefs`.
    - Updates statistics/sigma and histogram filling to iterate using `clus->getNhits()` / `clus->getHit(i)`.
    - Uses `pthread_mutex_t mythreadlock` for synchronized updates to shared per-thread containers/vectors and fitting histogram creation.

- **Build / linkage integration**
  - Added `LaserClusterHelper.{h,cc}` to the `offline/packages/tpc` build (header to `pkginclude_HEADERS`, source to `libtpc_la_SOURCES`).
  - Updated `offline/QA/Tpc/Makefile.am` to add `-lg4detectors_io` to `libtpcqa_la` link inputs.

## Potential Risk Areas
- **Reconstruction / calibration behavior changes**
  - Cluster positions now come from **ADC-weighted centroids of transformed hit positions**, with explicit NaN skipping and an ADC-sum validity check (`<= 0` → NaN centroid).
  - Z handling is mode-dependent: when `set_useZ(false)`, `env_z` stays at **0**; enabling Z uses drift-velocity/max-drift-length and `zcenter(it)`.

- **Edge-case robustness**
  - `LaserClusterizer` divides by `adcSum` when computing means/sigmas; if `adcSum` ends up as 0 (e.g., all hit ADCs are zero), this could cause invalid values unless upstream guarantees ADC > 0.

- **IO / schema compatibility**
  - Downstream expectations tied to the older stored cluster/hit coordinates may break because consumers now rely on hit keys and ADC (legacy `getX/getY/getZ` still return NaNs by default in the base `LaserCluster`).

- **Thread-safety / performance**
  - `LaserClusterHelper` stores geometry pointers set by `loadNodes()`; correctness depends on those pointers being available and stable during event processing.
  - Hit-level coordinate transforms (`getHitGlobalPosition`) are called per hit in QA and centroiding paths—this can increase CPU time.

## Possible Future Improvements
- Add explicit `adcSum > 0` guarding (or validation) inside `LaserClusterizer` before any division.
- Consider caching per-hit global positions within an event to reduce repeated `getHitGlobalPosition` calls (where safe).
- Add regression tests comparing v2 vs v3 centroid/fit outputs across both `set_useZ` modes, including NaN/ADC-sum edge cases.
- Document the intended semantics of the Z approximation (“hard code at 0” behavior) and when it’s expected to be enabled.

*Note: AI can make mistakes when inferring behavior from summaries—please verify the most consequential logic (centroid ADC-sum guards, NaN skipping, and the practical impact of `set_useZ`) against the full code and any QA plots.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->