### PR TITLE
updated MB classifier for O+O and species dependence

### DIFF
--- a/offline/packages/centrality/CentralityInfov2.cc
+++ b/offline/packages/centrality/CentralityInfov2.cc
@@ -11,6 +11,12 @@ void CentralityInfov2::identify(std::ostream &os) const
   return;
 }
 
+void CentralityInfov2::Reset()
+{
+  CentralityInfov1::Reset();
+  _centrality_bin_map.clear();
+}
+
 bool CentralityInfov2::has_centrality_bin(const PROP prop_id) const
 {
   return _centrality_bin_map.contains(prop_id);

--- a/offline/packages/centrality/CentralityInfov2.h
+++ b/offline/packages/centrality/CentralityInfov2.h
@@ -13,7 +13,7 @@ class CentralityInfov2 : public CentralityInfov1
   ~CentralityInfov2() override = default;
 
   void identify(std::ostream &os = std::cout) const override;
-  void Reset() override {}
+  void Reset() override;
 
   PHObject* CloneMe() const override { return new CentralityInfov2(*this); }
   void CopyTo(CentralityInfo *info) override;

--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -258,10 +258,13 @@ int CentralityReco::process_event(PHCompositeNode *topNode)
   }
 
   // Get Nodes from the Tree
-  if (GetNodes(topNode))
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
   {
-    return Fun4AllReturnCodes::ABORTRUN;
+    return ret;
   }
+
+  m_central->Reset();
 
   if (!m_mb_info->isAuAuMinimumBias())
   {

--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -264,8 +264,6 @@ int CentralityReco::process_event(PHCompositeNode *topNode)
     return ret;
   }
 
-  m_central->Reset();
-
   if (!m_mb_info->isAuAuMinimumBias())
   {
     return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trigger/MinimumBiasClassifier.cc
+++ b/offline/packages/trigger/MinimumBiasClassifier.cc
@@ -42,44 +42,24 @@ int MinimumBiasClassifier::InitRun(PHCompositeNode *topNode)
     std::cout << __FILE__ << " :: " << __FUNCTION__ << std::endl;
   }
 
-  if (m_species == MinimumBiasInfo::SPECIES::AUAU)
-  {
-    m_useZDC          = true;
-    m_box_cut         = true;
-    m_hit_cut         = 2;
-    m_max_charge_cut  = 2100;
-    m_mbd_charge_cut  = 0.5;
-    m_mbd_time_cut    = 25.;
-    m_z_vtx_cut       = 60.;
-    m_mbd_north_cut   = 10.;
-    m_mbd_south_cut   = 150.;
-    m_zdc_cut         = 60.;
-  }
   if (m_species == MinimumBiasInfo::SPECIES::OO)
   {
-    m_useZDC          = false;
-    m_box_cut         = false;
-    m_hit_cut         = 1;
-    m_max_charge_cut  = 400;
-    m_mbd_charge_cut  = 0.4;
-    m_mbd_time_cut    = 20.;
-    m_z_vtx_cut       = 150.;
-    m_mbd_north_cut   = 10.;
-    m_mbd_south_cut   = 150.;
-    m_zdc_cut         = 60.;
+    m_useZDC         = false;
+    m_box_cut        = false;
+    m_hit_cut        = 1;
+    m_max_charge_cut = 400;
+    m_mbd_charge_cut = 0.4;
+    m_mbd_time_cut   = 20.;
+    m_z_vtx_cut      = 150.;
   }
-  if (m_species == MinimumBiasInfo::SPECIES::PP)
+  else if (m_species == MinimumBiasInfo::SPECIES::PP)
   {
-    m_useZDC          = false;
-    m_box_cut         = false;
-    m_hit_cut         = 1;
-    m_max_charge_cut  = 300;
-    m_mbd_charge_cut  = 0.4;
-    m_mbd_time_cut    = 20.;
-    m_z_vtx_cut       = 60.;
-    m_mbd_north_cut   = 10.;
-    m_mbd_south_cut   = 150.;
-    m_zdc_cut         = 60.;
+    m_useZDC         = false;
+    m_box_cut        = false;
+    m_hit_cut        = 1;
+    m_max_charge_cut = 300;
+    m_mbd_charge_cut = 0.4;
+    m_mbd_time_cut   = 20.;
   }
 
   CDBInterface *m_cdb = CDBInterface::instance();
@@ -289,9 +269,10 @@ int MinimumBiasClassifier::process_event(PHCompositeNode *topNode)
   }
 
   // Get Nodes from the Tree
-  if (GetNodes(topNode))
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
   {
-    return Fun4AllReturnCodes::EVENT_OK;
+    return ret;
   }
 
   if (FillMinimumBiasInfo())
@@ -376,7 +357,6 @@ void MinimumBiasClassifier::CreateNodes(PHCompositeNode *topNode)
   PHCompositeNode *detNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", "GLOBAL"));
   if (!detNode)
   {
-    std::cout << PHWHERE << "Detector Node missing, making one" << std::endl;
     detNode = new PHCompositeNode("GLOBAL");
     dstNode->addNode(detNode);
   }

--- a/offline/packages/trigger/MinimumBiasClassifier.cc
+++ b/offline/packages/trigger/MinimumBiasClassifier.cc
@@ -44,24 +44,42 @@ int MinimumBiasClassifier::InitRun(PHCompositeNode *topNode)
 
   if (m_species == MinimumBiasInfo::SPECIES::AUAU)
   {
-    m_useZDC = true;
-    m_max_charge_cut = 2100;
-    m_box_cut = true;
-    m_hit_cut = 2;
+    m_useZDC          = true;
+    m_box_cut         = true;
+    m_hit_cut         = 2;
+    m_max_charge_cut  = 2100;
+    m_mbd_charge_cut  = 0.5;
+    m_mbd_time_cut    = 25.;
+    m_z_vtx_cut       = 60.;
+    m_mbd_north_cut   = 10.;
+    m_mbd_south_cut   = 150.;
+    m_zdc_cut         = 60.;
   }
   if (m_species == MinimumBiasInfo::SPECIES::OO)
   {
-    m_useZDC = false;
-    m_max_charge_cut = 300;
-    m_box_cut = false;
-    m_hit_cut = 1;
+    m_useZDC          = false;
+    m_box_cut         = false;
+    m_hit_cut         = 1;
+    m_max_charge_cut  = 400;
+    m_mbd_charge_cut  = 0.4;
+    m_mbd_time_cut    = 20.;
+    m_z_vtx_cut       = 150.;
+    m_mbd_north_cut   = 10.;
+    m_mbd_south_cut   = 150.;
+    m_zdc_cut         = 60.;
   }
   if (m_species == MinimumBiasInfo::SPECIES::PP)
   {
-    m_useZDC = false;
-    m_max_charge_cut = 300;
-    m_box_cut = false;
-    m_hit_cut = 1;
+    m_useZDC          = false;
+    m_box_cut         = false;
+    m_hit_cut         = 1;
+    m_max_charge_cut  = 300;
+    m_mbd_charge_cut  = 0.4;
+    m_mbd_time_cut    = 20.;
+    m_z_vtx_cut       = 60.;
+    m_mbd_north_cut   = 10.;
+    m_mbd_south_cut   = 150.;
+    m_zdc_cut         = 60.;
   }
 
   CDBInterface *m_cdb = CDBInterface::instance();
@@ -248,6 +266,11 @@ int MinimumBiasClassifier::FillMinimumBiasInfo()
     minbiascheck = false;
     // m_mb_info->setIsAuAuMinimumBias(false);
     // return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  if (m_species == MinimumBiasInfo::SPECIES::OO && m_reject_pileup && (m_mbd_charge_sum[0] + m_mbd_charge_sum[1]) > m_pileup_charge_cut && minbiascheck)
+  {
+    minbiascheck = false;
   }
 
   m_mb_info->setIsAuAuMinimumBias(minbiascheck);

--- a/offline/packages/trigger/MinimumBiasClassifier.h
+++ b/offline/packages/trigger/MinimumBiasClassifier.h
@@ -59,6 +59,8 @@ class MinimumBiasClassifier : public SubsysReco
 
   void setSpecies(MinimumBiasInfo::SPECIES spec) { m_species = spec; };
 
+  void setRejectPileup(bool v) { m_reject_pileup = v; };
+
   void abortEvents(const bool abort) { m_abortEvents = abort; };
 
   void set_minbiasNodeName(const std::string &name)
@@ -91,6 +93,9 @@ class MinimumBiasClassifier : public SubsysReco
   bool m_issim{false};
   bool m_useZDC{true};
   bool m_box_cut{true};
+  bool m_reject_pileup{true};
+
+  float m_pileup_charge_cut{200.};
 
   int m_hit_cut{2};
 
@@ -100,13 +105,13 @@ class MinimumBiasClassifier : public SubsysReco
 
   float m_vertex{std::numeric_limits<float>::quiet_NaN()};
 
-  static constexpr float m_z_vtx_cut{60.};
-  static constexpr float m_mbd_north_cut{10.};
-  static constexpr float m_mbd_south_cut{150};
-  static constexpr float m_mbd_charge_cut{0.5};
-  static constexpr float m_mbd_time_cut{25.};
+  float m_z_vtx_cut{60.};
+  float m_mbd_north_cut{10.};
+  float m_mbd_south_cut{150.};
+  float m_mbd_charge_cut{0.5};
+  float m_mbd_time_cut{25.};
   //  const int m_mbd_tube_cut{2};
-  static constexpr float m_zdc_cut{60.};
+  float m_zdc_cut{60.};
 
   MinimumBiasInfo::SPECIES m_species{MinimumBiasInfo::SPECIES::AUAU};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context

Update the minimum-bias (MB) classifier to better support O+O collisions with species-dependent selection criteria, including optional pileup rejection, and address event-centrality consistency issues when an event fails the MB classifier.

## Key changes

- **MinimumBiasClassifier (offline/packages/trigger/MinimumBiasClassifier.cc / .h)**
  - **Species-dependent cut initialization** in `InitRun` using an `if/else-if` split:
    - For **O+O**: sets `m_max_charge_cut=400` (was 300), enables additional vertex/MBd-related thresholds (including `m_z_vtx_cut`), and initializes MBD charge/time cuts.
    - For **p+p**: keeps the simpler baseline setup while initializing the relevant MBD charge/time cuts.
  - **OO-only pileup rejection** in `FillMinimumBiasInfo`: when `m_reject_pileup` is enabled and total summed MBD charge exceeds `m_pileup_charge_cut`, `minbiascheck` is forced false.
  - **Correct Fun4All return-code propagation**: `process_event()` now returns `GetNodes(topNode)` non-`EVENT_OK` codes directly.
  - **Reduced node-missing logging**: removed an unnecessary log message when the `GLOBAL` node is absent.
  - **New configuration knob**: added `setRejectPileup(bool)` and the associated per-instance state (`m_reject_pileup`, `m_pileup_charge_cut`).
  - **Cut values moved to per-instance members** (instead of `static constexpr` constants) to support per-instance configuration.

- **Centrality consistency fixes**
  - `CentralityReco::process_event()` now calls **`m_central->Reset()` before** the MB check, preventing centrality from carrying over from the previous event when MB fails.
  - `CentralityInfov2::Reset()` is now properly implemented to reset base state and **clear `_centrality_bin_map`**, ensuring v2 centrality bin info doesn’t persist across resets.

## Potential risk areas

- **Physics/event selection impact**: changed MB thresholds for O+O and introduced OO pileup veto behavior can alter accepted event fractions and downstream physics yields.
- **Centrality output behavior changes**: centrality is now reset earlier—events failing MB will no longer retain previous-event centrality values.
- **Configuration/state safety**: per-instance cut parameters and the new `setRejectPileup` setter should be reviewed for any shared-instance/threading assumptions.
- **Behavior on missing nodes**: `process_event()` now propagates `GetNodes()` return codes directly, which may affect how failures are handled/aborted in the running framework.

## Possible future improvements

- Move remaining “magic-number” MB cut defaults (e.g., pileup/MBD/vertex thresholds) into **CDB/calibration inputs** as requested by reviewers, rather than hardcoded per-instance values.
- Add **regression/unit tests** covering:
  - OO pileup rejection boundary conditions (`m_pileup_charge_cut` just above/below)
  - centrality reset behavior for MB-failing events
  - return-code handling for missing/invalid detector nodes.
- Validate MB efficiency and rejection rates for O+O against reference data/sim.

*Note: AI-generated summaries can contain errors—please use these details as a starting point and rely on direct code/physics validation when making decisions.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->