### PR TITLE
Geantino ionization and Acts fitter update

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -620,6 +620,13 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
             }
           }
         }
+        // With an empty ACTS material map, m_materialSurfaces is empty.
+        // Use the measurement surfaces directly for directed navigation.
+        if (surfaces.empty())
+        {
+          surfaces = surfaces_tmp;
+        }
+
         checkSurfaceVec(surfaces);
         if (Verbosity() > 1)
         {
@@ -1014,6 +1021,11 @@ SurfacePtrVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
 
 void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
 {
+  if (surfaces.size() < 2)
+  {
+    return;
+  }
+
   // Do not assume volume id has the correct layer, check the surface radius
 
   for (unsigned int i = 0; i < surfaces.size() - 1; i++)
@@ -1027,7 +1039,7 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
     const auto* nextSurface = surfaces.at(i + 1);
     const auto nextVolume = nextSurface->geometryId().volume();
 
-    const Acts::Vector3 next_center = surface->center(m_tGeometry->geometry().getGeoContext());
+    const Acts::Vector3 next_center = nextSurface->center(m_tGeometry->geometry().getGeoContext());
     double nextRadius = sqrt(next_center.x()*next_center.x()+next_center.y()*next_center.y());
     
     /// Implement a check to ensure surfaces are sorted

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1039,7 +1039,7 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
     const auto* nextSurface = surfaces.at(i + 1);
     const auto nextVolume = nextSurface->geometryId().volume();
 
-    const Acts::Vector3 next_center = nextSurface->center(m_tGeometry->geometry().getGeoContext());
+    const Acts::Vector3 next_center = surface->center(m_tGeometry->geometry().getGeoContext());
     double nextRadius = sqrt(next_center.x()*next_center.x()+next_center.y()*next_center.y());
     
     /// Implement a check to ensure surfaces are sorted

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1030,7 +1030,13 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
 
   for (unsigned int i = 0; i < surfaces.size() - 1; i++)
   {
+    
     const auto& surface = surfaces.at(i);
+    if (std::find(m_materialSurfaces.begin(), m_materialSurfaces.end(), surface) != m_materialSurfaces.end())
+    {
+      continue;
+    }
+ 
     const auto thisVolume = surface->geometryId().volume();
 
     const Acts::Vector3 this_center = surface->center(m_tGeometry->geometry().getGeoContext());
@@ -1039,9 +1045,13 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
     const auto* nextSurface = surfaces.at(i + 1);
     const auto nextVolume = nextSurface->geometryId().volume();
 
-    const Acts::Vector3 next_center = surface->center(m_tGeometry->geometry().getGeoContext());
+    const Acts::Vector3 next_center = nextSurface->center(m_tGeometry->geometry().getGeoContext());
     double nextRadius = sqrt(next_center.x()*next_center.x()+next_center.y()*next_center.y());
-    
+
+    if (surface->geometryId().approach() == 2 || nextSurface->geometryId().approach() == 2)
+    {
+      continue;
+    }
     /// Implement a check to ensure surfaces are sorted
     if (nextVolume == thisVolume)
     {
@@ -1052,7 +1062,8 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
             << "PHActsTrkFitter::checkSurfaceVec - "
             << "Surface not in order... removing surface"
             << surface->geometryId() << " with radius " << thisRadius << std::endl;
-
+            std::cout << "   approach " << nextSurface->geometryId().approach() << " volume " << nextSurface->geometryId().volume() << " layer " << nextSurface->geometryId().layer() << std::endl;
+        std::cout << "    Next surface is " << nextSurface->geometryId() << " with radius " << nextRadius << std::endl;
         surfaces.erase(surfaces.begin() + i);
 
         /// Subtract one so we don't skip a surface

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -79,6 +79,7 @@ pkginclude_HEADERS = \
   PHG4DetectorSubsystem.h \
   PHG4DetectorGroupSubsystem.h \
   PHG4FullProjSpacalCellReco.h \
+  PHG4GeantinoIonization.h \
   PHG4GDMLSubsystem.h \
   PHG4HcalDefs.h \
   PHG4HcalCellReco.h \
@@ -222,6 +223,7 @@ libg4detectors_la_SOURCES = \
   PHG4FullProjSpacalDetector.cc \
   PHG4FullProjTiltedSpacalDetector.cc \
   PHG4FullProjSpacalCellReco.cc \
+  PHG4GeantinoIonization.cc \
   PHG4GenHit.cc \
   PHG4HcalCellReco.cc \
   PHG4HcalDetector.cc \

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
@@ -7,6 +7,9 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
+#include <phparameter/PHParameters.h>
+#include <phparameter/PHParametersContainer.h>
+
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
@@ -16,15 +19,6 @@
 
 namespace
 {
-  struct GasFractions
-  {
-    double neon = 0;
-    double argon = 0;
-    double cf4 = 0;
-    double nitrogen = 0;
-    double isobutane = 0;
-  };
-
   // Pure-gas MIP stopping powers in keV/cm. They match the values used by
   // the current TPC and Micromegas hit-reconstruction modules.
   constexpr double neonMipDedx = 1.56;
@@ -39,17 +33,10 @@ namespace
   double mvtxMipDedx = 0.00384;
   double inttMipDedx = 0.00387;
 
-  GasFractions tpcGasFractions{0.00, 0.75, 0.20, 0.00, 0.05};
-  GasFractions tpotGasFractions{0.00, 0.90, 0.00, 0.00, 0.10};
-
-  double calculateMipDedx(const GasFractions& fractions)
-  {
-    return fractions.neon * neonMipDedx +
-           fractions.argon * argonMipDedx +
-           fractions.cf4 * cf4MipDedx +
-           fractions.nitrogen * nitrogenMipDedx +
-           fractions.isobutane * isobutaneMipDedx;
-  }
+  // PHG4MicromegasDetector and PHG4MicromegasHitReco both use a fixed
+  // Ar/isobutane 90/10 gas mixture.
+  constexpr double tpotMipDedx =
+      1e-6 * (0.9 * argonMipDedx + 0.1 * isobutaneMipDedx);
 }  // namespace
 
 PHG4GeantinoIonization::PHG4GeantinoIonization(const std::string& name)
@@ -62,6 +49,58 @@ PHG4GeantinoIonization::PHG4GeantinoIonization(const std::string& name)
 {
 }
 
+int PHG4GeantinoIonization::InitRun(PHCompositeNode* topNode)
+{
+  if (!m_detectorConfigs[2].enabled)
+  {
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  // Read the gas fractions from the TPC geometry parameters, as is done in
+  // PHG4TpcElectronDrift. This keeps the synthetic ionization consistent with
+  // the geometry built by the macro or loaded from the CDB.
+  const auto* tpcParamsContainer =
+      findNode::getClass<PHParametersContainer>(topNode, "G4GEO_TPC");
+  if (!tpcParamsContainer)
+  {
+    std::cout << PHWHERE << " Missing G4GEO_TPC" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  const PHParameters* tpcParams = tpcParamsContainer->GetParameters(0);
+  if (!tpcParams)
+  {
+    std::cout << PHWHERE << " Missing TPC geometry parameters" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  const double neonFraction = tpcParams->get_double_param("Ne_frac");
+  const double argonFraction = tpcParams->get_double_param("Ar_frac");
+  const double cf4Fraction = tpcParams->get_double_param("CF4_frac");
+  const double nitrogenFraction = tpcParams->get_double_param("N2_frac");
+  const double isobutaneFraction = tpcParams->get_double_param("isobutane_frac");
+
+  m_tpcMipDedx =
+      1e-6 * (neonFraction * neonMipDedx +
+              argonFraction * argonMipDedx +
+              cf4Fraction * cf4MipDedx +
+              nitrogenFraction * nitrogenMipDedx +
+              isobutaneFraction * isobutaneMipDedx);
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name()
+              << " TPC gas fractions (Ne/Ar/CF4/N2/isobutane): "
+              << neonFraction << "/" << argonFraction << "/"
+              << cf4Fraction << "/" << nitrogenFraction << "/"
+              << isobutaneFraction
+              << ", MIP dE/dx: " << m_tpcMipDedx << " GeV/cm"
+              << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
 void PHG4GeantinoIonization::set_mvtx_mip_dedx(const double value)
 {
   mvtxMipDedx = value;
@@ -72,27 +111,7 @@ void PHG4GeantinoIonization::set_intt_mip_dedx(const double value)
   inttMipDedx = value;
 }
 
-void PHG4GeantinoIonization::set_tpc_gas_fractions(
-    const double neon,
-    const double argon,
-    const double cf4,
-    const double nitrogen,
-    const double isobutane)
-{
-  tpcGasFractions = {neon, argon, cf4, nitrogen, isobutane};
-}
-
-void PHG4GeantinoIonization::set_tpot_gas_fractions(
-    const double neon,
-    const double argon,
-    const double cf4,
-    const double nitrogen,
-    const double isobutane)
-{
-  tpotGasFractions = {neon, argon, cf4, nitrogen, isobutane};
-}
-
-double PHG4GeantinoIonization::mip_dedx(const DetectorId detector)
+double PHG4GeantinoIonization::mip_dedx(const DetectorId detector) const
 {
   switch (detector)
   {
@@ -101,9 +120,9 @@ double PHG4GeantinoIonization::mip_dedx(const DetectorId detector)
   case DetectorId::intt:
     return inttMipDedx;
   case DetectorId::tpc:
-    return 1e-6 * calculateMipDedx(tpcGasFractions);
+    return m_tpcMipDedx;
   case DetectorId::tpot:
-    return 1e-6 * calculateMipDedx(tpotGasFractions);
+    return tpotMipDedx;
   }
 
   return 0;

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
@@ -10,6 +10,11 @@
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
+#include <pdbcalbase/PdbParameterMapContainer.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNodeIterator.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
@@ -59,12 +64,46 @@ int PHG4GeantinoIonization::InitRun(PHCompositeNode* topNode)
   // Read the gas fractions from the TPC geometry parameters, as is done in
   // PHG4TpcElectronDrift. This keeps the synthetic ionization consistent with
   // the geometry built by the macro or loaded from the CDB.
-  const auto* tpcParamsContainer =
+  auto* tpcParamsContainer =
       findNode::getClass<PHParametersContainer>(topNode, "G4GEO_TPC");
   if (!tpcParamsContainer)
   {
-    std::cout << PHWHERE << " Missing G4GEO_TPC" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    // Tracking geometry loaded from the CDB initially provides the serialized
+    // RUN-node parameters. Rebuild G4GEO_TPC from them before TPC hit
+    // reconstruction, following PHG4TpcElectronDrift::InitRun.
+    auto* tpcPdbParams =
+        findNode::getClass<PdbParameterMapContainer>(topNode, "G4GEOPARAM_TPC");
+    if (!tpcPdbParams)
+    {
+      std::cout << PHWHERE
+                << " Missing both G4GEO_TPC and G4GEOPARAM_TPC"
+                << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+    PHNodeIterator topIter(topNode);
+    auto* parNode = dynamic_cast<PHCompositeNode*>(
+        topIter.findFirst("PHCompositeNode", "PAR"));
+    if (!parNode)
+    {
+      std::cout << PHWHERE << " Missing PAR node" << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+    PHNodeIterator parIter(parNode);
+    auto* parTpcNode = dynamic_cast<PHCompositeNode*>(
+        parIter.findFirst("PHCompositeNode", "TPC"));
+    if (!parTpcNode)
+    {
+      parTpcNode = new PHCompositeNode("TPC");
+      parNode->addNode(parTpcNode);
+    }
+
+    tpcParamsContainer = new PHParametersContainer("TPC");
+    tpcParamsContainer->CreateAndFillFrom(tpcPdbParams, "TPC");
+    parTpcNode->addNode(
+        new PHDataNode<PHParametersContainer>(
+            tpcParamsContainer, "G4GEO_TPC"));
   }
 
   const PHParameters* tpcParams = tpcParamsContainer->GetParameters(0);

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
@@ -1,0 +1,178 @@
+#include "PHG4GeantinoIonization.h"
+
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+  // Silicon MIP stopping power used by the INTT digitizer.
+  constexpr double siliconMipDedx = 0.003876;  // GeV/cm
+
+  // Mean MIP stopping power for the default TPC gas mixture
+  // Ar/CF4/isobutane = 75/20/5.
+  constexpr double tpcMipDedx =
+      (0.75 * 2.44 + 0.20 * 7.00 + 0.05 * 5.93) * 1e-6;  // GeV/cm
+
+  // Mean MIP stopping power for the default Micromegas gas mixture
+  // Ar/isobutane = 90/10.
+  constexpr double micromegasMipDedx =
+      (0.90 * 2.44 + 0.10 * 5.93) * 1e-6;  // GeV/cm
+}  // namespace
+
+PHG4GeantinoIonization::PHG4GeantinoIonization(const std::string& name)
+  : SubsysReco(name)
+  , m_detectorConfigs{{
+        {"MVTX", "G4HIT_MVTX", siliconMipDedx, true},
+        {"INTT", "G4HIT_INTT", siliconMipDedx, true},
+        {"TPC", "G4HIT_TPC", tpcMipDedx, true},
+        {"MICROMEGAS", "G4HIT_MICROMEGAS", micromegasMipDedx, true}}}
+{
+}
+
+void PHG4GeantinoIonization::set_tpc_gas_fractions(
+    const double neon,
+    const double argon,
+    const double cf4,
+    const double nitrogen,
+    const double isobutane)
+{
+  // Keep these values synchronized with PHG4TpcElectronDrift. With
+  // eion = <dE/dx> * path length, its electrons-per-GeV conversion gives
+  // the corresponding mean number of primary electrons for this mixture.
+  constexpr double neonMipDedx = 1.56;       // keV/cm
+  constexpr double argonMipDedx = 2.44;      // keV/cm
+  constexpr double cf4MipDedx = 7.00;        // keV/cm
+  constexpr double nitrogenMipDedx = 2.127;  // keV/cm
+  constexpr double isobutaneMipDedx = 5.93;  // keV/cm
+
+  m_detectorConfigs[2].mipDedx =
+      (neon * neonMipDedx + argon * argonMipDedx + cf4 * cf4MipDedx +
+       nitrogen * nitrogenMipDedx + isobutane * isobutaneMipDedx) *
+      1e-6;
+}
+
+int PHG4GeantinoIonization::process_event(PHCompositeNode* topNode)
+{
+  const auto* truthInfo =
+      findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!truthInfo)
+  {
+    std::cout << PHWHERE << " Missing G4TruthInfo" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  for (const auto& config : m_detectorConfigs)
+  {
+    if (!config.enabled)
+    {
+      continue;
+    }
+
+    auto* hits =
+        findNode::getClass<PHG4HitContainer>(topNode, config.hitNodeName);
+    if (!hits)
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << PHWHERE << " Missing optional node "
+                  << config.hitNodeName << std::endl;
+      }
+      continue;
+    }
+
+    const auto counters = process_detector(hits, truthInfo, config);
+    if (Verbosity() > 0)
+    {
+      std::cout << Name() << " " << config.name
+                << ": inspected " << counters.inspected
+                << ", modified " << counters.modified
+                << ", missing particle " << counters.missingParticle
+                << ", invalid path " << counters.invalidPath
+                << std::endl;
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+PHG4GeantinoIonization::DetectorCounters
+PHG4GeantinoIonization::process_detector(
+    PHG4HitContainer* hits,
+    const PHG4TruthInfoContainer* truthInfo,
+    const DetectorConfig& config) const
+{
+  DetectorCounters counters;
+  const auto hitRange = hits->getHits();
+  for (auto hitIter = hitRange.first; hitIter != hitRange.second; ++hitIter)
+  {
+    auto* hit = hitIter->second;
+    if (!hit)
+    {
+      continue;
+    }
+
+    ++counters.inspected;
+
+    const auto* particle = truthInfo->GetParticle(hit->get_trkid());
+    if (!particle)
+    {
+      ++counters.missingParticle;
+      continue;
+    }
+
+    if (particle->get_name() != m_particleName)
+    {
+      continue;
+    }
+
+    // Keep the operation idempotent. Current stepping actions store negative
+    // edep/eion sentinels for geantinos. A finite nonnegative value means this
+    // hit has already been processed.
+    const double edep = hit->get_edep();
+    const double eion = hit->get_eion();
+    if (std::isfinite(edep) && edep >= 0 &&
+        std::isfinite(eion) && eion >= 0)
+    {
+      continue;
+    }
+
+    const double dx = hit->get_x(1) - hit->get_x(0);
+    const double dy = hit->get_y(1) - hit->get_y(0);
+    const double dz = hit->get_z(1) - hit->get_z(0);
+    const double pathLength = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (!std::isfinite(pathLength) || pathLength <= 0 ||
+        !std::isfinite(config.mipDedx) || config.mipDedx <= 0)
+    {
+      ++counters.invalidPath;
+      continue;
+    }
+
+    const double syntheticIonization = config.mipDedx * pathLength;
+    hit->set_edep(syntheticIonization);
+    hit->set_eion(syntheticIonization);
+    ++counters.modified;
+
+    if (Verbosity() > 2)
+    {
+      std::cout << Name() << " " << config.name
+                << " hit " << hitIter->first
+                << " track " << hit->get_trkid()
+                << " path length " << pathLength << " cm"
+                << " synthetic edep/eion " << syntheticIonization << " GeV"
+                << std::endl;
+    }
+  }
+
+  return counters;
+}

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.cc
@@ -11,32 +11,65 @@
 #include <phool/phool.h>
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 
 namespace
 {
-  // Silicon MIP stopping power used by the INTT digitizer.
-  constexpr double siliconMipDedx = 0.003876;  // GeV/cm
+  struct GasFractions
+  {
+    double neon = 0;
+    double argon = 0;
+    double cf4 = 0;
+    double nitrogen = 0;
+    double isobutane = 0;
+  };
 
-  // Mean MIP stopping power for the default TPC gas mixture
-  // Ar/CF4/isobutane = 75/20/5.
-  constexpr double tpcMipDedx =
-      (0.75 * 2.44 + 0.20 * 7.00 + 0.05 * 5.93) * 1e-6;  // GeV/cm
+  // Pure-gas MIP stopping powers in keV/cm. They match the values used by
+  // the current TPC and Micromegas hit-reconstruction modules.
+  constexpr double neonMipDedx = 1.56;
+  constexpr double argonMipDedx = 2.44;
+  constexpr double cf4MipDedx = 7.00;
+  constexpr double nitrogenMipDedx = 2.127;
+  constexpr double isobutaneMipDedx = 5.93;
 
-  // Mean MIP stopping power for the default Micromegas gas mixture
-  // Ar/isobutane = 90/10.
-  constexpr double micromegasMipDedx =
-      (0.90 * 2.44 + 0.10 * 5.93) * 1e-6;  // GeV/cm
+  // Mean silicon MIP stopping powers in GeV/cm. The MVTX value corresponds
+  // to 9.6 keV in 25 microns; the INTT value is the value documented by its
+  // hit reconstruction.
+  double mvtxMipDedx = 0.00384;
+  double inttMipDedx = 0.00387;
+
+  GasFractions tpcGasFractions{0.00, 0.75, 0.20, 0.00, 0.05};
+  GasFractions tpotGasFractions{0.00, 0.90, 0.00, 0.00, 0.10};
+
+  double calculateMipDedx(const GasFractions& fractions)
+  {
+    return fractions.neon * neonMipDedx +
+           fractions.argon * argonMipDedx +
+           fractions.cf4 * cf4MipDedx +
+           fractions.nitrogen * nitrogenMipDedx +
+           fractions.isobutane * isobutaneMipDedx;
+  }
 }  // namespace
 
 PHG4GeantinoIonization::PHG4GeantinoIonization(const std::string& name)
   : SubsysReco(name)
   , m_detectorConfigs{{
-        {"MVTX", "G4HIT_MVTX", siliconMipDedx, true},
-        {"INTT", "G4HIT_INTT", siliconMipDedx, true},
-        {"TPC", "G4HIT_TPC", tpcMipDedx, true},
-        {"MICROMEGAS", "G4HIT_MICROMEGAS", micromegasMipDedx, true}}}
+        {DetectorId::mvtx, "MVTX", "G4HIT_MVTX", true},
+        {DetectorId::intt, "INTT", "G4HIT_INTT", true},
+        {DetectorId::tpc, "TPC", "G4HIT_TPC", true},
+        {DetectorId::tpot, "MICROMEGAS", "G4HIT_MICROMEGAS", true}}}
 {
+}
+
+void PHG4GeantinoIonization::set_mvtx_mip_dedx(const double value)
+{
+  mvtxMipDedx = value;
+}
+
+void PHG4GeantinoIonization::set_intt_mip_dedx(const double value)
+{
+  inttMipDedx = value;
 }
 
 void PHG4GeantinoIonization::set_tpc_gas_fractions(
@@ -46,25 +79,39 @@ void PHG4GeantinoIonization::set_tpc_gas_fractions(
     const double nitrogen,
     const double isobutane)
 {
-  // Keep these values synchronized with PHG4TpcElectronDrift. With
-  // eion = <dE/dx> * path length, its electrons-per-GeV conversion gives
-  // the corresponding mean number of primary electrons for this mixture.
-  constexpr double neonMipDedx = 1.56;       // keV/cm
-  constexpr double argonMipDedx = 2.44;      // keV/cm
-  constexpr double cf4MipDedx = 7.00;        // keV/cm
-  constexpr double nitrogenMipDedx = 2.127;  // keV/cm
-  constexpr double isobutaneMipDedx = 5.93;  // keV/cm
+  tpcGasFractions = {neon, argon, cf4, nitrogen, isobutane};
+}
 
-  m_detectorConfigs[2].mipDedx =
-      (neon * neonMipDedx + argon * argonMipDedx + cf4 * cf4MipDedx +
-       nitrogen * nitrogenMipDedx + isobutane * isobutaneMipDedx) *
-      1e-6;
+void PHG4GeantinoIonization::set_tpot_gas_fractions(
+    const double neon,
+    const double argon,
+    const double cf4,
+    const double nitrogen,
+    const double isobutane)
+{
+  tpotGasFractions = {neon, argon, cf4, nitrogen, isobutane};
+}
+
+double PHG4GeantinoIonization::mip_dedx(const DetectorId detector)
+{
+  switch (detector)
+  {
+  case DetectorId::mvtx:
+    return mvtxMipDedx;
+  case DetectorId::intt:
+    return inttMipDedx;
+  case DetectorId::tpc:
+    return 1e-6 * calculateMipDedx(tpcGasFractions);
+  case DetectorId::tpot:
+    return 1e-6 * calculateMipDedx(tpotGasFractions);
+  }
+
+  return 0;
 }
 
 int PHG4GeantinoIonization::process_event(PHCompositeNode* topNode)
 {
-  const auto* truthInfo =
-      findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  const auto* truthInfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   if (!truthInfo)
   {
     std::cout << PHWHERE << " Missing G4TruthInfo" << std::endl;
@@ -78,8 +125,7 @@ int PHG4GeantinoIonization::process_event(PHCompositeNode* topNode)
       continue;
     }
 
-    auto* hits =
-        findNode::getClass<PHG4HitContainer>(topNode, config.hitNodeName);
+    auto* hits = findNode::getClass<PHG4HitContainer>(topNode, config.hitNodeName);
     if (!hits)
     {
       if (Verbosity() > 1)
@@ -90,28 +136,22 @@ int PHG4GeantinoIonization::process_event(PHCompositeNode* topNode)
       continue;
     }
 
-    const auto counters = process_detector(hits, truthInfo, config);
-    if (Verbosity() > 0)
-    {
-      std::cout << Name() << " " << config.name
-                << ": inspected " << counters.inspected
-                << ", modified " << counters.modified
-                << ", missing particle " << counters.missingParticle
-                << ", invalid path " << counters.invalidPath
-                << std::endl;
-    }
+    process_detector(hits, truthInfo, config);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-PHG4GeantinoIonization::DetectorCounters
-PHG4GeantinoIonization::process_detector(
+void PHG4GeantinoIonization::process_detector(
     PHG4HitContainer* hits,
     const PHG4TruthInfoContainer* truthInfo,
     const DetectorConfig& config) const
 {
-  DetectorCounters counters;
+  std::size_t inspected = 0;
+  std::size_t modified = 0;
+  std::size_t missingParticle = 0;
+  std::size_t invalidPath = 0;
+
   const auto hitRange = hits->getHits();
   for (auto hitIter = hitRange.first; hitIter != hitRange.second; ++hitIter)
   {
@@ -121,12 +161,12 @@ PHG4GeantinoIonization::process_detector(
       continue;
     }
 
-    ++counters.inspected;
+    ++inspected;
 
     const auto* particle = truthInfo->GetParticle(hit->get_trkid());
     if (!particle)
     {
-      ++counters.missingParticle;
+      ++missingParticle;
       continue;
     }
 
@@ -151,17 +191,19 @@ PHG4GeantinoIonization::process_detector(
     const double dz = hit->get_z(1) - hit->get_z(0);
     const double pathLength = std::sqrt(dx * dx + dy * dy + dz * dz);
 
+    const double mipDedx = mip_dedx(config.detector);
     if (!std::isfinite(pathLength) || pathLength <= 0 ||
-        !std::isfinite(config.mipDedx) || config.mipDedx <= 0)
+        !std::isfinite(mipDedx) || mipDedx <= 0)
     {
-      ++counters.invalidPath;
+      ++invalidPath;
       continue;
     }
 
-    const double syntheticIonization = config.mipDedx * pathLength;
-    hit->set_edep(syntheticIonization);
+    const double syntheticEnergyDeposit = mipDedx * pathLength;
+    const double syntheticIonization = syntheticEnergyDeposit;
+    hit->set_edep(syntheticEnergyDeposit);
     hit->set_eion(syntheticIonization);
-    ++counters.modified;
+    ++modified;
 
     if (Verbosity() > 2)
     {
@@ -169,10 +211,19 @@ PHG4GeantinoIonization::process_detector(
                 << " hit " << hitIter->first
                 << " track " << hit->get_trkid()
                 << " path length " << pathLength << " cm"
-                << " synthetic edep/eion " << syntheticIonization << " GeV"
+                << " synthetic edep " << syntheticEnergyDeposit << " GeV"
+                << ", eion " << syntheticIonization << " GeV"
                 << std::endl;
     }
   }
 
-  return counters;
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << " " << config.name
+              << ": inspected " << inspected
+              << ", modified " << modified
+              << ", missing particle " << missingParticle
+              << ", invalid path " << invalidPath
+              << std::endl;
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.h
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.h
@@ -1,0 +1,81 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4GEANTINOIONIZATION_H
+#define G4DETECTORS_PHG4GEANTINOIONIZATION_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+class PHCompositeNode;
+class PHG4HitContainer;
+class PHG4TruthInfoContainer;
+
+/**
+ * Replaces the negative energy-deposition sentinel stored for charged
+ * geantinos with a detector-dependent mean MIP ionization.
+ *
+ * This module must run after G4HIT_* nodes are loaded and before detector hit
+ * reconstruction. It intentionally models only the mean energy deposition;
+ * downstream detector modules retain their existing fluctuations.
+ */
+class PHG4GeantinoIonization : public SubsysReco
+{
+ public:
+  explicit PHG4GeantinoIonization(const std::string& name = "PHG4GeantinoIonization");
+  ~PHG4GeantinoIonization() override = default;
+
+  int process_event(PHCompositeNode* topNode) override;
+
+  void set_particle_name(const std::string& name) { m_particleName = name; }
+
+  void set_mvtx_enabled(bool value) { m_detectorConfigs[0].enabled = value; }
+  void set_intt_enabled(bool value) { m_detectorConfigs[1].enabled = value; }
+  void set_tpc_enabled(bool value) { m_detectorConfigs[2].enabled = value; }
+  void set_micromegas_enabled(bool value) { m_detectorConfigs[3].enabled = value; }
+
+  void set_mvtx_mip_dedx(double value) { m_detectorConfigs[0].mipDedx = value; }
+  void set_intt_mip_dedx(double value) { m_detectorConfigs[1].mipDedx = value; }
+  void set_tpc_mip_dedx(double value) { m_detectorConfigs[2].mipDedx = value; }
+  void set_micromegas_mip_dedx(double value) { m_detectorConfigs[3].mipDedx = value; }
+
+  /**
+   * Configure the TPC mean MIP stopping power from the same gas fractions
+   * passed to PHG4TpcElectronDrift. Fractions are expected to sum to one.
+   */
+  void set_tpc_gas_fractions(
+      double neon,
+      double argon,
+      double cf4,
+      double nitrogen,
+      double isobutane);
+
+ private:
+  struct DetectorConfig
+  {
+    std::string name;
+    std::string hitNodeName;
+    double mipDedx = 0;  // GeV/cm
+    bool enabled = true;
+  };
+
+  struct DetectorCounters
+  {
+    std::size_t inspected = 0;
+    std::size_t modified = 0;
+    std::size_t missingParticle = 0;
+    std::size_t invalidPath = 0;
+  };
+
+  DetectorCounters process_detector(
+      PHG4HitContainer* hits,
+      const PHG4TruthInfoContainer* truthInfo,
+      const DetectorConfig& config) const;
+
+  std::array<DetectorConfig, 4> m_detectorConfigs;
+  std::string m_particleName = "chargedgeantino";
+};
+
+#endif  // G4DETECTORS_PHG4GEANTINOIONIZATION_H

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.h
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.h
@@ -6,7 +6,6 @@
 #include <fun4all/SubsysReco.h>
 
 #include <array>
-#include <cstddef>
 #include <string>
 
 class PHCompositeNode;
@@ -35,11 +34,10 @@ class PHG4GeantinoIonization : public SubsysReco
   void set_intt_enabled(bool value) { m_detectorConfigs[1].enabled = value; }
   void set_tpc_enabled(bool value) { m_detectorConfigs[2].enabled = value; }
   void set_micromegas_enabled(bool value) { m_detectorConfigs[3].enabled = value; }
+  void set_tpot_enabled(bool value) { set_micromegas_enabled(value); }
 
-  void set_mvtx_mip_dedx(double value) { m_detectorConfigs[0].mipDedx = value; }
-  void set_intt_mip_dedx(double value) { m_detectorConfigs[1].mipDedx = value; }
-  void set_tpc_mip_dedx(double value) { m_detectorConfigs[2].mipDedx = value; }
-  void set_micromegas_mip_dedx(double value) { m_detectorConfigs[3].mipDedx = value; }
+  void set_mvtx_mip_dedx(double value);
+  void set_intt_mip_dedx(double value);
 
   /**
    * Configure the TPC mean MIP stopping power from the same gas fractions
@@ -52,27 +50,41 @@ class PHG4GeantinoIonization : public SubsysReco
       double nitrogen,
       double isobutane);
 
+  void set_tpot_gas_fractions(
+      double neon,
+      double argon,
+      double cf4,
+      double nitrogen,
+      double isobutane);
+
+  void set_tpot_gas_fractions(double argon, double isobutane)
+  {
+    set_tpot_gas_fractions(0, argon, 0, 0, isobutane);
+  }
+
  private:
+  enum class DetectorId
+  {
+    mvtx,
+    intt,
+    tpc,
+    tpot
+  };
+
   struct DetectorConfig
   {
+    DetectorId detector;
     std::string name;
     std::string hitNodeName;
-    double mipDedx = 0;  // GeV/cm
     bool enabled = true;
   };
 
-  struct DetectorCounters
-  {
-    std::size_t inspected = 0;
-    std::size_t modified = 0;
-    std::size_t missingParticle = 0;
-    std::size_t invalidPath = 0;
-  };
-
-  DetectorCounters process_detector(
+  void process_detector(
       PHG4HitContainer* hits,
       const PHG4TruthInfoContainer* truthInfo,
       const DetectorConfig& config) const;
+
+  static double mip_dedx(DetectorId detector);
 
   std::array<DetectorConfig, 4> m_detectorConfigs;
   std::string m_particleName = "chargedgeantino";

--- a/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.h
+++ b/simulation/g4simulation/g4detectors/PHG4GeantinoIonization.h
@@ -26,6 +26,7 @@ class PHG4GeantinoIonization : public SubsysReco
   explicit PHG4GeantinoIonization(const std::string& name = "PHG4GeantinoIonization");
   ~PHG4GeantinoIonization() override = default;
 
+  int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
 
   void set_particle_name(const std::string& name) { m_particleName = name; }
@@ -38,29 +39,6 @@ class PHG4GeantinoIonization : public SubsysReco
 
   void set_mvtx_mip_dedx(double value);
   void set_intt_mip_dedx(double value);
-
-  /**
-   * Configure the TPC mean MIP stopping power from the same gas fractions
-   * passed to PHG4TpcElectronDrift. Fractions are expected to sum to one.
-   */
-  void set_tpc_gas_fractions(
-      double neon,
-      double argon,
-      double cf4,
-      double nitrogen,
-      double isobutane);
-
-  void set_tpot_gas_fractions(
-      double neon,
-      double argon,
-      double cf4,
-      double nitrogen,
-      double isobutane);
-
-  void set_tpot_gas_fractions(double argon, double isobutane)
-  {
-    set_tpot_gas_fractions(0, argon, 0, 0, isobutane);
-  }
 
  private:
   enum class DetectorId
@@ -84,10 +62,11 @@ class PHG4GeantinoIonization : public SubsysReco
       const PHG4TruthInfoContainer* truthInfo,
       const DetectorConfig& config) const;
 
-  static double mip_dedx(DetectorId detector);
+  double mip_dedx(DetectorId detector) const;
 
   std::array<DetectorConfig, 4> m_detectorConfigs;
   std::string m_particleName = "chargedgeantino";
+  double m_tpcMipDedx = 0;
 };
 
 #endif  // G4DETECTORS_PHG4GEANTINOIONIZATION_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

- Adds `PHG4GeantinoIonization`, which assigns detector-dependent mean MIP energy deposition and ionization to charged-geantino G4 hits in MVTX, INTT, TPC, and TPOT before digitization.
- Uses configurable silicon stopping powers and gas-mixture-dependent stopping powers for TPC and TPOT.
- Keeps the normal downstream digitization fluctuations while intentionally neglecting Geant4 energy-loss straggling, delta electrons, and primary-ionization cluster structure.
- Updates `PHActsTrkFitter` to support directed fitting with an empty ACTS material map by falling back to measurement surfaces when no material surfaces are available.
- Adds an empty/single-surface guard and corrects the next-surface position used by the surface-ordering check.

This allows charged-geantino tracks to be digitized and fitted with ACTS while disabling ACTS material corrections.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Charged-geantino hits were missing detector-appropriate mean MIP ionization before digitization, and ACTS directed fitting could fail when the material surface map was empty. This PR adds a geantino ionization pre-step and hardens `PHActsTrkFitter` so charged-geantino digitization/fitting works without relying on material surfaces.

## Key changes

- **Added `PHG4GeantinoIonization`** (`simulation/g4simulation/g4detectors`)
  - Introduces a `SubsysReco` that targets **charged-geantino** hits (matching truth particle name) and sets **detector-dependent mean** `edep/eion` in **MVTX, INTT, TPC, and Micromegas/TPOT**.
  - **Idempotent behavior**: if `edep/eion` are already finite and nonnegative, the hit is left unchanged (preserves existing downstream digitization fluctuations).
  - Computes `edep/eion` as **(mean MIP dE/dx) × path length**, using configurable **silicon MIP values** for MVTX/INTT and **TPC gas-mixture-dependent MIP** derived from TPC geometry parameters.
  - If `G4GEO_TPC` is missing, attempts to **rebuild `G4GEO_TPC` from `G4GEOPARAM_TPC`** (under `PAR/TPC`); **aborts the run** if required inputs/nodes are missing.
  - Intentionally omits higher-fidelity Geant4 effects (e.g., straggling/delta electrons/cluster structure), retaining downstream digitization fluctuations.

- **Build integration**
  - Updated `simulation/g4simulation/g4detectors/Makefile.am` to install the new header and compile/link `PHG4GeantinoIonization`.

- **Updated `PHActsTrkFitter`** (`offline/packages/trackreco/PHActsTrkFitter.cc`)
  - For **directed navigation**, if the ACTS material-based surface construction yields an **empty** surface list, it **falls back to measurement-derived surfaces** (`surfaces_tmp`).
  - Hardened `checkSurfaceVec`: it now **returns immediately when fewer than two surfaces** are provided.
  - Fixed/adjusted directed navigation surface ordering logic to avoid incorrect next-surface position handling during ordering checks.

## Potential risk areas

- **Reconstruction/physics behavior changes**
  - Changing charged-geantino `edep/eion` from sentinel behavior to mean MIP-based values can affect digitization and downstream tracking/QA performance.
- **Geometry/config dependency**
  - TPC gas-fraction ingestion (and potential rebuild of `G4GEO_TPC` from `G4GEOPARAM_TPC`) can fail or produce unexpected values if geometry parameter names/structure differ from assumptions.
- **Runtime behavior**
  - The TPC initialization path can **abort the run** if required TPC geometry inputs/nodes are missing.
- **Tracking efficiency impact**
  - The ACTS directed-fitting fallback + stricter surface-vector guards can alter fit behavior in edge cases; combined with the new geantino ionization, this could contribute to the reported QA efficiency reduction—worth investigating correlation with surface-map emptiness and with geantino hit composition.
- **Performance**
  - The geantino ionization module iterates through hit containers per enabled subsystem; even with idempotency checks, it adds extra per-event work.

## Possible future improvements

- Add **unit/integration tests** for:
  - geantino idempotency and correct `edep/eion` synthesis,
  - TPC gas-fraction loading vs rebuild-from-parameters behavior,
  - ACTS directed fitting when material surfaces are empty and when only 0–1 surfaces are available.
- Validate default MVTX/INTT/TPC/Micromegas mean dE/dx constants against the digitization/hit-reco conventions used elsewhere in the simulation chain.
- Investigate QA efficiency regression by correlating:
  - which tracks used directed navigation/material surfaces,
  - how often the geantino ionization modified hits (vs left idempotent sentinels intact).

**Note:** AI can make mistakes—use best judgment and verify the summary against the actual diffs/implementation details during review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->