### PR TITLE
Reproducible tfiles

### DIFF
--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -8,6 +8,7 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHTimeStamp.h>
+#include <phool/PHUtils.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
@@ -384,7 +385,8 @@ int PHParameters::WriteToCDBFile(const std::string &filename)
 {
   PdbParameterMap *myparm = new PdbParameterMap();
   CopyToPdbParameterMap(myparm);
-  TFile *f = TFile::Open(filename.c_str(), "recreate");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(filename);
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
   myparm->Write();
   delete f;
   delete myparm;
@@ -416,7 +418,8 @@ int PHParameters::WriteToFile(const std::string &extension, const std::string &d
 
   PdbParameterMap *myparm = new PdbParameterMap();
   CopyToPdbParameterMap(myparm);
-  TFile *f = TFile::Open(fullpath.str().c_str(), "recreate");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(fullpath.str());
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
   // force xml file writing to use extended precision shown experimentally
   // to not modify input parameters (.17g)
   std::string floatformat = TBufferXML::GetFloatFormat();

--- a/offline/database/PHParameter/PHParametersContainer.cc
+++ b/offline/database/PHParameter/PHParametersContainer.cc
@@ -9,6 +9,7 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHTimeStamp.h>
+#include <phool/PHUtils.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
@@ -148,7 +149,8 @@ int PHParametersContainer::WriteToFile(const std::string &extension, const std::
 
   PdbParameterMapContainer *myparm = new PdbParameterMapContainer();
   CopyToPdbParameterMapContainer(myparm);
-  TFile *f = TFile::Open(fullpath.str().c_str(), "recreate");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(fullpath.str());
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
   // force xml file writing to use extended precision shown experimentally
   // to not modify input parameters (.15e)
   std::string floatformat = TBufferXML::GetFloatFormat();

--- a/offline/database/cdbobjects/CDBHistos.cc
+++ b/offline/database/cdbobjects/CDBHistos.cc
@@ -36,7 +36,8 @@ void CDBHistos::WriteCDBHistos()
     return;
   }
   std::string currdir = gDirectory->GetPath();
-  TFile *f = TFile::Open(m_Filename.c_str(), "RECREATE");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(m_Filename);
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
   for (auto &iter : m_HistoMap)
   {
     iter.second->Write();

--- a/offline/database/cdbobjects/CDBHistos.cc
+++ b/offline/database/cdbobjects/CDBHistos.cc
@@ -1,5 +1,7 @@
 #include "CDBHistos.h"
 
+#include <phool/PHUtils.h>
+
 #include <TClass.h>       // for TClass
 #include <TCollection.h>  // for TIter
 #include <TDirectory.h>   // for TDirectoryAtomicAdapter, TDirectory, gDirec...

--- a/offline/database/cdbobjects/CDBTF.cc
+++ b/offline/database/cdbobjects/CDBTF.cc
@@ -36,7 +36,8 @@ void CDBTF::WriteCDBTF()
     return;
   }
   std::string currdir = gDirectory->GetPath();
-  TFile *f = TFile::Open(m_Filename.c_str(), "RECREATE");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(m_Filename);
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
   for (auto &iter : m_TFMap)
   {
     iter.second->Write();

--- a/offline/database/cdbobjects/CDBTF.cc
+++ b/offline/database/cdbobjects/CDBTF.cc
@@ -1,5 +1,7 @@
 #include "CDBTF.h"
 
+#include <phool/PHUtils.h>
+
 #include <TClass.h>       // for TClass
 #include <TCollection.h>  // for TIter
 #include <TDirectory.h>   // for TDirectoryAtomicAdapter, TDirectory, gDirec...

--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -1,5 +1,6 @@
 #include "CDBTTree.h"
 
+#include <phool/PHUtils.h>
 #include <phool/phool.h>
 
 #include <TBranch.h>      // for TBranch
@@ -470,8 +471,8 @@ void CDBTTree::WriteCDBTTree()
   }
 
   std::string currdir = gDirectory->GetPath();
-
-  TFile *f = TFile::Open(m_Filename.c_str(), "RECREATE");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(m_Filename);
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
   if (!empty_single)
   {
     WriteSingleCDBTTree();

--- a/offline/database/cdbobjects/Makefile.am
+++ b/offline/database/cdbobjects/Makefile.am
@@ -15,6 +15,9 @@ libcdbobjects_la_SOURCES = \
   CDBTTree.cc
 
 libcdbobjects_la_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -lphool \
   `root-config --libs`
 
 ##############################################

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -3,6 +3,7 @@
 #include "PdbParameterMap.h"
 
 #include <phool/PHTimeStamp.h>
+#include <phool/PHUtils.h>
 #include <phool/phool.h>
 
 #include <TBufferXML.h>
@@ -111,7 +112,8 @@ int PdbParameterMapContainer::WriteToFile(const std::string &detector_name,
   std::cout << "PdbParameterMapContainer::WriteToFile - save to " << fullpath.str()
             << std::endl;
 
-  TFile *f = TFile::Open(fullpath.str().c_str(), "recreate");
+  std::string reproducible_TFile_name = PHUtils::CreateReproducibleTFileName(fullpath.str());
+  TFile *f = TFile::Open(reproducible_TFile_name.c_str(), "RECREATE");
 
   PdbParameterMapContainer *container = new PdbParameterMapContainer();
   for (std::map<int, PdbParameterMap *>::const_iterator it =

--- a/offline/framework/fun4all/PHTFileServer.h
+++ b/offline/framework/fun4all/PHTFileServer.h
@@ -13,6 +13,8 @@
 #ifndef FUN4ALL_PHTFILESERVER_H
 #define FUN4ALL_PHTFILESERVER_H
 
+#include <phool/PHUtils.h>
+
 #include <TFile.h>
 
 #include <map>
@@ -71,7 +73,7 @@ class PHTFileServer
    public:
     //! constructor
     SafeTFile(const std::string& filename, const std::string& type = "RECREATE")
-      : TFile(filename.c_str(), type.c_str())
+      : TFile(PHUtils::CreateReproducibleTFileName(filename).c_str(), type.c_str())
       , _filename(filename)
       , _counter(1)
     {

--- a/offline/framework/phool/Makefile.am
+++ b/offline/framework/phool/Makefile.am
@@ -60,6 +60,7 @@ libphool_la_SOURCES = \
   PHTimer.cc \
   PHTimeServer.cc \
   PHTimeStamp.cc \
+  PHUtils.cc \
   recoConsts.cc
 
 pkginclude_HEADERS =  \
@@ -87,6 +88,7 @@ pkginclude_HEADERS =  \
   PHTimeServer.h \
   PHTimeStamp.h \
   PHTypedNodeIterator.h \
+  PHUtils.h \
   recoConsts.h \
   RunnumberRange.h \
   sphenix_constants.h

--- a/offline/framework/phool/PHUtils.cc
+++ b/offline/framework/phool/PHUtils.cc
@@ -1,0 +1,19 @@
+#include "PHUtils.h"
+
+#include <phool/phool.h>
+
+#include <filesystem>
+#include <iostream>
+
+std::string PHUtils::CreateReproducibleTFileName(const std::string &filename)
+{
+  std::string outfilename = filename;
+  if (filename.empty())
+  {
+    std::cout << PHWHERE << " called with empty filename string, returning empty string" << std::endl;
+    return outfilename;
+  }
+  std::filesystem::path p = filename;
+  outfilename = outfilename + std::string("?reproducible=") + std::string(p.filename());
+  return outfilename;
+}

--- a/offline/framework/phool/PHUtils.h
+++ b/offline/framework/phool/PHUtils.h
@@ -1,0 +1,13 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHOOL_PHUTILS_H
+#define PHOOL_PHUTILS_H
+
+#include <string>
+
+namespace PHUtils
+{
+  std::string CreateReproducibleTFileName(const std::string &filename);
+}
+
+#endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR makes our TFiles binary identical for identical payloads. ROOT by default saves the date when the files was written as well as its absolute path. The consequence is that identical content written later or to a different directory have differing md5sums. By adding some parameters to the filename which is passed down to TFile::Open, one can prevent root from doing this and files with identical payloads are binary identical. This string is generated by a utility function PHUtils::CreateReproducibleTFileName(filename). This PR does not cover all files we write, that's for another PR

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

