### PR TITLE
Add get_*cal_frac functions. For z-vertex relative jet task, add has_…

### DIFF
--- a/offline/packages/jetbackground/FastJetAlgoSub.cc
+++ b/offline/packages/jetbackground/FastJetAlgoSub.cc
@@ -14,6 +14,58 @@
 #include <sstream>  // for basic_ostringstream
 #include <vector>
 
+namespace
+{
+  // which calorimeter layer a jet input source belongs to,
+  // for the EMCal/iHCal/oHCal jet energy fractions
+  enum class CaloLayer
+  {
+    NONE,
+    EMCAL,
+    IHCAL,
+    OHCAL
+  };
+
+  CaloLayer get_calo_layer(Jet::SRC src)
+  {
+    switch (src)
+    {
+    case Jet::CEMC_TOWER:
+    case Jet::CEMC_CLUSTER:
+    case Jet::CEMC_TOWER_RETOWER:
+    case Jet::CEMC_TOWER_SUB1:
+    case Jet::CEMC_TOWER_SUB1CS:
+    case Jet::CEMC_TOWERINFO:
+    case Jet::CEMC_TOWERINFO_RETOWER:
+    case Jet::CEMC_TOWERINFO_SUB1:
+    case Jet::CEMC_TOWERINFO_EMBED:
+    case Jet::CEMC_TOWERINFO_SIM:
+    case Jet::ECAL_TOPO_CLUSTER:
+      return CaloLayer::EMCAL;
+    case Jet::HCALIN_TOWER:
+    case Jet::HCALIN_CLUSTER:
+    case Jet::HCALIN_TOWER_SUB1:
+    case Jet::HCALIN_TOWER_SUB1CS:
+    case Jet::HCALIN_TOWERINFO:
+    case Jet::HCALIN_TOWERINFO_SUB1:
+    case Jet::HCALIN_TOWERINFO_EMBED:
+    case Jet::HCALIN_TOWERINFO_SIM:
+      return CaloLayer::IHCAL;
+    case Jet::HCALOUT_TOWER:
+    case Jet::HCALOUT_CLUSTER:
+    case Jet::HCALOUT_TOWER_SUB1:
+    case Jet::HCALOUT_TOWER_SUB1CS:
+    case Jet::HCALOUT_TOWERINFO:
+    case Jet::HCALOUT_TOWERINFO_SUB1:
+    case Jet::HCALOUT_TOWERINFO_EMBED:
+    case Jet::HCALOUT_TOWERINFO_SIM:
+      return CaloLayer::OHCAL;
+    default:
+      return CaloLayer::NONE;
+    }
+  }
+}  // namespace
+
 FastJetAlgoSub::FastJetAlgoSub(const FastJetOptions& options)
   : m_opt{options}
 {
@@ -140,6 +192,9 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
     float total_e = 0;
     float w_t_sum = 0;
     float w_e_sum = 0;
+    float emcal_e = 0;
+    float ihcal_e = 0;
+    float ohcal_e = 0;
     // copy components into output jet
     std::vector<fastjet::PseudoJet> comps = fastjets[ijet].constituents();
     for (auto& comp : comps)
@@ -150,6 +205,23 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
       total_py += particle->get_py();
       total_pz += particle->get_pz();
       total_e += particle->get_e();
+      if (m_opt.calc_calo_fracs && !particle->get_comp_vec().empty())
+      {
+        switch (get_calo_layer(particle->get_comp_vec().front().first))
+        {
+        case CaloLayer::EMCAL:
+          emcal_e += particle->get_e();
+          break;
+        case CaloLayer::IHCAL:
+          ihcal_e += particle->get_e();
+          break;
+        case CaloLayer::OHCAL:
+          ohcal_e += particle->get_e();
+          break;
+        case CaloLayer::NONE:
+          break;
+        }
+      }
       if(particle->size_properties() > Jet::PROPERTY::prop_t)
 	{
 	  if(!std::isnan(particle->get_property(Jet::PROPERTY::prop_t)))
@@ -167,7 +239,7 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
     jet->set_property(Jet::PROPERTY::prop_t,w_t_sum/w_e_sum); //This intentionally becomes nan (0/0) if the
                                                               //value has not been filled at all so that
                                                               //the jet auto-fails timing cuts if necessary
-      
+
     jet->set_comp_sort_flag();  // make sure jet know comps might not be sorted
                                 // alternatively can just ommit the `true`
                                 // in insert_comp call above
@@ -176,6 +248,14 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
     jet->set_pz(total_pz);
     jet->set_e(total_e);
     jet->set_id(ijet);
+
+    // calo energy fractions: original tower energy per layer / jet total energy
+    if (m_opt.calc_calo_fracs && jet->get_e() != 0)
+    {
+      jet->set_emcal_frac(emcal_e / jet->get_e());
+      jet->set_ihcal_frac(ihcal_e / jet->get_e());
+      jet->set_ohcal_frac(ohcal_e / jet->get_e());
+    }
 
     if (m_opt.verbosity > 5 && fastjets[ijet].perp() > 15)
     {

--- a/offline/packages/jetbackground/FastJetAlgoSub.cc
+++ b/offline/packages/jetbackground/FastJetAlgoSub.cc
@@ -14,57 +14,10 @@
 #include <sstream>  // for basic_ostringstream
 #include <vector>
 
-namespace
-{
-  // which calorimeter layer a jet input source belongs to,
-  // for the EMCal/iHCal/oHCal jet energy fractions
-  enum class CaloLayer
-  {
-    NONE,
-    EMCAL,
-    IHCAL,
-    OHCAL
-  };
-
-  CaloLayer get_calo_layer(Jet::SRC src)
-  {
-    switch (src)
-    {
-    case Jet::CEMC_TOWER:
-    case Jet::CEMC_CLUSTER:
-    case Jet::CEMC_TOWER_RETOWER:
-    case Jet::CEMC_TOWER_SUB1:
-    case Jet::CEMC_TOWER_SUB1CS:
-    case Jet::CEMC_TOWERINFO:
-    case Jet::CEMC_TOWERINFO_RETOWER:
-    case Jet::CEMC_TOWERINFO_SUB1:
-    case Jet::CEMC_TOWERINFO_EMBED:
-    case Jet::CEMC_TOWERINFO_SIM:
-    case Jet::ECAL_TOPO_CLUSTER:
-      return CaloLayer::EMCAL;
-    case Jet::HCALIN_TOWER:
-    case Jet::HCALIN_CLUSTER:
-    case Jet::HCALIN_TOWER_SUB1:
-    case Jet::HCALIN_TOWER_SUB1CS:
-    case Jet::HCALIN_TOWERINFO:
-    case Jet::HCALIN_TOWERINFO_SUB1:
-    case Jet::HCALIN_TOWERINFO_EMBED:
-    case Jet::HCALIN_TOWERINFO_SIM:
-      return CaloLayer::IHCAL;
-    case Jet::HCALOUT_TOWER:
-    case Jet::HCALOUT_CLUSTER:
-    case Jet::HCALOUT_TOWER_SUB1:
-    case Jet::HCALOUT_TOWER_SUB1CS:
-    case Jet::HCALOUT_TOWERINFO:
-    case Jet::HCALOUT_TOWERINFO_SUB1:
-    case Jet::HCALOUT_TOWERINFO_EMBED:
-    case Jet::HCALOUT_TOWERINFO_SIM:
-      return CaloLayer::OHCAL;
-    default:
-      return CaloLayer::NONE;
-    }
-  }
-}  // namespace
+// calorimeter-layer classification of jet input sources: shared with
+// FastJetAlgo in jetbase, single source of truth in jetbase/FastJetOptions.h
+using JetCalo::CaloLayer;
+using JetCalo::get_calo_layer;
 
 FastJetAlgoSub::FastJetAlgoSub(const FastJetOptions& options)
   : m_opt{options}

--- a/offline/packages/jetbackground/FastJetAlgoSub.h
+++ b/offline/packages/jetbackground/FastJetAlgoSub.h
@@ -28,6 +28,10 @@ class FastJetAlgoSub : public JetAlgo
   Jet::ALGO get_algo() override { return m_opt.algo; }
   float get_par() override { return m_opt.jet_R; }
 
+  // calculate the EMCal/iHCal/oHCal energy fractions (layer energy / jet total
+  // energy), read back with Jet::get_emcal_frac() etc.; on by default
+  void set_calc_calo_fractions(bool b) { m_opt.calc_calo_fracs = b; }
+
   /* std::vector<Jet*> get_jets(std::vector<Jet*> particles) override; */
   void cluster_and_fill(std::vector<Jet*>& particles, JetContainer* jetcont) override;
 

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -15,6 +15,7 @@
 // standard includes
 #include <cassert>
 #include <iostream>
+#include <limits>
 #include <map>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 #include <vector>
@@ -54,6 +55,8 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   }
 
   CLHEP::Hep3Vector vertex(0, 0, 0);
+  m_used_vertex_type = "UNDEFINED";
+  m_used_vertex_z = std::numeric_limits<float>::quiet_NaN();
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
@@ -90,6 +93,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
               continue;
             }
             vertex.set(v->get_x(), v->get_y(), v->get_z());
+            m_used_vertex_type = get_vtxtype_name(m_vertex_type);
           }
         }
       }
@@ -104,6 +108,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       vertex.set(0, 0, 0);
     }
   }
+  m_used_vertex_z = vertex.z();  // the z the cluster kinematics are computed with
 
   RawClusterContainer *clusters = nullptr;
   if (m_Input == Jet::CEMC_CLUSTER)

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -55,6 +55,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   }
 
   CLHEP::Hep3Vector vertex(0, 0, 0);
+  m_has_zvertex = false;
   m_used_vertex_type = "UNDEFINED";
   m_used_vertex_z = std::numeric_limits<float>::quiet_NaN();
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
@@ -93,6 +94,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
               continue;
             }
             vertex.set(v->get_x(), v->get_y(), v->get_z());
+            m_has_zvertex = true;
             m_used_vertex_type = get_vtxtype_name(m_vertex_type);
           }
         }
@@ -100,12 +102,14 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       else
       {
         vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
+        m_has_zvertex = true;
       }
     }
 
     if (std::isnan(vertex.z()))
     {
       vertex.set(0, 0, 0);
+      m_has_zvertex = false;  // no valid vertex, jets are reconstructed with z=0
     }
   }
   m_used_vertex_z = vertex.z();  // the z the cluster kinematics are computed with

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -57,6 +57,13 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   CLHEP::Hep3Vector vertex(0, 0, 0);
   m_has_zvertex = false;
   m_used_vertex_type = "UNDEFINED";
+  if (m_use_vertextype)
+  {
+    // record the REQUESTED vertex type even when no vertex is found this event
+    // (so e.g. "MBD" with has_zvertex() == false means: MBD selection active,
+    // but no valid MBD vertex); "UNDEFINED" is left for no type selection.
+    m_used_vertex_type = get_vtxtype_name(m_vertex_type);
+  }
   m_used_vertex_z = std::numeric_limits<float>::quiet_NaN();
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)

--- a/offline/packages/jetbase/ClusterJetInput.h
+++ b/offline/packages/jetbase/ClusterJetInput.h
@@ -11,6 +11,8 @@
 
 // finally system includes
 #include <iostream>  // for cout, ostream
+#include <limits>
+#include <string>
 #include <vector>
 
 // forward declarations
@@ -29,17 +31,26 @@ class ClusterJetInput : public JetInput
 
   std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
-  void set_GlobalVertexType(GlobalVertex::VTXTYPE type) 
+  void set_GlobalVertexType(GlobalVertex::VTXTYPE type)
   {
     m_use_vertextype = true;
     m_vertex_type = type;
   }
+
+  // vertex actually used in the last get_input() call.
+  // The z is the value the cluster kinematics were computed with, i.e. 0 when
+  // the vertex was NaN or missing.
+  bool has_zvertex() const override { return true; }
+  std::string get_vertex_type() const override { return m_used_vertex_type; }
+  float get_vertex_z() const override { return m_used_vertex_z; }
 
  private:
   int m_Verbosity = 0;
   Jet::SRC m_Input = Jet::VOID;
   bool m_use_vertextype {false};
   GlobalVertex::VTXTYPE m_vertex_type = GlobalVertex::UNDEFINED;
+  std::string m_used_vertex_type{"UNDEFINED"};
+  float m_used_vertex_z{std::numeric_limits<float>::quiet_NaN()};
 };
 
 #endif

--- a/offline/packages/jetbase/ClusterJetInput.h
+++ b/offline/packages/jetbase/ClusterJetInput.h
@@ -38,9 +38,9 @@ class ClusterJetInput : public JetInput
   }
 
   // vertex actually used in the last get_input() call.
-  // The z is the value the cluster kinematics were computed with, i.e. 0 when
-  // the vertex was NaN or missing.
-  bool has_zvertex() const override { return true; }
+  // has_zvertex() is false when no valid vertex was found (empty map or NaN);
+  // the z is then 0, the value the cluster kinematics fell back to.
+  bool has_zvertex() const override { return m_has_zvertex; }
   std::string get_vertex_type() const override { return m_used_vertex_type; }
   float get_vertex_z() const override { return m_used_vertex_z; }
 
@@ -49,6 +49,7 @@ class ClusterJetInput : public JetInput
   Jet::SRC m_Input = Jet::VOID;
   bool m_use_vertextype {false};
   GlobalVertex::VTXTYPE m_vertex_type = GlobalVertex::UNDEFINED;
+  bool m_has_zvertex{false};
   std::string m_used_vertex_type{"UNDEFINED"};
   float m_used_vertex_z{std::numeric_limits<float>::quiet_NaN()};
 };

--- a/offline/packages/jetbase/FastJetAlgo.cc
+++ b/offline/packages/jetbase/FastJetAlgo.cc
@@ -37,6 +37,58 @@
 #include <utility>  // for pair
 #include <vector>
 
+namespace
+{
+  // which calorimeter layer a jet input source belongs to,
+  // for the EMCal/iHCal/oHCal jet energy fractions
+  enum class CaloLayer
+  {
+    NONE,
+    EMCAL,
+    IHCAL,
+    OHCAL
+  };
+
+  CaloLayer get_calo_layer(Jet::SRC src)
+  {
+    switch (src)
+    {
+    case Jet::CEMC_TOWER:
+    case Jet::CEMC_CLUSTER:
+    case Jet::CEMC_TOWER_RETOWER:
+    case Jet::CEMC_TOWER_SUB1:
+    case Jet::CEMC_TOWER_SUB1CS:
+    case Jet::CEMC_TOWERINFO:
+    case Jet::CEMC_TOWERINFO_RETOWER:
+    case Jet::CEMC_TOWERINFO_SUB1:
+    case Jet::CEMC_TOWERINFO_EMBED:
+    case Jet::CEMC_TOWERINFO_SIM:
+    case Jet::ECAL_TOPO_CLUSTER:
+      return CaloLayer::EMCAL;
+    case Jet::HCALIN_TOWER:
+    case Jet::HCALIN_CLUSTER:
+    case Jet::HCALIN_TOWER_SUB1:
+    case Jet::HCALIN_TOWER_SUB1CS:
+    case Jet::HCALIN_TOWERINFO:
+    case Jet::HCALIN_TOWERINFO_SUB1:
+    case Jet::HCALIN_TOWERINFO_EMBED:
+    case Jet::HCALIN_TOWERINFO_SIM:
+      return CaloLayer::IHCAL;
+    case Jet::HCALOUT_TOWER:
+    case Jet::HCALOUT_CLUSTER:
+    case Jet::HCALOUT_TOWER_SUB1:
+    case Jet::HCALOUT_TOWER_SUB1CS:
+    case Jet::HCALOUT_TOWERINFO:
+    case Jet::HCALOUT_TOWERINFO_SUB1:
+    case Jet::HCALOUT_TOWERINFO_EMBED:
+    case Jet::HCALOUT_TOWERINFO_SIM:
+      return CaloLayer::OHCAL;
+    default:
+      return CaloLayer::NONE;
+    }
+  }
+}  // namespace
+
 FastJetAlgo::FastJetAlgo(const FastJetOptions& options)
   : m_opt{options}
 {
@@ -376,33 +428,51 @@ void FastJetAlgo::cluster_and_fill(std::vector<Jet*>& particles, JetContainer* j
     }
 
     // Count clustered components. If desired, put original components into the output jet.
+    // If desired, also sum the constituent energy per calorimeter layer for the energy fractions.
     //    int n_clustered = 0;
+    float emcal_e = 0.;
+    float ihcal_e = 0.;
+    float ohcal_e = 0.;
     std::vector<fastjet::PseudoJet> constituents = fastjets[ijet].constituents();
-    if (m_opt.calc_area)
+    for (auto& comp : constituents)
     {
-      for (auto& comp : constituents)
+      if (m_opt.calc_area && comp.is_pure_ghost())
       {
-        if (comp.is_pure_ghost())
-        {
-          continue;
-        }
-        //        ++n_clustered;
-        if (m_opt.save_jet_components)
-        {
-          jet->insert_comp(particles[comp.user_index()]->get_comp_vec(), true);
-        }
-      }  // end loop over all constituents
-    }
-    else
-    {  // didn't calculate jet area
-       //      n_clustered += constituents.size();
+        continue;
+      }
+      //        ++n_clustered;
       if (m_opt.save_jet_components)
       {
-        for (auto& comp : constituents)
+        jet->insert_comp(particles[comp.user_index()]->get_comp_vec(), true);
+      }
+      if (m_opt.calc_calo_fracs)
+      {
+        auto& src_comps = particles[comp.user_index()]->get_comp_vec();
+        if (!src_comps.empty())
         {
-          jet->insert_comp(particles[comp.user_index()]->get_comp_vec(), true);
+          switch (get_calo_layer(src_comps.front().first))
+          {
+          case CaloLayer::EMCAL:
+            emcal_e += comp.e();
+            break;
+          case CaloLayer::IHCAL:
+            ihcal_e += comp.e();
+            break;
+          case CaloLayer::OHCAL:
+            ohcal_e += comp.e();
+            break;
+          case CaloLayer::NONE:
+            break;
+          }
         }
       }
+    }  // end loop over all constituents
+
+    if (m_opt.calc_calo_fracs && jet->get_e() != 0.)
+    {
+      jet->set_emcal_frac(emcal_e / jet->get_e());
+      jet->set_ihcal_frac(ihcal_e / jet->get_e());
+      jet->set_ohcal_frac(ohcal_e / jet->get_e());
     }
     jet->set_comp_sort_flag();  // make surce comp knows it might not be sorted
   }

--- a/offline/packages/jetbase/FastJetAlgo.cc
+++ b/offline/packages/jetbase/FastJetAlgo.cc
@@ -37,57 +37,10 @@
 #include <utility>  // for pair
 #include <vector>
 
-namespace
-{
-  // which calorimeter layer a jet input source belongs to,
-  // for the EMCal/iHCal/oHCal jet energy fractions
-  enum class CaloLayer
-  {
-    NONE,
-    EMCAL,
-    IHCAL,
-    OHCAL
-  };
-
-  CaloLayer get_calo_layer(Jet::SRC src)
-  {
-    switch (src)
-    {
-    case Jet::CEMC_TOWER:
-    case Jet::CEMC_CLUSTER:
-    case Jet::CEMC_TOWER_RETOWER:
-    case Jet::CEMC_TOWER_SUB1:
-    case Jet::CEMC_TOWER_SUB1CS:
-    case Jet::CEMC_TOWERINFO:
-    case Jet::CEMC_TOWERINFO_RETOWER:
-    case Jet::CEMC_TOWERINFO_SUB1:
-    case Jet::CEMC_TOWERINFO_EMBED:
-    case Jet::CEMC_TOWERINFO_SIM:
-    case Jet::ECAL_TOPO_CLUSTER:
-      return CaloLayer::EMCAL;
-    case Jet::HCALIN_TOWER:
-    case Jet::HCALIN_CLUSTER:
-    case Jet::HCALIN_TOWER_SUB1:
-    case Jet::HCALIN_TOWER_SUB1CS:
-    case Jet::HCALIN_TOWERINFO:
-    case Jet::HCALIN_TOWERINFO_SUB1:
-    case Jet::HCALIN_TOWERINFO_EMBED:
-    case Jet::HCALIN_TOWERINFO_SIM:
-      return CaloLayer::IHCAL;
-    case Jet::HCALOUT_TOWER:
-    case Jet::HCALOUT_CLUSTER:
-    case Jet::HCALOUT_TOWER_SUB1:
-    case Jet::HCALOUT_TOWER_SUB1CS:
-    case Jet::HCALOUT_TOWERINFO:
-    case Jet::HCALOUT_TOWERINFO_SUB1:
-    case Jet::HCALOUT_TOWERINFO_EMBED:
-    case Jet::HCALOUT_TOWERINFO_SIM:
-      return CaloLayer::OHCAL;
-    default:
-      return CaloLayer::NONE;
-    }
-  }
-}  // namespace
+// calorimeter-layer classification of jet input sources: shared with
+// FastJetAlgoSub in jetbackground, single source of truth in FastJetOptions.h
+using JetCalo::CaloLayer;
+using JetCalo::get_calo_layer;
 
 FastJetAlgo::FastJetAlgo(const FastJetOptions& options)
   : m_opt{options}

--- a/offline/packages/jetbase/FastJetAlgo.h
+++ b/offline/packages/jetbase/FastJetAlgo.h
@@ -46,6 +46,10 @@ class FastJetAlgo : public JetAlgo
   void set_SoftDrop_zcut(float zcut) { m_opt.SD_zcut = zcut; }
   //--end-legacy-code-interface-------------------------------------------
 
+  // calculate the EMCal/iHCal/oHCal energy fractions (layer energy / jet total
+  // energy), read back with Jet::get_emcal_frac() etc.; on by default
+  void set_calc_calo_fractions(bool b) { m_opt.calc_calo_fracs = b; }
+
   std::vector<Jet*> get_jets(std::vector<Jet*> particles) override;
   void cluster_and_fill(std::vector<Jet*>& particles, JetContainer* jetcont) override;
 

--- a/offline/packages/jetbase/FastJetOptions.cc
+++ b/offline/packages/jetbase/FastJetOptions.cc
@@ -170,6 +170,7 @@ void FastJetOptions::print(std::ostream& os)
     }
     os << std::endl
      << " - save jet components ids: " << (save_jet_components ? "yes" : "no") << std::endl
+     << " - calo energy fractions (EMCal/iHCal/oHCal): " << (calc_calo_fracs ? "yes" : "no") << std::endl
      << " - verbosity: " << verbosity << std::endl;
   if (use_constituent_min_pt)
   {

--- a/offline/packages/jetbase/FastJetOptions.h
+++ b/offline/packages/jetbase/FastJetOptions.h
@@ -95,6 +95,11 @@ struct FastJetOptions
 
   bool save_jet_components{true};
 
+  // calculate calorimeter energy fractions (layer energy / jet total energy),
+  // stored in the jet and read back with Jet::get_emcal_frac()/get_ihcal_frac()/get_ohcal_frac().
+  // Toggle with set_calc_calo_fractions(bool) on FastJetAlgo/FastJetAlgoSub.
+  bool calc_calo_fracs{true};
+
   // softdrop
   bool doSoftDrop{false};
   float SD_beta{0};

--- a/offline/packages/jetbase/FastJetOptions.h
+++ b/offline/packages/jetbase/FastJetOptions.h
@@ -131,4 +131,58 @@ struct FastJetOptions
   bool use_jet_selection{false};  // set when initialized
 };
 
+// Which calorimeter layer a jet input source belongs to, used for the
+// EMCal/iHCal/oHCal jet energy fractions (see calc_calo_fracs above).
+// Single source of truth shared by FastJetAlgo (jetbase) and FastJetAlgoSub
+// (jetbackground): new Jet::SRC values only need to be classified here.
+namespace JetCalo
+{
+  enum class CaloLayer
+  {
+    NONE,
+    EMCAL,
+    IHCAL,
+    OHCAL
+  };
+
+  inline CaloLayer get_calo_layer(Jet::SRC src)
+  {
+    switch (src)
+    {
+    case Jet::CEMC_TOWER:
+    case Jet::CEMC_CLUSTER:
+    case Jet::CEMC_TOWER_RETOWER:
+    case Jet::CEMC_TOWER_SUB1:
+    case Jet::CEMC_TOWER_SUB1CS:
+    case Jet::CEMC_TOWERINFO:
+    case Jet::CEMC_TOWERINFO_RETOWER:
+    case Jet::CEMC_TOWERINFO_SUB1:
+    case Jet::CEMC_TOWERINFO_EMBED:
+    case Jet::CEMC_TOWERINFO_SIM:
+    case Jet::ECAL_TOPO_CLUSTER:
+      return CaloLayer::EMCAL;
+    case Jet::HCALIN_TOWER:
+    case Jet::HCALIN_CLUSTER:
+    case Jet::HCALIN_TOWER_SUB1:
+    case Jet::HCALIN_TOWER_SUB1CS:
+    case Jet::HCALIN_TOWERINFO:
+    case Jet::HCALIN_TOWERINFO_SUB1:
+    case Jet::HCALIN_TOWERINFO_EMBED:
+    case Jet::HCALIN_TOWERINFO_SIM:
+      return CaloLayer::IHCAL;
+    case Jet::HCALOUT_TOWER:
+    case Jet::HCALOUT_CLUSTER:
+    case Jet::HCALOUT_TOWER_SUB1:
+    case Jet::HCALOUT_TOWER_SUB1CS:
+    case Jet::HCALOUT_TOWERINFO:
+    case Jet::HCALOUT_TOWERINFO_SUB1:
+    case Jet::HCALOUT_TOWERINFO_EMBED:
+    case Jet::HCALOUT_TOWERINFO_SIM:
+      return CaloLayer::OHCAL;
+    default:
+      return CaloLayer::NONE;
+    }
+  }
+}  // namespace JetCalo
+
 #endif

--- a/offline/packages/jetbase/Jet.h
+++ b/offline/packages/jetbase/Jet.h
@@ -182,6 +182,17 @@ class Jet : public PHObject
   virtual float get_mass() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual float get_mass2() const { return std::numeric_limits<float>::quiet_NaN(); }
 
+  // calorimeter energy fractions (layer energy / jet total energy),
+  // filled during jet reconstruction by FastJetAlgo/FastJetAlgoSub
+  virtual float get_emcal_frac() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_emcal_frac(float) { return; }
+
+  virtual float get_ihcal_frac() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_ihcal_frac(float) { return; }
+
+  virtual float get_ohcal_frac() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_ohcal_frac(float) { return; }
+
   // --------------------------------------------------------------------------
   // Functions for jet properties (always float values)
   // --------------------------------------------------------------------------

--- a/offline/packages/jetbase/JetContainer.h
+++ b/offline/packages/jetbase/JetContainer.h
@@ -13,6 +13,7 @@
 #include <limits>
 #include <map>
 #include <set>
+#include <string>
 #include <vector>
 
 class Jet;
@@ -122,6 +123,22 @@ class JetContainer : public PHObject
 
   virtual void set_rho_median(float /**/){};
   virtual float get_rho_median() const { return std::numeric_limits<float>::quiet_NaN(); };
+
+  // ---------------------------------------------------------------------------------------
+  // z-vertex used in the jet reconstruction, recorded from the jet inputs.
+  // The type is the GlobalVertex::VTXTYPE name selected with
+  // TowerJetInput::set_GlobalVertexType() ("MBD", "SVTX", ...), "UNDEFINED" when
+  // no type selection was applied, or "" when the inputs did not use a vertex.
+  // The z is the value actually used in the reconstruction: 0 when the vertex
+  // was NaN or missing, NaN only when the inputs did not use a vertex at all.
+  // ---------------------------------------------------------------------------------------
+  virtual bool has_zvertex() const { return false; };
+
+  virtual void set_vertex_type(const std::string& /**/){};
+  virtual std::string get_vertex_type() const { return ""; };
+
+  virtual void set_vertex_z(float /**/){};
+  virtual float get_vertex_z() const { return std::numeric_limits<float>::quiet_NaN(); };
 
  private:
   ClassDefOverride(JetContainer, 1);

--- a/offline/packages/jetbase/JetContainer.h
+++ b/offline/packages/jetbase/JetContainer.h
@@ -130,8 +130,10 @@ class JetContainer : public PHObject
   // events without one the jets are reconstructed with z=0, has_zvertex() is
   // false and get_vertex_z() returns 0.
   // The type is the GlobalVertex::VTXTYPE name selected with
-  // TowerJetInput::set_GlobalVertexType() ("MBD", "SVTX", ...), "UNDEFINED" when
-  // no type selection was applied, or "" when the inputs did not use a vertex.
+  // TowerJetInput::set_GlobalVertexType() ("MBD", "SVTX", ...), reported whether
+  // or not a vertex was actually found this event (check has_zvertex() for that);
+  // "UNDEFINED" when no type selection was applied, or "" when the inputs did
+  // not use a vertex.
   // ---------------------------------------------------------------------------------------
   virtual void set_has_zvertex(bool /**/){};
   virtual bool has_zvertex() const { return false; };

--- a/offline/packages/jetbase/JetContainer.h
+++ b/offline/packages/jetbase/JetContainer.h
@@ -126,12 +126,14 @@ class JetContainer : public PHObject
 
   // ---------------------------------------------------------------------------------------
   // z-vertex used in the jet reconstruction, recorded from the jet inputs.
+  // has_zvertex() is true only when a valid z-vertex was found and used; on
+  // events without one the jets are reconstructed with z=0, has_zvertex() is
+  // false and get_vertex_z() returns 0.
   // The type is the GlobalVertex::VTXTYPE name selected with
   // TowerJetInput::set_GlobalVertexType() ("MBD", "SVTX", ...), "UNDEFINED" when
   // no type selection was applied, or "" when the inputs did not use a vertex.
-  // The z is the value actually used in the reconstruction: 0 when the vertex
-  // was NaN or missing, NaN only when the inputs did not use a vertex at all.
   // ---------------------------------------------------------------------------------------
+  virtual void set_has_zvertex(bool /**/){};
   virtual bool has_zvertex() const { return false; };
 
   virtual void set_vertex_type(const std::string& /**/){};

--- a/offline/packages/jetbase/JetContainerv1.cc
+++ b/offline/packages/jetbase/JetContainerv1.cc
@@ -14,8 +14,12 @@ JetContainerv1::JetContainerv1() : m_clones(new TClonesArray("Jetv2", 50))
 
 void JetContainerv1::identify(std::ostream& os) const
 {
-  os << "JetContainerv1: size = " << m_clones->GetEntriesFast() << std::endl
-     << "  Contains jets with the following properties:" << std::endl;
+  os << "JetContainerv1: size = " << m_clones->GetEntriesFast() << std::endl;
+  if (!m_vertex_type.empty())
+  {
+    os << "  reconstructed with vertex type " << m_vertex_type << " at z = " << m_vertex_z << std::endl;
+  }
+  os << "  Contains jets with the following properties:" << std::endl;
   print_property_types(os);
   return;
 }
@@ -25,8 +29,10 @@ JetContainerv1::JetContainerv1(const JetContainer& rhs)
   , m_pindex{rhs.property_indices()}
   , m_psize{rhs.size_properties()}
   , m_RhoMedian{rhs.get_rho_median()}
+  , m_vertex_type{rhs.get_vertex_type()}
+  , m_vertex_z{rhs.get_vertex_z()}
 {
-  
+
 
   for (auto src = rhs.begin_src(); src != rhs.end_src(); ++src)
   {
@@ -47,6 +53,8 @@ void JetContainerv1::Reset()
   m_clones->Clear("C");
   m_njets = 0;
   m_RhoMedian = std::numeric_limits<float>::quiet_NaN();
+  m_vertex_type.clear();
+  m_vertex_z = std::numeric_limits<float>::quiet_NaN();
 }
 
 Jet* JetContainerv1::add_jet()
@@ -200,6 +208,8 @@ std::string JetContainerv1::str_Jet_PROPERTY(Jet::PROPERTY prop)
     return "JetHadronZT";
   case Jet::PROPERTY::prop_area:
     return "area";
+  case Jet::PROPERTY::prop_t:
+    return "t";
   default:
     return "no_property";
   }

--- a/offline/packages/jetbase/JetContainerv1.cc
+++ b/offline/packages/jetbase/JetContainerv1.cc
@@ -29,6 +29,7 @@ JetContainerv1::JetContainerv1(const JetContainer& rhs)
   , m_pindex{rhs.property_indices()}
   , m_psize{rhs.size_properties()}
   , m_RhoMedian{rhs.get_rho_median()}
+  , m_has_zvertex{rhs.has_zvertex()}
   , m_vertex_type{rhs.get_vertex_type()}
   , m_vertex_z{rhs.get_vertex_z()}
 {
@@ -53,6 +54,7 @@ void JetContainerv1::Reset()
   m_clones->Clear("C");
   m_njets = 0;
   m_RhoMedian = std::numeric_limits<float>::quiet_NaN();
+  m_has_zvertex = false;
   m_vertex_type.clear();
   m_vertex_z = std::numeric_limits<float>::quiet_NaN();
 }

--- a/offline/packages/jetbase/JetContainerv1.h
+++ b/offline/packages/jetbase/JetContainerv1.h
@@ -93,6 +93,16 @@ class JetContainerv1 : public JetContainer
   void set_rho_median(float _) override { m_RhoMedian = _; };
   float get_rho_median() const override { return m_RhoMedian; };
 
+  // z-vertex used in the jet reconstruction
+  // (a set vertex type marks that the jet inputs used a z-vertex)
+  bool has_zvertex() const override { return !m_vertex_type.empty(); };
+
+  void set_vertex_type(const std::string& type) override { m_vertex_type = type; };
+  std::string get_vertex_type() const override { return m_vertex_type; };
+
+  void set_vertex_z(float z) override { m_vertex_z = z; };
+  float get_vertex_z() const override { return m_vertex_z; };
+
  private:
   static std::string str_Jet_PROPERTY(Jet::PROPERTY) ;
 
@@ -113,7 +123,11 @@ class JetContainerv1 : public JetContainer
 
   float m_RhoMedian{std::numeric_limits<float>::signaling_NaN()};
 
-  ClassDefOverride(JetContainerv1, 1);
+  // z-vertex used in the jet reconstruction
+  std::string m_vertex_type;
+  float m_vertex_z{std::numeric_limits<float>::quiet_NaN()};
+
+  ClassDefOverride(JetContainerv1, 2);
 };
 
 #endif

--- a/offline/packages/jetbase/JetContainerv1.h
+++ b/offline/packages/jetbase/JetContainerv1.h
@@ -94,8 +94,9 @@ class JetContainerv1 : public JetContainer
   float get_rho_median() const override { return m_RhoMedian; };
 
   // z-vertex used in the jet reconstruction
-  // (a set vertex type marks that the jet inputs used a z-vertex)
-  bool has_zvertex() const override { return !m_vertex_type.empty(); };
+  // (has_zvertex() false: no valid vertex was found, jets reconstructed with z=0)
+  void set_has_zvertex(bool b) override { m_has_zvertex = b; };
+  bool has_zvertex() const override { return m_has_zvertex; };
 
   void set_vertex_type(const std::string& type) override { m_vertex_type = type; };
   std::string get_vertex_type() const override { return m_vertex_type; };
@@ -124,6 +125,7 @@ class JetContainerv1 : public JetContainer
   float m_RhoMedian{std::numeric_limits<float>::signaling_NaN()};
 
   // z-vertex used in the jet reconstruction
+  bool m_has_zvertex{false};
   std::string m_vertex_type;
   float m_vertex_z{std::numeric_limits<float>::quiet_NaN()};
 

--- a/offline/packages/jetbase/JetInput.h
+++ b/offline/packages/jetbase/JetInput.h
@@ -3,7 +3,11 @@
 
 #include "Jet.h"
 
+#include <globalvertex/GlobalVertex.h>
+
 #include <iostream>
+#include <limits>
+#include <string>
 #include <vector>
 
 class PHCompositeNode;
@@ -26,6 +30,45 @@ class JetInput
   }
   virtual int Verbosity() const { return m_Verbosity; }
   virtual void Verbosity(int i) { m_Verbosity = i; }
+
+  // vertex actually used by this input in the last get_input() call.
+  // has_zvertex() is true for inputs which use a z-vertex in their kinematics
+  // (e.g. TowerJetInput, ClusterJetInput). For those, get_vertex_z() returns
+  // the z value actually used (0 when the vertex was NaN or missing), and
+  // get_vertex_type() returns the GlobalVertex::VTXTYPE name ("MBD", "SVTX", ...)
+  // or "UNDEFINED" when no vertex type selection was applied.
+  virtual bool has_zvertex() const { return false; }
+  virtual std::string get_vertex_type() const { return ""; }
+  virtual float get_vertex_z() const { return std::numeric_limits<float>::quiet_NaN(); }
+
+  // name of a GlobalVertex::VTXTYPE, used by get_vertex_type().
+  // A type without a case here is reported as "VTXTYPE_<number>", so this
+  // does NOT need to be edited when GlobalVertex gains a new type --
+  // add a case only if you want a nicer name for it.
+  static std::string get_vtxtype_name(GlobalVertex::VTXTYPE type)
+  {
+    switch (type)
+    {
+    case GlobalVertex::UNDEFINED:
+      return "UNDEFINED";
+    case GlobalVertex::TRUTH:
+      return "TRUTH";
+    case GlobalVertex::SMEARED:
+      return "SMEARED";
+    case GlobalVertex::CALO:
+      return "CALO";
+    case GlobalVertex::MBD:
+      return "MBD";
+    case GlobalVertex::MBD_CALO:
+      return "MBD_CALO";
+    case GlobalVertex::SVTX:
+      return "SVTX";
+    case GlobalVertex::SVTX_MBD:
+      return "SVTX_MBD";
+    default:
+      return "VTXTYPE_" + std::to_string(static_cast<int>(type));
+    }
+  }
 
  protected:
   JetInput()

--- a/offline/packages/jetbase/JetInput.h
+++ b/offline/packages/jetbase/JetInput.h
@@ -32,11 +32,12 @@ class JetInput
   virtual void Verbosity(int i) { m_Verbosity = i; }
 
   // vertex actually used by this input in the last get_input() call.
-  // has_zvertex() is true for inputs which use a z-vertex in their kinematics
-  // (e.g. TowerJetInput, ClusterJetInput). For those, get_vertex_z() returns
-  // the z value actually used (0 when the vertex was NaN or missing), and
-  // get_vertex_type() returns the GlobalVertex::VTXTYPE name ("MBD", "SVTX", ...)
-  // or "UNDEFINED" when no vertex type selection was applied.
+  // has_zvertex() is true only when a valid z-vertex was found and used;
+  // it is false when this input does not use a vertex at all, and also on
+  // events where no valid vertex was found (the kinematics then fall back
+  // to z=0 and get_vertex_z() returns 0). get_vertex_type() returns the
+  // GlobalVertex::VTXTYPE name ("MBD", "SVTX", ...), "UNDEFINED" when no
+  // vertex type selection was applied, or "" for inputs without vertexing.
   virtual bool has_zvertex() const { return false; }
   virtual std::string get_vertex_type() const { return ""; }
   virtual float get_vertex_z() const { return std::numeric_limits<float>::quiet_NaN(); }

--- a/offline/packages/jetbase/JetReco.cc
+++ b/offline/packages/jetbase/JetReco.cc
@@ -298,6 +298,18 @@ void JetReco::FillJetContainer(PHCompositeNode *topNode, int ipos, std::vector<J
     jetconn->insert_src(_input->get_src());
   }
 
+  // record the vertex used by the inputs (all vertex-using inputs are normally
+  // configured with the same vertex type, so the first one found is recorded)
+  for (auto &_input : _inputs)
+  {
+    if (_input->has_zvertex())
+    {
+      jetconn->set_vertex_type(_input->get_vertex_type());
+      jetconn->set_vertex_z(_input->get_vertex_z());
+      break;
+    }
+  }
+
   if (Verbosity() > 7)
   {
     std::cout << " Verbosity()>7:: jets in container " << _outputs[ipos] << std::endl;

--- a/offline/packages/jetbase/JetReco.cc
+++ b/offline/packages/jetbase/JetReco.cc
@@ -298,12 +298,15 @@ void JetReco::FillJetContainer(PHCompositeNode *topNode, int ipos, std::vector<J
     jetconn->insert_src(_input->get_src());
   }
 
-  // record the vertex used by the inputs (all vertex-using inputs are normally
-  // configured with the same vertex type, so the first one found is recorded)
+  // record the vertex used by the inputs; a non-empty vertex type marks inputs
+  // which use a vertex, whether or not one was found this event (all vertex-using
+  // inputs are normally configured with the same vertex type, so the first one
+  // found is recorded)
   for (auto &_input : _inputs)
   {
-    if (_input->has_zvertex())
+    if (!_input->get_vertex_type().empty())
     {
+      jetconn->set_has_zvertex(_input->has_zvertex());
       jetconn->set_vertex_type(_input->get_vertex_type());
       jetconn->set_vertex_z(_input->get_vertex_z());
       break;

--- a/offline/packages/jetbase/Jetv2.cc
+++ b/offline/packages/jetbase/Jetv2.cc
@@ -97,6 +97,9 @@ void Jetv2::Reset()
   _id = 0xFFFFFFFF;
   std::fill(std::begin(_mom), std::end(_mom), std::numeric_limits<float>::quiet_NaN());
   _e = std::numeric_limits<float>::quiet_NaN();
+  _emcal_frac = std::numeric_limits<float>::quiet_NaN();
+  _ihcal_frac = std::numeric_limits<float>::quiet_NaN();
+  _ohcal_frac = std::numeric_limits<float>::quiet_NaN();
   _comp_ids.clear();
   _properties.clear();
 }

--- a/offline/packages/jetbase/Jetv2.h
+++ b/offline/packages/jetbase/Jetv2.h
@@ -75,6 +75,16 @@ class Jetv2 : public Jet
   float get_e() const override { return _e; }
   void set_e(float e) override { _e = e; }
 
+  // calorimeter energy fractions (layer energy / jet total energy)
+  float get_emcal_frac() const override { return _emcal_frac; }
+  void set_emcal_frac(float frac) override { _emcal_frac = frac; }
+
+  float get_ihcal_frac() const override { return _ihcal_frac; }
+  void set_ihcal_frac(float frac) override { _ihcal_frac = frac; }
+
+  float get_ohcal_frac() const override { return _ohcal_frac; }
+  void set_ohcal_frac(float frac) override { _ohcal_frac = frac; }
+
   float get_eta() const override;
 
   int get_isCalib()  override {return _isCalib;}
@@ -133,6 +143,11 @@ class Jetv2 : public Jet
   /// jet energy
   float _e {std::numeric_limits<float>::quiet_NaN()};
 
+  /// calorimeter energy fractions (layer energy / jet total energy)
+  float _emcal_frac{std::numeric_limits<float>::quiet_NaN()};
+  float _ihcal_frac{std::numeric_limits<float>::quiet_NaN()};
+  float _ohcal_frac{std::numeric_limits<float>::quiet_NaN()};
+
   /// calibration flag
   int _isCalib{0};
   /// source id -> component id
@@ -166,7 +181,7 @@ class Jetv2 : public Jet
   void erase_comp(Iter /*iter*/) override;
   void erase_comp(Iter /*first*/, Iter /*last*/) override;
 
-  ClassDefOverride(Jetv2, 1);
+  ClassDefOverride(Jetv2, 2);
 };
 
 #endif  // JETBASE_JETV2_H

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cmath>  // for asinh, atan2, cos, cosh
 #include <iostream>
+#include <limits>
 #include <map>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 #include <vector>
@@ -65,6 +66,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     std::cout << "TowerJetInput::process_event -- entered" << std::endl;
   }
   float vtxz = 0;  // default to 0
+  m_used_vertex_type = "UNDEFINED";
+  m_used_vertex_z = std::numeric_limits<float>::quiet_NaN();
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
@@ -90,6 +93,16 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	    if(vertices.at(0))
 	      {
 		vtxz = vertices.at(0)->get_z();
+		// record which of the requested vertex types the chosen vertex actually contains
+		for (auto type : m_vertex_type)
+		  {
+		    auto iter = vertices.at(0)->find_vertexes(type);
+		    if (iter != vertices.at(0)->end_vertexes() && iter->first == type)
+		      {
+			m_used_vertex_type = get_vtxtype_name(type);
+			break;
+		      }
+		  }
 	      }
 	    if(vertices.size() > 1 && Verbosity() > 0)
 	      {
@@ -128,6 +141,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     }
     vtxz = 0;
   }
+  m_used_vertex_z = vtxz;  // the z the tower kinematics are computed with
 
   m_use_towerinfo = false;
 

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -66,6 +66,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     std::cout << "TowerJetInput::process_event -- entered" << std::endl;
   }
   float vtxz = 0;  // default to 0
+  m_has_zvertex = false;
   m_used_vertex_type = "UNDEFINED";
   m_used_vertex_z = std::numeric_limits<float>::quiet_NaN();
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
@@ -93,6 +94,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	    if(vertices.at(0))
 	      {
 		vtxz = vertices.at(0)->get_z();
+		m_has_zvertex = true;
 		// record which of the requested vertex types the chosen vertex actually contains
 		for (auto type : m_vertex_type)
 		  {
@@ -116,6 +118,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	if (vtx)
 	  {
 	    vtxz = vtx->get_z();
+	    m_has_zvertex = true;
 	  }
       }
   }
@@ -128,6 +131,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
       std::cout << "TowerJetInput::get_input - WARNING - vertex is NAN. Continue with zvtx = 0 (further vertex warning will be suppressed)." << std::endl;
     }
     vtxz = 0;
+    m_has_zvertex = false;  // no valid vertex, jets are reconstructed with z=0
   }
 
   if (std::abs(vtxz) > 1e3)  // code crashes with very large z vertex, so skip these events
@@ -140,6 +144,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
       std::cout << "TowerJetInput::get_input - WARNING - vertex is " << vtxz << ". Set vtxz = 0 (further vertex warning will be suppressed)." << std::endl;
     }
     vtxz = 0;
+    m_has_zvertex = false;  // no valid vertex, jets are reconstructed with z=0
   }
   m_used_vertex_z = vtxz;  // the z the tower kinematics are computed with
 

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -68,6 +68,13 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   float vtxz = 0;  // default to 0
   m_has_zvertex = false;
   m_used_vertex_type = "UNDEFINED";
+  if (m_use_vertextype && !m_vertex_type.empty())
+  {
+    // record the REQUESTED vertex type even when no vertex is found this event
+    // (so e.g. "MBD" with has_zvertex() == false means: MBD selection active,
+    // but no valid MBD vertex); "UNDEFINED" is left for no type selection.
+    m_used_vertex_type = get_vtxtype_name(m_vertex_type.at(0));
+  }
   m_used_vertex_z = std::numeric_limits<float>::quiet_NaN();
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)

--- a/offline/packages/jetbase/TowerJetInput.h
+++ b/offline/packages/jetbase/TowerJetInput.h
@@ -8,6 +8,8 @@
 #include <globalvertex/GlobalVertex.h>
 
 #include <iostream>  // for cout, ostream
+#include <limits>
+#include <string>
 
 #include <vector>
 // forward declarations
@@ -55,8 +57,15 @@ class TowerJetInput : public JetInput
   }
 
   float get_timing_e_threshold() { return m_timing_e_threshold; }
-  
+
   void set_timing_e_threshold(float new_threshold) { m_timing_e_threshold = new_threshold; }
+
+  // vertex actually used in the last get_input() call.
+  // The z is the value the tower kinematics were computed with, i.e. 0 when
+  // the vertex was NaN or missing.
+  bool has_zvertex() const override { return true; }
+  std::string get_vertex_type() const override { return m_used_vertex_type; }
+  float get_vertex_z() const override { return m_used_vertex_z; }
 
  private:
   Jet::SRC m_input;
@@ -67,6 +76,8 @@ class TowerJetInput : public JetInput
   bool m_use_vertextype {false};
   std::vector<GlobalVertex::VTXTYPE> m_vertex_type{GlobalVertex::UNDEFINED};
   float m_timing_e_threshold{0.1};
+  std::string m_used_vertex_type{"UNDEFINED"};
+  float m_used_vertex_z{std::numeric_limits<float>::quiet_NaN()};
 };
 
 #endif

--- a/offline/packages/jetbase/TowerJetInput.h
+++ b/offline/packages/jetbase/TowerJetInput.h
@@ -61,9 +61,10 @@ class TowerJetInput : public JetInput
   void set_timing_e_threshold(float new_threshold) { m_timing_e_threshold = new_threshold; }
 
   // vertex actually used in the last get_input() call.
-  // The z is the value the tower kinematics were computed with, i.e. 0 when
-  // the vertex was NaN or missing.
-  bool has_zvertex() const override { return true; }
+  // has_zvertex() is false when no valid vertex was found (empty map, NaN,
+  // or oversized z); the z is then 0, the value the tower kinematics fell
+  // back to.
+  bool has_zvertex() const override { return m_has_zvertex; }
   std::string get_vertex_type() const override { return m_used_vertex_type; }
   float get_vertex_z() const override { return m_used_vertex_z; }
 
@@ -76,6 +77,7 @@ class TowerJetInput : public JetInput
   bool m_use_vertextype {false};
   std::vector<GlobalVertex::VTXTYPE> m_vertex_type{GlobalVertex::UNDEFINED};
   float m_timing_e_threshold{0.1};
+  bool m_has_zvertex{false};
   std::string m_used_vertex_type{"UNDEFINED"};
   float m_used_vertex_z{std::numeric_limits<float>::quiet_NaN()};
 };

--- a/offline/packages/jetbase/TowerJetInput.h
+++ b/offline/packages/jetbase/TowerJetInput.h
@@ -63,7 +63,8 @@ class TowerJetInput : public JetInput
   // vertex actually used in the last get_input() call.
   // has_zvertex() is false when no valid vertex was found (empty map, NaN,
   // or oversized z); the z is then 0, the value the tower kinematics fell
-  // back to.
+  // back to. The type is the REQUESTED vertex type when a type selection is
+  // active (even if no vertex was found); "UNDEFINED" without a selection.
   bool has_zvertex() const override { return m_has_zvertex; }
   std::string get_vertex_type() const override { return m_used_vertex_type; }
   float get_vertex_z() const override { return m_used_vertex_z; }


### PR DESCRIPTION
…zvertex, get_vertex_type, get_vertex_z functions

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

This PR adds calorimeter energy fractions and z-vertex metadata for jet studies. It also updates versioned classes. Compatibility with existing DST data, especially `DST_TRUTH_JET`, requires verification.

## Key Changes

- Add EMCal, inner HCal, and outer HCal fraction calculation.
- Add `set_calc_calo_fractions(bool)` and enable calculation by default.
- Add fraction accessors to `Jet` and `Jetv2`.
- Centralize calorimeter classification in `FastJetOptions.h`.
- Add z-vertex validity, type, and position accessors.
- Record vertex metadata during jet reconstruction.
- Handle missing or invalid vertices with explicit fallback state.
- Increment ROOT class versions for `Jetv2` and `JetContainerv1`.

## Potential Risk Areas

- Test reading old DST files, including `DST_TRUTH_JET`, after the class-version changes.
- Verify vertex fallback behavior and per-event state reset.
- Measure the performance cost of calorimeter fraction calculation.
- Confirm that the shared calorimeter classification remains consistent across jet algorithms.
- AI-generated summaries can contain mistakes. Review the implementation and test results before merging.

## Possible Future Improvements

- Add regression tests for old and new DST files.
- Add tests for missing, invalid, and alternative vertex types.
- Benchmark enabled and disabled calorimeter fraction calculation.
- Document fraction and vertex metadata conventions for downstream users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->