### PR TITLE
Add TPC-only helix/Kalman fitters and V0 candidate diagnostics

### DIFF
--- a/offline/packages/TrackingDiagnostics/Makefile.am
+++ b/offline/packages/TrackingDiagnostics/Makefile.am
@@ -15,6 +15,7 @@ pkginclude_HEADERS = \
   Tpc_AssembledTrackDisplay.h \
   Tpc_PolyClusterDisplay.h \
   Tpc_PolyClusterResiduals.h \
+  TpcV0CandidateTree.h \
   BeamCrossingAnalysis.h \
   helixResiduals.h \
   KshortReconstruction.h \
@@ -31,6 +32,7 @@ libTrackingDiagnostics_la_SOURCES = \
   Tpc_AssembledTrackDisplay.cc \
   Tpc_PolyClusterDisplay.cc \
   Tpc_PolyClusterResiduals.cc \
+  TpcV0CandidateTree.cc \
   BeamCrossingAnalysis.cc \
   helixResiduals.cc \
   KshortReconstruction.cc \
@@ -40,11 +42,13 @@ libTrackingDiagnostics_la_SOURCES = \
   TrkrNtuplizer.cc
 
 libTrackingDiagnostics_la_LIBADD = \
+  -lffaobjects \
   -lphool \
   -lfun4all \
   -lg4eval \
   -lg4eval_io \
   -lphg4hit \
+  -lphfield \
   -lmbd_io \
   -lg4detectors_io \
   -lmvtx \

--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
@@ -1,0 +1,2820 @@
+#include "TpcV0CandidateTree.h"
+
+#include <tpctrackreco/TpcTrackHelixFitter.h>
+#include <tpctrackreco/TpcTrackKalmanFitter.h>
+#include <tpctrackreco/Tpc_PolyCluster.h>
+#include <tpctrackreco/Tpc_PolyClusterContainer.h>
+#include <tpctrackreco/Tpc_PolyTrack.h>
+#include <tpctrackreco/Tpc_PolyTrackContainer.h>
+#include <tpctrackreco/Tpc_PolyTrackVertexContainer.h>
+
+#include <trackbase/TrkrDefs.h>
+
+#include <g4main/PHG4EventHeader.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4VtxPoint.h>
+
+#include <ffaobjects/EventHeader.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phfield/PHField.h>
+#include <phfield/PHFieldUtility.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <Eigen/Dense>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <tuple>
+#include <utility>
+
+namespace
+{
+  constexpr double kPi = 3.14159265358979323846;
+  constexpr double kPionMass = 0.13957039;
+  constexpr double kProtonMass = 0.938272088;
+
+  template <class T>
+  constexpr T square(const T &value)
+  {
+    return value * value;
+  }
+
+  [[maybe_unused]] int sign_to_charge(const double value)
+  {
+    if (!std::isfinite(value) || value == 0.0)
+    {
+      return 0;
+    }
+    return value > 0.0 ? 1 : -1;
+  }
+
+  double normalize_phi(const double phi)
+  {
+    return std::atan2(std::sin(phi), std::cos(phi));
+  }
+
+  double unwrap_to_near(double theta, const double reference)
+  {
+    while (theta - reference > kPi)
+    {
+      theta -= 2.0 * kPi;
+    }
+    while (theta - reference < -kPi)
+    {
+      theta += 2.0 * kPi;
+    }
+    return theta;
+  }
+
+  bool helix_point_at_beam_radius(const TpcTrackHelix &helix,
+                                  const double beam_radius,
+                                  const double theta_hint,
+                                  double &theta,
+                                  TpcTrackVec3 &position)
+  {
+    if (beam_radius <= 0.0 || helix.radius <= 0.0 ||
+        !std::isfinite(beam_radius) || !std::isfinite(helix.radius))
+    {
+      return false;
+    }
+
+    const double center_radius = std::hypot(helix.cx, helix.cy);
+    if (center_radius <= 1.0e-12)
+    {
+      theta = theta_hint;
+      position = TpcTrackHelixFitter::point(helix, theta);
+      return TpcTrackHelixFitter::finite(position);
+    }
+
+    const double rhs = (square(beam_radius) - square(center_radius) - square(helix.radius)) /
+                       (2.0 * helix.radius * center_radius);
+    if (rhs < -1.0 - 1.0e-9 || rhs > 1.0 + 1.0e-9)
+    {
+      return false;
+    }
+
+    const double clamped_rhs = std::clamp(rhs, -1.0, 1.0);
+    const double center_phi = std::atan2(helix.cy, helix.cx);
+    const double delta = std::acos(clamped_rhs);
+    const double theta_a = unwrap_to_near(center_phi + delta, theta_hint);
+    const double theta_b = unwrap_to_near(center_phi - delta, theta_hint);
+    theta = (std::abs(theta_a - theta_hint) <= std::abs(theta_b - theta_hint)) ? theta_a : theta_b;
+    position = TpcTrackHelixFitter::point(helix, theta);
+    return TpcTrackHelixFitter::finite(position);
+  }
+
+  bool helix_cluster_residual(const TpcTrackHelix &helix,
+                              const TpcTrackPoint &point,
+                              double &previous_theta,
+                              bool &have_previous_theta,
+                              TpcTrackVec3 &fit_position,
+                              double &residual_r,
+                              double &residual_rphi,
+                              double &residual_z)
+  {
+    const TpcTrackVec3 &cluster = point.position;
+    const double cluster_r = std::hypot(cluster.x, cluster.y);
+    double theta_hint = std::atan2(cluster.y - helix.cy,
+                                   cluster.x - helix.cx);
+    theta_hint = unwrap_to_near(theta_hint,
+                                have_previous_theta ? previous_theta
+                                                    : helix.theta_first);
+
+    double theta = theta_hint;
+    if (!helix_point_at_beam_radius(helix, cluster_r, theta_hint, theta, fit_position))
+    {
+      fit_position = TpcTrackHelixFitter::point(helix, theta_hint);
+      theta = theta_hint;
+      if (!TpcTrackHelixFitter::finite(fit_position))
+      {
+        return false;
+      }
+    }
+
+    previous_theta = theta;
+    have_previous_theta = true;
+
+    const double fit_r = std::hypot(fit_position.x, fit_position.y);
+    const double cluster_phi = std::atan2(cluster.y, cluster.x);
+    const double fit_phi = std::atan2(fit_position.y, fit_position.x);
+    residual_r = cluster_r - fit_r;
+    residual_rphi = cluster_r * normalize_phi(cluster_phi - fit_phi);
+    residual_z = cluster.z - fit_position.z;
+    return std::isfinite(residual_r) &&
+           std::isfinite(residual_rphi) &&
+           std::isfinite(residual_z);
+  }
+}  // namespace
+
+TpcV0CandidateTree::TpcV0CandidateTree(const std::string &name,
+                                       const std::string &filename)
+  : SubsysReco(name)
+  , m_filename(filename)
+{
+  m_kalman_config.bfield_t = m_bfield_t;
+  m_kalman_config.point_order = m_point_order;
+}
+
+void TpcV0CandidateTree::set_primary_vertex(const double x, const double y, const double z)
+{
+  m_fixed_primary_vertex = {x, y, z};
+}
+
+bool TpcV0CandidateTree::set_point_order(const std::string &mode)
+{
+  PointOrder order = PointOrder::Path;
+  if (!parse_point_order(mode, order))
+  {
+    std::cerr << PHWHERE << Name() << ": unknown point order mode '" << mode
+              << "'. Valid modes are path, input, radius, theta-z, auto." << std::endl;
+    return false;
+  }
+
+  m_point_order = order;
+  m_kalman_config.point_order = order;
+  return true;
+}
+
+bool TpcV0CandidateTree::set_track_fit_method(const std::string &mode)
+{
+  std::string lowered = mode;
+  std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                 [](const unsigned char ch)
+                 { return static_cast<char>(std::tolower(ch)); });
+
+  if (lowered == "helix" || lowered == "circle")
+  {
+    set_fit_helix(true);
+    return true;
+  }
+  if (lowered == "kalman" || lowered == "kf")
+  {
+    set_fit_kalman(true);
+    return true;
+  }
+  if (lowered == "none" || lowered == "line")
+  {
+    m_fit_helix_tracks = false;
+    m_fit_kalman_tracks = false;
+    return true;
+  }
+
+  std::cerr << PHWHERE << Name() << ": unknown track fit method '" << mode
+            << "'. Valid methods are helix, kalman, and line." << std::endl;
+  return false;
+}
+
+int TpcV0CandidateTree::Init(PHCompositeNode *topNode)
+{
+  if (m_use_kalman_field_map && m_kalman_config.magnetic_field == nullptr && topNode != nullptr)
+  {
+    m_kalman_config.magnetic_field =
+        findNode::getClass<PHField>(topNode, PHFieldUtility::GetDSTFieldMapNodeName());
+  }
+
+  m_file = new TFile(m_filename.c_str(), "RECREATE");
+  if (!m_file || m_file->IsZombie())
+  {
+    std::cout << Name() << ": failed to create output file " << m_filename << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_pair_tree = new TTree("pairTree", "TPC truth-point V0 candidates");
+  m_track_tree = new TTree("trackTree", "TPC track QA before V0 pairing preselection");
+  if (m_write_cluster_residual_tree)
+  {
+    m_cluster_residual_tree = new TTree("clusterResidualTree", "TPC per-cluster residual QA");
+  }
+  create_branches();
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcV0CandidateTree::process_event(PHCompositeNode *topNode)
+{
+  const auto event_start = std::chrono::steady_clock::now();
+  const double kalman_fit_before = m_timing_kalman_fit_seconds;
+  const double kalman_pca_before = m_timing_kalman_pca_seconds;
+  const std::uint64_t rkn_propagations_before = m_timing_rkn_propagations;
+  const std::uint64_t rkn_steps_before = m_timing_rkn_accepted_steps;
+  const std::uint64_t rkn_retries_before = m_timing_rkn_rejected_trials;
+  const std::uint64_t rkn_failures_before = m_timing_rkn_failures;
+  const int run_number = get_run_number(topNode);
+  const int event_number = get_event_number(topNode);
+  Vec3 primary_vertex = m_fixed_primary_vertex;
+  Tpc_PolyTrackVertexContainer *pattern_vertices = nullptr;
+  std::map<int, Tracklet> tracklet_map;
+
+  const auto track_build_start = std::chrono::steady_clock::now();
+  if (m_use_pattern_cluster_tracks)
+  {
+    auto *clusters = findNode::getClass<Tpc_PolyClusterContainer>(
+        topNode, m_tpc_sa_cluster_node);
+    auto *tracks = findNode::getClass<Tpc_PolyTrackContainer>(
+        topNode, m_tpc_sa_track_node);
+    pattern_vertices = findNode::getClass<Tpc_PolyTrackVertexContainer>(
+        topNode, m_tpc_sa_track_vertex_node);
+
+    if (!clusters || !tracks)
+    {
+      if (Verbosity() > 0)
+      {
+        std::cout << PHWHERE << Name() << ": missing pattern-reco nodes "
+                  << m_tpc_sa_cluster_node << "/" << m_tpc_sa_track_node << std::endl;
+      }
+      return Fun4AllReturnCodes::EVENT_OK;
+    }
+
+    if (!pattern_vertices && Verbosity() > 1)
+    {
+      std::cout << PHWHERE << Name() << ": missing pattern-reco vertex node "
+                << m_tpc_sa_track_vertex_node
+                << "; trackTree vertex_z will use the configured fallback vertex" << std::endl;
+    }
+    tracklet_map = build_pattern_tracklets(clusters, tracks);
+  }
+  else
+  {
+    auto *truth_points = findNode::getClass<PHG4HitContainer>(topNode, m_truth_point_node);
+    if (!truth_points)
+    {
+      if (Verbosity() > 0)
+      {
+        std::cout << PHWHERE << Name() << ": missing truth point node "
+                  << m_truth_point_node << std::endl;
+      }
+      return Fun4AllReturnCodes::EVENT_OK;
+    }
+
+    auto *truth_info = findNode::getClass<PHG4TruthInfoContainer>(topNode, m_truth_info_node);
+    if (!truth_info && Verbosity() > 0)
+    {
+      std::cout << PHWHERE << Name() << ": missing truth info node "
+                << m_truth_info_node << "; no charged truth tracklets can be built" << std::endl;
+    }
+
+    primary_vertex = get_primary_vertex(truth_info);
+    tracklet_map = build_tracklets(truth_points, truth_info);
+  }
+  const double track_build_seconds = std::chrono::duration<double>(
+                                         std::chrono::steady_clock::now() - track_build_start)
+                                         .count();
+  if (m_print_timing)
+  {
+    std::cout << "[V0TimingStage] run=" << run_number
+              << " event=" << event_number
+              << " stage=track_build_done"
+              << " tracks=" << tracklet_map.size()
+              << " stage_s=" << track_build_seconds
+              << " kalman_fit_s=" << (m_timing_kalman_fit_seconds - kalman_fit_before)
+              << " rkn_propagations=" << (m_timing_rkn_propagations - rkn_propagations_before)
+              << " rkn_steps=" << (m_timing_rkn_accepted_steps - rkn_steps_before)
+              << std::endl;
+  }
+
+  const auto dca_cache_start = std::chrono::steady_clock::now();
+  for (auto &entry : tracklet_map)
+  {
+    auto &tracklet = entry.second;
+    tracklet.has_beamline_pca = track_pca_to_xy(
+        tracklet, Vec3{0.0, 0.0, 0.0}, tracklet.beamline_pca, tracklet.rdca_zero);
+    tracklet.has_pattern_vertex = choose_pattern_collision_vertex(
+        tracklet, pattern_vertices, tracklet.pattern_vertex,
+        tracklet.pattern_vertex_z_rms, tracklet.pattern_vertex_ntracks);
+    const Vec3 &dca_vertex = tracklet.has_pattern_vertex
+                                 ? tracklet.pattern_vertex
+                                 : primary_vertex;
+    tracklet.vertex_dca = fitted_track_dca_to_vertex(tracklet, dca_vertex);
+    tracklet.has_vertex_dca =
+        std::isfinite(tracklet.vertex_dca.first) &&
+        std::isfinite(tracklet.vertex_dca.second);
+  }
+  const double dca_cache_seconds = std::chrono::duration<double>(
+                                       std::chrono::steady_clock::now() - dca_cache_start)
+                                       .count();
+  m_timing_dca_cache_seconds += dca_cache_seconds;
+  if (m_print_timing)
+  {
+    std::cout << "[V0TimingStage] run=" << run_number
+              << " event=" << event_number
+              << " stage=dca_cache_done"
+              << " tracks=" << tracklet_map.size()
+              << " stage_s=" << dca_cache_seconds
+              << std::endl;
+  }
+
+  std::vector<const Tracklet *> tracklets;
+  tracklets.reserve(tracklet_map.size());
+  for (const auto &entry : tracklet_map)
+  {
+    tracklets.push_back(&entry.second);
+  }
+
+  const auto track_qa_start = std::chrono::steady_clock::now();
+  for (const auto *tracklet : tracklets)
+  {
+    fill_track_row(*tracklet, primary_vertex, run_number, event_number);
+    if (m_cluster_residual_tree)
+    {
+      fill_cluster_residual_rows(*tracklet, primary_vertex, run_number, event_number);
+    }
+  }
+  const double track_qa_seconds = std::chrono::duration<double>(
+                                      std::chrono::steady_clock::now() - track_qa_start)
+                                      .count();
+  if (m_print_timing)
+  {
+    std::cout << "[V0TimingStage] run=" << run_number
+              << " event=" << event_number
+              << " stage=track_qa_done"
+              << " stage_s=" << track_qa_seconds
+              << std::endl;
+  }
+
+  const auto pair_loop_start = std::chrono::steady_clock::now();
+  std::uint64_t event_pairs_processed = 0;
+  const std::uint64_t event_pairs_total =
+      tracklets.size() > 1
+          ? static_cast<std::uint64_t>(tracklets.size()) *
+                static_cast<std::uint64_t>(tracklets.size() - 1) / 2
+          : 0;
+  if (m_print_timing)
+  {
+    std::cout << "[V0TimingStage] run=" << run_number
+              << " event=" << event_number
+              << " stage=pair_loop_start"
+              << " pairs=" << event_pairs_total
+              << std::endl;
+  }
+  for (std::size_t i = 0; i < tracklets.size(); ++i)
+  {
+    for (std::size_t j = i + 1; j < tracklets.size(); ++j)
+    {
+      make_pair_row(*tracklets[i], *tracklets[j], primary_vertex, run_number, event_number);
+      ++event_pairs_processed;
+      if (m_print_timing &&
+          (event_pairs_processed == 1 || event_pairs_processed % 1000 == 0))
+      {
+        std::cout << "[V0TimingPair] run=" << run_number
+                  << " event=" << event_number
+                  << " done=" << event_pairs_processed
+                  << " total=" << event_pairs_total
+                  << " pair_loop_s=" << std::chrono::duration<double>(std::chrono::steady_clock::now() - pair_loop_start).count()
+                  << " kalman_pca_s=" << (m_timing_kalman_pca_seconds - kalman_pca_before)
+                  << std::endl;
+      }
+    }
+  }
+  const double pair_loop_seconds = std::chrono::duration<double>(
+                                       std::chrono::steady_clock::now() - pair_loop_start)
+                                       .count();
+  const double total_seconds = std::chrono::duration<double>(
+                                   std::chrono::steady_clock::now() - event_start)
+                                   .count();
+  const double kalman_fit_seconds = m_timing_kalman_fit_seconds - kalman_fit_before;
+  const double kalman_pca_seconds = m_timing_kalman_pca_seconds - kalman_pca_before;
+
+  ++m_timing_events;
+  m_timing_total_seconds += total_seconds;
+  m_timing_track_build_seconds += track_build_seconds;
+  m_timing_track_qa_seconds += track_qa_seconds;
+  m_timing_pair_loop_seconds += pair_loop_seconds;
+
+  if (m_print_timing)
+  {
+    std::cout << "[V0Timing] run=" << run_number
+              << " event=" << event_number
+              << " tracks=" << tracklets.size()
+              << " total_s=" << total_seconds
+              << " track_build_s=" << track_build_seconds
+              << " kalman_fit_s=" << kalman_fit_seconds
+              << " track_qa_s=" << track_qa_seconds
+              << " pair_loop_s=" << pair_loop_seconds
+              << " kalman_pca_s=" << kalman_pca_seconds
+              << " rkn_propagations=" << (m_timing_rkn_propagations - rkn_propagations_before)
+              << " rkn_steps=" << (m_timing_rkn_accepted_steps - rkn_steps_before)
+              << " rkn_retries=" << (m_timing_rkn_rejected_trials - rkn_retries_before)
+              << " rkn_failures=" << (m_timing_rkn_failures - rkn_failures_before)
+              << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcV0CandidateTree::End(PHCompositeNode * /*topNode*/)
+{
+  if (m_file)
+  {
+    m_file->cd();
+    if (m_pair_tree)
+    {
+      m_pair_tree->Write();
+    }
+    if (m_track_tree)
+    {
+      m_track_tree->Write();
+    }
+    if (m_cluster_residual_tree)
+    {
+      m_cluster_residual_tree->Write();
+    }
+    m_file->Close();
+    delete m_file;
+    m_file = nullptr;
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << ": pair counters: raw=" << m_counter_raw_pairs
+              << " reject_charge=" << m_counter_reject_charge
+              << " reject_preselection=" << m_counter_reject_preselection
+              << " reject_pca=" << m_counter_reject_pca
+              << " reject_pointing=" << m_counter_reject_pointing
+              << " reject_ap=" << m_counter_reject_ap
+              << " reject_pair_selection=" << m_counter_reject_pair_selection
+              << " written=" << m_counter_written
+              << " tracks_written=" << m_counter_tracks_written
+              << " reject_helix_anchor=" << m_counter_reject_helix_anchor
+              << " cluster_residuals_written=" << m_counter_cluster_residuals_written
+              << std::endl;
+  }
+
+  if (m_print_timing)
+  {
+    std::cout << "[V0TimingSummary] events=" << m_timing_events
+              << " total_s=" << m_timing_total_seconds
+              << " track_build_s=" << m_timing_track_build_seconds
+              << " kalman_fits=" << m_timing_kalman_fits
+              << " kalman_fit_s=" << m_timing_kalman_fit_seconds
+              << " rkn_s=" << m_timing_rkn_seconds
+              << " dca_cache_s=" << m_timing_dca_cache_seconds
+              << " track_qa_s=" << m_timing_track_qa_seconds
+              << " pair_loop_s=" << m_timing_pair_loop_seconds
+              << " kalman_pca_s=" << m_timing_kalman_pca_seconds
+              << " rkn_propagations=" << m_timing_rkn_propagations
+              << " rkn_steps=" << m_timing_rkn_accepted_steps
+              << " rkn_retries=" << m_timing_rkn_rejected_trials
+              << " rkn_failures=" << m_timing_rkn_failures
+              << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcV0CandidateTree::get_event_number(PHCompositeNode *topNode) const
+{
+  if (auto *event_header = findNode::getClass<EventHeader>(topNode, "EventHeader"))
+  {
+    return event_header->get_EvtSequence();
+  }
+  if (auto *g4_event_header = findNode::getClass<PHG4EventHeader>(topNode, "EventHeader"))
+  {
+    return g4_event_header->get_EvtSequence();
+  }
+  return 0;
+}
+
+int TpcV0CandidateTree::get_run_number(PHCompositeNode *topNode) const
+{
+  if (auto *event_header = findNode::getClass<EventHeader>(topNode, "EventHeader"))
+  {
+    return event_header->get_RunNumber();
+  }
+  return 1;
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::get_primary_vertex(PHG4TruthInfoContainer *truth_info) const
+{
+  if (!m_use_truth_primary_vertex || !truth_info)
+  {
+    return m_fixed_primary_vertex;
+  }
+
+  const auto vtx_range = truth_info->GetPrimaryVtxRange();
+  for (auto iter = vtx_range.first; iter != vtx_range.second; ++iter)
+  {
+    const auto *vtx = iter->second;
+    if (vtx)
+    {
+      return {vtx->get_x(), vtx->get_y(), vtx->get_z()};
+    }
+  }
+
+  return m_fixed_primary_vertex;
+}
+
+std::map<int, TpcV0CandidateTree::Tracklet> TpcV0CandidateTree::build_tracklets(
+    PHG4HitContainer *truth_points,
+    PHG4TruthInfoContainer *truth_info) const
+{
+  std::map<int, Tracklet> tracklets;
+  if (!truth_points)
+  {
+    return tracklets;
+  }
+
+  const auto hit_range = truth_points->getHits();
+  for (auto hit_iter = hit_range.first; hit_iter != hit_range.second; ++hit_iter)
+  {
+    const PHG4Hit *hit = hit_iter->second;
+    if (!hit)
+    {
+      continue;
+    }
+
+    const int track_id = hit->get_trkid();
+    Tracklet &tracklet = tracklets[track_id];
+    if (tracklet.points.empty())
+    {
+      tracklet.track_id = track_id;
+      tracklet.shower_id = hit->get_shower_id();
+    }
+
+    TruthPoint point;
+    point.track_id = track_id;
+    point.shower_id = hit->get_shower_id();
+    point.layer = static_cast<int>(hit->get_layer());
+    point.position = {hit->get_x(0), hit->get_y(0), hit->get_z(0)};
+    point.momentum = {hit->get_px(0), hit->get_py(0), hit->get_pz(0)};
+    point.t = hit->get_t(0);
+    point.path = hit->get_path_length();
+    if (finite(point.position) && finite(point.momentum))
+    {
+      tracklet.points.push_back(point);
+    }
+  }
+
+  for (auto iter = tracklets.begin(); iter != tracklets.end();)
+  {
+    Tracklet &tracklet = iter->second;
+    order_track_points(tracklet.points, m_point_order);
+    tracklet.npoints = static_cast<int>(tracklet.points.size());
+    tracklet.ntpc_clusters = static_cast<unsigned int>(tracklet.points.size());
+    if (!tracklet.points.empty())
+    {
+      tracklet.side = tracklet.points.front().position.z < 0.0 ? 0 : 1;
+    }
+
+    if (tracklet.npoints < m_min_points)
+    {
+      iter = tracklets.erase(iter);
+      continue;
+    }
+
+    if (truth_info)
+    {
+      const PHG4Particle *particle = truth_info->GetParticle(tracklet.track_id);
+      if (particle)
+      {
+        tracklet.pid = particle->get_pid();
+        tracklet.parent_id = particle->get_parent_id();
+        tracklet.primary_id = particle->get_primary_id();
+        tracklet.vtx_id = particle->get_vtx_id();
+        tracklet.barcode = particle->get_barcode();
+        tracklet.embed_id = truth_info->isEmbeded(tracklet.track_id);
+        tracklet.is_primary = truth_info->is_primary(particle) ? 1 : 0;
+        tracklet.charge = pdg_charge(tracklet.pid);
+        tracklet.truth_momentum = {particle->get_px(), particle->get_py(), particle->get_pz()};
+        tracklet.truth_e = particle->get_e();
+
+        if (const PHG4Particle *parent = truth_info->GetParticle(tracklet.parent_id))
+        {
+          tracklet.parent_pid = parent->get_pid();
+        }
+
+        if (auto *vtx = truth_info->GetVtx(tracklet.vtx_id))
+        {
+          tracklet.truth_vertex = {vtx->get_x(), vtx->get_y(), vtx->get_z()};
+          tracklet.truth_vt = vtx->get_t();
+        }
+      }
+    }
+
+    if (tracklet.charge == 0)
+    {
+      iter = tracklets.erase(iter);
+      continue;
+    }
+
+    if (m_fit_kalman_tracks)
+    {
+      tracklet.has_kalman = fit_kalman(tracklet.points, tracklet.charge, tracklet.kalman);
+      if (!tracklet.has_kalman || tracklet.kalman.states_smoothed.empty())
+      {
+        iter = tracklets.erase(iter);
+        continue;
+      }
+
+      const auto state = TpcTrackKalmanFitter::propagation_state(tracklet.kalman, Vec3{});
+      tracklet.position = TpcTrackKalmanFitter::state_position(state);
+      tracklet.momentum = TpcTrackKalmanFitter::state_momentum(state);
+    }
+    else if (m_fit_helix_tracks)
+    {
+      tracklet.has_helix = fit_helix(tracklet.points, m_fit_first_points,
+                                     tracklet.charge, m_bfield_t, tracklet.helix);
+      if (!tracklet.has_helix)
+      {
+        iter = tracklets.erase(iter);
+        continue;
+      }
+      tracklet.position = helix_point(tracklet.helix, tracklet.helix.theta_first);
+      tracklet.momentum = helix_momentum(tracklet.helix, tracklet.helix.theta_first);
+    }
+    else
+    {
+      tracklet.position = tracklet.points.front().position;
+      tracklet.momentum = tracklet.points.front().momentum;
+    }
+
+    assign_fit_quality(tracklet);
+
+    if (!finite(tracklet.truth_momentum) || norm(tracklet.truth_momentum) <= 0.0)
+    {
+      tracklet.truth_momentum = tracklet.momentum;
+    }
+
+    ++iter;
+  }
+
+  return tracklets;
+}
+
+std::map<int, TpcV0CandidateTree::Tracklet> TpcV0CandidateTree::build_pattern_tracklets(
+    Tpc_PolyClusterContainer *clusters,
+    Tpc_PolyTrackContainer *tracks) const
+{
+  std::map<int, Tracklet> tracklets;
+
+  if (!clusters || !tracks)
+  {
+    return tracklets;
+  }
+
+  std::map<unsigned int, std::vector<const Tpc_PolyCluster *>> clusters_by_source_id;
+  for (unsigned int icluster = 0; icluster < clusters->size(); ++icluster)
+  {
+    const Tpc_PolyCluster *cluster = clusters->get_cluster(icluster);
+    if (!cluster || !cluster->isValid())
+    {
+      continue;
+    }
+    clusters_by_source_id[cluster->get_source_assembled_track_id()].push_back(cluster);
+  }
+
+  for (unsigned int itrack = 0; itrack < tracks->size(); ++itrack)
+  {
+    const Tpc_PolyTrack *track = tracks->get_track(itrack);
+    if (!track || !track->isValid() || track->get_fit_status() == 0)
+    {
+      continue;
+    }
+
+    const unsigned int source_id = track->get_source_assembled_track_id();
+    const auto cluster_iter = clusters_by_source_id.find(source_id);
+    if (cluster_iter == clusters_by_source_id.end())
+    {
+      continue;
+    }
+
+    const unsigned int pattern_track_id = track->get_track_id();
+    const int track_id = static_cast<int>(pattern_track_id != 0 ? pattern_track_id : itrack + 1);
+
+    Tracklet tracklet;
+    tracklet.track_id = track_id;
+    tracklet.shower_id = static_cast<int>(source_id);
+    tracklet.charge = sign_to_charge(track->get_charge());
+    tracklet.position = {track->get_x(), track->get_y(), track->get_z()};
+    tracklet.momentum = {track->get_px(), track->get_py(), track->get_pz()};
+    tracklet.truth_momentum = tracklet.momentum;
+    tracklet.dedx = track->get_dedx();
+    tracklet.has_dedx = std::isfinite(tracklet.dedx);
+
+    std::map<int, unsigned int> side_counts;
+    const auto &track_clusters = cluster_iter->second;
+    tracklet.points.reserve(track_clusters.size());
+    for (unsigned int icluster = 0; icluster < track_clusters.size(); ++icluster)
+    {
+      const Tpc_PolyCluster *cluster = track_clusters[icluster];
+      if (!cluster || !cluster->isValid())
+      {
+        continue;
+      }
+
+      TruthPoint point;
+      point.track_id = track_id;
+      point.shower_id = static_cast<int>(source_id);
+      point.layer = -1;
+      if (cluster->size_hits() > 0)
+      {
+        point.layer = static_cast<int>(TrkrDefs::getLayer(cluster->get_hit_index(0).first));
+      }
+      point.position = {cluster->get_centroid_x(),
+                        cluster->get_centroid_y(),
+                        cluster->get_centroid_z()};
+      point.momentum = tracklet.momentum;
+      point.t = 0.0;
+      point.path = point.layer >= 0 ? static_cast<double>(point.layer)
+                                    : static_cast<double>(icluster);
+      if (finite(point.position))
+      {
+        tracklet.points.push_back(point);
+        ++side_counts[cluster->get_side()];
+      }
+    }
+
+    if (!side_counts.empty())
+    {
+      tracklet.side = std::max_element(
+                          side_counts.begin(), side_counts.end(),
+                          [](const auto &lhs, const auto &rhs)
+                          { return lhs.second < rhs.second; })
+                          ->first;
+    }
+    tracklet.ntpc_clusters = track->get_nclusters() > 0
+                                 ? track->get_nclusters()
+                                 : static_cast<unsigned int>(tracklet.points.size());
+
+    const bool has_upstream_state = finite(tracklet.position) &&
+                                    finite(tracklet.momentum) &&
+                                    norm(tracklet.momentum) > 0.0;
+    if (!finalize_pattern_tracklet(tracklet, has_upstream_state))
+    {
+      continue;
+    }
+
+    tracklet.truth_momentum = tracklet.momentum;
+    tracklets[track_id] = std::move(tracklet);
+  }
+  return tracklets;
+}
+
+bool TpcV0CandidateTree::finalize_pattern_tracklet(Tracklet &tracklet,
+                                                   const bool has_upstream_state) const
+{
+  order_track_points(tracklet.points, m_point_order);
+  tracklet.npoints = static_cast<int>(tracklet.points.size());
+  if (tracklet.npoints < m_min_points || tracklet.charge == 0)
+  {
+    return false;
+  }
+
+  if (m_fit_kalman_tracks)
+  {
+    tracklet.has_kalman = fit_kalman(tracklet.points, tracklet.charge, tracklet.kalman);
+    if (!tracklet.has_kalman || tracklet.kalman.states_smoothed.empty())
+    {
+      return false;
+    }
+
+    const auto state = TpcTrackKalmanFitter::propagation_state(tracklet.kalman, Vec3{});
+    tracklet.position = TpcTrackKalmanFitter::state_position(state);
+    tracklet.momentum = TpcTrackKalmanFitter::state_momentum(state);
+  }
+  else if (m_use_final_track_helix && has_upstream_state)
+  {
+    tracklet.has_helix = helix_from_state(tracklet.position, tracklet.momentum,
+                                          tracklet.charge, m_bfield_t, tracklet.helix);
+    if (!tracklet.has_helix)
+    {
+      return false;
+    }
+
+    tracklet.has_helix_search_range =
+        TpcTrackHelixFitter::measurement_anchored_search_range(
+            tracklet.helix, tracklet.points,
+            m_final_track_helix_max_upstream_cm,
+            m_final_track_helix_downstream_margin_cm,
+            tracklet.helix_search_range);
+    if (!tracklet.has_helix_search_range)
+    {
+      ++m_counter_reject_helix_anchor;
+      return false;
+    }
+
+    tracklet.position = helix_point(tracklet.helix, tracklet.helix.theta_first);
+    tracklet.momentum = helix_momentum(tracklet.helix, tracklet.helix.theta_first);
+  }
+  else if (m_fit_helix_tracks)
+  {
+    tracklet.has_helix = fit_helix(tracklet.points, m_fit_first_points,
+                                   tracklet.charge, m_bfield_t, tracklet.helix);
+    if (!tracklet.has_helix)
+    {
+      return false;
+    }
+
+    tracklet.position = helix_point(tracklet.helix, tracklet.helix.theta_first);
+    tracklet.momentum = helix_momentum(tracklet.helix, tracklet.helix.theta_first);
+  }
+  else if (!has_upstream_state)
+  {
+    if (tracklet.points.size() < 2)
+    {
+      return false;
+    }
+    tracklet.position = tracklet.points.front().position;
+    tracklet.momentum = subtract(tracklet.points[1].position,
+                                 tracklet.points.front().position);
+  }
+
+  assign_fit_quality(tracklet);
+  return finite(tracklet.position) && finite(tracklet.momentum) &&
+         norm(tracklet.momentum) > 0.0;
+}
+
+bool TpcV0CandidateTree::track_pca_to_xy(const Tracklet &tracklet,
+                                         const Vec3 &beamline,
+                                         Vec3 &pca,
+                                         double &signed_dca_xy) const
+{
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  pca = {nan, nan, nan};
+  signed_dca_xy = nan;
+
+  if (tracklet.has_kalman && !tracklet.kalman.states_smoothed.empty())
+  {
+    const auto state = TpcTrackKalmanFitter::propagation_state(tracklet.kalman, beamline);
+    const Vec3 position = TpcTrackKalmanFitter::state_position(state);
+    const Vec3 momentum = TpcTrackKalmanFitter::state_momentum(state);
+    const double qop_t = state[TpcTrackKalmanFitter::QOverPt];
+    const double omega = 0.003 * tracklet.kalman.bfield_t * qop_t;
+    if (std::abs(omega) >= 1.0e-10)
+    {
+      const double radius = std::abs(1.0 / omega);
+      const double center_x = state[TpcTrackKalmanFitter::X] -
+                              std::sin(state[TpcTrackKalmanFitter::Phi]) / omega;
+      const double center_y = state[TpcTrackKalmanFitter::Y] +
+                              std::cos(state[TpcTrackKalmanFitter::Phi]) / omega;
+      const double dx = beamline.x - center_x;
+      const double dy = beamline.y - center_y;
+      const double center_distance = std::hypot(dx, dy);
+      if (center_distance > 1.0e-12)
+      {
+        const double closest_x = center_x + radius * dx / center_distance;
+        const double closest_y = center_y + radius * dy / center_distance;
+        const double theta0 = std::atan2(position.y - center_y, position.x - center_x);
+        const double theta_closest = std::atan2(closest_y - center_y,
+                                                closest_x - center_x);
+        const double path_cm = normalize_phi(theta_closest - theta0) / omega;
+        TpcKalmanConfig config = m_kalman_config;
+        config.bfield_t = tracklet.kalman.bfield_t;
+        config.magnetic_field = tracklet.kalman.magnetic_field;
+        config.analytic_uniform_propagation = tracklet.kalman.analytic_uniform_propagation;
+        const auto closest_state = TpcTrackKalmanFitter::propagate_state(
+            state, path_cm, config, tracklet.kalman.mass_gev);
+        pca = TpcTrackKalmanFitter::state_position(closest_state);
+        signed_dca_xy = center_distance - radius;
+        return finite(pca) && std::isfinite(signed_dca_xy);
+      }
+
+      pca = position;
+      signed_dca_xy = -radius;
+      return finite(pca);
+    }
+
+    const double transverse_momentum2 = square(momentum.x) + square(momentum.y);
+    if (transverse_momentum2 <= 0.0)
+    {
+      return false;
+    }
+    const Vec3 relative = subtract(position, beamline);
+    const double scale_to_pca = -(relative.x * momentum.x + relative.y * momentum.y) /
+                                transverse_momentum2;
+    pca = add(position, scale(momentum, scale_to_pca));
+    signed_dca_xy = (relative.x * momentum.y - relative.y * momentum.x) /
+                    std::sqrt(transverse_momentum2);
+    return finite(pca) && std::isfinite(signed_dca_xy);
+  }
+
+  if (tracklet.has_helix && tracklet.helix.radius > 0.0)
+  {
+    const double dx = beamline.x - tracklet.helix.cx;
+    const double dy = beamline.y - tracklet.helix.cy;
+    const double center_distance = std::hypot(dx, dy);
+    double theta = tracklet.helix.theta_first;
+    if (center_distance > 1.0e-12)
+    {
+      const double theta_raw = std::atan2(dy, dx);
+      theta = unwrap_to_near(theta_raw, tracklet.helix.theta_first);
+    }
+    pca = helix_point(tracklet.helix, theta);
+    signed_dca_xy = center_distance - tracklet.helix.radius;
+    return finite(pca) && std::isfinite(signed_dca_xy);
+  }
+
+  const double transverse_momentum2 = square(tracklet.momentum.x) + square(tracklet.momentum.y);
+  if (transverse_momentum2 <= 0.0)
+  {
+    return false;
+  }
+  const Vec3 relative = subtract(tracklet.position, beamline);
+  const double scale_to_pca = -(relative.x * tracklet.momentum.x +
+                                relative.y * tracklet.momentum.y) /
+                              transverse_momentum2;
+  pca = add(tracklet.position, scale(tracklet.momentum, scale_to_pca));
+  signed_dca_xy = (relative.x * tracklet.momentum.y -
+                   relative.y * tracklet.momentum.x) /
+                  std::sqrt(transverse_momentum2);
+  return finite(pca) && std::isfinite(signed_dca_xy);
+}
+
+bool TpcV0CandidateTree::choose_pattern_collision_vertex(
+    const Tracklet &tracklet,
+    Tpc_PolyTrackVertexContainer *vertices,
+    Vec3 &vertex,
+    double &z_rms,
+    unsigned int &ntracks) const
+{
+  if (!vertices || vertices->get_collision_vertex_valid() == 0)
+  {
+    return false;
+  }
+
+  double best_dz = std::numeric_limits<double>::max();
+  const unsigned int count = vertices->get_collision_vertex_count();
+  for (unsigned int index = 0; index < count; ++index)
+  {
+    const Vec3 candidate{vertices->get_collision_x(index),
+                         vertices->get_collision_y(index),
+                         vertices->get_collision_z(index)};
+    if (!finite(candidate))
+    {
+      continue;
+    }
+
+    Vec3 candidate_pca;
+    double candidate_dca = 0.0;
+    if (!track_pca_to_xy(tracklet, candidate, candidate_pca, candidate_dca))
+    {
+      continue;
+    }
+    const double dz = std::abs(candidate_pca.z - candidate.z);
+    if (dz < best_dz)
+    {
+      best_dz = dz;
+      vertex = candidate;
+      z_rms = vertices->get_collision_z_rms(index);
+      ntracks = vertices->get_collision_ntracks(index);
+    }
+  }
+  return best_dz < std::numeric_limits<double>::max();
+}
+
+bool TpcV0CandidateTree::make_pair_row(const Tracklet &track1, const Tracklet &track2,
+                                       const Vec3 &primary_vertex,
+                                       const int run_number,
+                                       const int event_number)
+{
+  ++m_counter_raw_pairs;
+
+  if (!m_write_same_sign_pairs && track1.charge == track2.charge)
+  {
+    ++m_counter_reject_charge;
+    return false;
+  }
+
+  if (!passes_preselection(track1, track2, primary_vertex))
+  {
+    ++m_counter_reject_preselection;
+    return false;
+  }
+
+  Vec3 pca1;
+  Vec3 pca2;
+  Vec3 mom1 = track1.momentum;
+  Vec3 mom2 = track2.momentum;
+  double pair_dca = 0.0;
+  double theta1 = quiet_nan();
+  double theta2 = quiet_nan();
+  std::pair<double, double> dca1;
+  std::pair<double, double> dca2;
+
+  if (m_fit_kalman_tracks && track1.has_kalman && track2.has_kalman)
+  {
+    const auto pca_start = std::chrono::steady_clock::now();
+    auto candidates = kalman_pca_candidates(
+        track1.kalman, track2.kalman, m_kalman_config, primary_vertex,
+        m_kalman_max_upstream_cm, m_kalman_downstream_margin_cm,
+        m_coarse_steps, m_pca_candidates);
+    m_timing_kalman_pca_seconds += std::chrono::duration<double>(
+                                       std::chrono::steady_clock::now() - pca_start)
+                                       .count();
+    if (candidates.empty())
+    {
+      ++m_counter_reject_pca;
+      return false;
+    }
+
+    auto best = candidates.front();
+    if (m_prefer_positive_pointing)
+    {
+      double best_score = std::numeric_limits<double>::max();
+      for (const auto &candidate : candidates)
+      {
+        const Vec3 cand_mom1 = kalman_momentum(track1.kalman, candidate.s1, m_kalman_config, primary_vertex);
+        const Vec3 cand_mom2 = kalman_momentum(track2.kalman, candidate.s2, m_kalman_config, primary_vertex);
+        const Vec3 cand_vertex = scale(add(candidate.pca1, candidate.pca2), 0.5);
+        const Vec3 flight = subtract(cand_vertex, primary_vertex);
+        const Vec3 total_mom = add(cand_mom1, cand_mom2);
+        const double cos_theta = vector_cosine(flight, total_mom);
+        const double penalty = (std::isfinite(cos_theta) && cos_theta > 0.0) ? 0.0 : 1000.0;
+        const double score = penalty + candidate.dca - 1e-3 * cos_theta;
+        if (score < best_score)
+        {
+          best_score = score;
+          best = candidate;
+        }
+      }
+    }
+
+    pca1 = best.pca1;
+    pca2 = best.pca2;
+    pair_dca = best.dca;
+    theta1 = best.s1;
+    theta2 = best.s2;
+    mom1 = kalman_momentum(track1.kalman, theta1, m_kalman_config, primary_vertex);
+    mom2 = kalman_momentum(track2.kalman, theta2, m_kalman_config, primary_vertex);
+    dca1 = track1.has_vertex_dca
+               ? track1.vertex_dca
+               : TpcTrackKalmanFitter::dca_to_vertex(
+                     track1.kalman, primary_vertex, &m_kalman_config);
+    dca2 = track2.has_vertex_dca
+               ? track2.vertex_dca
+               : TpcTrackKalmanFitter::dca_to_vertex(
+                     track2.kalman, primary_vertex, &m_kalman_config);
+  }
+  else if (m_fit_helix_tracks && track1.has_helix && track2.has_helix)
+  {
+    std::vector<HelixPca> candidates;
+    if (track1.has_helix_search_range && track2.has_helix_search_range)
+    {
+      candidates = TpcTrackHelixFitter::pca_candidates_in_ranges(
+          track1.helix, track2.helix,
+          track1.helix_search_range, track2.helix_search_range,
+          m_coarse_steps, m_pca_candidates);
+    }
+    else
+    {
+      candidates = helix_helix_pca_candidates(
+          track1.helix, track2.helix, m_theta_extension, m_coarse_steps,
+          m_downstream_margin, m_pca_candidates);
+    }
+    if (candidates.empty())
+    {
+      ++m_counter_reject_pca;
+      return false;
+    }
+
+    auto best = candidates.front();
+    if (m_prefer_positive_pointing)
+    {
+      double best_score = std::numeric_limits<double>::max();
+      for (const auto &candidate : candidates)
+      {
+        const Vec3 cand_mom1 = helix_momentum(track1.helix, candidate.theta1);
+        const Vec3 cand_mom2 = helix_momentum(track2.helix, candidate.theta2);
+        const Vec3 cand_vertex = scale(add(candidate.pca1, candidate.pca2), 0.5);
+        const Vec3 flight = subtract(cand_vertex, primary_vertex);
+        const Vec3 total_mom = add(cand_mom1, cand_mom2);
+        const double cos_theta = vector_cosine(flight, total_mom);
+        const double penalty = (std::isfinite(cos_theta) && cos_theta > 0.0) ? 0.0 : 1000.0;
+        const double score = penalty + candidate.dca - 1e-3 * cos_theta;
+        if (score < best_score)
+        {
+          best_score = score;
+          best = candidate;
+        }
+      }
+    }
+
+    pca1 = best.pca1;
+    pca2 = best.pca2;
+    pair_dca = best.dca;
+    theta1 = best.theta1;
+    theta2 = best.theta2;
+    mom1 = helix_momentum(track1.helix, theta1);
+    mom2 = helix_momentum(track2.helix, theta2);
+    dca1 = helix_dca_to_vertex(track1.helix, primary_vertex);
+    dca2 = helix_dca_to_vertex(track2.helix, primary_vertex);
+  }
+  else
+  {
+    LinePca pca;
+    if (!line_line_pca(track1.position, track1.momentum, track2.position, track2.momentum, pca, true))
+    {
+      ++m_counter_reject_pca;
+      return false;
+    }
+    pca1 = pca.pca1;
+    pca2 = pca.pca2;
+    pair_dca = pca.dca;
+    dca1 = track_dca_to_vertex(track1.position, track1.momentum, primary_vertex);
+    dca2 = track_dca_to_vertex(track2.position, track2.momentum, primary_vertex);
+  }
+
+  const Vec3 pair_vertex = scale(add(pca1, pca2), 0.5);
+  const Vec3 total_mom = add(mom1, mom2);
+  const Vec3 flight = subtract(pair_vertex, primary_vertex);
+  const double cos_theta = vector_cosine(flight, total_mom);
+  if (!std::isfinite(cos_theta) || norm(flight) <= 0.0 || norm(total_mom) <= 0.0)
+  {
+    ++m_counter_reject_pointing;
+    return false;
+  }
+
+  const Vec3 &pplus = (track1.charge > 0) ? mom1 : mom2;
+  const Vec3 &pminus = (track1.charge > 0) ? mom2 : mom1;
+  double alpha = 0.0;
+  double qt = 0.0;
+  if (!armenteros(pplus, pminus, alpha, qt))
+  {
+    ++m_counter_reject_ap;
+    return false;
+  }
+
+  if (!passes_pair_selection(pca1, pca2, pair_vertex, primary_vertex,
+                             pair_dca, cos_theta, alpha))
+  {
+    ++m_counter_reject_pair_selection;
+    return false;
+  }
+
+  const Vec3 &truth_pplus = (track1.charge > 0) ? track1.truth_momentum : track2.truth_momentum;
+  const Vec3 &truth_pminus = (track1.charge > 0) ? track2.truth_momentum : track1.truth_momentum;
+  double truth_alpha = quiet_nan();
+  double truth_qt = quiet_nan();
+  armenteros(truth_pplus, truth_pminus, truth_alpha, truth_qt);
+
+  Vec3 true_decay{quiet_nan(), quiet_nan(), quiet_nan()};
+  double pca_to_true_3d = quiet_nan();
+  double pca_to_true_xy = quiet_nan();
+  double pca_to_true_z = quiet_nan();
+  if (track1.parent_id != 0 && track1.parent_id == track2.parent_id)
+  {
+    true_decay = scale(add(track1.truth_vertex, track2.truth_vertex), 0.5);
+    const Vec3 delta = subtract(pair_vertex, true_decay);
+    pca_to_true_3d = norm(delta);
+    pca_to_true_xy = std::sqrt(square(delta.x) + square(delta.y));
+    pca_to_true_z = std::abs(delta.z);
+  }
+
+  const Vec3 positive_mom = (track1.charge > 0) ? mom1 : mom2;
+  const Vec3 negative_mom = (track1.charge > 0) ? mom2 : mom1;
+
+  reset_pair_row();
+  m_pair.run = run_number;
+  m_pair.evt = event_number;
+  m_pair.cross1 = 0;
+  m_pair.cross2 = 0;
+  m_pair.px1 = static_cast<float>(mom1.x);
+  m_pair.py1 = static_cast<float>(mom1.y);
+  m_pair.pz1 = static_cast<float>(mom1.z);
+  m_pair.px2 = static_cast<float>(mom2.x);
+  m_pair.py2 = static_cast<float>(mom2.y);
+  m_pair.pz2 = static_cast<float>(mom2.z);
+  m_pair.dca_xy1 = static_cast<float>(dca1.first);
+  m_pair.dca_z1 = static_cast<float>(dca1.second);
+  m_pair.dca_xy2 = static_cast<float>(dca2.first);
+  m_pair.dca_z2 = static_cast<float>(dca2.second);
+  m_pair.pairDCA = static_cast<float>(pair_dca);
+  m_pair.alpha = static_cast<float>(alpha);
+  m_pair.qT = static_cast<float>(qt);
+  m_pair.charge1 = static_cast<float>(track1.charge);
+  m_pair.charge2 = static_cast<float>(track2.charge);
+  m_pair.dedx_1 = track1.has_dedx ? static_cast<float>(track1.dedx) : quiet_nan();
+  m_pair.dedx_2 = track2.has_dedx ? static_cast<float>(track2.dedx) : quiet_nan();
+  m_pair.cosThetaReco = static_cast<float>(cos_theta);
+  m_pair.Lproj = static_cast<float>(norm(flight));
+
+  m_pair.pca_x = static_cast<float>(pair_vertex.x);
+  m_pair.pca_y = static_cast<float>(pair_vertex.y);
+  m_pair.pca_z = static_cast<float>(pair_vertex.z);
+  m_pair.pca1_x = static_cast<float>(pca1.x);
+  m_pair.pca1_y = static_cast<float>(pca1.y);
+  m_pair.pca1_z = static_cast<float>(pca1.z);
+  m_pair.pca2_x = static_cast<float>(pca2.x);
+  m_pair.pca2_y = static_cast<float>(pca2.y);
+  m_pair.pca2_z = static_cast<float>(pca2.z);
+
+  m_pair.v0_px = static_cast<float>(total_mom.x);
+  m_pair.v0_py = static_cast<float>(total_mom.y);
+  m_pair.v0_pz = static_cast<float>(total_mom.z);
+  m_pair.v0_pt = static_cast<float>(pt(total_mom));
+  m_pair.mass_Kshort = static_cast<float>(invariant_mass(mom1, kPionMass, mom2, kPionMass));
+  m_pair.mass_Lambda = static_cast<float>(invariant_mass(positive_mom, kProtonMass, negative_mom, kPionMass));
+  m_pair.mass_AntiLambda = static_cast<float>(invariant_mass(positive_mom, kPionMass, negative_mom, kProtonMass));
+
+  m_pair.true_decay_x = static_cast<float>(true_decay.x);
+  m_pair.true_decay_y = static_cast<float>(true_decay.y);
+  m_pair.true_decay_z = static_cast<float>(true_decay.z);
+  m_pair.pca_to_true_3d = static_cast<float>(pca_to_true_3d);
+  m_pair.pca_to_true_xy = static_cast<float>(pca_to_true_xy);
+  m_pair.pca_to_true_z = static_cast<float>(pca_to_true_z);
+  m_pair.truth_alpha = static_cast<float>(truth_alpha);
+  m_pair.truth_qT = static_cast<float>(truth_qt);
+  m_pair.delta_alpha = static_cast<float>(alpha - truth_alpha);
+  m_pair.delta_qT = static_cast<float>(qt - truth_qt);
+  m_pair.truth_px1 = static_cast<float>(track1.truth_momentum.x);
+  m_pair.truth_py1 = static_cast<float>(track1.truth_momentum.y);
+  m_pair.truth_pz1 = static_cast<float>(track1.truth_momentum.z);
+  m_pair.truth_px2 = static_cast<float>(track2.truth_momentum.x);
+  m_pair.truth_py2 = static_cast<float>(track2.truth_momentum.y);
+  m_pair.truth_pz2 = static_cast<float>(track2.truth_momentum.z);
+  m_pair.cos_mom1_truth = static_cast<float>(vector_cosine(mom1, track1.truth_momentum));
+  m_pair.cos_mom2_truth = static_cast<float>(vector_cosine(mom2, track2.truth_momentum));
+  m_pair.pca_theta1 = static_cast<float>(theta1);
+  m_pair.pca_theta2 = static_cast<float>(theta2);
+  if (track1.has_kalman)
+  {
+    m_pair.kalman_chi2_1 = static_cast<float>(track1.kalman.chi2);
+    m_pair.kalman_ndof1 = track1.kalman.ndof;
+    m_pair.kalman_chi2_ndf1 =
+        (track1.kalman.ndof > 0 && std::isfinite(track1.kalman.chi2))
+            ? static_cast<float>(track1.kalman.chi2 / track1.kalman.ndof)
+            : quiet_nan();
+  }
+  if (track2.has_kalman)
+  {
+    m_pair.kalman_chi2_2 = static_cast<float>(track2.kalman.chi2);
+    m_pair.kalman_ndof2 = track2.kalman.ndof;
+    m_pair.kalman_chi2_ndf2 =
+        (track2.kalman.ndof > 0 && std::isfinite(track2.kalman.chi2))
+            ? static_cast<float>(track2.kalman.chi2 / track2.kalman.ndof)
+            : quiet_nan();
+  }
+  m_pair.quality1 = std::isfinite(track1.fit_chi2_ndf)
+                        ? static_cast<float>(track1.fit_chi2_ndf)
+                        : quiet_nan();
+  m_pair.quality2 = std::isfinite(track2.fit_chi2_ndf)
+                        ? static_cast<float>(track2.fit_chi2_ndf)
+                        : quiet_nan();
+  m_pair.track_id1 = track1.track_id;
+  m_pair.track_id2 = track2.track_id;
+  m_pair.pid1 = track1.pid;
+  m_pair.pid2 = track2.pid;
+  m_pair.parent_id1 = track1.parent_id;
+  m_pair.parent_id2 = track2.parent_id;
+  m_pair.parent_pid = (track1.parent_id != 0 && track1.parent_id == track2.parent_id) ? track1.parent_pid : 0;
+  m_pair.npoints1 = static_cast<short>(track1.npoints);
+  m_pair.npoints2 = static_cast<short>(track2.npoints);
+
+  m_pair_tree->Fill();
+  ++m_counter_written;
+  return true;
+}
+
+void TpcV0CandidateTree::fill_track_row(const Tracklet &tracklet,
+                                        const Vec3 &primary_vertex,
+                                        const int run_number,
+                                        const int event_number)
+{
+  reset_track_row();
+  const float nan = quiet_nan();
+
+  m_track.run = run_number;
+  m_track.evt = event_number;
+  m_track.track_id = tracklet.track_id;
+  m_track.shower_id = tracklet.shower_id;
+  m_track.pid = tracklet.pid;
+  m_track.parent_id = tracklet.parent_id;
+  m_track.parent_pid = tracklet.parent_pid;
+  m_track.charge = static_cast<double>(tracklet.charge);
+  m_track.side = tracklet.side;
+  m_track.npoints = tracklet.npoints;
+  m_track.ntpc_clusters = tracklet.ntpc_clusters;
+  m_track.has_helix = tracklet.has_helix ? 1 : 0;
+  m_track.has_kalman = tracklet.has_kalman ? 1 : 0;
+  m_track.is_primary = tracklet.is_primary;
+
+  if (m_kalman_config.collect_innovation_components)
+  {
+    m_track.kalman_measurement_sigma_r =
+        static_cast<float>(m_kalman_config.meas_sigma_r_cm);
+    m_track.kalman_measurement_sigma_rphi =
+        static_cast<float>(m_kalman_config.meas_sigma_rphi_cm);
+    m_track.kalman_measurement_sigma_z =
+        static_cast<float>(m_kalman_config.meas_sigma_z_cm);
+  }
+
+  Vec3 row_position = tracklet.position;
+  Vec3 row_momentum = tracklet.momentum;
+  std::array<double, TpcTrackKalmanFitter::StateDim> kalman_row_state{};
+  bool has_kalman_row_state = false;
+  if (tracklet.has_kalman)
+  {
+    kalman_row_state = TpcTrackKalmanFitter::propagation_state(tracklet.kalman, primary_vertex);
+    row_position = TpcTrackKalmanFitter::state_position(kalman_row_state);
+    row_momentum = TpcTrackKalmanFitter::state_momentum(kalman_row_state);
+    has_kalman_row_state = true;
+  }
+
+  m_track.px = row_momentum.x;
+  m_track.py = row_momentum.y;
+  m_track.pz = row_momentum.z;
+  m_track.pt = pt(row_momentum);
+  m_track.p = norm(row_momentum);
+  m_track.eta = m_track.pt > 0.0
+                    ? std::asinh(row_momentum.z / m_track.pt)
+                    : static_cast<double>(nan);
+  m_track.dedx = tracklet.has_dedx ? tracklet.dedx : static_cast<double>(nan);
+  m_track.x = static_cast<float>(row_position.x);
+  m_track.y = static_cast<float>(row_position.y);
+  m_track.z = static_cast<float>(row_position.z);
+
+  if (!tracklet.points.empty())
+  {
+    const auto &first = tracklet.points.front().position;
+    const auto &last = tracklet.points.back().position;
+    m_track.first_x = static_cast<float>(first.x);
+    m_track.first_y = static_cast<float>(first.y);
+    m_track.first_z = static_cast<float>(first.z);
+    m_track.first_r = static_cast<float>(pt(first));
+    m_track.last_x = static_cast<float>(last.x);
+    m_track.last_y = static_cast<float>(last.y);
+    m_track.last_z = static_cast<float>(last.z);
+    m_track.last_r = static_cast<float>(pt(last));
+  }
+
+  m_track.cluster_index.reserve(tracklet.points.size());
+  m_track.cluster_side.reserve(tracklet.points.size());
+  m_track.layer.reserve(tracklet.points.size());
+  m_track.cluster_z.reserve(tracklet.points.size());
+  m_track.cluster_r.reserve(tracklet.points.size());
+  m_track.cluster_phi.reserve(tracklet.points.size());
+  m_track.residual_z.reserve(tracklet.points.size());
+  m_track.residual_r.reserve(tracklet.points.size());
+  m_track.residual_rphi.reserve(tracklet.points.size());
+
+  double previous_theta = tracklet.has_helix ? tracklet.helix.theta_first : 0.0;
+  bool have_previous_theta = false;
+  for (std::size_t index = 0; index < tracklet.points.size(); ++index)
+  {
+    const auto &point = tracklet.points[index];
+    const Vec3 &cluster = point.position;
+    const double cluster_r = pt(cluster);
+    const double cluster_phi = std::atan2(cluster.y, cluster.x);
+
+    double residual_r = std::numeric_limits<double>::quiet_NaN();
+    double residual_rphi = std::numeric_limits<double>::quiet_NaN();
+    double residual_z = std::numeric_limits<double>::quiet_NaN();
+
+    if (tracklet.has_kalman && index < tracklet.kalman.states_smoothed.size())
+    {
+      const Vec3 fit_position = TpcTrackKalmanFitter::state_position(tracklet.kalman.states_smoothed[index]);
+      const Vec3 delta = subtract(cluster, fit_position);
+      const double fit_phi = std::atan2(fit_position.y, fit_position.x);
+      residual_r = std::cos(fit_phi) * delta.x + std::sin(fit_phi) * delta.y;
+      residual_rphi = -std::sin(fit_phi) * delta.x + std::cos(fit_phi) * delta.y;
+      residual_z = delta.z;
+    }
+    else if (tracklet.has_helix)
+    {
+      double theta_hint = std::atan2(cluster.y - tracklet.helix.cy,
+                                     cluster.x - tracklet.helix.cx);
+      theta_hint = unwrap_to_near(theta_hint,
+                                  have_previous_theta ? previous_theta
+                                                      : tracklet.helix.theta_first);
+
+      double theta = theta_hint;
+      Vec3 fit_position;
+      if (!helix_point_at_beam_radius(tracklet.helix, cluster_r, theta_hint, theta, fit_position))
+      {
+        fit_position = helix_point(tracklet.helix, theta_hint);
+        theta = theta_hint;
+      }
+
+      if (finite(fit_position))
+      {
+        previous_theta = theta;
+        have_previous_theta = true;
+        const double fit_r = pt(fit_position);
+        const double fit_phi = std::atan2(fit_position.y, fit_position.x);
+        residual_r = cluster_r - fit_r;
+        residual_rphi = cluster_r * normalize_phi(cluster_phi - fit_phi);
+        residual_z = cluster.z - fit_position.z;
+      }
+    }
+
+    m_track.cluster_index.push_back(static_cast<unsigned int>(index));
+    m_track.cluster_side.push_back(tracklet.side);
+    m_track.layer.push_back(static_cast<unsigned int>(std::max(point.layer, 0)));
+    m_track.cluster_z.push_back(cluster.z);
+    m_track.cluster_r.push_back(cluster_r);
+    m_track.cluster_phi.push_back(cluster_phi);
+    m_track.residual_z.push_back(std::isfinite(residual_z) ? residual_z : static_cast<double>(nan));
+    m_track.residual_r.push_back(std::isfinite(residual_r) ? residual_r : static_cast<double>(nan));
+    m_track.residual_rphi.push_back(std::isfinite(residual_rphi) ? residual_rphi : static_cast<double>(nan));
+  }
+
+  const Vec3 &track_vertex = tracklet.has_pattern_vertex
+                                 ? tracklet.pattern_vertex
+                                 : primary_vertex;
+  auto dca = tracklet.vertex_dca;
+  if (!tracklet.has_vertex_dca)
+  {
+    dca = fitted_track_dca_to_vertex(tracklet, track_vertex);
+  }
+  m_track.dca_xy = static_cast<float>(dca.first);
+  m_track.dca_z = static_cast<float>(dca.second);
+  m_track.vertex_x = track_vertex.x;
+  m_track.vertex_y = track_vertex.y;
+  m_track.vertex_z = track_vertex.z;
+  m_track.vertex_from_upstream = tracklet.has_pattern_vertex ? 1 : 0;
+  if (tracklet.has_pattern_vertex)
+  {
+    m_track.vertex_z_rms = tracklet.pattern_vertex_z_rms;
+    m_track.vertex_ntracks = tracklet.pattern_vertex_ntracks;
+  }
+  if (tracklet.has_beamline_pca)
+  {
+    m_track.pca_x = tracklet.beamline_pca.x;
+    m_track.pca_y = tracklet.beamline_pca.y;
+    m_track.pca_z = tracklet.beamline_pca.z;
+    m_track.rDCA_zero = tracklet.rdca_zero;
+    m_track.zDCA = tracklet.beamline_pca.z - track_vertex.z;
+  }
+
+  if (tracklet.has_helix)
+  {
+    m_track.helix_cx = static_cast<float>(tracklet.helix.cx);
+    m_track.helix_cy = static_cast<float>(tracklet.helix.cy);
+    m_track.helix_radius = static_cast<float>(tracklet.helix.radius);
+    m_track.helix_z0 = static_cast<float>(tracklet.helix.z0);
+    m_track.helix_pitch = static_cast<float>(tracklet.helix.pitch);
+    m_track.helix_theta_first = static_cast<float>(tracklet.helix.theta_first);
+    m_track.helix_theta_last = static_cast<float>(tracklet.helix.theta_last);
+    m_track.helix_direction = static_cast<float>(tracklet.helix.direction);
+    if (tracklet.has_helix_search_range)
+    {
+      const auto &range = tracklet.helix_search_range;
+      m_track.helix_search_anchored = 1;
+      m_track.helix_anchor_point_index = range.anchor_point_index;
+      m_track.helix_anchor_theta = static_cast<float>(range.anchor_theta);
+      m_track.helix_anchor_path_cm = static_cast<float>(range.anchor_path_cm);
+      m_track.helix_anchor_residual_cm = static_cast<float>(range.anchor_residual_cm);
+      m_track.helix_search_theta_min = static_cast<float>(range.theta_min);
+      m_track.helix_search_theta_max = static_cast<float>(range.theta_max);
+      m_track.helix_search_upstream_cm = static_cast<float>(range.upstream_cm);
+      m_track.helix_search_downstream_cm = static_cast<float>(range.downstream_cm);
+    }
+  }
+
+  if (tracklet.has_kalman)
+  {
+    m_track.kalman_chi2 = static_cast<float>(tracklet.kalman.chi2);
+    m_track.kalman_ndof = tracklet.kalman.ndof;
+    m_track.kalman_naccepted = static_cast<unsigned int>(tracklet.kalman.naccepted);
+    m_track.kalman_nrejected = static_cast<unsigned int>(tracklet.kalman.nrejected);
+    m_track.kalman_measurement_chi2 = tracklet.kalman.measurement_chi2;
+    m_track.kalman_measurement_used = tracklet.kalman.measurement_used;
+    if (m_kalman_config.collect_innovation_components)
+    {
+      m_track.kalman_measurement_in_seed = tracklet.kalman.measurement_in_seed;
+      m_track.kalman_innovation_residual_r = tracklet.kalman.innovation_residual_r;
+      m_track.kalman_innovation_residual_rphi = tracklet.kalman.innovation_residual_rphi;
+      m_track.kalman_innovation_residual_z = tracklet.kalman.innovation_residual_z;
+      m_track.kalman_prediction_sigma_r = tracklet.kalman.prediction_sigma_r;
+      m_track.kalman_prediction_sigma_rphi = tracklet.kalman.prediction_sigma_rphi;
+      m_track.kalman_prediction_sigma_z = tracklet.kalman.prediction_sigma_z;
+      m_track.kalman_innovation_sigma_r = tracklet.kalman.innovation_sigma_r;
+      m_track.kalman_innovation_sigma_rphi = tracklet.kalman.innovation_sigma_rphi;
+      m_track.kalman_innovation_sigma_z = tracklet.kalman.innovation_sigma_z;
+      m_track.kalman_innovation_rho_r_rphi = tracklet.kalman.innovation_rho_r_rphi;
+      m_track.kalman_innovation_rho_r_z = tracklet.kalman.innovation_rho_r_z;
+      m_track.kalman_innovation_rho_rphi_z = tracklet.kalman.innovation_rho_rphi_z;
+      m_track.kalman_innovation_whitened_0 = tracklet.kalman.innovation_whitened_0;
+      m_track.kalman_innovation_whitened_1 = tracklet.kalman.innovation_whitened_1;
+      m_track.kalman_innovation_whitened_2 = tracklet.kalman.innovation_whitened_2;
+    }
+    if (has_kalman_row_state)
+    {
+      const auto &state = kalman_row_state;
+      const double qop_t = state[TpcTrackKalmanFitter::QOverPt];
+      const double omega = 0.003 * tracklet.kalman.bfield_t * qop_t;
+      m_track.kalman_qop_t = static_cast<float>(qop_t);
+      m_track.kalman_omega = static_cast<float>(omega);
+      if (std::abs(omega) > 1.0e-12)
+      {
+        const double center_x = state[TpcTrackKalmanFitter::X] -
+                                std::sin(state[TpcTrackKalmanFitter::Phi]) / omega;
+        const double center_y = state[TpcTrackKalmanFitter::Y] +
+                                std::cos(state[TpcTrackKalmanFitter::Phi]) / omega;
+        m_track.kalman_cx = static_cast<float>(center_x);
+        m_track.kalman_cy = static_cast<float>(center_y);
+        m_track.kalman_radius = static_cast<float>(std::abs(1.0 / omega));
+      }
+    }
+  }
+
+  m_track.fit_chi2 = std::isfinite(tracklet.fit_chi2)
+                         ? static_cast<float>(tracklet.fit_chi2)
+                         : nan;
+  m_track.fit_ndf = tracklet.fit_ndf;
+  m_track.quality = std::isfinite(tracklet.fit_chi2_ndf)
+                        ? static_cast<float>(tracklet.fit_chi2_ndf)
+                        : nan;
+
+  m_track.truth_px = static_cast<float>(tracklet.truth_momentum.x);
+  m_track.truth_py = static_cast<float>(tracklet.truth_momentum.y);
+  m_track.truth_pz = static_cast<float>(tracklet.truth_momentum.z);
+  m_track.cos_mom_truth = static_cast<float>(vector_cosine(row_momentum, tracklet.truth_momentum));
+
+  m_track_tree->Fill();
+  ++m_counter_tracks_written;
+}
+
+void TpcV0CandidateTree::fill_cluster_residual_rows(const Tracklet &tracklet,
+                                                    const Vec3 & /*primary_vertex*/,
+                                                    const int run_number,
+                                                    const int event_number)
+{
+  if (!m_cluster_residual_tree || tracklet.points.empty())
+  {
+    return;
+  }
+
+  const float nan = quiet_nan();
+  double fit_chi2 = std::numeric_limits<double>::quiet_NaN();
+  int fit_ndf = 0;
+
+  const double sigma_rphi = std::max(m_kalman_config.meas_sigma_rphi_cm,
+                                     m_kalman_config.min_measurement_sigma_cm);
+  const double sigma_z = std::max(m_kalman_config.meas_sigma_z_cm,
+                                  m_kalman_config.min_measurement_sigma_cm);
+
+  auto helix_residual = [&](const TruthPoint &point,
+                            double &previous_theta,
+                            bool &have_previous_theta,
+                            Vec3 &fit_position,
+                            double &residual_r,
+                            double &residual_rphi,
+                            double &residual_z) -> bool
+  {
+    if (!tracklet.has_helix)
+    {
+      return false;
+    }
+
+    const Vec3 &cluster = point.position;
+    const double cluster_r = pt(cluster);
+    double theta_hint = std::atan2(cluster.y - tracklet.helix.cy,
+                                   cluster.x - tracklet.helix.cx);
+    theta_hint = unwrap_to_near(theta_hint,
+                                have_previous_theta ? previous_theta
+                                                    : tracklet.helix.theta_first);
+
+    double theta = theta_hint;
+    if (!helix_point_at_beam_radius(tracklet.helix, cluster_r, theta_hint, theta, fit_position))
+    {
+      fit_position = helix_point(tracklet.helix, theta_hint);
+      theta = theta_hint;
+      if (!finite(fit_position))
+      {
+        return false;
+      }
+    }
+
+    previous_theta = theta;
+    have_previous_theta = true;
+
+    const double fit_r = pt(fit_position);
+    const double cluster_phi = std::atan2(cluster.y, cluster.x);
+    const double fit_phi = std::atan2(fit_position.y, fit_position.x);
+    residual_r = cluster_r - fit_r;
+    residual_rphi = cluster_r * normalize_phi(cluster_phi - fit_phi);
+    residual_z = cluster.z - fit_position.z;
+    return std::isfinite(residual_r) &&
+           std::isfinite(residual_rphi) &&
+           std::isfinite(residual_z);
+  };
+
+  if (tracklet.has_kalman)
+  {
+    fit_chi2 = tracklet.kalman.chi2;
+    fit_ndf = tracklet.kalman.ndof;
+  }
+  else if (tracklet.has_helix)
+  {
+    double chi2 = 0.0;
+    int nresiduals = 0;
+    double previous_theta = tracklet.helix.theta_first;
+    bool have_previous_theta = false;
+    for (const auto &point : tracklet.points)
+    {
+      Vec3 fit_position;
+      double residual_r = 0.0;
+      double residual_rphi = 0.0;
+      double residual_z = 0.0;
+      if (!helix_residual(point, previous_theta, have_previous_theta,
+                          fit_position, residual_r, residual_rphi, residual_z))
+      {
+        continue;
+      }
+      chi2 += square(residual_rphi / sigma_rphi) + square(residual_z / sigma_z);
+      nresiduals += 2;
+    }
+    fit_chi2 = chi2;
+    fit_ndf = std::max(0, nresiduals - 5);
+  }
+
+  double previous_theta = tracklet.has_helix ? tracklet.helix.theta_first : 0.0;
+  bool have_previous_theta = false;
+  for (std::size_t index = 0; index < tracklet.points.size(); ++index)
+  {
+    const auto &point = tracklet.points[index];
+    const Vec3 &cluster = point.position;
+    Vec3 fit_position{nan, nan, nan};
+    double residual_r = std::numeric_limits<double>::quiet_NaN();
+    double residual_rphi = std::numeric_limits<double>::quiet_NaN();
+    double residual_z = std::numeric_limits<double>::quiet_NaN();
+
+    if (tracklet.has_kalman && index < tracklet.kalman.states_smoothed.size())
+    {
+      fit_position = TpcTrackKalmanFitter::state_position(tracklet.kalman.states_smoothed[index]);
+      const Vec3 delta = subtract(cluster, fit_position);
+      const double fit_phi = std::atan2(fit_position.y, fit_position.x);
+      residual_r = std::cos(fit_phi) * delta.x + std::sin(fit_phi) * delta.y;
+      residual_rphi = -std::sin(fit_phi) * delta.x + std::cos(fit_phi) * delta.y;
+      residual_z = delta.z;
+    }
+    else if (tracklet.has_helix)
+    {
+      helix_residual(point, previous_theta, have_previous_theta,
+                     fit_position, residual_r, residual_rphi, residual_z);
+    }
+
+    reset_cluster_residual_row();
+    m_cluster_residual.run = run_number;
+    m_cluster_residual.evt = event_number;
+    m_cluster_residual.track_id = tracklet.track_id;
+    m_cluster_residual.charge = tracklet.charge;
+    m_cluster_residual.side = (cluster.z >= 0.0) ? 1 : -1;
+    m_cluster_residual.layer = point.layer;
+    m_cluster_residual.cluster_index = static_cast<int>(index);
+    m_cluster_residual.ntp_cluster = tracklet.npoints;
+    m_cluster_residual.npoints = tracklet.npoints;
+    m_cluster_residual.has_helix = tracklet.has_helix ? 1 : 0;
+    m_cluster_residual.has_kalman = tracklet.has_kalman ? 1 : 0;
+
+    m_cluster_residual.cluster_x = static_cast<float>(cluster.x);
+    m_cluster_residual.cluster_y = static_cast<float>(cluster.y);
+    m_cluster_residual.cluster_z = static_cast<float>(cluster.z);
+    m_cluster_residual.cluster_r = static_cast<float>(pt(cluster));
+    m_cluster_residual.cluster_phi = static_cast<float>(std::atan2(cluster.y, cluster.x));
+
+    m_cluster_residual.fit_x = static_cast<float>(fit_position.x);
+    m_cluster_residual.fit_y = static_cast<float>(fit_position.y);
+    m_cluster_residual.fit_z = static_cast<float>(fit_position.z);
+    m_cluster_residual.fit_r = static_cast<float>(pt(fit_position));
+    m_cluster_residual.fit_phi = static_cast<float>(std::atan2(fit_position.y, fit_position.x));
+
+    m_cluster_residual.residual_x = static_cast<float>(cluster.x - fit_position.x);
+    m_cluster_residual.residual_y = static_cast<float>(cluster.y - fit_position.y);
+    m_cluster_residual.residual_z = static_cast<float>(residual_z);
+    m_cluster_residual.residual_r = static_cast<float>(residual_r);
+    m_cluster_residual.residual_rphi = static_cast<float>(residual_rphi);
+
+    m_cluster_residual.fit_chi2 = static_cast<float>(fit_chi2);
+    m_cluster_residual.fit_ndf = fit_ndf;
+    m_cluster_residual.fit_chi2_ndf =
+        (fit_ndf > 0 && std::isfinite(fit_chi2)) ? static_cast<float>(fit_chi2 / fit_ndf) : nan;
+
+    m_cluster_residual_tree->Fill();
+    ++m_counter_cluster_residuals_written;
+  }
+}
+
+void TpcV0CandidateTree::assign_fit_quality(Tracklet &tracklet) const
+{
+  tracklet.fit_chi2 = std::numeric_limits<double>::quiet_NaN();
+  tracklet.fit_ndf = 0;
+  tracklet.fit_chi2_ndf = std::numeric_limits<double>::quiet_NaN();
+
+  if (tracklet.has_kalman)
+  {
+    tracklet.fit_chi2 = tracklet.kalman.chi2;
+    tracklet.fit_ndf = tracklet.kalman.ndof;
+  }
+  else if (tracklet.has_helix)
+  {
+    const double sigma_rphi = std::max(m_kalman_config.meas_sigma_rphi_cm,
+                                       m_kalman_config.min_measurement_sigma_cm);
+    const double sigma_z = std::max(m_kalman_config.meas_sigma_z_cm,
+                                    m_kalman_config.min_measurement_sigma_cm);
+
+    double chi2 = 0.0;
+    int nresiduals = 0;
+    double previous_theta = tracklet.helix.theta_first;
+    bool have_previous_theta = false;
+    for (const auto &point : tracklet.points)
+    {
+      Vec3 fit_position;
+      double residual_r = 0.0;
+      double residual_rphi = 0.0;
+      double residual_z = 0.0;
+      if (!helix_cluster_residual(tracklet.helix, point, previous_theta, have_previous_theta,
+                                  fit_position, residual_r, residual_rphi, residual_z))
+      {
+        continue;
+      }
+      chi2 += square(residual_rphi / sigma_rphi) + square(residual_z / sigma_z);
+      nresiduals += 2;
+    }
+
+    tracklet.fit_chi2 = chi2;
+    tracklet.fit_ndf = std::max(0, nresiduals - 5);
+  }
+
+  if (tracklet.fit_ndf > 0 && std::isfinite(tracklet.fit_chi2))
+  {
+    tracklet.fit_chi2_ndf = tracklet.fit_chi2 / tracklet.fit_ndf;
+  }
+}
+
+void TpcV0CandidateTree::reset_pair_row()
+{
+  m_pair = {};
+  const float nan = quiet_nan();
+  m_pair.dca_xy1 = nan;
+  m_pair.dca_z1 = nan;
+  m_pair.dca_xy2 = nan;
+  m_pair.dca_z2 = nan;
+  m_pair.pairDCA = nan;
+  m_pair.alpha = nan;
+  m_pair.qT = nan;
+  m_pair.dedx_1 = nan;
+  m_pair.dedx_2 = nan;
+  m_pair.cosThetaReco = nan;
+  m_pair.Lproj = nan;
+  m_pair.pca_x = nan;
+  m_pair.pca_y = nan;
+  m_pair.pca_z = nan;
+  m_pair.pca1_x = nan;
+  m_pair.pca1_y = nan;
+  m_pair.pca1_z = nan;
+  m_pair.pca2_x = nan;
+  m_pair.pca2_y = nan;
+  m_pair.pca2_z = nan;
+  m_pair.v0_px = nan;
+  m_pair.v0_py = nan;
+  m_pair.v0_pz = nan;
+  m_pair.v0_pt = nan;
+  m_pair.mass_Kshort = nan;
+  m_pair.mass_Lambda = nan;
+  m_pair.mass_AntiLambda = nan;
+  m_pair.true_decay_x = nan;
+  m_pair.true_decay_y = nan;
+  m_pair.true_decay_z = nan;
+  m_pair.pca_to_true_3d = nan;
+  m_pair.pca_to_true_xy = nan;
+  m_pair.pca_to_true_z = nan;
+  m_pair.truth_alpha = nan;
+  m_pair.truth_qT = nan;
+  m_pair.delta_alpha = nan;
+  m_pair.delta_qT = nan;
+  m_pair.truth_px1 = nan;
+  m_pair.truth_py1 = nan;
+  m_pair.truth_pz1 = nan;
+  m_pair.truth_px2 = nan;
+  m_pair.truth_py2 = nan;
+  m_pair.truth_pz2 = nan;
+  m_pair.cos_mom1_truth = nan;
+  m_pair.cos_mom2_truth = nan;
+  m_pair.pca_theta1 = nan;
+  m_pair.pca_theta2 = nan;
+  m_pair.kalman_chi2_1 = nan;
+  m_pair.kalman_chi2_2 = nan;
+  m_pair.kalman_chi2_ndf1 = nan;
+  m_pair.kalman_chi2_ndf2 = nan;
+  m_pair.quality1 = nan;
+  m_pair.quality2 = nan;
+  m_pair.kalman_ndof1 = 0;
+  m_pair.kalman_ndof2 = 0;
+}
+
+void TpcV0CandidateTree::reset_track_row()
+{
+  m_track = {};
+  const float nan = quiet_nan();
+  m_track.px = nan;
+  m_track.py = nan;
+  m_track.pz = nan;
+  m_track.pt = nan;
+  m_track.p = nan;
+  m_track.eta = nan;
+  m_track.dedx = nan;
+  m_track.x = nan;
+  m_track.y = nan;
+  m_track.z = nan;
+  m_track.first_x = nan;
+  m_track.first_y = nan;
+  m_track.first_z = nan;
+  m_track.first_r = nan;
+  m_track.last_x = nan;
+  m_track.last_y = nan;
+  m_track.last_z = nan;
+  m_track.last_r = nan;
+  m_track.dca_xy = nan;
+  m_track.dca_z = nan;
+  m_track.vertex_x = nan;
+  m_track.vertex_y = nan;
+  m_track.vertex_z = nan;
+  m_track.vertex_z_rms = nan;
+  m_track.pca_x = nan;
+  m_track.pca_y = nan;
+  m_track.pca_z = nan;
+  m_track.rDCA_zero = nan;
+  m_track.zDCA = nan;
+  m_track.helix_cx = nan;
+  m_track.helix_cy = nan;
+  m_track.helix_radius = nan;
+  m_track.helix_z0 = nan;
+  m_track.helix_pitch = nan;
+  m_track.helix_theta_first = nan;
+  m_track.helix_theta_last = nan;
+  m_track.helix_direction = nan;
+  m_track.helix_search_anchored = 0;
+  m_track.helix_anchor_point_index = -1;
+  m_track.helix_anchor_theta = nan;
+  m_track.helix_anchor_path_cm = nan;
+  m_track.helix_anchor_residual_cm = nan;
+  m_track.helix_search_theta_min = nan;
+  m_track.helix_search_theta_max = nan;
+  m_track.helix_search_upstream_cm = nan;
+  m_track.helix_search_downstream_cm = nan;
+  m_track.kalman_chi2 = nan;
+  m_track.kalman_ndof = 0;
+  m_track.kalman_qop_t = nan;
+  m_track.kalman_omega = nan;
+  m_track.kalman_cx = nan;
+  m_track.kalman_cy = nan;
+  m_track.kalman_radius = nan;
+  m_track.fit_chi2 = nan;
+  m_track.fit_ndf = 0;
+  m_track.quality = nan;
+  m_track.truth_px = nan;
+  m_track.truth_py = nan;
+  m_track.truth_pz = nan;
+  m_track.cos_mom_truth = nan;
+}
+
+void TpcV0CandidateTree::reset_cluster_residual_row()
+{
+  m_cluster_residual = {};
+  const float nan = quiet_nan();
+  m_cluster_residual.cluster_x = nan;
+  m_cluster_residual.cluster_y = nan;
+  m_cluster_residual.cluster_z = nan;
+  m_cluster_residual.cluster_r = nan;
+  m_cluster_residual.cluster_phi = nan;
+  m_cluster_residual.fit_x = nan;
+  m_cluster_residual.fit_y = nan;
+  m_cluster_residual.fit_z = nan;
+  m_cluster_residual.fit_r = nan;
+  m_cluster_residual.fit_phi = nan;
+  m_cluster_residual.residual_x = nan;
+  m_cluster_residual.residual_y = nan;
+  m_cluster_residual.residual_z = nan;
+  m_cluster_residual.residual_r = nan;
+  m_cluster_residual.residual_rphi = nan;
+  m_cluster_residual.fit_chi2 = nan;
+  m_cluster_residual.fit_ndf = 0;
+  m_cluster_residual.fit_chi2_ndf = nan;
+}
+
+void TpcV0CandidateTree::create_branches()
+{
+  m_pair_tree->Branch("run", &m_pair.run, "run/I");
+  m_pair_tree->Branch("evt", &m_pair.evt, "evt/I");
+  m_pair_tree->Branch("cross1", &m_pair.cross1, "cross1/S");
+  m_pair_tree->Branch("cross2", &m_pair.cross2, "cross2/S");
+  m_pair_tree->Branch("px1", &m_pair.px1, "px1/F");
+  m_pair_tree->Branch("py1", &m_pair.py1, "py1/F");
+  m_pair_tree->Branch("pz1", &m_pair.pz1, "pz1/F");
+  m_pair_tree->Branch("px2", &m_pair.px2, "px2/F");
+  m_pair_tree->Branch("py2", &m_pair.py2, "py2/F");
+  m_pair_tree->Branch("pz2", &m_pair.pz2, "pz2/F");
+  m_pair_tree->Branch("dca_xy1", &m_pair.dca_xy1, "dca_xy1/F");
+  m_pair_tree->Branch("dca_z1", &m_pair.dca_z1, "dca_z1/F");
+  m_pair_tree->Branch("dca_xy2", &m_pair.dca_xy2, "dca_xy2/F");
+  m_pair_tree->Branch("dca_z2", &m_pair.dca_z2, "dca_z2/F");
+  m_pair_tree->Branch("pairDCA", &m_pair.pairDCA, "pairDCA/F");
+  m_pair_tree->Branch("alpha", &m_pair.alpha, "alpha/F");
+  m_pair_tree->Branch("qT", &m_pair.qT, "qT/F");
+  m_pair_tree->Branch("charge1", &m_pair.charge1, "charge1/F");
+  m_pair_tree->Branch("charge2", &m_pair.charge2, "charge2/F");
+  m_pair_tree->Branch("dedx_1", &m_pair.dedx_1, "dedx_1/F");
+  m_pair_tree->Branch("dedx_2", &m_pair.dedx_2, "dedx_2/F");
+  m_pair_tree->Branch("cosThetaReco", &m_pair.cosThetaReco, "cosThetaReco/F");
+  m_pair_tree->Branch("Lproj", &m_pair.Lproj, "Lproj/F");
+  m_pair_tree->Branch("pca_x", &m_pair.pca_x, "pca_x/F");
+  m_pair_tree->Branch("pca_y", &m_pair.pca_y, "pca_y/F");
+  m_pair_tree->Branch("pca_z", &m_pair.pca_z, "pca_z/F");
+  m_pair_tree->Branch("pca1_x", &m_pair.pca1_x, "pca1_x/F");
+  m_pair_tree->Branch("pca1_y", &m_pair.pca1_y, "pca1_y/F");
+  m_pair_tree->Branch("pca1_z", &m_pair.pca1_z, "pca1_z/F");
+  m_pair_tree->Branch("pca2_x", &m_pair.pca2_x, "pca2_x/F");
+  m_pair_tree->Branch("pca2_y", &m_pair.pca2_y, "pca2_y/F");
+  m_pair_tree->Branch("pca2_z", &m_pair.pca2_z, "pca2_z/F");
+  m_pair_tree->Branch("v0_px", &m_pair.v0_px, "v0_px/F");
+  m_pair_tree->Branch("v0_py", &m_pair.v0_py, "v0_py/F");
+  m_pair_tree->Branch("v0_pz", &m_pair.v0_pz, "v0_pz/F");
+  m_pair_tree->Branch("v0_pt", &m_pair.v0_pt, "v0_pt/F");
+  m_pair_tree->Branch("mass_Kshort", &m_pair.mass_Kshort, "mass_Kshort/F");
+  m_pair_tree->Branch("mass_Lambda", &m_pair.mass_Lambda, "mass_Lambda/F");
+  m_pair_tree->Branch("mass_AntiLambda", &m_pair.mass_AntiLambda, "mass_AntiLambda/F");
+  m_pair_tree->Branch("true_decay_x", &m_pair.true_decay_x, "true_decay_x/F");
+  m_pair_tree->Branch("true_decay_y", &m_pair.true_decay_y, "true_decay_y/F");
+  m_pair_tree->Branch("true_decay_z", &m_pair.true_decay_z, "true_decay_z/F");
+  m_pair_tree->Branch("pca_to_true_3d", &m_pair.pca_to_true_3d, "pca_to_true_3d/F");
+  m_pair_tree->Branch("pca_to_true_xy", &m_pair.pca_to_true_xy, "pca_to_true_xy/F");
+  m_pair_tree->Branch("pca_to_true_z", &m_pair.pca_to_true_z, "pca_to_true_z/F");
+  m_pair_tree->Branch("truth_alpha", &m_pair.truth_alpha, "truth_alpha/F");
+  m_pair_tree->Branch("truth_qT", &m_pair.truth_qT, "truth_qT/F");
+  m_pair_tree->Branch("delta_alpha", &m_pair.delta_alpha, "delta_alpha/F");
+  m_pair_tree->Branch("delta_qT", &m_pair.delta_qT, "delta_qT/F");
+  m_pair_tree->Branch("truth_px1", &m_pair.truth_px1, "truth_px1/F");
+  m_pair_tree->Branch("truth_py1", &m_pair.truth_py1, "truth_py1/F");
+  m_pair_tree->Branch("truth_pz1", &m_pair.truth_pz1, "truth_pz1/F");
+  m_pair_tree->Branch("truth_px2", &m_pair.truth_px2, "truth_px2/F");
+  m_pair_tree->Branch("truth_py2", &m_pair.truth_py2, "truth_py2/F");
+  m_pair_tree->Branch("truth_pz2", &m_pair.truth_pz2, "truth_pz2/F");
+  m_pair_tree->Branch("cos_mom1_truth", &m_pair.cos_mom1_truth, "cos_mom1_truth/F");
+  m_pair_tree->Branch("cos_mom2_truth", &m_pair.cos_mom2_truth, "cos_mom2_truth/F");
+  m_pair_tree->Branch("pca_theta1", &m_pair.pca_theta1, "pca_theta1/F");
+  m_pair_tree->Branch("pca_theta2", &m_pair.pca_theta2, "pca_theta2/F");
+  m_pair_tree->Branch("kalman_chi2_1", &m_pair.kalman_chi2_1, "kalman_chi2_1/F");
+  m_pair_tree->Branch("kalman_chi2_2", &m_pair.kalman_chi2_2, "kalman_chi2_2/F");
+  m_pair_tree->Branch("kalman_chi2_ndf1", &m_pair.kalman_chi2_ndf1, "kalman_chi2_ndf1/F");
+  m_pair_tree->Branch("kalman_chi2_ndf2", &m_pair.kalman_chi2_ndf2, "kalman_chi2_ndf2/F");
+  m_pair_tree->Branch("quality1", &m_pair.quality1, "quality1/F");
+  m_pair_tree->Branch("quality2", &m_pair.quality2, "quality2/F");
+  m_pair_tree->Branch("track_id1", &m_pair.track_id1, "track_id1/I");
+  m_pair_tree->Branch("track_id2", &m_pair.track_id2, "track_id2/I");
+  m_pair_tree->Branch("pid1", &m_pair.pid1, "pid1/I");
+  m_pair_tree->Branch("pid2", &m_pair.pid2, "pid2/I");
+  m_pair_tree->Branch("parent_id1", &m_pair.parent_id1, "parent_id1/I");
+  m_pair_tree->Branch("parent_id2", &m_pair.parent_id2, "parent_id2/I");
+  m_pair_tree->Branch("parent_pid", &m_pair.parent_pid, "parent_pid/I");
+  m_pair_tree->Branch("kalman_ndof1", &m_pair.kalman_ndof1, "kalman_ndof1/I");
+  m_pair_tree->Branch("kalman_ndof2", &m_pair.kalman_ndof2, "kalman_ndof2/I");
+  m_pair_tree->Branch("npoints1", &m_pair.npoints1, "npoints1/S");
+  m_pair_tree->Branch("npoints2", &m_pair.npoints2, "npoints2/S");
+
+  m_track_tree->Branch("run", &m_track.run, "run/I");
+  m_track_tree->Branch("evt", &m_track.evt, "evt/I");
+  m_track_tree->Branch("track_id", &m_track.track_id, "track_id/I");
+  m_track_tree->Branch("shower_id", &m_track.shower_id, "shower_id/I");
+  m_track_tree->Branch("pid", &m_track.pid, "pid/I");
+  m_track_tree->Branch("parent_id", &m_track.parent_id, "parent_id/I");
+  m_track_tree->Branch("parent_pid", &m_track.parent_pid, "parent_pid/I");
+  m_track_tree->Branch("charge", &m_track.charge, "charge/D");
+  m_track_tree->Branch("side", &m_track.side, "side/I");
+  m_track_tree->Branch("npoints", &m_track.npoints, "npoints/I");
+  m_track_tree->Branch("ntpc_clusters", &m_track.ntpc_clusters, "ntpc_clusters/i");
+  m_track_tree->Branch("has_helix", &m_track.has_helix, "has_helix/I");
+  m_track_tree->Branch("has_kalman", &m_track.has_kalman, "has_kalman/I");
+  m_track_tree->Branch("is_primary", &m_track.is_primary, "is_primary/I");
+  m_track_tree->Branch("px", &m_track.px, "px/D");
+  m_track_tree->Branch("py", &m_track.py, "py/D");
+  m_track_tree->Branch("pz", &m_track.pz, "pz/D");
+  m_track_tree->Branch("pt", &m_track.pt, "pt/D");
+  m_track_tree->Branch("p", &m_track.p, "p/D");
+  m_track_tree->Branch("eta", &m_track.eta, "eta/D");
+  m_track_tree->Branch("dedx", &m_track.dedx, "dedx/D");
+  m_track_tree->Branch("x", &m_track.x, "x/F");
+  m_track_tree->Branch("y", &m_track.y, "y/F");
+  m_track_tree->Branch("z", &m_track.z, "z/F");
+  m_track_tree->Branch("first_x", &m_track.first_x, "first_x/F");
+  m_track_tree->Branch("first_y", &m_track.first_y, "first_y/F");
+  m_track_tree->Branch("first_z", &m_track.first_z, "first_z/F");
+  m_track_tree->Branch("first_r", &m_track.first_r, "first_r/F");
+  m_track_tree->Branch("last_x", &m_track.last_x, "last_x/F");
+  m_track_tree->Branch("last_y", &m_track.last_y, "last_y/F");
+  m_track_tree->Branch("last_z", &m_track.last_z, "last_z/F");
+  m_track_tree->Branch("last_r", &m_track.last_r, "last_r/F");
+  m_track_tree->Branch("dca_xy", &m_track.dca_xy, "dca_xy/F");
+  m_track_tree->Branch("dca_z", &m_track.dca_z, "dca_z/F");
+  m_track_tree->Branch("vertex_x", &m_track.vertex_x, "vertex_x/D");
+  m_track_tree->Branch("vertex_y", &m_track.vertex_y, "vertex_y/D");
+  m_track_tree->Branch("vertex_z", &m_track.vertex_z, "vertex_z/D");
+  m_track_tree->Branch("vertex_from_upstream", &m_track.vertex_from_upstream,
+                       "vertex_from_upstream/I");
+  m_track_tree->Branch("vertex_z_rms", &m_track.vertex_z_rms, "vertex_z_rms/D");
+  m_track_tree->Branch("vertex_ntracks", &m_track.vertex_ntracks, "vertex_ntracks/i");
+  m_track_tree->Branch("pca_x", &m_track.pca_x, "pca_x/D");
+  m_track_tree->Branch("pca_y", &m_track.pca_y, "pca_y/D");
+  m_track_tree->Branch("pca_z", &m_track.pca_z, "pca_z/D");
+  m_track_tree->Branch("rDCA_zero", &m_track.rDCA_zero, "rDCA_zero/D");
+  m_track_tree->Branch("zDCA", &m_track.zDCA, "zDCA/D");
+  m_track_tree->Branch("helix_cx", &m_track.helix_cx, "helix_cx/F");
+  m_track_tree->Branch("helix_cy", &m_track.helix_cy, "helix_cy/F");
+  m_track_tree->Branch("helix_radius", &m_track.helix_radius, "helix_radius/F");
+  m_track_tree->Branch("helix_z0", &m_track.helix_z0, "helix_z0/F");
+  m_track_tree->Branch("helix_pitch", &m_track.helix_pitch, "helix_pitch/F");
+  m_track_tree->Branch("helix_theta_first", &m_track.helix_theta_first, "helix_theta_first/F");
+  m_track_tree->Branch("helix_theta_last", &m_track.helix_theta_last, "helix_theta_last/F");
+  m_track_tree->Branch("helix_direction", &m_track.helix_direction, "helix_direction/F");
+  m_track_tree->Branch("helix_search_anchored", &m_track.helix_search_anchored,
+                       "helix_search_anchored/I");
+  m_track_tree->Branch("helix_anchor_point_index", &m_track.helix_anchor_point_index,
+                       "helix_anchor_point_index/I");
+  m_track_tree->Branch("helix_anchor_theta", &m_track.helix_anchor_theta,
+                       "helix_anchor_theta/F");
+  m_track_tree->Branch("helix_anchor_path_cm", &m_track.helix_anchor_path_cm,
+                       "helix_anchor_path_cm/F");
+  m_track_tree->Branch("helix_anchor_residual_cm", &m_track.helix_anchor_residual_cm,
+                       "helix_anchor_residual_cm/F");
+  m_track_tree->Branch("helix_search_theta_min", &m_track.helix_search_theta_min,
+                       "helix_search_theta_min/F");
+  m_track_tree->Branch("helix_search_theta_max", &m_track.helix_search_theta_max,
+                       "helix_search_theta_max/F");
+  m_track_tree->Branch("helix_search_upstream_cm", &m_track.helix_search_upstream_cm,
+                       "helix_search_upstream_cm/F");
+  m_track_tree->Branch("helix_search_downstream_cm", &m_track.helix_search_downstream_cm,
+                       "helix_search_downstream_cm/F");
+  m_track_tree->Branch("kalman_chi2", &m_track.kalman_chi2, "kalman_chi2/F");
+  m_track_tree->Branch("kalman_ndof", &m_track.kalman_ndof, "kalman_ndof/I");
+  m_track_tree->Branch("kalman_naccepted", &m_track.kalman_naccepted, "kalman_naccepted/i");
+  m_track_tree->Branch("kalman_nrejected", &m_track.kalman_nrejected, "kalman_nrejected/i");
+  m_track_tree->Branch("kalman_measurement_chi2", &m_track.kalman_measurement_chi2);
+  m_track_tree->Branch("kalman_measurement_used", &m_track.kalman_measurement_used);
+  if (m_kalman_config.collect_innovation_components)
+  {
+    m_track_tree->Branch("kalman_measurement_sigma_r", &m_track.kalman_measurement_sigma_r,
+                         "kalman_measurement_sigma_r/F");
+    m_track_tree->Branch("kalman_measurement_sigma_rphi", &m_track.kalman_measurement_sigma_rphi,
+                         "kalman_measurement_sigma_rphi/F");
+    m_track_tree->Branch("kalman_measurement_sigma_z", &m_track.kalman_measurement_sigma_z,
+                         "kalman_measurement_sigma_z/F");
+    m_track_tree->Branch("kalman_measurement_in_seed", &m_track.kalman_measurement_in_seed);
+    m_track_tree->Branch("kalman_innovation_residual_r", &m_track.kalman_innovation_residual_r);
+    m_track_tree->Branch("kalman_innovation_residual_rphi", &m_track.kalman_innovation_residual_rphi);
+    m_track_tree->Branch("kalman_innovation_residual_z", &m_track.kalman_innovation_residual_z);
+    m_track_tree->Branch("kalman_prediction_sigma_r", &m_track.kalman_prediction_sigma_r);
+    m_track_tree->Branch("kalman_prediction_sigma_rphi", &m_track.kalman_prediction_sigma_rphi);
+    m_track_tree->Branch("kalman_prediction_sigma_z", &m_track.kalman_prediction_sigma_z);
+    m_track_tree->Branch("kalman_innovation_sigma_r", &m_track.kalman_innovation_sigma_r);
+    m_track_tree->Branch("kalman_innovation_sigma_rphi", &m_track.kalman_innovation_sigma_rphi);
+    m_track_tree->Branch("kalman_innovation_sigma_z", &m_track.kalman_innovation_sigma_z);
+    m_track_tree->Branch("kalman_innovation_rho_r_rphi", &m_track.kalman_innovation_rho_r_rphi);
+    m_track_tree->Branch("kalman_innovation_rho_r_z", &m_track.kalman_innovation_rho_r_z);
+    m_track_tree->Branch("kalman_innovation_rho_rphi_z", &m_track.kalman_innovation_rho_rphi_z);
+    m_track_tree->Branch("kalman_innovation_whitened_0", &m_track.kalman_innovation_whitened_0);
+    m_track_tree->Branch("kalman_innovation_whitened_1", &m_track.kalman_innovation_whitened_1);
+    m_track_tree->Branch("kalman_innovation_whitened_2", &m_track.kalman_innovation_whitened_2);
+  }
+  m_track_tree->Branch("kalman_qop_t", &m_track.kalman_qop_t, "kalman_qop_t/F");
+  m_track_tree->Branch("kalman_omega", &m_track.kalman_omega, "kalman_omega/F");
+  m_track_tree->Branch("kalman_cx", &m_track.kalman_cx, "kalman_cx/F");
+  m_track_tree->Branch("kalman_cy", &m_track.kalman_cy, "kalman_cy/F");
+  m_track_tree->Branch("kalman_radius", &m_track.kalman_radius, "kalman_radius/F");
+  m_track_tree->Branch("fit_chi2", &m_track.fit_chi2, "fit_chi2/F");
+  m_track_tree->Branch("fit_ndf", &m_track.fit_ndf, "fit_ndf/I");
+  m_track_tree->Branch("quality", &m_track.quality, "quality/F");
+  m_track_tree->Branch("truth_px", &m_track.truth_px, "truth_px/F");
+  m_track_tree->Branch("truth_py", &m_track.truth_py, "truth_py/F");
+  m_track_tree->Branch("truth_pz", &m_track.truth_pz, "truth_pz/F");
+  m_track_tree->Branch("cos_mom_truth", &m_track.cos_mom_truth, "cos_mom_truth/F");
+  m_track_tree->Branch("cluster_index", &m_track.cluster_index);
+  m_track_tree->Branch("cluster_side", &m_track.cluster_side);
+  m_track_tree->Branch("layer", &m_track.layer);
+  m_track_tree->Branch("cluster_z", &m_track.cluster_z);
+  m_track_tree->Branch("cluster_r", &m_track.cluster_r);
+  m_track_tree->Branch("cluster_phi", &m_track.cluster_phi);
+  m_track_tree->Branch("residual_z", &m_track.residual_z);
+  m_track_tree->Branch("residual_r", &m_track.residual_r);
+  m_track_tree->Branch("residual_rphi", &m_track.residual_rphi);
+
+  if (!m_cluster_residual_tree)
+  {
+    return;
+  }
+
+  m_cluster_residual_tree->Branch("run", &m_cluster_residual.run, "run/I");
+  m_cluster_residual_tree->Branch("evt", &m_cluster_residual.evt, "evt/I");
+  m_cluster_residual_tree->Branch("track_id", &m_cluster_residual.track_id, "track_id/I");
+  m_cluster_residual_tree->Branch("charge", &m_cluster_residual.charge, "charge/I");
+  m_cluster_residual_tree->Branch("side", &m_cluster_residual.side, "side/I");
+  m_cluster_residual_tree->Branch("layer", &m_cluster_residual.layer, "layer/I");
+  m_cluster_residual_tree->Branch("cluster_index", &m_cluster_residual.cluster_index, "cluster_index/I");
+  m_cluster_residual_tree->Branch("ntp_cluster", &m_cluster_residual.ntp_cluster, "ntp_cluster/I");
+  m_cluster_residual_tree->Branch("npoints", &m_cluster_residual.npoints, "npoints/I");
+  m_cluster_residual_tree->Branch("has_helix", &m_cluster_residual.has_helix, "has_helix/I");
+  m_cluster_residual_tree->Branch("has_kalman", &m_cluster_residual.has_kalman, "has_kalman/I");
+  m_cluster_residual_tree->Branch("cluster_x", &m_cluster_residual.cluster_x, "cluster_x/F");
+  m_cluster_residual_tree->Branch("cluster_y", &m_cluster_residual.cluster_y, "cluster_y/F");
+  m_cluster_residual_tree->Branch("cluster_z", &m_cluster_residual.cluster_z, "cluster_z/F");
+  m_cluster_residual_tree->Branch("cluster_r", &m_cluster_residual.cluster_r, "cluster_r/F");
+  m_cluster_residual_tree->Branch("cluster_phi", &m_cluster_residual.cluster_phi, "cluster_phi/F");
+  m_cluster_residual_tree->Branch("fit_x", &m_cluster_residual.fit_x, "fit_x/F");
+  m_cluster_residual_tree->Branch("fit_y", &m_cluster_residual.fit_y, "fit_y/F");
+  m_cluster_residual_tree->Branch("fit_z", &m_cluster_residual.fit_z, "fit_z/F");
+  m_cluster_residual_tree->Branch("fit_r", &m_cluster_residual.fit_r, "fit_r/F");
+  m_cluster_residual_tree->Branch("fit_phi", &m_cluster_residual.fit_phi, "fit_phi/F");
+  m_cluster_residual_tree->Branch("residual_x", &m_cluster_residual.residual_x, "residual_x/F");
+  m_cluster_residual_tree->Branch("residual_y", &m_cluster_residual.residual_y, "residual_y/F");
+  m_cluster_residual_tree->Branch("residual_z", &m_cluster_residual.residual_z, "residual_z/F");
+  m_cluster_residual_tree->Branch("residual_r", &m_cluster_residual.residual_r, "residual_r/F");
+  m_cluster_residual_tree->Branch("residual_rphi", &m_cluster_residual.residual_rphi, "residual_rphi/F");
+  m_cluster_residual_tree->Branch("fit_chi2", &m_cluster_residual.fit_chi2, "fit_chi2/F");
+  m_cluster_residual_tree->Branch("fit_ndf", &m_cluster_residual.fit_ndf, "fit_ndf/I");
+  m_cluster_residual_tree->Branch("fit_chi2_ndf", &m_cluster_residual.fit_chi2_ndf, "fit_chi2_ndf/F");
+}
+
+int TpcV0CandidateTree::pdg_charge(const int pid)
+{
+  const int apid = std::abs(pid);
+  int charge = 0;
+  switch (apid)
+  {
+  case 11:
+  case 13:
+    charge = -1;
+    break;
+  case 211:
+  case 321:
+  case 2212:
+  case 3222:
+    charge = 1;
+    break;
+  case 3112:
+  case 3312:
+  case 3334:
+    charge = -1;
+    break;
+  default:
+    charge = 0;
+    break;
+  }
+  return (pid < 0) ? -charge : charge;
+}
+
+float TpcV0CandidateTree::quiet_nan()
+{
+  return std::numeric_limits<float>::quiet_NaN();
+}
+
+bool TpcV0CandidateTree::parse_point_order(const std::string &mode, PointOrder &order)
+{
+  return TpcTrackHelixFitter::parse_point_order(mode, order);
+}
+
+bool TpcV0CandidateTree::finite(const Vec3 &value)
+{
+  return TpcTrackHelixFitter::finite(value);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::add(const Vec3 &lhs, const Vec3 &rhs)
+{
+  return TpcTrackHelixFitter::add(lhs, rhs);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::subtract(const Vec3 &lhs, const Vec3 &rhs)
+{
+  return TpcTrackHelixFitter::subtract(lhs, rhs);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::scale(const Vec3 &value, const double factor)
+{
+  return TpcTrackHelixFitter::scale(value, factor);
+}
+
+double TpcV0CandidateTree::dot(const Vec3 &lhs, const Vec3 &rhs)
+{
+  return TpcTrackHelixFitter::dot(lhs, rhs);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::cross(const Vec3 &lhs, const Vec3 &rhs)
+{
+  return {
+      lhs.y * rhs.z - lhs.z * rhs.y,
+      lhs.z * rhs.x - lhs.x * rhs.z,
+      lhs.x * rhs.y - lhs.y * rhs.x};
+}
+
+double TpcV0CandidateTree::norm(const Vec3 &value)
+{
+  return TpcTrackHelixFitter::norm(value);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::unit(const Vec3 &value)
+{
+  return TpcTrackHelixFitter::unit(value);
+}
+
+double TpcV0CandidateTree::pt(const Vec3 &value)
+{
+  return TpcTrackHelixFitter::pt(value);
+}
+
+double TpcV0CandidateTree::distance(const Vec3 &lhs, const Vec3 &rhs)
+{
+  return TpcTrackHelixFitter::distance(lhs, rhs);
+}
+
+double TpcV0CandidateTree::vector_cosine(const Vec3 &lhs, const Vec3 &rhs)
+{
+  return TpcTrackHelixFitter::vector_cosine(lhs, rhs);
+}
+
+bool TpcV0CandidateTree::fit_circle_least_squares(const std::vector<TruthPoint> &points,
+                                                  const std::size_t nfit,
+                                                  double &cx,
+                                                  double &cy,
+                                                  double &radius)
+{
+  return TpcTrackHelixFitter::fit_circle_least_squares(points, nfit, cx, cy, radius);
+}
+
+void TpcV0CandidateTree::order_track_points(std::vector<TruthPoint> &points, const PointOrder order)
+{
+  TpcTrackHelixFitter::order_points(points, order);
+}
+
+bool TpcV0CandidateTree::fit_helix(const std::vector<TruthPoint> &points,
+                                   const int fit_first_points,
+                                   const int charge,
+                                   const double bfield_t,
+                                   HelixFit &helix)
+{
+  return TpcTrackHelixFitter::fit(points, fit_first_points, bfield_t, helix) &&
+         TpcTrackHelixFitter::orient_to_charge(helix, charge);
+}
+
+bool TpcV0CandidateTree::fit_kalman(const std::vector<TruthPoint> &points,
+                                    const int charge,
+                                    TpcKalmanResult &kalman) const
+{
+  const auto start = std::chrono::steady_clock::now();
+  const bool success = TpcTrackKalmanFitter::fit(
+      points, charge, m_kalman_config, kalman, kPionMass);
+  const double fit_seconds = std::chrono::duration<double>(
+                                 std::chrono::steady_clock::now() - start)
+                                 .count();
+  m_timing_kalman_fit_seconds += fit_seconds;
+  m_timing_rkn_seconds += kalman.rkn_seconds;
+  m_timing_rkn_propagations += kalman.rkn_propagations;
+  m_timing_rkn_accepted_steps += kalman.rkn_accepted_steps;
+  m_timing_rkn_rejected_trials += kalman.rkn_rejected_trials;
+  m_timing_rkn_failures += kalman.rkn_failures;
+  ++m_timing_kalman_fits;
+  if (m_print_timing &&
+      (m_timing_kalman_fits <= 3 || m_timing_kalman_fits % 10 == 0 || fit_seconds > 1.0))
+  {
+    std::cout << "[V0TimingFit] fit=" << m_timing_kalman_fits
+              << " points=" << points.size()
+              << " success=" << success
+              << " fit_s=" << fit_seconds
+              << " rkn_s=" << kalman.rkn_seconds
+              << " rkn_propagations=" << kalman.rkn_propagations
+              << " rkn_steps=" << kalman.rkn_accepted_steps
+              << " rkn_retries=" << kalman.rkn_rejected_trials
+              << " rkn_failures=" << kalman.rkn_failures
+              << std::endl;
+  }
+  return success;
+}
+
+bool TpcV0CandidateTree::helix_from_state(const Vec3 &position, const Vec3 &momentum,
+                                          const int charge, const double bfield_t,
+                                          HelixFit &helix)
+{
+  return TpcTrackHelixFitter::from_state(position, momentum, charge, bfield_t, helix);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::helix_point(const HelixFit &helix, const double theta)
+{
+  return TpcTrackHelixFitter::point(helix, theta);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::helix_tangent(const HelixFit &helix, const double theta)
+{
+  return TpcTrackHelixFitter::tangent(helix, theta);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::helix_momentum(const HelixFit &helix, const double theta)
+{
+  return TpcTrackHelixFitter::momentum(helix, theta);
+}
+
+std::pair<double, double> TpcV0CandidateTree::theta_search_range(const HelixFit &helix,
+                                                                 const double theta_extension,
+                                                                 const double downstream_margin)
+{
+  return TpcTrackHelixFitter::theta_search_range(helix, theta_extension, downstream_margin);
+}
+
+bool TpcV0CandidateTree::line_line_pca(const Vec3 &pos1, const Vec3 &dir1,
+                                       const Vec3 &pos2, const Vec3 &dir2,
+                                       LinePca &pca, const bool normalize_dirs)
+{
+  return TpcTrackHelixFitter::line_line_pca(pos1, dir1, pos2, dir2, pca, normalize_dirs);
+}
+
+TpcV0CandidateTree::HelixPca TpcV0CandidateTree::refine_helix_pair(
+    const HelixFit &helix1, const HelixFit &helix2,
+    double theta1, double theta2,
+    const double min1, const double max1,
+    const double min2, const double max2,
+    double max_step)
+{
+  return TpcTrackHelixFitter::refine_pair(helix1, helix2, theta1, theta2,
+                                          min1, max1, min2, max2, max_step);
+}
+
+std::vector<TpcV0CandidateTree::HelixPca> TpcV0CandidateTree::helix_helix_pca_candidates(
+    const HelixFit &helix1, const HelixFit &helix2,
+    const double theta_extension,
+    const int coarse_steps,
+    const double downstream_margin,
+    const int max_candidates)
+{
+  return TpcTrackHelixFitter::pca_candidates(helix1, helix2, theta_extension,
+                                             coarse_steps, downstream_margin,
+                                             max_candidates);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::kalman_point(const TpcKalmanResult &kalman,
+                                                          const double s_cm,
+                                                          const TpcKalmanConfig &config,
+                                                          const Vec3 &reference_vertex)
+{
+  if (!kalman.success || kalman.states_smoothed.empty())
+  {
+    const double nan = quiet_nan();
+    return {nan, nan, nan};
+  }
+
+  const auto state = TpcTrackKalmanFitter::propagate_state(
+      TpcTrackKalmanFitter::propagation_state(kalman, reference_vertex), s_cm, config, kalman.mass_gev);
+  return TpcTrackKalmanFitter::state_position(state);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::kalman_tangent(const TpcKalmanResult &kalman,
+                                                            const double s_cm,
+                                                            const TpcKalmanConfig &config,
+                                                            const Vec3 &reference_vertex)
+{
+  if (!kalman.success || kalman.states_smoothed.empty())
+  {
+    const double nan = quiet_nan();
+    return {nan, nan, nan};
+  }
+
+  const auto state = TpcTrackKalmanFitter::propagate_state(
+      TpcTrackKalmanFitter::propagation_state(kalman, reference_vertex), s_cm, config, kalman.mass_gev);
+  return TpcTrackKalmanFitter::state_tangent(state);
+}
+
+TpcV0CandidateTree::Vec3 TpcV0CandidateTree::kalman_momentum(const TpcKalmanResult &kalman,
+                                                             const double s_cm,
+                                                             const TpcKalmanConfig &config,
+                                                             const Vec3 &reference_vertex)
+{
+  if (!kalman.success || kalman.states_smoothed.empty())
+  {
+    const double nan = quiet_nan();
+    return {nan, nan, nan};
+  }
+
+  const auto state = TpcTrackKalmanFitter::propagate_state(
+      TpcTrackKalmanFitter::propagation_state(kalman, reference_vertex), s_cm, config, kalman.mass_gev);
+  return TpcTrackKalmanFitter::state_momentum(state);
+}
+
+TpcV0CandidateTree::KalmanPca TpcV0CandidateTree::refine_kalman_pair(
+    const TpcKalmanResult &kalman1,
+    const TpcKalmanResult &kalman2,
+    const TpcKalmanConfig &config,
+    const Vec3 &reference_vertex,
+    double s1, double s2,
+    const double min1, const double max1,
+    const double min2, const double max2,
+    double max_step,
+    const int max_iterations)
+{
+  KalmanPca best;
+  best.s1 = s1;
+  best.s2 = s2;
+  best.pca1 = kalman_point(kalman1, s1, config, reference_vertex);
+  best.pca2 = kalman_point(kalman2, s2, config, reference_vertex);
+  double best_dca2 = square(distance(best.pca1, best.pca2));
+
+  for (int iter = 0; iter < std::max(1, max_iterations); ++iter)
+  {
+    const Vec3 pos1 = kalman_point(kalman1, s1, config, reference_vertex);
+    const Vec3 pos2 = kalman_point(kalman2, s2, config, reference_vertex);
+    const Vec3 tan1 = kalman_tangent(kalman1, s1, config, reference_vertex);
+    const Vec3 tan2 = kalman_tangent(kalman2, s2, config, reference_vertex);
+
+    LinePca line_pca;
+    if (!line_line_pca(pos1, tan1, pos2, tan2, line_pca, false))
+    {
+      break;
+    }
+
+    const double step1 = std::clamp(line_pca.step1, -max_step, max_step);
+    const double step2 = std::clamp(line_pca.step2, -max_step, max_step);
+    if (std::abs(step1) < 1.0e-4 && std::abs(step2) < 1.0e-4)
+    {
+      break;
+    }
+
+    const double candidate_s1 = std::clamp(s1 + step1, min1, max1);
+    const double candidate_s2 = std::clamp(s2 + step2, min2, max2);
+    const Vec3 candidate_pos1 = kalman_point(kalman1, candidate_s1, config, reference_vertex);
+    const Vec3 candidate_pos2 = kalman_point(kalman2, candidate_s2, config, reference_vertex);
+    const double candidate_dca2 = square(distance(candidate_pos1, candidate_pos2));
+    if (candidate_dca2 < best_dca2)
+    {
+      s1 = candidate_s1;
+      s2 = candidate_s2;
+      best_dca2 = candidate_dca2;
+    }
+    else
+    {
+      max_step *= 0.5;
+      if (max_step < 1.0e-3)
+      {
+        break;
+      }
+    }
+  }
+
+  best.s1 = s1;
+  best.s2 = s2;
+  best.pca1 = kalman_point(kalman1, s1, config, reference_vertex);
+  best.pca2 = kalman_point(kalman2, s2, config, reference_vertex);
+  best.dca = distance(best.pca1, best.pca2);
+  return best;
+}
+
+std::vector<TpcV0CandidateTree::KalmanPca> TpcV0CandidateTree::kalman_pca_candidates(
+    const TpcKalmanResult &kalman1,
+    const TpcKalmanResult &kalman2,
+    const TpcKalmanConfig &config,
+    const Vec3 &reference_vertex,
+    const double max_upstream_cm,
+    const double downstream_margin_cm,
+    const int coarse_steps,
+    const int max_candidates)
+{
+  std::vector<KalmanPca> candidates;
+  if (!kalman1.success || !kalman2.success ||
+      kalman1.states_smoothed.empty() || kalman2.states_smoothed.empty())
+  {
+    return candidates;
+  }
+
+  const double min1 = -std::abs(max_upstream_cm);
+  const double max1 = std::abs(downstream_margin_cm);
+  const double min2 = -std::abs(max_upstream_cm);
+  const double max2 = std::abs(downstream_margin_cm);
+  const int nsteps = std::max(8, coarse_steps);
+  const int ncandidates = std::max(1, max_candidates);
+  const bool use_fast_field_pca =
+      config.magnetic_field != nullptr && config.rkn_fast_field_pca;
+  TpcKalmanConfig search_config = config;
+  if (use_fast_field_pca)
+  {
+    // Use a cheap uniform-Bz trajectory only to locate promising path lengths.
+    // The selected candidates are refined below with the full field map.
+    search_config.magnetic_field = nullptr;
+    search_config.rkn_step_tolerance = 0.0;
+    search_config.rkn_max_step_cm = std::max(20.0, std::abs(config.rkn_max_step_cm));
+  }
+  const TpcKalmanConfig &coarse_config = use_fast_field_pca ? search_config : config;
+
+  std::vector<std::tuple<double, double, double>> seeds;
+  const auto nsteps_size = static_cast<std::size_t>(nsteps);
+  seeds.reserve(nsteps_size * nsteps_size);
+  std::vector<double> s1_values(static_cast<std::size_t>(nsteps));
+  std::vector<double> s2_values(static_cast<std::size_t>(nsteps));
+  std::vector<Vec3> points1(static_cast<std::size_t>(nsteps));
+  std::vector<Vec3> points2(static_cast<std::size_t>(nsteps));
+  for (int i = 0; i < nsteps; ++i)
+  {
+    s1_values[static_cast<std::size_t>(i)] =
+        min1 + (max1 - min1) * static_cast<double>(i) / static_cast<double>(nsteps - 1);
+    s2_values[static_cast<std::size_t>(i)] =
+        min2 + (max2 - min2) * static_cast<double>(i) / static_cast<double>(nsteps - 1);
+    points1[static_cast<std::size_t>(i)] =
+        kalman_point(kalman1, s1_values[static_cast<std::size_t>(i)], coarse_config, reference_vertex);
+    points2[static_cast<std::size_t>(i)] =
+        kalman_point(kalman2, s2_values[static_cast<std::size_t>(i)], coarse_config, reference_vertex);
+  }
+
+  for (int i = 0; i < nsteps; ++i)
+  {
+    const double s1 = s1_values[static_cast<std::size_t>(i)];
+    const Vec3 &pos1 = points1[static_cast<std::size_t>(i)];
+    for (int j = 0; j < nsteps; ++j)
+    {
+      const double s2 = s2_values[static_cast<std::size_t>(j)];
+      const Vec3 &pos2 = points2[static_cast<std::size_t>(j)];
+      const double d2 = square(distance(pos1, pos2));
+      if (std::isfinite(d2))
+      {
+        seeds.emplace_back(d2, s1, s2);
+      }
+    }
+  }
+
+  std::sort(seeds.begin(), seeds.end(),
+            [](const auto &lhs, const auto &rhs)
+            { return std::get<0>(lhs) < std::get<0>(rhs); });
+
+  const double max_step = std::max(max1 - min1, max2 - min2) / static_cast<double>(nsteps);
+  const int nrefine = std::min(ncandidates, static_cast<int>(seeds.size()));
+  candidates.reserve(static_cast<std::size_t>(nrefine));
+  for (int index = 0; index < nrefine; ++index)
+  {
+    double seed_s1 = std::get<1>(seeds[static_cast<std::size_t>(index)]);
+    double seed_s2 = std::get<2>(seeds[static_cast<std::size_t>(index)]);
+    if (use_fast_field_pca)
+    {
+      const auto surrogate = refine_kalman_pair(
+          kalman1, kalman2, search_config, reference_vertex,
+          seed_s1, seed_s2, min1, max1, min2, max2, max_step, 12);
+      seed_s1 = surrogate.s1;
+      seed_s2 = surrogate.s2;
+    }
+
+    candidates.push_back(refine_kalman_pair(
+        kalman1, kalman2, config, reference_vertex,
+        seed_s1, seed_s2, min1, max1, min2, max2, max_step,
+        use_fast_field_pca
+            ? std::max(1, config.rkn_field_pca_refine_iterations)
+            : 30));
+  }
+
+  std::sort(candidates.begin(), candidates.end(),
+            [](const KalmanPca &lhs, const KalmanPca &rhs)
+            { return lhs.dca < rhs.dca; });
+  return candidates;
+}
+
+std::pair<double, double> TpcV0CandidateTree::track_dca_to_vertex(const Vec3 &pos,
+                                                                  const Vec3 &mom,
+                                                                  const Vec3 &vertex)
+{
+  return TpcTrackHelixFitter::line_dca_to_vertex(pos, mom, vertex);
+}
+
+std::pair<double, double> TpcV0CandidateTree::helix_dca_to_vertex(const HelixFit &helix,
+                                                                  const Vec3 &vertex)
+{
+  return TpcTrackHelixFitter::helix_dca_to_vertex(helix, vertex);
+}
+
+std::pair<double, double> TpcV0CandidateTree::fitted_track_dca_to_vertex(
+    const Tracklet &tracklet,
+    const Vec3 &vertex) const
+{
+  if (tracklet.has_kalman)
+  {
+    return TpcTrackKalmanFitter::dca_to_vertex(
+        tracklet.kalman, vertex, &m_kalman_config);
+  }
+  if (tracklet.has_helix)
+  {
+    return helix_dca_to_vertex(tracklet.helix, vertex);
+  }
+  return track_dca_to_vertex(tracklet.position, tracklet.momentum, vertex);
+}
+
+bool TpcV0CandidateTree::armenteros(const Vec3 &pplus, const Vec3 &pminus,
+                                    double &alpha, double &qt)
+{
+  const Vec3 v0p = add(pplus, pminus);
+  const Vec3 direction = unit(v0p);
+  if (!finite(direction))
+  {
+    return false;
+  }
+
+  const double pl_plus = dot(pplus, direction);
+  const double pl_minus = dot(pminus, direction);
+  const double denom = pl_plus + pl_minus;
+  if (std::abs(denom) < 1e-10)
+  {
+    return false;
+  }
+
+  alpha = (pl_plus - pl_minus) / denom;
+  qt = norm(subtract(pplus, scale(direction, pl_plus)));
+  return true;
+}
+
+double TpcV0CandidateTree::invariant_mass(const Vec3 &mom1, const double mass1,
+                                          const Vec3 &mom2, const double mass2)
+{
+  const double e1 = std::sqrt(dot(mom1, mom1) + square(mass1));
+  const double e2 = std::sqrt(dot(mom2, mom2) + square(mass2));
+  const Vec3 total_mom = add(mom1, mom2);
+  const double mass2_total = square(e1 + e2) - dot(total_mom, total_mom);
+  return (mass2_total > 0.0) ? std::sqrt(mass2_total) : 0.0;
+}
+
+bool TpcV0CandidateTree::passes_preselection(const Tracklet &track1, const Tracklet &track2,
+                                             const Vec3 &primary_vertex) const
+{
+  if (m_pre_track_npoints_min > 0 &&
+      (track1.npoints < m_pre_track_npoints_min || track2.npoints < m_pre_track_npoints_min))
+  {
+    return false;
+  }
+
+  if (m_pre_track_quality_max >= 0.0 &&
+      (!std::isfinite(track1.fit_chi2_ndf) || !std::isfinite(track2.fit_chi2_ndf) ||
+       track1.fit_chi2_ndf >= m_pre_track_quality_max ||
+       track2.fit_chi2_ndf >= m_pre_track_quality_max))
+  {
+    return false;
+  }
+
+  if (m_pre_track_pt_min > 0.0 &&
+      (pt(track1.momentum) < m_pre_track_pt_min || pt(track2.momentum) < m_pre_track_pt_min))
+  {
+    return false;
+  }
+
+  auto dca1 = track1.vertex_dca;
+  if (!track1.has_vertex_dca)
+  {
+    dca1 = fitted_track_dca_to_vertex(track1, primary_vertex);
+  }
+  auto dca2 = track2.vertex_dca;
+  if (!track2.has_vertex_dca)
+  {
+    dca2 = fitted_track_dca_to_vertex(track2, primary_vertex);
+  }
+  if (!std::isfinite(dca1.first) || !std::isfinite(dca1.second) ||
+      !std::isfinite(dca2.first) || !std::isfinite(dca2.second))
+  {
+    return false;
+  }
+
+  if (m_pre_track_dca_xy_min >= 0.0 &&
+      (dca1.first < m_pre_track_dca_xy_min || dca2.first < m_pre_track_dca_xy_min))
+  {
+    return false;
+  }
+  if (m_pre_track_dca_z_min >= 0.0 &&
+      (dca1.second < m_pre_track_dca_z_min || dca2.second < m_pre_track_dca_z_min))
+  {
+    return false;
+  }
+  if (m_pre_track_dca_xy_max >= 0.0 &&
+      (dca1.first > m_pre_track_dca_xy_max || dca2.first > m_pre_track_dca_xy_max))
+  {
+    return false;
+  }
+  if (m_pre_track_dca_z_max >= 0.0 &&
+      (dca1.second > m_pre_track_dca_z_max || dca2.second > m_pre_track_dca_z_max))
+  {
+    return false;
+  }
+
+  if (m_pre_pair_dca_max < 0.0 && m_pre_lproj_min < 0.0 && m_pre_cos_theta_min < -1.0)
+  {
+    return true;
+  }
+
+  LinePca rough_pca;
+  if (!line_line_pca(track1.position, track1.momentum, track2.position, track2.momentum, rough_pca, true))
+  {
+    return false;
+  }
+
+  if (m_pre_pair_dca_max >= 0.0 && rough_pca.dca > m_pre_pair_dca_max)
+  {
+    return false;
+  }
+
+  const Vec3 rough_vertex = scale(add(rough_pca.pca1, rough_pca.pca2), 0.5);
+  const Vec3 flight = subtract(rough_vertex, primary_vertex);
+  const Vec3 total_mom = add(track1.momentum, track2.momentum);
+  const double lproj = norm(flight);
+  const double cos_theta = vector_cosine(flight, total_mom);
+
+  if (m_pre_lproj_min >= 0.0 && (!std::isfinite(lproj) || lproj < m_pre_lproj_min))
+  {
+    return false;
+  }
+  if (m_pre_cos_theta_min >= -1.0 &&
+      (!std::isfinite(cos_theta) || cos_theta < m_pre_cos_theta_min))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool TpcV0CandidateTree::passes_pair_selection(const Vec3 &pca1, const Vec3 &pca2,
+                                               const Vec3 &pair_vertex,
+                                               const Vec3 &primary_vertex,
+                                               const double pair_dca,
+                                               const double cos_theta,
+                                               const double alpha) const
+{
+  if (m_pair_pca_z_max >= 0.0 &&
+      (!std::isfinite(pair_vertex.z) || std::abs(pair_vertex.z) >= m_pair_pca_z_max))
+  {
+    return false;
+  }
+
+  const double pca_dz = std::abs(pca1.z - pca2.z);
+  if (m_pair_pca_dz_max >= 0.0 &&
+      (!std::isfinite(pca_dz) || pca_dz >= m_pair_pca_dz_max))
+  {
+    return false;
+  }
+
+  const double dx = pair_vertex.x - primary_vertex.x;
+  const double dy = pair_vertex.y - primary_vertex.y;
+  const double decay_radius = std::hypot(dx, dy);
+  if (m_pair_decay_radius_min >= 0.0 &&
+      (!std::isfinite(decay_radius) || decay_radius <= m_pair_decay_radius_min))
+  {
+    return false;
+  }
+
+  if (m_pair_alpha_abs_max >= 0.0 &&
+      (!std::isfinite(alpha) || std::abs(alpha) >= m_pair_alpha_abs_max))
+  {
+    return false;
+  }
+
+  if (m_pair_dca_max >= 0.0 &&
+      (!std::isfinite(pair_dca) || pair_dca >= m_pair_dca_max))
+  {
+    return false;
+  }
+
+  if (m_pair_dira_min >= -1.0 &&
+      (!std::isfinite(cos_theta) || cos_theta <= m_pair_dira_min))
+  {
+    return false;
+  }
+
+  return true;
+}

--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.h
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.h
@@ -1,0 +1,694 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef TRACKINGDIAGNOSTICS_TPCV0CANDIDATETREE_H
+#define TRACKINGDIAGNOSTICS_TPCV0CANDIDATETREE_H
+
+#include <tpctrackreco/TpcTrackFit.h>
+
+#include <fun4all/SubsysReco.h>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+class PHCompositeNode;
+class PHField;
+class PHG4Hit;
+class PHG4HitContainer;
+class PHG4TruthInfoContainer;
+class TFile;
+class TTree;
+class Tpc_PolyClusterContainer;
+class Tpc_PolyTrackContainer;
+class Tpc_PolyTrackVertexContainer;
+
+class TpcV0CandidateTree : public SubsysReco
+{
+ public:
+  TpcV0CandidateTree(const std::string &name = "TpcV0CandidateTree",
+                     const std::string &filename = "TpcV0Candidates.root");
+  ~TpcV0CandidateTree() override = default;
+
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+  void set_output_file(const std::string &filename) { m_filename = filename; }
+  void set_truth_point_node(const std::string &name) { m_truth_point_node = name; }
+  void set_truth_info_node(const std::string &name) { m_truth_info_node = name; }
+  void set_tpc_sa_cluster_node(const std::string &name) { m_tpc_sa_cluster_node = name; }
+  void set_tpc_sa_track_node(const std::string &name) { m_tpc_sa_track_node = name; }
+  void set_tpc_sa_track_vertex_node(const std::string &name) { m_tpc_sa_track_vertex_node = name; }
+  void use_pattern_cluster_tracks(const bool value = true) { m_use_pattern_cluster_tracks = value; }
+  void set_use_truth_primary_vertex(const bool value) { m_use_truth_primary_vertex = value; }
+  void set_primary_vertex(const double x, const double y, const double z);
+
+  void set_min_points(const int value) { m_min_points = value; }
+  void set_fit_helix(const bool value)
+  {
+    m_fit_helix_tracks = value;
+    if (value)
+    {
+      m_fit_kalman_tracks = false;
+    }
+  }
+  void set_fit_kalman(const bool value)
+  {
+    m_fit_kalman_tracks = value;
+    if (value)
+    {
+      m_fit_helix_tracks = false;
+      m_use_final_track_helix = false;
+    }
+  }
+  bool set_track_fit_method(const std::string &mode);
+  void set_use_final_track_helix(const bool value) { m_use_final_track_helix = value; }
+  bool set_point_order(const std::string &mode);
+  void set_fit_first_points(const int value) { m_fit_first_points = value; }
+  void set_bfield(const double value)
+  {
+    m_bfield_t = value;
+    m_kalman_config.bfield_t = value;
+  }
+  void set_kalman_magnetic_field(const PHField *field) { m_kalman_config.magnetic_field = field; }
+  void set_kalman_analytic_uniform_propagation(const bool value = true)
+  {
+    m_kalman_config.analytic_uniform_propagation = value;
+  }
+  void use_kalman_field_map(const bool value = true)
+  {
+    m_use_kalman_field_map = value;
+    if (!value)
+    {
+      m_kalman_config.magnetic_field = nullptr;
+    }
+  }
+  void set_kalman_rkn4(const double max_step_cm,
+                       const double step_tolerance,
+                       const int max_step_trials = 12,
+                       const int max_total_steps = 2000)
+  {
+    m_kalman_config.rkn_max_step_cm = max_step_cm;
+    m_kalman_config.rkn_step_tolerance = step_tolerance;
+    m_kalman_config.rkn_max_step_trials = max_step_trials;
+    m_kalman_config.rkn_max_total_steps = max_total_steps;
+  }
+  void set_kalman_fast_field_jacobian(const bool value = true)
+  {
+    m_kalman_config.rkn_fast_field_jacobian = value;
+  }
+  void set_kalman_fast_field_pca(const bool value = true)
+  {
+    m_kalman_config.rkn_fast_field_pca = value;
+  }
+  void set_kalman_field_pca_refine_iterations(const int value)
+  {
+    m_kalman_config.rkn_field_pca_refine_iterations = value;
+  }
+  void set_theta_extension(const double value) { m_theta_extension = value; }
+  void set_coarse_steps(const int value) { m_coarse_steps = value; }
+  void set_pca_candidates(const int value) { m_pca_candidates = value; }
+  void set_print_timing(const bool value = true) { m_print_timing = value; }
+  void set_downstream_margin(const double value) { m_downstream_margin = value; }
+  void set_final_track_helix_search(const double max_upstream_cm,
+                                    const double downstream_margin_cm)
+  {
+    m_final_track_helix_max_upstream_cm = max_upstream_cm;
+    m_final_track_helix_downstream_margin_cm = downstream_margin_cm;
+  }
+  void set_kalman_search(const double max_upstream_cm, const double downstream_margin_cm)
+  {
+    m_kalman_max_upstream_cm = max_upstream_cm;
+    m_kalman_downstream_margin_cm = downstream_margin_cm;
+  }
+  void set_kalman_measurement_sigmas(const double xy_cm, const double z_cm)
+  {
+    set_kalman_measurement_sigmas(xy_cm, xy_cm, z_cm);
+  }
+  void set_kalman_measurement_sigmas(const double rphi_cm,
+                                     const double r_cm,
+                                     const double z_cm)
+  {
+    m_kalman_config.meas_sigma_rphi_cm = rphi_cm;
+    m_kalman_config.meas_sigma_r_cm = r_cm;
+    m_kalman_config.meas_sigma_z_cm = z_cm;
+  }
+  void set_write_kalman_innovation_diagnostics(const bool value = true)
+  {
+    m_kalman_config.collect_innovation_components = value;
+  }
+  void set_kalman_process_sigmas(const double pos_cm,
+                                 const double phi,
+                                 const double qop_t,
+                                 const double tanl)
+  {
+    m_kalman_config.process_sigma_pos_cm = pos_cm;
+    m_kalman_config.process_sigma_phi = phi;
+    m_kalman_config.process_sigma_qop_t = qop_t;
+    m_kalman_config.process_sigma_tanl = tanl;
+  }
+  void set_kalman_material(const double x0_per_cm,
+                           const double multiple_scattering_scale,
+                           const double energy_loss_gev_per_cm,
+                           const double energy_loss_sigma_fraction)
+  {
+    m_kalman_config.material_x0_per_cm = x0_per_cm;
+    m_kalman_config.multiple_scattering_scale = multiple_scattering_scale;
+    m_kalman_config.energy_loss_gev_per_cm = energy_loss_gev_per_cm;
+    m_kalman_config.energy_loss_sigma_fraction = energy_loss_sigma_fraction;
+  }
+  void set_prefer_positive_pointing(const bool value) { m_prefer_positive_pointing = value; }
+
+  void set_pre_track_pt_min(const double value) { m_pre_track_pt_min = value; }
+  void set_pre_track_dca_xy_min(const double value) { m_pre_track_dca_xy_min = value; }
+  void set_pre_track_dca_z_min(const double value) { m_pre_track_dca_z_min = value; }
+  void set_pre_track_dca_xy_max(const double value) { m_pre_track_dca_xy_max = value; }
+  void set_pre_track_dca_z_max(const double value) { m_pre_track_dca_z_max = value; }
+  void set_pre_pair_dca_max(const double value) { m_pre_pair_dca_max = value; }
+  void set_pre_lproj_min(const double value) { m_pre_lproj_min = value; }
+  void set_pre_cos_theta_min(const double value) { m_pre_cos_theta_min = value; }
+  void set_pre_track_quality_max(const double value) { m_pre_track_quality_max = value; }
+  void set_pre_track_npoints_min(const int value) { m_pre_track_npoints_min = value; }
+  void set_pair_pca_z_max(const double value) { m_pair_pca_z_max = value; }
+  void set_pair_pca_dz_max(const double value) { m_pair_pca_dz_max = value; }
+  void set_pair_decay_radius_min(const double value) { m_pair_decay_radius_min = value; }
+  void set_pair_alpha_abs_max(const double value) { m_pair_alpha_abs_max = value; }
+  void set_pair_dca_max(const double value) { m_pair_dca_max = value; }
+  void set_pair_dira_min(const double value) { m_pair_dira_min = value; }
+  void set_write_same_sign_pairs(const bool value) { m_write_same_sign_pairs = value; }
+  void set_write_cluster_residual_tree(const bool value) { m_write_cluster_residual_tree = value; }
+
+ private:
+  using Vec3 = TpcTrackVec3;
+  using TruthPoint = TpcTrackPoint;
+  using HelixFit = TpcTrackHelix;
+  using HelixPca = TpcTrackHelixPca;
+  using HelixSearchRange = TpcTrackHelixSearchRange;
+  using LinePca = TpcTrackLinePca;
+  using PointOrder = TpcTrackPointOrder;
+
+  struct Tracklet
+  {
+    int track_id{0};
+    int shower_id{0};
+    int pid{0};
+    int parent_id{0};
+    int parent_pid{0};
+    int primary_id{0};
+    int vtx_id{0};
+    int barcode{0};
+    int embed_id{0};
+    int is_primary{0};
+    int charge{0};
+    int side{-1};
+    int npoints{0};
+    unsigned int ntpc_clusters{0};
+    bool has_dedx{false};
+    double dedx{0.0};
+    Vec3 position;
+    Vec3 momentum;
+    Vec3 truth_momentum;
+    double truth_e{0.0};
+    Vec3 truth_vertex;
+    double truth_vt{0.0};
+    std::vector<TruthPoint> points;
+    bool has_helix{false};
+    HelixFit helix;
+    bool has_helix_search_range{false};
+    HelixSearchRange helix_search_range;
+    bool has_kalman{false};
+    TpcKalmanResult kalman;
+    double fit_chi2{0.0};
+    int fit_ndf{0};
+    double fit_chi2_ndf{0.0};
+    bool has_vertex_dca{false};
+    std::pair<double, double> vertex_dca;
+    bool has_beamline_pca{false};
+    Vec3 beamline_pca;
+    double rdca_zero{0.0};
+    bool has_pattern_vertex{false};
+    Vec3 pattern_vertex;
+    double pattern_vertex_z_rms{0.0};
+    unsigned int pattern_vertex_ntracks{0};
+  };
+
+  struct KalmanPca
+  {
+    Vec3 pca1;
+    Vec3 pca2;
+    double dca{0.0};
+    double s1{0.0};
+    double s2{0.0};
+  };
+
+  struct PairRow
+  {
+    int run{0};
+    int evt{0};
+    short cross1{0};
+    short cross2{0};
+
+    float px1{0.0F};
+    float py1{0.0F};
+    float pz1{0.0F};
+    float px2{0.0F};
+    float py2{0.0F};
+    float pz2{0.0F};
+
+    float dca_xy1{0.0F};
+    float dca_z1{0.0F};
+    float dca_xy2{0.0F};
+    float dca_z2{0.0F};
+    float pairDCA{0.0F};
+
+    float alpha{0.0F};
+    float qT{0.0F};
+    float charge1{0.0F};
+    float charge2{0.0F};
+    float dedx_1{0.0F};
+    float dedx_2{0.0F};
+    float cosThetaReco{0.0F};
+    float Lproj{0.0F};
+
+    float pca_x{0.0F};
+    float pca_y{0.0F};
+    float pca_z{0.0F};
+    float pca1_x{0.0F};
+    float pca1_y{0.0F};
+    float pca1_z{0.0F};
+    float pca2_x{0.0F};
+    float pca2_y{0.0F};
+    float pca2_z{0.0F};
+
+    float v0_px{0.0F};
+    float v0_py{0.0F};
+    float v0_pz{0.0F};
+    float v0_pt{0.0F};
+    float mass_Kshort{0.0F};
+    float mass_Lambda{0.0F};
+    float mass_AntiLambda{0.0F};
+
+    float true_decay_x{0.0F};
+    float true_decay_y{0.0F};
+    float true_decay_z{0.0F};
+    float pca_to_true_3d{0.0F};
+    float pca_to_true_xy{0.0F};
+    float pca_to_true_z{0.0F};
+    float truth_alpha{0.0F};
+    float truth_qT{0.0F};
+    float delta_alpha{0.0F};
+    float delta_qT{0.0F};
+    float truth_px1{0.0F};
+    float truth_py1{0.0F};
+    float truth_pz1{0.0F};
+    float truth_px2{0.0F};
+    float truth_py2{0.0F};
+    float truth_pz2{0.0F};
+    float cos_mom1_truth{0.0F};
+    float cos_mom2_truth{0.0F};
+    float pca_theta1{0.0F};
+    float pca_theta2{0.0F};
+    float kalman_chi2_1{0.0F};
+    float kalman_chi2_2{0.0F};
+    float kalman_chi2_ndf1{0.0F};
+    float kalman_chi2_ndf2{0.0F};
+    float quality1{0.0F};
+    float quality2{0.0F};
+
+    int track_id1{0};
+    int track_id2{0};
+    int pid1{0};
+    int pid2{0};
+    int parent_id1{0};
+    int parent_id2{0};
+    int parent_pid{0};
+    int kalman_ndof1{0};
+    int kalman_ndof2{0};
+    short npoints1{0};
+    short npoints2{0};
+  };
+
+  struct TrackRow
+  {
+    int run{0};
+    int evt{0};
+    int track_id{0};
+    int shower_id{0};
+    int pid{0};
+    int parent_id{0};
+    int parent_pid{0};
+    double charge{0.0};
+    int side{-1};
+    int npoints{0};
+    unsigned int ntpc_clusters{0};
+    int has_helix{0};
+    int has_kalman{0};
+    int is_primary{0};
+
+    double px{0.0};
+    double py{0.0};
+    double pz{0.0};
+    double pt{0.0};
+    double p{0.0};
+    double eta{0.0};
+    double dedx{0.0};
+    float x{0.0F};
+    float y{0.0F};
+    float z{0.0F};
+
+    float first_x{0.0F};
+    float first_y{0.0F};
+    float first_z{0.0F};
+    float first_r{0.0F};
+    float last_x{0.0F};
+    float last_y{0.0F};
+    float last_z{0.0F};
+    float last_r{0.0F};
+
+    float dca_xy{0.0F};
+    float dca_z{0.0F};
+    double vertex_x{0.0};
+    double vertex_y{0.0};
+    double vertex_z{0.0};
+    int vertex_from_upstream{0};
+    double vertex_z_rms{0.0};
+    unsigned int vertex_ntracks{0};
+    double pca_x{0.0};
+    double pca_y{0.0};
+    double pca_z{0.0};
+    double rDCA_zero{0.0};
+    double zDCA{0.0};
+
+    float helix_cx{0.0F};
+    float helix_cy{0.0F};
+    float helix_radius{0.0F};
+    float helix_z0{0.0F};
+    float helix_pitch{0.0F};
+    float helix_theta_first{0.0F};
+    float helix_theta_last{0.0F};
+    float helix_direction{0.0F};
+    int helix_search_anchored{0};
+    int helix_anchor_point_index{-1};
+    float helix_anchor_theta{0.0F};
+    float helix_anchor_path_cm{0.0F};
+    float helix_anchor_residual_cm{0.0F};
+    float helix_search_theta_min{0.0F};
+    float helix_search_theta_max{0.0F};
+    float helix_search_upstream_cm{0.0F};
+    float helix_search_downstream_cm{0.0F};
+
+    float kalman_chi2{0.0F};
+    int kalman_ndof{0};
+    unsigned int kalman_naccepted{0};
+    unsigned int kalman_nrejected{0};
+    float kalman_measurement_sigma_r{0.0F};
+    float kalman_measurement_sigma_rphi{0.0F};
+    float kalman_measurement_sigma_z{0.0F};
+    float kalman_qop_t{0.0F};
+    float kalman_omega{0.0F};
+    float kalman_cx{0.0F};
+    float kalman_cy{0.0F};
+    float kalman_radius{0.0F};
+    float fit_chi2{0.0F};
+    int fit_ndf{0};
+    float quality{0.0F};
+
+    float truth_px{0.0F};
+    float truth_py{0.0F};
+    float truth_pz{0.0F};
+    float cos_mom_truth{0.0F};
+
+    std::vector<unsigned int> cluster_index;
+    std::vector<int> cluster_side;
+    std::vector<unsigned int> layer;
+    std::vector<double> cluster_z;
+    std::vector<double> cluster_r;
+    std::vector<double> cluster_phi;
+    std::vector<double> residual_z;
+    std::vector<double> residual_r;
+    std::vector<double> residual_rphi;
+    std::vector<double> kalman_measurement_chi2;
+    std::vector<unsigned char> kalman_measurement_used;
+    std::vector<unsigned char> kalman_measurement_in_seed;
+    std::vector<double> kalman_innovation_residual_r;
+    std::vector<double> kalman_innovation_residual_rphi;
+    std::vector<double> kalman_innovation_residual_z;
+    std::vector<double> kalman_prediction_sigma_r;
+    std::vector<double> kalman_prediction_sigma_rphi;
+    std::vector<double> kalman_prediction_sigma_z;
+    std::vector<double> kalman_innovation_sigma_r;
+    std::vector<double> kalman_innovation_sigma_rphi;
+    std::vector<double> kalman_innovation_sigma_z;
+    std::vector<double> kalman_innovation_rho_r_rphi;
+    std::vector<double> kalman_innovation_rho_r_z;
+    std::vector<double> kalman_innovation_rho_rphi_z;
+    std::vector<double> kalman_innovation_whitened_0;
+    std::vector<double> kalman_innovation_whitened_1;
+    std::vector<double> kalman_innovation_whitened_2;
+  };
+
+  struct ClusterResidualRow
+  {
+    int run{0};
+    int evt{0};
+    int track_id{0};
+    int charge{0};
+    int side{0};
+    int layer{0};
+    int cluster_index{0};
+    int ntp_cluster{0};
+    int npoints{0};
+    int has_helix{0};
+    int has_kalman{0};
+
+    float cluster_x{0.0F};
+    float cluster_y{0.0F};
+    float cluster_z{0.0F};
+    float cluster_r{0.0F};
+    float cluster_phi{0.0F};
+
+    float fit_x{0.0F};
+    float fit_y{0.0F};
+    float fit_z{0.0F};
+    float fit_r{0.0F};
+    float fit_phi{0.0F};
+
+    float residual_x{0.0F};
+    float residual_y{0.0F};
+    float residual_z{0.0F};
+    float residual_r{0.0F};
+    float residual_rphi{0.0F};
+
+    float fit_chi2{0.0F};
+    int fit_ndf{0};
+    float fit_chi2_ndf{0.0F};
+  };
+
+  int get_event_number(PHCompositeNode *topNode) const;
+  int get_run_number(PHCompositeNode *topNode) const;
+  Vec3 get_primary_vertex(PHG4TruthInfoContainer *truth_info) const;
+  std::map<int, Tracklet> build_tracklets(PHG4HitContainer *truth_points,
+                                          PHG4TruthInfoContainer *truth_info) const;
+  std::map<int, Tracklet> build_pattern_tracklets(Tpc_PolyClusterContainer *clusters,
+                                                  Tpc_PolyTrackContainer *tracks) const;
+  bool finalize_pattern_tracklet(Tracklet &tracklet, bool has_upstream_state) const;
+  bool make_pair_row(const Tracklet &track1, const Tracklet &track2,
+                     const Vec3 &primary_vertex, const int run_number,
+                     const int event_number);
+  void fill_track_row(const Tracklet &tracklet, const Vec3 &primary_vertex,
+                      int run_number, int event_number);
+  void fill_cluster_residual_rows(const Tracklet &tracklet, const Vec3 &primary_vertex,
+                                  int run_number, int event_number);
+  bool track_pca_to_xy(const Tracklet &tracklet, const Vec3 &beamline,
+                       Vec3 &pca, double &signed_dca_xy) const;
+  bool choose_pattern_collision_vertex(const Tracklet &tracklet,
+                                       Tpc_PolyTrackVertexContainer *vertices,
+                                       Vec3 &vertex, double &z_rms,
+                                       unsigned int &ntracks) const;
+  void assign_fit_quality(Tracklet &tracklet) const;
+  void reset_pair_row();
+  void reset_track_row();
+  void reset_cluster_residual_row();
+  void create_branches();
+
+  static int pdg_charge(int pid);
+  static bool parse_point_order(const std::string &mode, PointOrder &order);
+  static float quiet_nan();
+  static bool finite(const Vec3 &value);
+  static Vec3 add(const Vec3 &lhs, const Vec3 &rhs);
+  static Vec3 subtract(const Vec3 &lhs, const Vec3 &rhs);
+  static Vec3 scale(const Vec3 &value, double factor);
+  static double dot(const Vec3 &lhs, const Vec3 &rhs);
+  static Vec3 cross(const Vec3 &lhs, const Vec3 &rhs);
+  static double norm(const Vec3 &value);
+  static Vec3 unit(const Vec3 &value);
+  static double pt(const Vec3 &value);
+  static double distance(const Vec3 &lhs, const Vec3 &rhs);
+  static double vector_cosine(const Vec3 &lhs, const Vec3 &rhs);
+  static bool fit_circle_least_squares(const std::vector<TruthPoint> &points,
+                                       std::size_t nfit,
+                                       double &cx,
+                                       double &cy,
+                                       double &radius);
+  static void order_track_points(std::vector<TruthPoint> &points, PointOrder order);
+
+  static bool fit_helix(const std::vector<TruthPoint> &points, int fit_first_points,
+                        int charge, double bfield_t, HelixFit &helix);
+  bool fit_kalman(const std::vector<TruthPoint> &points,
+                  int charge,
+                  TpcKalmanResult &kalman) const;
+  static bool helix_from_state(const Vec3 &position, const Vec3 &momentum,
+                               int charge, double bfield_t, HelixFit &helix);
+  static Vec3 helix_point(const HelixFit &helix, double theta);
+  static Vec3 helix_tangent(const HelixFit &helix, double theta);
+  static Vec3 helix_momentum(const HelixFit &helix, double theta);
+  static std::pair<double, double> theta_search_range(const HelixFit &helix,
+                                                      double theta_extension,
+                                                      double downstream_margin);
+  static bool line_line_pca(const Vec3 &pos1, const Vec3 &dir1,
+                            const Vec3 &pos2, const Vec3 &dir2,
+                            LinePca &pca, bool normalize_dirs);
+  static HelixPca refine_helix_pair(const HelixFit &helix1, const HelixFit &helix2,
+                                    double theta1, double theta2,
+                                    double min1, double max1,
+                                    double min2, double max2,
+                                    double max_step);
+  static std::vector<HelixPca> helix_helix_pca_candidates(const HelixFit &helix1,
+                                                          const HelixFit &helix2,
+                                                          double theta_extension,
+                                                          int coarse_steps,
+                                                          double downstream_margin,
+                                                          int max_candidates);
+  static Vec3 kalman_point(const TpcKalmanResult &kalman,
+                           double s_cm,
+                           const TpcKalmanConfig &config,
+                           const Vec3 &reference_vertex);
+  static Vec3 kalman_tangent(const TpcKalmanResult &kalman,
+                             double s_cm,
+                             const TpcKalmanConfig &config,
+                             const Vec3 &reference_vertex);
+  static Vec3 kalman_momentum(const TpcKalmanResult &kalman,
+                              double s_cm,
+                              const TpcKalmanConfig &config,
+                              const Vec3 &reference_vertex);
+  static KalmanPca refine_kalman_pair(const TpcKalmanResult &kalman1,
+                                      const TpcKalmanResult &kalman2,
+                                      const TpcKalmanConfig &config,
+                                      const Vec3 &reference_vertex,
+                                      double s1, double s2,
+                                      double min1, double max1,
+                                      double min2, double max2,
+                                      double max_step,
+                                      int max_iterations = 30);
+  static std::vector<KalmanPca> kalman_pca_candidates(const TpcKalmanResult &kalman1,
+                                                      const TpcKalmanResult &kalman2,
+                                                      const TpcKalmanConfig &config,
+                                                      const Vec3 &reference_vertex,
+                                                      double max_upstream_cm,
+                                                      double downstream_margin_cm,
+                                                      int coarse_steps,
+                                                      int max_candidates);
+  static std::pair<double, double> track_dca_to_vertex(const Vec3 &pos,
+                                                       const Vec3 &mom,
+                                                       const Vec3 &vertex);
+  static std::pair<double, double> helix_dca_to_vertex(const HelixFit &helix,
+                                                       const Vec3 &vertex);
+  std::pair<double, double> fitted_track_dca_to_vertex(const Tracklet &tracklet,
+                                                       const Vec3 &vertex) const;
+  static bool armenteros(const Vec3 &pplus, const Vec3 &pminus,
+                         double &alpha, double &qt);
+  static double invariant_mass(const Vec3 &mom1, double mass1,
+                               const Vec3 &mom2, double mass2);
+
+  bool passes_preselection(const Tracklet &track1, const Tracklet &track2,
+                           const Vec3 &primary_vertex) const;
+  bool passes_pair_selection(const Vec3 &pca1, const Vec3 &pca2,
+                             const Vec3 &pair_vertex, const Vec3 &primary_vertex,
+                             double pair_dca, double cos_theta, double alpha) const;
+
+  std::string m_filename;
+  std::string m_truth_point_node{"G4HIT_TPC_TRUECLUSTER"};
+  std::string m_truth_info_node{"G4TruthInfo"};
+  std::string m_tpc_sa_cluster_node{"TPC_POLYCLUSTERS"};
+  std::string m_tpc_sa_track_node{"TPC_POLYTRACKS"};
+  std::string m_tpc_sa_track_vertex_node{"TPC_POLYTRACKVERTICES"};
+  bool m_use_pattern_cluster_tracks{false};
+
+  TFile *m_file{nullptr};
+  TTree *m_pair_tree{nullptr};
+  TTree *m_track_tree{nullptr};
+  TTree *m_cluster_residual_tree{nullptr};
+  PairRow m_pair;
+  TrackRow m_track;
+  ClusterResidualRow m_cluster_residual;
+
+  Vec3 m_fixed_primary_vertex{0.0, 0.0, 0.0};
+  bool m_use_truth_primary_vertex{true};
+  int m_min_points{5};
+  bool m_fit_helix_tracks{true};
+  bool m_fit_kalman_tracks{false};
+  bool m_use_final_track_helix{false};
+  PointOrder m_point_order{PointOrder::Path};
+  int m_fit_first_points{8};
+  double m_bfield_t{1.4};
+  TpcKalmanConfig m_kalman_config;
+  bool m_use_kalman_field_map{true};
+  double m_kalman_max_upstream_cm{80.0};
+  double m_kalman_downstream_margin_cm{5.0};
+  double m_theta_extension{2.0};
+  int m_coarse_steps{64};
+  int m_pca_candidates{32};
+  double m_downstream_margin{0.2};
+  double m_final_track_helix_max_upstream_cm{80.0};
+  double m_final_track_helix_downstream_margin_cm{5.0};
+  bool m_prefer_positive_pointing{false};
+  bool m_write_cluster_residual_tree{false};
+
+  double m_pre_track_pt_min{0.2};
+  double m_pre_track_dca_xy_min{0.03};
+  double m_pre_track_dca_z_min{-1.0};
+  double m_pre_track_dca_xy_max{-1.0};
+  double m_pre_track_dca_z_max{-1.0};
+  double m_pre_pair_dca_max{5.0};
+  double m_pre_lproj_min{0.2};
+  double m_pre_cos_theta_min{-2.0};
+  double m_pre_track_quality_max{-1.0};
+  int m_pre_track_npoints_min{0};
+  double m_pair_pca_z_max{-1.0};
+  double m_pair_pca_dz_max{-1.0};
+  double m_pair_decay_radius_min{-1.0};
+  double m_pair_alpha_abs_max{-1.0};
+  double m_pair_dca_max{-1.0};
+  double m_pair_dira_min{-2.0};
+  bool m_write_same_sign_pairs{false};
+  bool m_print_timing{false};
+
+  std::uint64_t m_counter_raw_pairs{0};
+  std::uint64_t m_counter_reject_charge{0};
+  std::uint64_t m_counter_reject_preselection{0};
+  std::uint64_t m_counter_reject_pca{0};
+  std::uint64_t m_counter_reject_pointing{0};
+  std::uint64_t m_counter_reject_ap{0};
+  std::uint64_t m_counter_reject_pair_selection{0};
+  std::uint64_t m_counter_written{0};
+  std::uint64_t m_counter_tracks_written{0};
+  std::uint64_t m_counter_cluster_residuals_written{0};
+  mutable std::uint64_t m_counter_reject_helix_anchor{0};
+  std::uint64_t m_timing_events{0};
+  mutable std::uint64_t m_timing_kalman_fits{0};
+  mutable std::uint64_t m_timing_rkn_propagations{0};
+  mutable std::uint64_t m_timing_rkn_accepted_steps{0};
+  mutable std::uint64_t m_timing_rkn_rejected_trials{0};
+  mutable std::uint64_t m_timing_rkn_failures{0};
+  double m_timing_total_seconds{0.0};
+  double m_timing_track_build_seconds{0.0};
+  mutable double m_timing_kalman_fit_seconds{0.0};
+  mutable double m_timing_rkn_seconds{0.0};
+  double m_timing_track_qa_seconds{0.0};
+  double m_timing_dca_cache_seconds{0.0};
+  double m_timing_pair_loop_seconds{0.0};
+  double m_timing_kalman_pca_seconds{0.0};
+};
+
+#endif

--- a/offline/packages/tpctrackreco/Makefile.am
+++ b/offline/packages/tpctrackreco/Makefile.am
@@ -39,6 +39,9 @@ pkginclude_HEADERS = \
   Tpc_PolyClusterContainerv1.h \
   Tpc_PolyClusterizer.h \
   Tpc_PolyTrackReco.h \
+  TpcTrackFit.h \
+  TpcTrackHelixFitter.h \
+  TpcTrackKalmanFitter.h \
   Tpc_FittingTools.h \
   IdealPadMap.h
 
@@ -104,6 +107,8 @@ libtpctrackreco_la_SOURCES = \
   Tpc_PolyClusterContainerv1.cc \
   Tpc_PolyClusterizer.cc \
   Tpc_PolyTrackReco.cc \
+  TpcTrackHelixFitter.cc \
+  TpcTrackKalmanFitter.cc \
   Tpc_FittingTools.cc \
   IdealPadMap.cc \
   $(ROOTDICTS)

--- a/offline/packages/tpctrackreco/TpcTrackFit.h
+++ b/offline/packages/tpctrackreco/TpcTrackFit.h
@@ -1,0 +1,173 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCTRACKFIT_H
+#define TPCTRACKRECO_TPCTRACKFIT_H
+
+#include <array>
+#include <string>
+#include <vector>
+
+class PHField;
+
+struct TpcTrackVec3
+{
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+};
+
+struct TpcTrackPoint
+{
+  int track_id{0};
+  int shower_id{0};
+  int layer{0};
+  TpcTrackVec3 position;
+  TpcTrackVec3 momentum;
+  double t{0.0};
+  double path{0.0};
+};
+
+struct TpcTrackHelix
+{
+  double cx{0.0};
+  double cy{0.0};
+  double radius{0.0};
+  double z0{0.0};
+  double pitch{0.0};
+  double theta_first{0.0};
+  double theta_last{0.0};
+  double theta_min{0.0};
+  double theta_max{0.0};
+  double direction{1.0};
+  double bfield_t{1.4};
+};
+
+struct TpcTrackLinePca
+{
+  TpcTrackVec3 pca1;
+  TpcTrackVec3 pca2;
+  double dca{0.0};
+  double step1{0.0};
+  double step2{0.0};
+};
+
+struct TpcTrackHelixPca
+{
+  TpcTrackVec3 pca1;
+  TpcTrackVec3 pca2;
+  double dca{0.0};
+  double theta1{0.0};
+  double theta2{0.0};
+};
+
+struct TpcTrackHelixSearchRange
+{
+  bool valid{false};
+  int anchor_point_index{-1};
+  double anchor_theta{0.0};
+  double anchor_path_cm{0.0};
+  double anchor_residual_cm{0.0};
+  double theta_min{0.0};
+  double theta_max{0.0};
+  double upstream_cm{0.0};
+  double downstream_cm{0.0};
+};
+
+enum class TpcTrackPointOrder
+{
+  Path,
+  Input,
+  Radius,
+  ThetaZ,
+  Auto
+};
+
+struct TpcTrackState
+{
+  TpcTrackVec3 position;
+  TpcTrackVec3 momentum;
+  int charge{0};
+  double chi2{0.0};
+  int ndof{0};
+  bool valid{false};
+};
+
+struct TpcKalmanConfig
+{
+  double bfield_t{1.4};
+  const PHField *magnetic_field{nullptr};
+  bool analytic_uniform_propagation{false};
+  double rkn_max_step_cm{5.0};
+  double rkn_step_tolerance{1.0e-4};
+  int rkn_max_step_trials{12};
+  int rkn_max_total_steps{2000};
+  bool rkn_fast_field_jacobian{true};
+  bool rkn_fast_field_pca{true};
+  int rkn_field_pca_refine_iterations{6};
+  TpcTrackPointOrder point_order{TpcTrackPointOrder::Radius};
+  double meas_sigma_rphi_cm{0.03};
+  double meas_sigma_r_cm{0.03};
+  double meas_sigma_z_cm{0.05};
+  double min_measurement_sigma_cm{1.0e-6};
+  double initial_sigma_pos_cm{0.1};
+  double initial_sigma_phi{0.2};
+  double initial_sigma_qop_t{0.2};
+  double initial_sigma_tanl{0.2};
+  double process_sigma_pos_cm{1.0e-4};
+  double process_sigma_phi{1.0e-5};
+  double process_sigma_qop_t{1.0e-6};
+  double process_sigma_tanl{1.0e-6};
+  bool collect_innovation_components{false};
+  double material_x0_per_cm{0.0};
+  double multiple_scattering_scale{1.0};
+  double energy_loss_gev_per_cm{0.0};
+  double energy_loss_sigma_fraction{0.0};
+  double min_pt_gev{0.05};
+};
+
+struct TpcKalmanResult
+{
+  bool success{false};
+  std::string message;
+  int charge{0};
+  double bfield_t{1.4};
+  const PHField *magnetic_field{nullptr};
+  bool analytic_uniform_propagation{false};
+  TpcTrackHelix seed;
+  std::vector<double> path_s;
+  std::vector<std::array<double, 6>> states_filtered;
+  std::vector<std::array<double, 36>> covs_filtered;
+  std::vector<std::array<double, 6>> states_smoothed;
+  std::vector<std::array<double, 36>> covs_smoothed;
+  std::vector<double> measurement_chi2;
+  std::vector<unsigned char> measurement_used;
+  std::vector<unsigned char> measurement_in_seed;
+  std::vector<double> innovation_residual_r;
+  std::vector<double> innovation_residual_rphi;
+  std::vector<double> innovation_residual_z;
+  std::vector<double> prediction_sigma_r;
+  std::vector<double> prediction_sigma_rphi;
+  std::vector<double> prediction_sigma_z;
+  std::vector<double> innovation_sigma_r;
+  std::vector<double> innovation_sigma_rphi;
+  std::vector<double> innovation_sigma_z;
+  std::vector<double> innovation_rho_r_rphi;
+  std::vector<double> innovation_rho_r_z;
+  std::vector<double> innovation_rho_rphi_z;
+  std::vector<double> innovation_whitened_0;
+  std::vector<double> innovation_whitened_1;
+  std::vector<double> innovation_whitened_2;
+  std::size_t naccepted{0};
+  std::size_t nrejected{0};
+  double chi2{0.0};
+  int ndof{0};
+  double mass_gev{0.13957039};
+  std::size_t rkn_propagations{0};
+  std::size_t rkn_accepted_steps{0};
+  std::size_t rkn_rejected_trials{0};
+  std::size_t rkn_max_trial_accepts{0};
+  std::size_t rkn_failures{0};
+  double rkn_seconds{0.0};
+};
+
+#endif

--- a/offline/packages/tpctrackreco/TpcTrackHelixFitter.cc
+++ b/offline/packages/tpctrackreco/TpcTrackHelixFitter.cc
@@ -1,0 +1,1432 @@
+#include "TpcTrackHelixFitter.h"
+
+#include <Eigen/Dense>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <tuple>
+
+namespace
+{
+  constexpr double kPi = 3.14159265358979323846;
+  constexpr double kCurvatureRefineMinRadiusCm = 150.0;
+  constexpr double kCurvatureRefineMaxThetaSpan = 1.0;
+  constexpr double kMinTurnDzForBranchingCm = 0.5;
+  constexpr double kAnchorResidualSlackCm = 5.0;
+  constexpr double kMaximumSearchTurnFraction = 0.95;
+  constexpr int kMaxMeasurementTurns = 32;
+
+  template <class T>
+  constexpr T square(const T &value)
+  {
+    return value * value;
+  }
+
+  double quiet_nan()
+  {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  double unwrap_to_previous(double theta, const double previous)
+  {
+    while (theta - previous > kPi)
+    {
+      theta -= 2.0 * kPi;
+    }
+    while (theta - previous < -kPi)
+    {
+      theta += 2.0 * kPi;
+    }
+    return theta;
+  }
+
+  bool solve3x3(double a[3][3], double b[3], double x[3])
+  {
+    for (int i = 0; i < 3; ++i)
+    {
+      int pivot = i;
+      double pivot_abs = std::abs(a[i][i]);
+      for (int row = i + 1; row < 3; ++row)
+      {
+        const double value_abs = std::abs(a[row][i]);
+        if (value_abs > pivot_abs)
+        {
+          pivot = row;
+          pivot_abs = value_abs;
+        }
+      }
+
+      if (pivot_abs < 1e-16)
+      {
+        return false;
+      }
+
+      if (pivot != i)
+      {
+        for (int col = i; col < 3; ++col)
+        {
+          std::swap(a[i][col], a[pivot][col]);
+        }
+        std::swap(b[i], b[pivot]);
+      }
+
+      const double diag = a[i][i];
+      for (int col = i; col < 3; ++col)
+      {
+        a[i][col] /= diag;
+      }
+      b[i] /= diag;
+
+      for (int row = 0; row < 3; ++row)
+      {
+        if (row == i)
+        {
+          continue;
+        }
+        const double factor = a[row][i];
+        if (std::abs(factor) < 1e-20)
+        {
+          continue;
+        }
+        for (int col = i; col < 3; ++col)
+        {
+          a[row][col] -= factor * a[i][col];
+        }
+        b[row] -= factor * b[i];
+      }
+    }
+
+    x[0] = b[0];
+    x[1] = b[1];
+    x[2] = b[2];
+    return true;
+  }
+
+  bool theta_span_for_circle(const std::vector<TpcTrackPoint> &points,
+                             const std::size_t nfit,
+                             const double cx,
+                             const double cy,
+                             double &theta_span)
+  {
+    theta_span = std::numeric_limits<double>::quiet_NaN();
+    if (nfit < 2 || points.size() < nfit)
+    {
+      return false;
+    }
+
+    std::vector<double> theta_values;
+    theta_values.reserve(nfit);
+    for (std::size_t i = 0; i < nfit; ++i)
+    {
+      const auto &pos = points[i].position;
+      if (!std::isfinite(pos.x) || !std::isfinite(pos.y))
+      {
+        return false;
+      }
+      double theta = std::atan2(pos.y - cy, pos.x - cx);
+      if (!theta_values.empty())
+      {
+        theta = unwrap_to_previous(theta, theta_values.back());
+      }
+      theta_values.push_back(theta);
+    }
+
+    const auto minmax = std::minmax_element(theta_values.begin(), theta_values.end());
+    if (minmax.first == theta_values.end())
+    {
+      return false;
+    }
+
+    theta_span = *minmax.second - *minmax.first;
+    return std::isfinite(theta_span) && theta_span >= 0.0;
+  }
+
+  bool prefer_curvature_refined_circle(const std::vector<TpcTrackPoint> &points,
+                                       const std::size_t nfit,
+                                       const double cx,
+                                       const double cy,
+                                       const double radius)
+  {
+    if (nfit < 4 || !std::isfinite(radius) || radius < kCurvatureRefineMinRadiusCm)
+    {
+      return false;
+    }
+
+    double theta_span = std::numeric_limits<double>::quiet_NaN();
+    if (!theta_span_for_circle(points, nfit, cx, cy, theta_span))
+    {
+      return false;
+    }
+
+    return theta_span < kCurvatureRefineMaxThetaSpan;
+  }
+}  // namespace
+
+bool TpcTrackHelixFitter::parse_point_order(const std::string &mode, TpcTrackPointOrder &order)
+{
+  if (mode == "path")
+  {
+    order = TpcTrackPointOrder::Path;
+    return true;
+  }
+  if (mode == "input")
+  {
+    order = TpcTrackPointOrder::Input;
+    return true;
+  }
+  if (mode == "radius" || mode == "r")
+  {
+    order = TpcTrackPointOrder::Radius;
+    return true;
+  }
+  if (mode == "theta-z" || mode == "thetaz" || mode == "theta_z")
+  {
+    order = TpcTrackPointOrder::ThetaZ;
+    return true;
+  }
+  if (mode == "auto")
+  {
+    order = TpcTrackPointOrder::Auto;
+    return true;
+  }
+  return false;
+}
+
+void TpcTrackHelixFitter::order_points(std::vector<TpcTrackPoint> &points,
+                                       const TpcTrackPointOrder order)
+{
+  if (points.size() <= 2 || order == TpcTrackPointOrder::Input)
+  {
+    return;
+  }
+
+  auto apply_order = [&points](const std::vector<std::size_t> &indices)
+  {
+    std::vector<TpcTrackPoint> ordered;
+    ordered.reserve(indices.size());
+    for (const auto index : indices)
+    {
+      ordered.push_back(points[index]);
+    }
+    points = std::move(ordered);
+  };
+
+  auto path_indices = [&points]()
+  {
+    std::vector<std::size_t> indices(points.size());
+    std::iota(indices.begin(), indices.end(), 0);
+    std::stable_sort(indices.begin(), indices.end(),
+                     [&points](const auto lhs, const auto rhs)
+                     { return points[lhs].path < points[rhs].path; });
+    return indices;
+  };
+
+  auto radius_indices = [&points]()
+  {
+    std::vector<std::size_t> indices(points.size());
+    std::iota(indices.begin(), indices.end(), 0);
+    std::stable_sort(indices.begin(), indices.end(),
+                     [&points](const auto lhs, const auto rhs)
+                     {
+                       const double lhs_r = pt(points[lhs].position);
+                       const double rhs_r = pt(points[rhs].position);
+                       if (std::abs(lhs_r - rhs_r) > 1.0e-6)
+                       {
+                         return lhs_r < rhs_r;
+                       }
+                       return points[lhs].layer < points[rhs].layer;
+                     });
+    return indices;
+  };
+
+  auto inner_first = [&points](std::vector<std::size_t> indices)
+  {
+    if (indices.size() >= 2)
+    {
+      const double first_r = pt(points[indices.front()].position);
+      const double last_r = pt(points[indices.back()].position);
+      if (first_r > last_r)
+      {
+        std::reverse(indices.begin(), indices.end());
+      }
+    }
+    return indices;
+  };
+
+  auto theta_z_indices = [&points, &path_indices, &inner_first]()
+  {
+    double cx = 0.0;
+    double cy = 0.0;
+    double radius = 0.0;
+    if (!fit_circle_least_squares(points, points.size(), cx, cy, radius))
+    {
+      return path_indices();
+    }
+
+    std::vector<double> raw_theta(points.size(), 0.0);
+    double z_min = points.front().position.z;
+    double z_max = points.front().position.z;
+    for (std::size_t i = 0; i < points.size(); ++i)
+    {
+      raw_theta[i] = std::atan2(points[i].position.y - cy, points[i].position.x - cx);
+      z_min = std::min(z_min, points[i].position.z);
+      z_max = std::max(z_max, points[i].position.z);
+    }
+
+    std::vector<std::size_t> indices(points.size());
+    std::iota(indices.begin(), indices.end(), 0);
+    if (z_max - z_min > 1.0e-3)
+    {
+      std::vector<std::size_t> z_order = indices;
+      std::stable_sort(z_order.begin(), z_order.end(),
+                       [&points](const auto lhs, const auto rhs)
+                       { return points[lhs].position.z < points[rhs].position.z; });
+
+      std::vector<double> unwrapped_theta = raw_theta;
+      bool have_previous = false;
+      double previous = 0.0;
+      for (const auto index : z_order)
+      {
+        double theta = raw_theta[index];
+        if (have_previous)
+        {
+          theta = unwrap_to_previous(theta, previous);
+        }
+        unwrapped_theta[index] = theta;
+        previous = theta;
+        have_previous = true;
+      }
+
+      std::stable_sort(indices.begin(), indices.end(),
+                       [&unwrapped_theta](const auto lhs, const auto rhs)
+                       { return unwrapped_theta[lhs] < unwrapped_theta[rhs]; });
+      return inner_first(indices);
+    }
+
+    std::stable_sort(indices.begin(), indices.end(),
+                     [&raw_theta](const auto lhs, const auto rhs)
+                     { return raw_theta[lhs] < raw_theta[rhs]; });
+    return inner_first(indices);
+  };
+
+  auto looks_like_looper = [&points, &path_indices]()
+  {
+    std::vector<int> layers;
+    layers.reserve(points.size());
+    for (const auto &point : points)
+    {
+      layers.push_back(point.layer);
+    }
+    std::sort(layers.begin(), layers.end());
+    if (std::adjacent_find(layers.begin(), layers.end()) != layers.end())
+    {
+      return true;
+    }
+
+    const auto sequence = path_indices();
+    std::vector<double> dr_values;
+    dr_values.reserve(sequence.size());
+    for (std::size_t i = 1; i < sequence.size(); ++i)
+    {
+      const double dr = pt(points[sequence[i]].position) - pt(points[sequence[i - 1]].position);
+      if (std::abs(dr) > 0.5)
+      {
+        dr_values.push_back(dr);
+      }
+    }
+    for (std::size_t i = 1; i < dr_values.size(); ++i)
+    {
+      if (dr_values[i] * dr_values[i - 1] < 0.0)
+      {
+        return true;
+      }
+    }
+
+    double cx = 0.0;
+    double cy = 0.0;
+    double radius = 0.0;
+    if (!fit_circle_least_squares(points, points.size(), cx, cy, radius) ||
+        points.size() < 4)
+    {
+      return false;
+    }
+
+    double z_min = points.front().position.z;
+    double z_max = points.front().position.z;
+    std::vector<std::size_t> z_order(points.size());
+    std::iota(z_order.begin(), z_order.end(), 0);
+    for (const auto &point : points)
+    {
+      z_min = std::min(z_min, point.position.z);
+      z_max = std::max(z_max, point.position.z);
+    }
+    if (z_max - z_min <= 1.0e-3)
+    {
+      return false;
+    }
+
+    std::stable_sort(z_order.begin(), z_order.end(),
+                     [&points](const auto lhs, const auto rhs)
+                     { return points[lhs].position.z < points[rhs].position.z; });
+
+    std::vector<double> theta_values;
+    theta_values.reserve(points.size());
+    for (const auto index : z_order)
+    {
+      double theta = std::atan2(points[index].position.y - cy, points[index].position.x - cx);
+      if (!theta_values.empty())
+      {
+        theta = unwrap_to_previous(theta, theta_values.back());
+      }
+      theta_values.push_back(theta);
+    }
+
+    const auto minmax_theta = std::minmax_element(theta_values.begin(), theta_values.end());
+    return minmax_theta.first != theta_values.end() &&
+           *minmax_theta.second - *minmax_theta.first > 1.5 * kPi;
+  };
+
+  switch (order)
+  {
+  case TpcTrackPointOrder::Path:
+    apply_order(path_indices());
+    break;
+  case TpcTrackPointOrder::Radius:
+    apply_order(radius_indices());
+    break;
+  case TpcTrackPointOrder::ThetaZ:
+    apply_order(theta_z_indices());
+    break;
+  case TpcTrackPointOrder::Auto:
+    apply_order(looks_like_looper() ? theta_z_indices() : radius_indices());
+    break;
+  case TpcTrackPointOrder::Input:
+    break;
+  }
+}
+
+bool TpcTrackHelixFitter::fit_circle_least_squares(const std::vector<TpcTrackPoint> &points,
+                                                   const std::size_t nfit,
+                                                   double &cx,
+                                                   double &cy,
+                                                   double &radius)
+{
+  if (nfit < 3 || points.size() < nfit)
+  {
+    return false;
+  }
+
+  Eigen::MatrixXd matrix(nfit, 3);
+  Eigen::VectorXd rhs(nfit);
+  for (std::size_t i = 0; i < nfit; ++i)
+  {
+    const auto &pos = points[i].position;
+    matrix(static_cast<int>(i), 0) = pos.x;
+    matrix(static_cast<int>(i), 1) = pos.y;
+    matrix(static_cast<int>(i), 2) = 1.0;
+    rhs(static_cast<int>(i)) = -(square(pos.x) + square(pos.y));
+  }
+
+  const Eigen::Vector3d solution = matrix.colPivHouseholderQr().solve(rhs);
+  cx = -0.5 * solution(0);
+  cy = -0.5 * solution(1);
+  const double radius2 = square(cx) + square(cy) - solution(2);
+  if (radius2 <= 0.0 || !std::isfinite(radius2))
+  {
+    return false;
+  }
+
+  radius = std::sqrt(radius2);
+  return radius > 0.0 && std::isfinite(radius);
+}
+
+bool TpcTrackHelixFitter::fit_circle_curvature_refined(const std::vector<TpcTrackPoint> &points,
+                                                       const std::size_t nfit,
+                                                       double &cx,
+                                                       double &cy,
+                                                       double &radius)
+{
+  cx = quiet_nan();
+  cy = quiet_nan();
+  radius = quiet_nan();
+
+  if (nfit < 4 || points.size() < nfit)
+  {
+    return false;
+  }
+
+  std::vector<TpcTrackVec3> positions;
+  positions.reserve(nfit);
+  for (std::size_t i = 0; i < nfit; ++i)
+  {
+    const auto &pos = points[i].position;
+    if (!finite(pos))
+    {
+      continue;
+    }
+    positions.push_back(pos);
+  }
+
+  if (positions.size() < 4)
+  {
+    return false;
+  }
+
+  const double npoints = static_cast<double>(positions.size());
+
+  double mean_x = 0.0;
+  double mean_y = 0.0;
+  for (const auto &pos : positions)
+  {
+    mean_x += pos.x;
+    mean_y += pos.y;
+  }
+  mean_x /= npoints;
+  mean_y /= npoints;
+
+  double cuu = 0.0;
+  double cvv = 0.0;
+  double cuv = 0.0;
+  for (const auto &pos : positions)
+  {
+    const double u = pos.x - mean_x;
+    const double v = pos.y - mean_y;
+    cuu += u * u;
+    cvv += v * v;
+    cuv += u * v;
+  }
+  const double phi = 0.5 * std::atan2(2.0 * cuv, cuu - cvv);
+  const double cphi = std::cos(phi);
+  const double sphi = std::sin(phi);
+
+  double sum_s = 0.0;
+  double sum_s2 = 0.0;
+  double sum_s3 = 0.0;
+  double sum_s4 = 0.0;
+  double sum_n = 0.0;
+  double sum_sn = 0.0;
+  double sum_s2n = 0.0;
+  for (const auto &pos : positions)
+  {
+    const double u = pos.x - mean_x;
+    const double v = pos.y - mean_y;
+    const double s = cphi * u + sphi * v;
+    const double n = -sphi * u + cphi * v;
+    sum_s += s;
+    sum_s2 += s * s;
+    sum_s3 += s * s * s;
+    sum_s4 += s * s * s * s;
+    sum_n += n;
+    sum_sn += s * n;
+    sum_s2n += s * s * n;
+  }
+
+  double seed_matrix[3][3] = {
+      {npoints, sum_s, sum_s2},
+      {sum_s, sum_s2, sum_s3},
+      {sum_s2, sum_s3, sum_s4}};
+  double seed_rhs[3] = {sum_n, sum_sn, sum_s2n};
+  double seed_coeffs[3] = {0.0, 0.0, 0.0};
+  if (!solve3x3(seed_matrix, seed_rhs, seed_coeffs))
+  {
+    return false;
+  }
+
+  const double a = seed_coeffs[0];
+  const double b = seed_coeffs[1];
+  const double c = seed_coeffs[2];
+  const double denom = std::pow(1.0 + b * b, 1.5);
+  if (!(denom > 0.0) || !std::isfinite(denom))
+  {
+    return false;
+  }
+
+  const double kappa = 2.0 * c / denom;
+  if (!std::isfinite(kappa) || !(std::abs(kappa) > 1e-14))
+  {
+    return false;
+  }
+
+  auto circle_from_local = [&](const double a_par,
+                               const double b_par,
+                               const double kappa_par,
+                               double &cx_out,
+                               double &cy_out,
+                               double &radius_out) -> bool
+  {
+    if (!std::isfinite(a_par) || !std::isfinite(b_par) || !std::isfinite(kappa_par))
+    {
+      return false;
+    }
+    if (!(std::abs(kappa_par) > 1e-18))
+    {
+      return false;
+    }
+
+    const double slope_norm = std::sqrt(1.0 + b_par * b_par);
+    if (!(slope_norm > 0.0) || !std::isfinite(slope_norm))
+    {
+      return false;
+    }
+
+    const double center_s = -b_par / (slope_norm * kappa_par);
+    const double center_n = a_par + 1.0 / (slope_norm * kappa_par);
+    const double radius_local = std::abs(1.0 / kappa_par);
+    if (!(radius_local > 0.0) || !std::isfinite(radius_local))
+    {
+      return false;
+    }
+
+    cx_out = mean_x + center_s * cphi - center_n * sphi;
+    cy_out = mean_y + center_s * sphi + center_n * cphi;
+    radius_out = radius_local;
+    return std::isfinite(cx_out) && std::isfinite(cy_out);
+  };
+
+  auto residuals_from_local = [&](const double a_par,
+                                  const double b_par,
+                                  const double kappa_par,
+                                  std::vector<double> &residuals,
+                                  double &chi2,
+                                  double *cx_out = nullptr,
+                                  double *cy_out = nullptr,
+                                  double *radius_out = nullptr) -> bool
+  {
+    double cx_fit = 0.0;
+    double cy_fit = 0.0;
+    double radius_fit = 0.0;
+    if (!circle_from_local(a_par, b_par, kappa_par, cx_fit, cy_fit, radius_fit))
+    {
+      return false;
+    }
+
+    residuals.resize(positions.size());
+    chi2 = 0.0;
+    for (std::size_t i = 0; i < positions.size(); ++i)
+    {
+      const double dx = positions[i].x - cx_fit;
+      const double dy = positions[i].y - cy_fit;
+      const double dist = std::sqrt(dx * dx + dy * dy);
+      if (!std::isfinite(dist))
+      {
+        return false;
+      }
+      const double resid = dist - radius_fit;
+      residuals[i] = resid;
+      chi2 += resid * resid;
+    }
+
+    if (cx_out)
+    {
+      *cx_out = cx_fit;
+    }
+    if (cy_out)
+    {
+      *cy_out = cy_fit;
+    }
+    if (radius_out)
+    {
+      *radius_out = radius_fit;
+    }
+    return std::isfinite(chi2);
+  };
+
+  double a_cur = a;
+  double b_cur = b;
+  double kappa_cur = kappa;
+  double cx_cur = 0.0;
+  double cy_cur = 0.0;
+  double radius_cur = 0.0;
+  std::vector<double> residuals_cur;
+  double chi2_cur = 0.0;
+  if (!residuals_from_local(a_cur, b_cur, kappa_cur, residuals_cur, chi2_cur,
+                            &cx_cur, &cy_cur, &radius_cur))
+  {
+    return false;
+  }
+
+  double lambda = 1e-3;
+  for (int iter = 0; iter < 30; ++iter)
+  {
+    const double step_a = std::max(1e-8, 1e-6 * std::max({1.0, std::abs(a_cur), 0.01 * radius_cur}));
+    const double step_b = std::max(1e-8, 1e-6 * std::max(1.0, std::abs(b_cur)));
+    const double step_kappa = std::max(1e-12, 1e-6 * std::max(std::abs(kappa_cur), 1.0 / std::max(radius_cur, 1.0)));
+    const double steps[3] = {step_a, step_b, step_kappa};
+
+    std::vector<double> jac_cols[3];
+    bool jacobian_ok = true;
+    for (int ipar = 0; ipar < 3; ++ipar)
+    {
+      jac_cols[ipar].assign(positions.size(), 0.0);
+
+      double a_plus = a_cur;
+      double b_plus = b_cur;
+      double kappa_plus = kappa_cur;
+      double a_minus = a_cur;
+      double b_minus = b_cur;
+      double kappa_minus = kappa_cur;
+      if (ipar == 0)
+      {
+        a_plus += steps[ipar];
+        a_minus -= steps[ipar];
+      }
+      else if (ipar == 1)
+      {
+        b_plus += steps[ipar];
+        b_minus -= steps[ipar];
+      }
+      else
+      {
+        kappa_plus += steps[ipar];
+        kappa_minus -= steps[ipar];
+      }
+
+      std::vector<double> residuals_plus;
+      std::vector<double> residuals_minus;
+      double chi2_dummy = 0.0;
+      const bool have_plus = residuals_from_local(a_plus, b_plus, kappa_plus, residuals_plus, chi2_dummy);
+      const bool have_minus = residuals_from_local(a_minus, b_minus, kappa_minus, residuals_minus, chi2_dummy);
+      if (!have_plus && !have_minus)
+      {
+        jacobian_ok = false;
+        break;
+      }
+
+      for (std::size_t ipoint = 0; ipoint < positions.size(); ++ipoint)
+      {
+        if (have_plus && have_minus)
+        {
+          jac_cols[ipar][ipoint] = (residuals_plus[ipoint] - residuals_minus[ipoint]) / (2.0 * steps[ipar]);
+        }
+        else if (have_plus)
+        {
+          jac_cols[ipar][ipoint] = (residuals_plus[ipoint] - residuals_cur[ipoint]) / steps[ipar];
+        }
+        else
+        {
+          jac_cols[ipar][ipoint] = (residuals_cur[ipoint] - residuals_minus[ipoint]) / steps[ipar];
+        }
+      }
+    }
+    if (!jacobian_ok)
+    {
+      break;
+    }
+
+    double jtj[3][3] = {};
+    double jtr[3] = {};
+    for (std::size_t ipoint = 0; ipoint < positions.size(); ++ipoint)
+    {
+      for (int i = 0; i < 3; ++i)
+      {
+        const double ji = jac_cols[i][ipoint];
+        jtr[i] += ji * residuals_cur[ipoint];
+        for (int j = 0; j < 3; ++j)
+        {
+          jtj[i][j] += ji * jac_cols[j][ipoint];
+        }
+      }
+    }
+
+    bool accepted = false;
+    double delta[3] = {0.0, 0.0, 0.0};
+    for (int trial = 0; trial < 8; ++trial)
+    {
+      double system[3][3] = {
+          {jtj[0][0], jtj[0][1], jtj[0][2]},
+          {jtj[1][0], jtj[1][1], jtj[1][2]},
+          {jtj[2][0], jtj[2][1], jtj[2][2]}};
+      for (int idiag = 0; idiag < 3; ++idiag)
+      {
+        system[idiag][idiag] += lambda * std::max(jtj[idiag][idiag], 1.0);
+      }
+
+      double neg_jtr[3] = {-jtr[0], -jtr[1], -jtr[2]};
+      if (!solve3x3(system, neg_jtr, delta))
+      {
+        lambda *= 10.0;
+        continue;
+      }
+
+      const double a_try = a_cur + delta[0];
+      const double b_try = b_cur + delta[1];
+      const double kappa_try = kappa_cur + delta[2];
+      std::vector<double> residuals_try;
+      double chi2_try = 0.0;
+      double cx_try = 0.0;
+      double cy_try = 0.0;
+      double radius_try = 0.0;
+      if (!residuals_from_local(a_try, b_try, kappa_try, residuals_try, chi2_try,
+                                &cx_try, &cy_try, &radius_try) ||
+          !(chi2_try < chi2_cur))
+      {
+        lambda *= 10.0;
+        continue;
+      }
+
+      a_cur = a_try;
+      b_cur = b_try;
+      kappa_cur = kappa_try;
+      residuals_cur.swap(residuals_try);
+      chi2_cur = chi2_try;
+      cx_cur = cx_try;
+      cy_cur = cy_try;
+      radius_cur = radius_try;
+      lambda = std::max(1e-12, lambda * 0.3);
+      accepted = true;
+      break;
+    }
+
+    if (!accepted)
+    {
+      break;
+    }
+
+    const double rel_step = std::sqrt(
+        std::pow(delta[0] / std::max({1.0, std::abs(a_cur), 0.01 * radius_cur}), 2) +
+        std::pow(delta[1] / std::max(1.0, std::abs(b_cur)), 2) +
+        std::pow(delta[2] / std::max(std::abs(kappa_cur), 1e-12), 2));
+    if (rel_step < 1e-10)
+    {
+      break;
+    }
+  }
+
+  cx = cx_cur;
+  cy = cy_cur;
+  radius = radius_cur;
+  return std::isfinite(cx) && std::isfinite(cy) &&
+         std::isfinite(radius) && radius > 0.0;
+}
+
+bool TpcTrackHelixFitter::fit(const std::vector<TpcTrackPoint> &points,
+                              const int fit_first_points,
+                              const double bfield_t,
+                              TpcTrackHelix &helix)
+{
+  const std::size_t nfit =
+      (fit_first_points > 0) ? std::min(points.size(), static_cast<std::size_t>(fit_first_points)) : points.size();
+  if (nfit < 3)
+  {
+    return false;
+  }
+
+  double cx = 0.0;
+  double cy = 0.0;
+  double radius = 0.0;
+  bool have_circle = fit_circle_least_squares(points, nfit, cx, cy, radius);
+  if (have_circle && prefer_curvature_refined_circle(points, nfit, cx, cy, radius))
+  {
+    double refined_cx = 0.0;
+    double refined_cy = 0.0;
+    double refined_radius = 0.0;
+    if (fit_circle_curvature_refined(points, nfit, refined_cx, refined_cy, refined_radius))
+    {
+      cx = refined_cx;
+      cy = refined_cy;
+      radius = refined_radius;
+    }
+  }
+  else if (!have_circle)
+  {
+    have_circle = fit_circle_curvature_refined(points, nfit, cx, cy, radius);
+  }
+
+  if (!have_circle)
+  {
+    return false;
+  }
+
+  Eigen::MatrixXd z_matrix(nfit, 2);
+  Eigen::VectorXd z_rhs(nfit);
+  std::vector<double> theta_values;
+  theta_values.reserve(nfit);
+  for (std::size_t i = 0; i < nfit; ++i)
+  {
+    double theta = std::atan2(points[i].position.y - cy, points[i].position.x - cx);
+    if (!theta_values.empty())
+    {
+      theta = unwrap_to_previous(theta, theta_values.back());
+    }
+    theta_values.push_back(theta);
+    z_matrix(static_cast<int>(i), 0) = theta;
+    z_matrix(static_cast<int>(i), 1) = 1.0;
+    z_rhs(static_cast<int>(i)) = points[i].position.z;
+  }
+
+  const auto minmax_theta = std::minmax_element(theta_values.begin(), theta_values.end());
+  if (minmax_theta.first == theta_values.end() ||
+      *minmax_theta.second - *minmax_theta.first < 1e-4)
+  {
+    return false;
+  }
+
+  const Eigen::Vector2d z_solution = z_matrix.colPivHouseholderQr().solve(z_rhs);
+  double direction = (theta_values.back() > theta_values.front()) ? 1.0 : -1.0;
+  if (std::abs(theta_values.back() - theta_values.front()) <= 0.0)
+  {
+    direction = 1.0;
+  }
+
+  helix.cx = cx;
+  helix.cy = cy;
+  helix.radius = radius;
+  helix.z0 = z_solution(1);
+  helix.pitch = z_solution(0);
+  helix.theta_first = theta_values.front();
+  helix.theta_last = theta_values.back();
+  helix.theta_min = *minmax_theta.first;
+  helix.theta_max = *minmax_theta.second;
+  helix.direction = direction;
+  helix.bfield_t = bfield_t;
+  return true;
+}
+
+bool TpcTrackHelixFitter::from_state(const TpcTrackVec3 &position,
+                                     const TpcTrackVec3 &momentum_value,
+                                     const int charge,
+                                     const double bfield_t,
+                                     TpcTrackHelix &helix)
+{
+  if (charge == 0 || bfield_t == 0.0 || !finite(position) || !finite(momentum_value))
+  {
+    return false;
+  }
+
+  const double p_t = pt(momentum_value);
+  if (p_t <= 0.0 || !std::isfinite(p_t))
+  {
+    return false;
+  }
+
+  const double radius = p_t / (0.003 * std::abs(bfield_t));
+  if (radius <= 0.0 || !std::isfinite(radius))
+  {
+    return false;
+  }
+
+  const double direction = -static_cast<double>(charge) * ((bfield_t > 0.0) ? 1.0 : -1.0);
+  const double radial_x = direction * momentum_value.y / p_t;
+  const double radial_y = -direction * momentum_value.x / p_t;
+  const double cx = position.x - radius * radial_x;
+  const double cy = position.y - radius * radial_y;
+  const double theta = std::atan2(position.y - cy, position.x - cx);
+  const double pitch = momentum_value.z * radius / (direction * p_t);
+  const double z0 = position.z - pitch * theta;
+
+  helix.cx = cx;
+  helix.cy = cy;
+  helix.radius = radius;
+  helix.z0 = z0;
+  helix.pitch = pitch;
+  helix.theta_first = theta;
+  helix.theta_last = theta;
+  helix.theta_min = theta;
+  helix.theta_max = theta;
+  helix.direction = direction;
+  helix.bfield_t = bfield_t;
+  return finite(point(helix, theta)) && finite(momentum(helix, theta));
+}
+
+bool TpcTrackHelixFitter::orient_to_charge(TpcTrackHelix &helix, const int charge)
+{
+  if (charge == 0 || helix.bfield_t == 0.0 || !std::isfinite(helix.bfield_t))
+  {
+    return false;
+  }
+
+  const double charge_sign = static_cast<double>((charge > 0) ? 1 : -1);
+  const double bfield_sign = (helix.bfield_t > 0.0) ? 1.0 : -1.0;
+  const double physical_direction = -charge_sign * bfield_sign;
+
+  // The geometric fit may be ordered opposite to physical time.  Keep the
+  // fitted helix, but make theta_first the physical initial branch.
+  if (helix.direction * physical_direction < 0.0)
+  {
+    std::swap(helix.theta_first, helix.theta_last);
+  }
+  helix.direction = physical_direction;
+  return true;
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::point(const TpcTrackHelix &helix, const double theta)
+{
+  return {
+      helix.cx + helix.radius * std::cos(theta),
+      helix.cy + helix.radius * std::sin(theta),
+      helix.z0 + helix.pitch * theta};
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::tangent(const TpcTrackHelix &helix, const double theta)
+{
+  return {
+      -helix.radius * std::sin(theta),
+      helix.radius * std::cos(theta),
+      helix.pitch};
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::momentum(const TpcTrackHelix &helix, const double theta)
+{
+  double p_t = 0.3 * std::abs(helix.bfield_t) * (helix.radius / 100.0);
+  if (p_t <= 0.0 || !std::isfinite(p_t))
+  {
+    p_t = 1.0;
+  }
+
+  return {
+      helix.direction * p_t * (-std::sin(theta)),
+      helix.direction * p_t * std::cos(theta),
+      helix.direction * p_t * helix.pitch / helix.radius};
+}
+
+std::pair<double, double> TpcTrackHelixFitter::theta_search_range(const TpcTrackHelix &helix,
+                                                                  const double theta_extension,
+                                                                  const double downstream_margin)
+{
+  const double upstream = helix.theta_first - helix.direction * theta_extension;
+  const double downstream = helix.theta_first + helix.direction * downstream_margin;
+  return {std::min(upstream, downstream), std::max(upstream, downstream)};
+}
+
+bool TpcTrackHelixFitter::measurement_anchored_search_range(
+    const TpcTrackHelix &helix,
+    const std::vector<TpcTrackPoint> &points,
+    const double max_upstream_cm,
+    const double downstream_margin_cm,
+    TpcTrackHelixSearchRange &range)
+{
+  range = {};
+  if (points.empty() || !(helix.radius > 0.0) ||
+      !std::isfinite(helix.radius) || !std::isfinite(helix.theta_first) ||
+      !std::isfinite(helix.direction) || std::abs(helix.direction) < 0.5)
+  {
+    return false;
+  }
+
+  const double direction = helix.direction > 0.0 ? 1.0 : -1.0;
+  const double reference_theta = helix.theta_first;
+  const double circumference_cm = 2.0 * kPi * helix.radius;
+  if (!(circumference_cm > 0.0) || !std::isfinite(circumference_cm))
+  {
+    return false;
+  }
+
+  struct Projection
+  {
+    int point_index{-1};
+    double theta{0.0};
+    double path_cm{0.0};
+    double residual_cm{0.0};
+  };
+
+  std::vector<Projection> projections;
+  projections.reserve(points.size());
+  double minimum_residual_cm = std::numeric_limits<double>::infinity();
+  const double turn_dz_cm = 2.0 * kPi * helix.pitch * direction;
+
+  for (std::size_t index = 0; index < points.size(); ++index)
+  {
+    const auto &measurement = points[index].position;
+    if (!finite(measurement))
+    {
+      continue;
+    }
+
+    const double raw_theta = std::atan2(measurement.y - helix.cy,
+                                        measurement.x - helix.cx);
+    // Path is signed relative to the transverse perigee. Measurements may be
+    // either before or after that point in physical time, so start from the
+    // nearest angular branch and let z resolve any additional full turns.
+    const double base_phase = std::remainder(
+        direction * (raw_theta - reference_theta), 2.0 * kPi);
+    const double base_theta = reference_theta + direction * base_phase;
+    const TpcTrackVec3 base_position = point(helix, base_theta);
+
+    int turn_guess = 0;
+    if (std::abs(turn_dz_cm) >= kMinTurnDzForBranchingCm)
+    {
+      turn_guess = static_cast<int>(std::llround(
+          (measurement.z - base_position.z) / turn_dz_cm));
+      turn_guess = std::clamp(turn_guess,
+                              -kMaxMeasurementTurns,
+                              kMaxMeasurementTurns);
+    }
+
+    const int first_turn = std::max(-kMaxMeasurementTurns, turn_guess - 2);
+    const int last_turn = std::min(kMaxMeasurementTurns, turn_guess + 2);
+    Projection best;
+    best.point_index = static_cast<int>(index);
+    best.residual_cm = std::numeric_limits<double>::infinity();
+    int best_turn = -1;
+    for (int turn = first_turn; turn <= last_turn; ++turn)
+    {
+      const double theta = base_theta + direction * 2.0 * kPi * turn;
+      const TpcTrackVec3 projected = point(helix, theta);
+      const double residual_cm = distance(projected, measurement);
+      if (!std::isfinite(residual_cm))
+      {
+        continue;
+      }
+
+      if (residual_cm < best.residual_cm - 1.0e-12 ||
+          (std::abs(residual_cm - best.residual_cm) <= 1.0e-12 &&
+           (best_turn < 0 || turn < best_turn)))
+      {
+        best.theta = theta;
+        best.path_cm = helix.radius * (base_phase + 2.0 * kPi * turn);
+        best.residual_cm = residual_cm;
+        best_turn = turn;
+      }
+    }
+
+    if (!std::isfinite(best.residual_cm))
+    {
+      continue;
+    }
+    projections.push_back(best);
+    minimum_residual_cm = std::min(minimum_residual_cm, best.residual_cm);
+  }
+
+  if (projections.empty() || !std::isfinite(minimum_residual_cm))
+  {
+    return false;
+  }
+
+  const double residual_limit_cm = minimum_residual_cm + kAnchorResidualSlackCm;
+  auto anchor_iter = projections.end();
+  for (auto iter = projections.begin(); iter != projections.end(); ++iter)
+  {
+    if (iter->residual_cm > residual_limit_cm)
+    {
+      continue;
+    }
+    if (anchor_iter == projections.end() ||
+        iter->path_cm < anchor_iter->path_cm - 1.0e-9 ||
+        (std::abs(iter->path_cm - anchor_iter->path_cm) <= 1.0e-9 &&
+         iter->residual_cm < anchor_iter->residual_cm))
+    {
+      anchor_iter = iter;
+    }
+  }
+  if (anchor_iter == projections.end())
+  {
+    return false;
+  }
+
+  const double requested_upstream_cm = std::max(0.0, max_upstream_cm);
+  const double requested_downstream_cm = std::max(0.0, downstream_margin_cm);
+  // Leave a finite gap between the two ends of the search domain. A cap that
+  // differs from one turn only by machine epsilon still permits duplicate
+  // geometric intersections and rounds back to 2*pi in float QA branches.
+  const double maximum_span_cm =
+      kMaximumSearchTurnFraction * circumference_cm;
+  const double downstream_cm =
+      std::min(requested_downstream_cm, maximum_span_cm);
+  const double upstream_cm = std::min(
+      requested_upstream_cm, std::max(0.0, maximum_span_cm - downstream_cm));
+  if (!(upstream_cm + downstream_cm > 0.0))
+  {
+    return false;
+  }
+
+  const double lower_path_cm = anchor_iter->path_cm - upstream_cm;
+  const double upper_path_cm = anchor_iter->path_cm + downstream_cm;
+  const double theta_a = reference_theta + direction * lower_path_cm / helix.radius;
+  const double theta_b = reference_theta + direction * upper_path_cm / helix.radius;
+
+  range.valid = true;
+  range.anchor_point_index = anchor_iter->point_index;
+  range.anchor_theta = anchor_iter->theta;
+  range.anchor_path_cm = anchor_iter->path_cm;
+  range.anchor_residual_cm = anchor_iter->residual_cm;
+  range.theta_min = std::min(theta_a, theta_b);
+  range.theta_max = std::max(theta_a, theta_b);
+  range.upstream_cm = upstream_cm;
+  range.downstream_cm = downstream_cm;
+  return std::isfinite(range.theta_min) && std::isfinite(range.theta_max) &&
+         range.theta_max > range.theta_min;
+}
+
+bool TpcTrackHelixFitter::line_line_pca(const TpcTrackVec3 &pos1,
+                                        const TpcTrackVec3 &dir1,
+                                        const TpcTrackVec3 &pos2,
+                                        const TpcTrackVec3 &dir2,
+                                        TpcTrackLinePca &pca,
+                                        const bool normalize_dirs)
+{
+  TpcTrackVec3 u1 = normalize_dirs ? unit(dir1) : dir1;
+  TpcTrackVec3 u2 = normalize_dirs ? unit(dir2) : dir2;
+  if (!finite(u1) || !finite(u2))
+  {
+    return false;
+  }
+
+  const TpcTrackVec3 w0 = subtract(pos1, pos2);
+  const double a = dot(u1, u1);
+  const double b = dot(u1, u2);
+  const double c = dot(u2, u2);
+  const double d = dot(u1, w0);
+  const double e = dot(u2, w0);
+  const double denom = a * c - b * b;
+  if (std::abs(denom) < 1e-12)
+  {
+    return false;
+  }
+
+  const double s = (b * e - c * d) / denom;
+  const double t = (a * e - b * d) / denom;
+  pca.pca1 = add(pos1, scale(u1, s));
+  pca.pca2 = add(pos2, scale(u2, t));
+  pca.dca = distance(pca.pca1, pca.pca2);
+  pca.step1 = s;
+  pca.step2 = t;
+  return true;
+}
+
+TpcTrackHelixPca TpcTrackHelixFitter::refine_pair(const TpcTrackHelix &helix1,
+                                                  const TpcTrackHelix &helix2,
+                                                  double theta1,
+                                                  double theta2,
+                                                  const double min1,
+                                                  const double max1,
+                                                  const double min2,
+                                                  const double max2,
+                                                  double max_step)
+{
+  double best_dca2 = square(distance(point(helix1, theta1), point(helix2, theta2)));
+
+  for (int iter = 0; iter < 30; ++iter)
+  {
+    TpcTrackLinePca line_pca;
+    if (!line_line_pca(point(helix1, theta1), tangent(helix1, theta1),
+                       point(helix2, theta2), tangent(helix2, theta2),
+                       line_pca, false))
+    {
+      break;
+    }
+
+    const double step1 = std::clamp(line_pca.step1, -max_step, max_step);
+    const double step2 = std::clamp(line_pca.step2, -max_step, max_step);
+    if (std::abs(step1) < 1e-5 && std::abs(step2) < 1e-5)
+    {
+      break;
+    }
+
+    const double candidate_theta1 = std::clamp(theta1 + step1, min1, max1);
+    const double candidate_theta2 = std::clamp(theta2 + step2, min2, max2);
+    const double candidate_dca2 = square(distance(point(helix1, candidate_theta1),
+                                                  point(helix2, candidate_theta2)));
+    if (candidate_dca2 < best_dca2)
+    {
+      theta1 = candidate_theta1;
+      theta2 = candidate_theta2;
+      best_dca2 = candidate_dca2;
+    }
+    else
+    {
+      max_step *= 0.5;
+      if (max_step < 1e-4)
+      {
+        break;
+      }
+    }
+  }
+
+  TpcTrackHelixPca output;
+  output.theta1 = theta1;
+  output.theta2 = theta2;
+  output.pca1 = point(helix1, theta1);
+  output.pca2 = point(helix2, theta2);
+  output.dca = distance(output.pca1, output.pca2);
+  return output;
+}
+
+std::vector<TpcTrackHelixPca> TpcTrackHelixFitter::pca_candidates(
+    const TpcTrackHelix &helix1,
+    const TpcTrackHelix &helix2,
+    const double theta_extension,
+    const int coarse_steps,
+    const double downstream_margin,
+    const int max_candidates)
+{
+  TpcTrackHelixSearchRange range1;
+  const auto legacy_range1 = theta_search_range(helix1, theta_extension, downstream_margin);
+  range1.valid = true;
+  range1.theta_min = legacy_range1.first;
+  range1.theta_max = legacy_range1.second;
+  TpcTrackHelixSearchRange range2;
+  const auto legacy_range2 = theta_search_range(helix2, theta_extension, downstream_margin);
+  range2.valid = true;
+  range2.theta_min = legacy_range2.first;
+  range2.theta_max = legacy_range2.second;
+  return pca_candidates_in_ranges(helix1, helix2, range1, range2,
+                                  coarse_steps, max_candidates);
+}
+
+std::vector<TpcTrackHelixPca> TpcTrackHelixFitter::pca_candidates_in_ranges(
+    const TpcTrackHelix &helix1,
+    const TpcTrackHelix &helix2,
+    const TpcTrackHelixSearchRange &range1,
+    const TpcTrackHelixSearchRange &range2,
+    const int coarse_steps,
+    const int max_candidates)
+{
+  if (!range1.valid || !range2.valid ||
+      !std::isfinite(range1.theta_min) || !std::isfinite(range1.theta_max) ||
+      !std::isfinite(range2.theta_min) || !std::isfinite(range2.theta_max) ||
+      !(range1.theta_max > range1.theta_min) ||
+      !(range2.theta_max > range2.theta_min))
+  {
+    return {};
+  }
+
+  const int n_steps = std::max(8, coarse_steps);
+
+  std::vector<double> theta1_values;
+  std::vector<double> theta2_values;
+  theta1_values.reserve(n_steps);
+  theta2_values.reserve(n_steps);
+  for (int i = 0; i < n_steps; ++i)
+  {
+    const double fraction = (n_steps == 1) ? 0.0 : static_cast<double>(i) / static_cast<double>(n_steps - 1);
+    theta1_values.push_back(range1.theta_min + fraction * (range1.theta_max - range1.theta_min));
+    theta2_values.push_back(range2.theta_min + fraction * (range2.theta_max - range2.theta_min));
+  }
+
+  std::vector<std::tuple<double, int, int>> coarse;
+  coarse.reserve(static_cast<std::size_t>(n_steps) * static_cast<std::size_t>(n_steps));
+  for (int i = 0; i < n_steps; ++i)
+  {
+    const TpcTrackVec3 point1 = point(helix1, theta1_values[i]);
+    for (int j = 0; j < n_steps; ++j)
+    {
+      const TpcTrackVec3 point2 = point(helix2, theta2_values[j]);
+      coarse.emplace_back(square(distance(point1, point2)), i, j);
+    }
+  }
+
+  std::sort(coarse.begin(), coarse.end(),
+            [](const auto &lhs, const auto &rhs)
+            { return std::get<0>(lhs) < std::get<0>(rhs); });
+
+  const double max_step = std::max(range1.theta_max - range1.theta_min,
+                                   range2.theta_max - range2.theta_min) /
+                          static_cast<double>(n_steps);
+  const int n_candidates = std::min({std::max(1, max_candidates), static_cast<int>(coarse.size())});
+
+  std::vector<TpcTrackHelixPca> candidates;
+  candidates.reserve(n_candidates);
+  for (int index = 0; index < n_candidates; ++index)
+  {
+    const int i = std::get<1>(coarse[index]);
+    const int j = std::get<2>(coarse[index]);
+    candidates.push_back(refine_pair(
+        helix1, helix2, theta1_values[i], theta2_values[j],
+        range1.theta_min, range1.theta_max,
+        range2.theta_min, range2.theta_max, max_step));
+  }
+
+  std::sort(candidates.begin(), candidates.end(),
+            [](const TpcTrackHelixPca &lhs, const TpcTrackHelixPca &rhs)
+            { return lhs.dca < rhs.dca; });
+  return candidates;
+}
+
+std::pair<double, double> TpcTrackHelixFitter::helix_dca_to_vertex(const TpcTrackHelix &helix,
+                                                                   const TpcTrackVec3 &vertex)
+{
+  const double vx = vertex.x - helix.cx;
+  const double vy = vertex.y - helix.cy;
+  const double distance_to_center = std::sqrt(square(vx) + square(vy));
+
+  double theta_raw = helix.theta_first;
+  double dca_xy = helix.radius;
+  if (distance_to_center > 0.0)
+  {
+    theta_raw = std::atan2(vy, vx);
+    dca_xy = std::abs(distance_to_center - helix.radius);
+  }
+
+  const double wraps = std::round((helix.theta_first - theta_raw) / (2.0 * kPi));
+  const double theta = theta_raw + 2.0 * kPi * wraps;
+  const TpcTrackVec3 closest = point(helix, theta);
+  return {dca_xy, std::abs(closest.z - vertex.z)};
+}
+
+std::pair<double, double> TpcTrackHelixFitter::line_dca_to_vertex(const TpcTrackVec3 &pos,
+                                                                  const TpcTrackVec3 &mom,
+                                                                  const TpcTrackVec3 &vertex)
+{
+  const TpcTrackVec3 rel = subtract(pos, vertex);
+  const double pt2 = square(mom.x) + square(mom.y);
+  if (pt2 <= 0.0)
+  {
+    return {quiet_nan(), quiet_nan()};
+  }
+  const double dca_xy = std::abs(rel.x * mom.y - rel.y * mom.x) / std::sqrt(pt2);
+  const double sxy = -(rel.x * mom.x + rel.y * mom.y) / pt2;
+  const TpcTrackVec3 closest = add(pos, scale(mom, sxy));
+  return {dca_xy, std::abs(closest.z - vertex.z)};
+}
+
+bool TpcTrackHelixFitter::finite(const TpcTrackVec3 &value)
+{
+  return std::isfinite(value.x) && std::isfinite(value.y) && std::isfinite(value.z);
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::add(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs)
+{
+  return {lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z};
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::subtract(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs)
+{
+  return {lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z};
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::scale(const TpcTrackVec3 &value, const double factor)
+{
+  return {value.x * factor, value.y * factor, value.z * factor};
+}
+
+double TpcTrackHelixFitter::dot(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs)
+{
+  return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z;
+}
+
+double TpcTrackHelixFitter::norm(const TpcTrackVec3 &value)
+{
+  return std::sqrt(dot(value, value));
+}
+
+TpcTrackVec3 TpcTrackHelixFitter::unit(const TpcTrackVec3 &value)
+{
+  const double length = norm(value);
+  if (length <= 0.0 || !std::isfinite(length))
+  {
+    return {quiet_nan(), quiet_nan(), quiet_nan()};
+  }
+  return scale(value, 1.0 / length);
+}
+
+double TpcTrackHelixFitter::pt(const TpcTrackVec3 &value)
+{
+  return std::sqrt(square(value.x) + square(value.y));
+}
+
+double TpcTrackHelixFitter::distance(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs)
+{
+  return norm(subtract(lhs, rhs));
+}
+
+double TpcTrackHelixFitter::vector_cosine(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs)
+{
+  const double denom = norm(lhs) * norm(rhs);
+  if (denom <= 0.0 || !std::isfinite(denom))
+  {
+    return quiet_nan();
+  }
+  return dot(lhs, rhs) / denom;
+}

--- a/offline/packages/tpctrackreco/TpcTrackHelixFitter.h
+++ b/offline/packages/tpctrackreco/TpcTrackHelixFitter.h
@@ -1,0 +1,100 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCTRACKHELIXFITTER_H
+#define TPCTRACKRECO_TPCTRACKHELIXFITTER_H
+
+#include "TpcTrackFit.h"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+class TpcTrackHelixFitter
+{
+ public:
+  static bool parse_point_order(const std::string &mode, TpcTrackPointOrder &order);
+  static void order_points(std::vector<TpcTrackPoint> &points, TpcTrackPointOrder order);
+
+  static bool fit_circle_least_squares(const std::vector<TpcTrackPoint> &points,
+                                       std::size_t nfit,
+                                       double &cx,
+                                       double &cy,
+                                       double &radius);
+  static bool fit_circle_curvature_refined(const std::vector<TpcTrackPoint> &points,
+                                           std::size_t nfit,
+                                           double &cx,
+                                           double &cy,
+                                           double &radius);
+  static bool fit(const std::vector<TpcTrackPoint> &points,
+                  int fit_first_points,
+                  double bfield_t,
+                  TpcTrackHelix &helix);
+  static bool from_state(const TpcTrackVec3 &position,
+                         const TpcTrackVec3 &momentum,
+                         int charge,
+                         double bfield_t,
+                         TpcTrackHelix &helix);
+  static bool orient_to_charge(TpcTrackHelix &helix, int charge);
+
+  static TpcTrackVec3 point(const TpcTrackHelix &helix, double theta);
+  static TpcTrackVec3 tangent(const TpcTrackHelix &helix, double theta);
+  static TpcTrackVec3 momentum(const TpcTrackHelix &helix, double theta);
+
+  static std::pair<double, double> theta_search_range(const TpcTrackHelix &helix,
+                                                      double theta_extension,
+                                                      double downstream_margin);
+  static bool measurement_anchored_search_range(
+      const TpcTrackHelix &helix,
+      const std::vector<TpcTrackPoint> &points,
+      double max_upstream_cm,
+      double downstream_margin_cm,
+      TpcTrackHelixSearchRange &range);
+  static bool line_line_pca(const TpcTrackVec3 &pos1,
+                            const TpcTrackVec3 &dir1,
+                            const TpcTrackVec3 &pos2,
+                            const TpcTrackVec3 &dir2,
+                            TpcTrackLinePca &pca,
+                            bool normalize_dirs);
+  static TpcTrackHelixPca refine_pair(const TpcTrackHelix &helix1,
+                                      const TpcTrackHelix &helix2,
+                                      double theta1,
+                                      double theta2,
+                                      double min1,
+                                      double max1,
+                                      double min2,
+                                      double max2,
+                                      double max_step);
+  static std::vector<TpcTrackHelixPca> pca_candidates(const TpcTrackHelix &helix1,
+                                                      const TpcTrackHelix &helix2,
+                                                      double theta_extension,
+                                                      int coarse_steps,
+                                                      double downstream_margin,
+                                                      int max_candidates);
+  static std::vector<TpcTrackHelixPca> pca_candidates_in_ranges(
+      const TpcTrackHelix &helix1,
+      const TpcTrackHelix &helix2,
+      const TpcTrackHelixSearchRange &range1,
+      const TpcTrackHelixSearchRange &range2,
+      int coarse_steps,
+      int max_candidates);
+
+  static std::pair<double, double> helix_dca_to_vertex(const TpcTrackHelix &helix,
+                                                       const TpcTrackVec3 &vertex);
+  static std::pair<double, double> line_dca_to_vertex(const TpcTrackVec3 &pos,
+                                                      const TpcTrackVec3 &mom,
+                                                      const TpcTrackVec3 &vertex);
+
+  static bool finite(const TpcTrackVec3 &value);
+  static TpcTrackVec3 add(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs);
+  static TpcTrackVec3 subtract(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs);
+  static TpcTrackVec3 scale(const TpcTrackVec3 &value, double factor);
+  static double dot(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs);
+  static double norm(const TpcTrackVec3 &value);
+  static TpcTrackVec3 unit(const TpcTrackVec3 &value);
+  static double pt(const TpcTrackVec3 &value);
+  static double distance(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs);
+  static double vector_cosine(const TpcTrackVec3 &lhs, const TpcTrackVec3 &rhs);
+};
+
+#endif

--- a/offline/packages/tpctrackreco/TpcTrackKalmanFitter.cc
+++ b/offline/packages/tpctrackreco/TpcTrackKalmanFitter.cc
@@ -1,0 +1,1149 @@
+#include "TpcTrackKalmanFitter.h"
+
+#include "TpcTrackHelixFitter.h"
+
+#include <phfield/PHField.h>
+
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include <Eigen/Dense>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <limits>
+
+namespace
+{
+  constexpr double kPi = 3.14159265358979323846;
+  constexpr double kCurvaturePerCm = 0.003;
+
+  template <class T>
+  constexpr T square(const T &value)
+  {
+    return value * value;
+  }
+
+  double normalize_phi(const double phi)
+  {
+    return std::atan2(std::sin(phi), std::cos(phi));
+  }
+
+  using StateVector = Eigen::Matrix<double, 6, 1>;
+  using StateMatrix = Eigen::Matrix<double, 6, 6>;
+  using Vector3 = Eigen::Matrix<double, 3, 1>;
+  using MeasurementVector = Eigen::Matrix<double, 3, 1>;
+  using MeasurementMatrix = Eigen::Matrix<double, 3, 6>;
+  using MeasurementCov = Eigen::Matrix<double, 3, 3>;
+
+  StateVector to_eigen(const std::array<double, 6> &state)
+  {
+    StateVector output;
+    for (int i = 0; i < 6; ++i)
+    {
+      output(i) = state[static_cast<std::size_t>(i)];
+    }
+    return output;
+  }
+
+  std::array<double, 6> to_array(const StateVector &state)
+  {
+    std::array<double, 6> output{};
+    for (int i = 0; i < 6; ++i)
+    {
+      output[static_cast<std::size_t>(i)] = state(i);
+    }
+    return output;
+  }
+
+  std::array<double, 36> to_array(const StateMatrix &matrix)
+  {
+    std::array<double, 36> output{};
+    for (int row = 0; row < 6; ++row)
+    {
+      for (int col = 0; col < 6; ++col)
+      {
+        const auto offset = static_cast<std::size_t>(row) * 6U + static_cast<std::size_t>(col);
+        output[offset] = matrix(row, col);
+      }
+    }
+    return output;
+  }
+
+  StateVector residual(const StateVector &lhs, const StateVector &rhs)
+  {
+    StateVector diff = lhs - rhs;
+    diff(TpcTrackKalmanFitter::Phi) = normalize_phi(diff(TpcTrackKalmanFitter::Phi));
+    return diff;
+  }
+
+  double omega_from_state(const StateVector &state, const double bfield_t)
+  {
+    return kCurvaturePerCm * bfield_t * state(TpcTrackKalmanFitter::QOverPt);
+  }
+
+  StateVector apply_mean_energy_loss_path3d(const StateVector &state,
+                                            const double signed_path3d_cm,
+                                            const TpcKalmanConfig &config,
+                                            const double mass_gev)
+  {
+    if (config.energy_loss_gev_per_cm <= 0.0 || signed_path3d_cm == 0.0)
+    {
+      return state;
+    }
+
+    StateVector output = state;
+    const double qop_t = output(TpcTrackKalmanFitter::QOverPt);
+    if (std::abs(qop_t) < 1.0e-12)
+    {
+      return output;
+    }
+
+    const double tanl = output(TpcTrackKalmanFitter::TanLambda);
+    const double path3d_cm = std::abs(signed_path3d_cm);
+    if (path3d_cm <= 0.0)
+    {
+      return output;
+    }
+
+    const double pt = 1.0 / std::abs(qop_t);
+    const double momentum = pt * std::sqrt(1.0 + tanl * tanl);
+    const double energy = std::sqrt(momentum * momentum + mass_gev * mass_gev);
+    const double signed_loss = std::copysign(config.energy_loss_gev_per_cm * path3d_cm,
+                                             signed_path3d_cm);
+    const double new_energy = std::max(mass_gev + 1.0e-9, energy - signed_loss);
+    const double new_momentum = std::sqrt(std::max(0.0, new_energy * new_energy - mass_gev * mass_gev));
+    if (new_momentum <= 0.0)
+    {
+      return output;
+    }
+
+    const double min_pt = std::max(config.min_pt_gev, 1.0e-6);
+    const double new_pt = std::max(min_pt, new_momentum / std::sqrt(1.0 + tanl * tanl));
+    output(TpcTrackKalmanFitter::QOverPt) = std::copysign(1.0 / new_pt, qop_t);
+    return output;
+  }
+
+  StateVector apply_mean_energy_loss(const StateVector &state,
+                                     const double ds_cm,
+                                     const TpcKalmanConfig &config,
+                                     const double mass_gev)
+  {
+    const double tanl = state(TpcTrackKalmanFitter::TanLambda);
+    return apply_mean_energy_loss_path3d(state, ds_cm * std::sqrt(1.0 + tanl * tanl),
+                                         config, mass_gev);
+  }
+
+  Vector3 direction_from_state(const StateVector &state)
+  {
+    Vector3 direction(std::cos(state(TpcTrackKalmanFitter::Phi)),
+                      std::sin(state(TpcTrackKalmanFitter::Phi)),
+                      state(TpcTrackKalmanFitter::TanLambda));
+    const double norm = direction.norm();
+    if (norm <= 0.0 || !std::isfinite(norm))
+    {
+      return Vector3(1.0, 0.0, 0.0);
+    }
+    return direction / norm;
+  }
+
+  Vector3 magnetic_field_tesla(const Vector3 &position_cm,
+                               const TpcKalmanConfig &config)
+  {
+    if (config.magnetic_field != nullptr)
+    {
+      const double point[4] = {position_cm.x() * CLHEP::cm,
+                               position_cm.y() * CLHEP::cm,
+                               position_cm.z() * CLHEP::cm,
+                               0.0};
+      double field[3] = {0.0, 0.0, 0.0};
+      config.magnetic_field->GetFieldValue(point, field);
+      Vector3 output(field[0] / CLHEP::tesla,
+                     field[1] / CLHEP::tesla,
+                     field[2] / CLHEP::tesla);
+      if (std::isfinite(output.x()) && std::isfinite(output.y()) &&
+          std::isfinite(output.z()))
+      {
+        return output;
+      }
+      return Vector3::Zero();
+    }
+
+    return Vector3(0.0, 0.0, config.bfield_t);
+  }
+
+  Vector3 rkn_acceleration(const Vector3 &direction,
+                           const Vector3 &bfield_tesla,
+                           const double q_over_p)
+  {
+    return kCurvaturePerCm * q_over_p * direction.cross(bfield_tesla);
+  }
+
+  struct RknStep
+  {
+    Vector3 position;
+    Vector3 direction;
+    double error{0.0};
+  };
+
+  struct RknDiagnostics
+  {
+    std::size_t propagations{0};
+    std::size_t accepted_steps{0};
+    std::size_t rejected_trials{0};
+    std::size_t max_trial_accepts{0};
+    std::size_t failures{0};
+    double seconds{0.0};
+  };
+
+  RknStep try_rkn4_step(const Vector3 &position_cm,
+                        const Vector3 &direction,
+                        const double q_over_p,
+                        const double h_cm,
+                        const TpcKalmanConfig &config)
+  {
+    const double h2 = h_cm * h_cm;
+    const double half_h = 0.5 * h_cm;
+
+    const Vector3 b_first = magnetic_field_tesla(position_cm, config);
+    const Vector3 k1 = rkn_acceleration(direction, b_first, q_over_p);
+
+    const Vector3 pos1 = position_cm + half_h * direction + 0.125 * h2 * k1;
+    const Vector3 b_middle = magnetic_field_tesla(pos1, config);
+    const Vector3 k2 = rkn_acceleration(direction + half_h * k1, b_middle, q_over_p);
+    const Vector3 k3 = rkn_acceleration(direction + half_h * k2, b_middle, q_over_p);
+
+    const Vector3 pos2 = position_cm + h_cm * direction + 0.5 * h2 * k3;
+    const Vector3 b_last = magnetic_field_tesla(pos2, config);
+    const Vector3 k4 = rkn_acceleration(direction + h_cm * k3, b_last, q_over_p);
+
+    RknStep output;
+    output.position = position_cm + h_cm * direction + h2 / 6.0 * (k1 + k2 + k3);
+    output.direction = direction + h_cm / 6.0 * (k1 + 2.0 * (k2 + k3) + k4);
+    const double direction_norm = output.direction.norm();
+    if (direction_norm > 0.0 && std::isfinite(direction_norm))
+    {
+      output.direction /= direction_norm;
+    }
+    else
+    {
+      output.direction = direction;
+    }
+    output.error = std::max(1.0e-20,
+                            h2 * (k1 - k2 - k3 + k4).template lpNorm<1>());
+    return output;
+  }
+
+  double rkn_step_scale(const double tolerance, const double error)
+  {
+    if (error <= 0.0 || !std::isfinite(error))
+    {
+      return 1.0;
+    }
+    return std::clamp(std::sqrt(std::sqrt(tolerance / error)), 0.25, 4.0);
+  }
+
+  bool advance_rkn4(Vector3 &position_cm,
+                    Vector3 &direction,
+                    const double q_over_p,
+                    const double signed_path3d_cm,
+                    const TpcKalmanConfig &config,
+                    RknDiagnostics *diagnostics)
+  {
+    double remaining = signed_path3d_cm;
+    if (remaining == 0.0)
+    {
+      return true;
+    }
+
+    constexpr double min_step_cm = 1.0e-5;
+    const std::size_t max_total_steps =
+        static_cast<std::size_t>(std::max(config.rkn_max_total_steps, 1));
+    const double max_step_cm = std::max(std::abs(config.rkn_max_step_cm), min_step_cm);
+    const double tolerance = std::max(config.rkn_step_tolerance, 1.0e-20);
+    const int max_trials = std::max(config.rkn_max_step_trials, 1);
+    const bool adaptive = config.rkn_step_tolerance > 0.0;
+
+    double h = std::copysign(std::min(std::abs(remaining), max_step_cm), remaining);
+    for (std::size_t nsteps = 0;
+         std::abs(remaining) > min_step_cm && nsteps < max_total_steps;
+         ++nsteps)
+    {
+      if (std::abs(h) > std::abs(remaining))
+      {
+        h = remaining;
+      }
+
+      RknStep trial;
+      int ntrials = 0;
+      while (true)
+      {
+        trial = try_rkn4_step(position_cm, direction, q_over_p, h, config);
+        if (!trial.position.allFinite() || !trial.direction.allFinite() ||
+            !std::isfinite(trial.error))
+        {
+          if (diagnostics != nullptr)
+          {
+            ++diagnostics->failures;
+          }
+          return false;
+        }
+        if (!adaptive || trial.error <= 4.0 * tolerance ||
+            std::abs(h) <= min_step_cm || ntrials >= max_trials)
+        {
+          if (adaptive && trial.error > 4.0 * tolerance && ntrials >= max_trials &&
+              diagnostics != nullptr)
+          {
+            ++diagnostics->max_trial_accepts;
+          }
+          break;
+        }
+        h *= rkn_step_scale(tolerance, trial.error);
+        ++ntrials;
+        if (diagnostics != nullptr)
+        {
+          ++diagnostics->rejected_trials;
+        }
+      }
+
+      position_cm = trial.position;
+      direction = trial.direction;
+      remaining -= h;
+      if (diagnostics != nullptr)
+      {
+        ++diagnostics->accepted_steps;
+      }
+
+      if (std::abs(remaining) <= min_step_cm)
+      {
+        break;
+      }
+
+      double next_h = std::abs(h);
+      if (adaptive)
+      {
+        next_h *= rkn_step_scale(tolerance, trial.error);
+      }
+      next_h = std::min({next_h, max_step_cm, std::abs(remaining)});
+      h = std::copysign(std::max(next_h, min_step_cm), remaining);
+    }
+
+    const bool complete = std::abs(remaining) <= min_step_cm;
+    if (!complete && diagnostics != nullptr)
+    {
+      ++diagnostics->failures;
+    }
+    return complete;
+  }
+
+  StateVector propagate_rkn4(const StateVector &state,
+                             const double ds_cm,
+                             const TpcKalmanConfig &config,
+                             const double mass_gev,
+                             RknDiagnostics *diagnostics = nullptr)
+  {
+    const auto propagation_start = std::chrono::steady_clock::now();
+    const auto record_seconds = [&]()
+    {
+      if (diagnostics != nullptr)
+      {
+        diagnostics->seconds += std::chrono::duration<double>(
+                                    std::chrono::steady_clock::now() - propagation_start)
+                                    .count();
+      }
+    };
+    if (diagnostics != nullptr)
+    {
+      ++diagnostics->propagations;
+    }
+    StateVector output = state;
+    if (ds_cm == 0.0)
+    {
+      output = apply_mean_energy_loss(output, ds_cm, config, mass_gev);
+      record_seconds();
+      return output;
+    }
+
+    Vector3 position_cm(state(TpcTrackKalmanFitter::X),
+                        state(TpcTrackKalmanFitter::Y),
+                        state(TpcTrackKalmanFitter::Z));
+    Vector3 direction = direction_from_state(state);
+    const double transverse = std::hypot(direction.x(), direction.y());
+    if (transverse <= 1.0e-12 || !std::isfinite(transverse))
+    {
+      output = apply_mean_energy_loss(output, ds_cm, config, mass_gev);
+      record_seconds();
+      return output;
+    }
+
+    const double q_over_p = -state(TpcTrackKalmanFitter::QOverPt) * transverse;
+    const double signed_path3d_cm = ds_cm / transverse;
+    if (!advance_rkn4(position_cm, direction, q_over_p, signed_path3d_cm,
+                      config, diagnostics))
+    {
+      record_seconds();
+      return StateVector::Constant(std::numeric_limits<double>::quiet_NaN());
+    }
+
+    const double final_transverse = std::hypot(direction.x(), direction.y());
+    output(TpcTrackKalmanFitter::X) = position_cm.x();
+    output(TpcTrackKalmanFitter::Y) = position_cm.y();
+    output(TpcTrackKalmanFitter::Z) = position_cm.z();
+    if (final_transverse > 1.0e-12 && std::isfinite(final_transverse))
+    {
+      output(TpcTrackKalmanFitter::Phi) =
+          normalize_phi(std::atan2(direction.y(), direction.x()));
+      output(TpcTrackKalmanFitter::TanLambda) = direction.z() / final_transverse;
+      output(TpcTrackKalmanFitter::QOverPt) = -q_over_p / final_transverse;
+      const double max_abs_qop_t = 1.0 / std::max(config.min_pt_gev, 1.0e-6);
+      if (std::abs(output(TpcTrackKalmanFitter::QOverPt)) > max_abs_qop_t)
+      {
+        output(TpcTrackKalmanFitter::QOverPt) =
+            std::copysign(max_abs_qop_t, output(TpcTrackKalmanFitter::QOverPt));
+      }
+    }
+
+    output = apply_mean_energy_loss_path3d(output, signed_path3d_cm, config, mass_gev);
+    record_seconds();
+    return output;
+  }
+
+  StateVector propagate_uniform_bz(const StateVector &state,
+                                   const double ds_cm,
+                                   const double bfield_t,
+                                   const TpcKalmanConfig &config,
+                                   const double mass_gev)
+  {
+    StateVector output = state;
+    const double phi = state(TpcTrackKalmanFitter::Phi);
+    const double omega = kCurvaturePerCm * bfield_t *
+                         state(TpcTrackKalmanFitter::QOverPt);
+
+    if (std::abs(omega) < 1.0e-12)
+    {
+      output(TpcTrackKalmanFitter::X) += ds_cm * std::cos(phi);
+      output(TpcTrackKalmanFitter::Y) += ds_cm * std::sin(phi);
+    }
+    else
+    {
+      const double phi2 = phi + omega * ds_cm;
+      output(TpcTrackKalmanFitter::X) +=
+          (std::sin(phi2) - std::sin(phi)) / omega;
+      output(TpcTrackKalmanFitter::Y) +=
+          -(std::cos(phi2) - std::cos(phi)) / omega;
+      output(TpcTrackKalmanFitter::Phi) = normalize_phi(phi2);
+    }
+    output(TpcTrackKalmanFitter::Z) +=
+        state(TpcTrackKalmanFitter::TanLambda) * ds_cm;
+    return apply_mean_energy_loss(output, ds_cm, config, mass_gev);
+  }
+
+  StateMatrix transport_jacobian(const StateVector &state,
+                                 const double ds_cm,
+                                 const TpcKalmanConfig &config,
+                                 const double mass_gev,
+                                 RknDiagnostics *diagnostics)
+  {
+    StateMatrix jac = StateMatrix::Identity();
+    const bool use_analytic_uniform =
+        config.magnetic_field == nullptr && config.analytic_uniform_propagation;
+    const bool use_fast_field_jacobian =
+        config.magnetic_field != nullptr && config.rkn_fast_field_jacobian;
+    double local_bz_t = config.bfield_t;
+    if (use_fast_field_jacobian)
+    {
+      const Vector3 position_cm(state(TpcTrackKalmanFitter::X),
+                                state(TpcTrackKalmanFitter::Y),
+                                state(TpcTrackKalmanFitter::Z));
+      local_bz_t = magnetic_field_tesla(position_cm, config).z();
+      if (!std::isfinite(local_bz_t))
+      {
+        local_bz_t = config.bfield_t;
+      }
+    }
+
+    const auto propagate_for_jacobian = [&](const StateVector &input)
+    {
+      if (use_analytic_uniform || use_fast_field_jacobian)
+      {
+        return propagate_uniform_bz(input, ds_cm, local_bz_t, config, mass_gev);
+      }
+      return propagate_rkn4(input, ds_cm, config, mass_gev, diagnostics);
+    };
+    const double scales[6] = {1.0e-4, 1.0e-4, 1.0e-4, 1.0e-5, 1.0e-6, 1.0e-6};
+    for (int col = 0; col < 6; ++col)
+    {
+      const double step = scales[col] * std::max(1.0, std::abs(state(col)));
+      StateVector plus = state;
+      StateVector minus = state;
+      plus(col) += step;
+      minus(col) -= step;
+      if (col == TpcTrackKalmanFitter::Phi)
+      {
+        plus(col) = normalize_phi(plus(col));
+        minus(col) = normalize_phi(minus(col));
+      }
+
+      const StateVector f_plus = propagate_for_jacobian(plus);
+      const StateVector f_minus = propagate_for_jacobian(minus);
+      if (!f_plus.allFinite() || !f_minus.allFinite())
+      {
+        return StateMatrix::Constant(std::numeric_limits<double>::quiet_NaN());
+      }
+      jac.col(col) = residual(f_plus, f_minus) / (2.0 * step);
+    }
+    return jac;
+  }
+
+  double multiple_scattering_theta0(const StateVector &state,
+                                    const double ds_cm,
+                                    const TpcKalmanConfig &config,
+                                    const double mass_gev)
+  {
+    if (config.material_x0_per_cm <= 0.0 || ds_cm == 0.0)
+    {
+      return 0.0;
+    }
+
+    const double qop_t = state(TpcTrackKalmanFitter::QOverPt);
+    if (std::abs(qop_t) < 1.0e-12)
+    {
+      return 0.0;
+    }
+
+    const double tanl = state(TpcTrackKalmanFitter::TanLambda);
+    const double path3d_cm = std::abs(ds_cm) * std::sqrt(1.0 + tanl * tanl);
+    const double x_over_x0 = config.material_x0_per_cm * path3d_cm;
+    if (x_over_x0 <= 0.0)
+    {
+      return 0.0;
+    }
+
+    const double pt = 1.0 / std::abs(qop_t);
+    const double momentum = pt * std::sqrt(1.0 + tanl * tanl);
+    const double energy = std::sqrt(momentum * momentum + mass_gev * mass_gev);
+    const double beta = (energy > 0.0) ? momentum / energy : 0.0;
+    if (beta <= 0.0 || momentum <= 0.0)
+    {
+      return 0.0;
+    }
+
+    const double log_term = 1.0 + 0.038 * std::log(x_over_x0);
+    return config.multiple_scattering_scale * 0.0136 / (beta * momentum) *
+           std::sqrt(x_over_x0) * log_term;
+  }
+
+  StateMatrix process_noise(const StateVector &state,
+                            const double ds_cm,
+                            const TpcKalmanConfig &config,
+                            const double mass_gev)
+  {
+    const double scale = std::max(1.0, std::abs(ds_cm));
+    StateMatrix noise = StateMatrix::Zero();
+    noise(TpcTrackKalmanFitter::X, TpcTrackKalmanFitter::X) = square(config.process_sigma_pos_cm * scale);
+    noise(TpcTrackKalmanFitter::Y, TpcTrackKalmanFitter::Y) = square(config.process_sigma_pos_cm * scale);
+    noise(TpcTrackKalmanFitter::Z, TpcTrackKalmanFitter::Z) = square(config.process_sigma_pos_cm * scale);
+    noise(TpcTrackKalmanFitter::Phi, TpcTrackKalmanFitter::Phi) = square(config.process_sigma_phi * scale);
+    noise(TpcTrackKalmanFitter::QOverPt, TpcTrackKalmanFitter::QOverPt) = square(config.process_sigma_qop_t * scale);
+    noise(TpcTrackKalmanFitter::TanLambda, TpcTrackKalmanFitter::TanLambda) = square(config.process_sigma_tanl * scale);
+
+    const double theta0 = multiple_scattering_theta0(state, ds_cm, config, mass_gev);
+    if (theta0 > 0.0)
+    {
+      const double tanl = state(TpcTrackKalmanFitter::TanLambda);
+      const double sec2_lambda = 1.0 + square(tanl);
+      noise(TpcTrackKalmanFitter::Phi, TpcTrackKalmanFitter::Phi) +=
+          square(theta0 * std::sqrt(sec2_lambda));
+      noise(TpcTrackKalmanFitter::TanLambda, TpcTrackKalmanFitter::TanLambda) +=
+          square(theta0 * sec2_lambda);
+    }
+
+    if (config.energy_loss_sigma_fraction > 0.0 && config.energy_loss_gev_per_cm > 0.0)
+    {
+      const double tanl = state(TpcTrackKalmanFitter::TanLambda);
+      const double path3d_cm = std::abs(ds_cm) * std::sqrt(1.0 + tanl * tanl);
+      const double loss_sigma = config.energy_loss_sigma_fraction *
+                                config.energy_loss_gev_per_cm * path3d_cm;
+      const double qop_t = state(TpcTrackKalmanFitter::QOverPt);
+      if (std::abs(qop_t) > 1.0e-12)
+      {
+        const double pt = 1.0 / std::abs(qop_t);
+        const double momentum = pt * std::sqrt(1.0 + tanl * tanl);
+        if (momentum > 0.0)
+        {
+          noise(TpcTrackKalmanFitter::QOverPt, TpcTrackKalmanFitter::QOverPt) +=
+              square(qop_t * loss_sigma / momentum);
+        }
+      }
+    }
+
+    return noise;
+  }
+
+  MeasurementCov measurement_covariance(const TpcTrackPoint &point,
+                                        const double var_rphi,
+                                        const double var_r,
+                                        const double var_z)
+  {
+    const double radius = std::hypot(point.position.x, point.position.y);
+    const double cos_phi = (radius > 0.0) ? point.position.x / radius : 1.0;
+    const double sin_phi = (radius > 0.0) ? point.position.y / radius : 0.0;
+
+    MeasurementCov cov = MeasurementCov::Zero();
+    cov(0, 0) = var_r * square(cos_phi) + var_rphi * square(sin_phi);
+    cov(1, 1) = var_r * square(sin_phi) + var_rphi * square(cos_phi);
+    cov(0, 1) = (var_r - var_rphi) * sin_phi * cos_phi;
+    cov(1, 0) = cov(0, 1);
+    cov(2, 2) = var_z;
+    return cov;
+  }
+
+  MeasurementCov measurement_local_rotation(const TpcTrackPoint &point)
+  {
+    const double radius = std::hypot(point.position.x, point.position.y);
+    const double cos_phi = (radius > 0.0) ? point.position.x / radius : 1.0;
+    const double sin_phi = (radius > 0.0) ? point.position.y / radius : 0.0;
+
+    MeasurementCov rotation = MeasurementCov::Zero();
+    rotation(0, 0) = cos_phi;
+    rotation(0, 1) = sin_phi;
+    rotation(1, 0) = -sin_phi;
+    rotation(1, 1) = cos_phi;
+    rotation(2, 2) = 1.0;
+    return rotation;
+  }
+
+  double covariance_sigma(const MeasurementCov &covariance, const int index)
+  {
+    return std::sqrt(std::max(0.0, covariance(index, index)));
+  }
+
+  double covariance_correlation(const MeasurementCov &covariance,
+                                const int first,
+                                const int second,
+                                const double sigma_first,
+                                const double sigma_second)
+  {
+    const double denominator = sigma_first * sigma_second;
+    if (!(denominator > 0.0) || !std::isfinite(denominator))
+    {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return std::clamp(covariance(first, second) / denominator, -1.0, 1.0);
+  }
+
+  MeasurementVector whiten_innovation(const MeasurementCov &innovation,
+                                      const MeasurementVector &residual)
+  {
+    MeasurementVector whitened = MeasurementVector::Constant(
+        std::numeric_limits<double>::quiet_NaN());
+
+    const Eigen::LLT<MeasurementCov> llt(innovation);
+    if (llt.info() == Eigen::Success)
+    {
+      whitened = llt.matrixL().solve(residual);
+      return whitened;
+    }
+
+    const Eigen::SelfAdjointEigenSolver<MeasurementCov> eigensolver(innovation);
+    if (eigensolver.info() != Eigen::Success ||
+        eigensolver.eigenvalues().minCoeff() <= 0.0)
+    {
+      return whitened;
+    }
+
+    whitened = eigensolver.eigenvalues().cwiseSqrt().cwiseInverse().asDiagonal() *
+               eigensolver.eigenvectors().transpose() * residual;
+    return whitened;
+  }
+
+  bool make_seed(const std::vector<TpcTrackPoint> &points,
+                 const TpcKalmanConfig &config,
+                 TpcTrackHelix &seed,
+                 std::vector<double> &theta_values,
+                 std::vector<double> &path_s)
+  {
+    if (!TpcTrackHelixFitter::fit(points, 0, config.bfield_t, seed))
+    {
+      return false;
+    }
+
+    theta_values.clear();
+    theta_values.reserve(points.size());
+    for (const auto &point : points)
+    {
+      double theta = std::atan2(point.position.y - seed.cy, point.position.x - seed.cx);
+      if (!theta_values.empty())
+      {
+        while (theta - theta_values.back() > kPi)
+        {
+          theta -= 2.0 * kPi;
+        }
+        while (theta - theta_values.back() < -kPi)
+        {
+          theta += 2.0 * kPi;
+        }
+      }
+      theta_values.push_back(theta);
+    }
+
+    if (theta_values.size() < 2)
+    {
+      return false;
+    }
+
+    path_s.assign(theta_values.size(), 0.0);
+    for (std::size_t i = 1; i < theta_values.size(); ++i)
+    {
+      path_s[i] = path_s[i - 1] + seed.radius * std::abs(theta_values[i] - theta_values[i - 1]);
+    }
+    return true;
+  }
+
+  bool initial_state(const std::vector<TpcTrackPoint> &points,
+                     const TpcTrackHelix &seed,
+                     const std::vector<double> &theta_values,
+                     const TpcKalmanConfig &config,
+                     StateVector &state)
+  {
+    if (points.empty() || theta_values.empty())
+    {
+      return false;
+    }
+
+    const double direction = seed.direction;
+    const double theta0 = theta_values.front();
+    const TpcTrackVec3 seed_position = TpcTrackHelixFitter::point(seed, theta0);
+    if (!TpcTrackHelixFitter::finite(seed_position))
+    {
+      return false;
+    }
+
+    const double denom = kCurvaturePerCm * config.bfield_t * seed.radius;
+    if (std::abs(denom) <= 0.0 || !std::isfinite(denom))
+    {
+      return false;
+    }
+
+    state.setZero();
+    state(TpcTrackKalmanFitter::X) = seed_position.x;
+    state(TpcTrackKalmanFitter::Y) = seed_position.y;
+    state(TpcTrackKalmanFitter::Z) = seed_position.z;
+    state(TpcTrackKalmanFitter::Phi) = normalize_phi(std::atan2(direction * std::cos(theta0),
+                                                                direction * -std::sin(theta0)));
+    state(TpcTrackKalmanFitter::QOverPt) = direction / denom;
+    state(TpcTrackKalmanFitter::TanLambda) = direction * seed.pitch / seed.radius;
+
+    const double max_abs_qop_t = 1.0 / std::max(config.min_pt_gev, 1.0e-6);
+    if (std::abs(state(TpcTrackKalmanFitter::QOverPt)) > max_abs_qop_t)
+    {
+      state(TpcTrackKalmanFitter::QOverPt) = std::copysign(max_abs_qop_t,
+                                                           state(TpcTrackKalmanFitter::QOverPt));
+    }
+    return true;
+  }
+}  // namespace
+
+bool TpcTrackKalmanFitter::fit(const std::vector<TpcTrackPoint> &input_points,
+                               const int charge,
+                               const TpcKalmanConfig &config,
+                               TpcKalmanResult &result,
+                               const double mass_gev)
+{
+  result = TpcKalmanResult{};
+  result.charge = charge;
+  result.bfield_t = config.bfield_t;
+  result.magnetic_field = config.magnetic_field;
+  result.analytic_uniform_propagation = config.analytic_uniform_propagation;
+  result.mass_gev = mass_gev;
+
+  if (input_points.size() < 5)
+  {
+    result.message = "need at least five TPC points";
+    return false;
+  }
+
+  std::vector<TpcTrackPoint> points = input_points;
+  TpcTrackHelixFitter::order_points(points, config.point_order);
+
+  std::vector<double> theta_values;
+  if (!make_seed(points, config, result.seed, theta_values, result.path_s))
+  {
+    result.message = "helix seed failed";
+    return false;
+  }
+
+  StateVector state;
+  if (!initial_state(points, result.seed, theta_values, config, state))
+  {
+    result.message = "initial state failed";
+    return false;
+  }
+
+  const std::size_t npoints = points.size();
+  std::vector<StateVector> states_filtered(npoints);
+  std::vector<StateVector> states_predicted(npoints);
+  std::vector<StateMatrix> covs_filtered(npoints);
+  std::vector<StateMatrix> covs_predicted(npoints);
+  std::vector<StateMatrix> transport(npoints);
+
+  const double min_meas = std::max(config.min_measurement_sigma_cm, 1.0e-12);
+  const double sigma_rphi = std::max(config.meas_sigma_rphi_cm, min_meas);
+  const double sigma_r = std::max(config.meas_sigma_r_cm, min_meas);
+  const double sigma_z = std::max(config.meas_sigma_z_cm, min_meas);
+  const double var_rphi = square(sigma_rphi);
+  const double var_r = square(sigma_r);
+  const double var_z = square(sigma_z);
+
+  MeasurementMatrix hmat = MeasurementMatrix::Zero();
+  hmat(0, X) = 1.0;
+  hmat(1, Y) = 1.0;
+  hmat(2, Z) = 1.0;
+
+  StateMatrix cov = StateMatrix::Zero();
+  cov(X, X) = square(config.initial_sigma_pos_cm);
+  cov(Y, Y) = square(config.initial_sigma_pos_cm);
+  cov(Z, Z) = square(config.initial_sigma_pos_cm);
+  cov(Phi, Phi) = square(config.initial_sigma_phi);
+  cov(QOverPt, QOverPt) = square(config.initial_sigma_qop_t);
+  cov(TanLambda, TanLambda) = square(config.initial_sigma_tanl);
+
+  double chi2 = 0.0;
+  int ndof = 0;
+  const StateMatrix eye = StateMatrix::Identity();
+  RknDiagnostics rkn_diagnostics;
+
+  result.measurement_chi2.reserve(npoints);
+  result.measurement_used.reserve(npoints);
+  if (config.collect_innovation_components)
+  {
+    result.measurement_in_seed.reserve(npoints);
+    result.innovation_residual_r.reserve(npoints);
+    result.innovation_residual_rphi.reserve(npoints);
+    result.innovation_residual_z.reserve(npoints);
+    result.prediction_sigma_r.reserve(npoints);
+    result.prediction_sigma_rphi.reserve(npoints);
+    result.prediction_sigma_z.reserve(npoints);
+    result.innovation_sigma_r.reserve(npoints);
+    result.innovation_sigma_rphi.reserve(npoints);
+    result.innovation_sigma_z.reserve(npoints);
+    result.innovation_rho_r_rphi.reserve(npoints);
+    result.innovation_rho_r_z.reserve(npoints);
+    result.innovation_rho_rphi_z.reserve(npoints);
+    result.innovation_whitened_0.reserve(npoints);
+    result.innovation_whitened_1.reserve(npoints);
+    result.innovation_whitened_2.reserve(npoints);
+  }
+
+  const auto copy_rkn_diagnostics = [&]()
+  {
+    result.rkn_propagations = rkn_diagnostics.propagations;
+    result.rkn_accepted_steps = rkn_diagnostics.accepted_steps;
+    result.rkn_rejected_trials = rkn_diagnostics.rejected_trials;
+    result.rkn_max_trial_accepts = rkn_diagnostics.max_trial_accepts;
+    result.rkn_failures = rkn_diagnostics.failures;
+    result.rkn_seconds = rkn_diagnostics.seconds;
+  };
+
+  for (std::size_t index = 0; index < npoints; ++index)
+  {
+    StateVector pred_state = state;
+    StateMatrix pred_cov = cov;
+    StateMatrix fmat = eye;
+    if (index > 0)
+    {
+      const double ds = result.path_s[index] - result.path_s[index - 1];
+      fmat = transport_jacobian(state, ds, config, mass_gev, &rkn_diagnostics);
+      pred_state = (config.magnetic_field == nullptr && config.analytic_uniform_propagation)
+                       ? propagate_uniform_bz(state, ds, config.bfield_t, config, mass_gev)
+                       : propagate_rkn4(state, ds, config, mass_gev, &rkn_diagnostics);
+      if (!fmat.allFinite() || !pred_state.allFinite())
+      {
+        copy_rkn_diagnostics();
+        result.message = "RK propagation exceeded its step budget or became non-finite";
+        return false;
+      }
+      pred_cov = fmat * cov * fmat.transpose() + process_noise(state, ds, config, mass_gev);
+      pred_cov = 0.5 * (pred_cov + pred_cov.transpose()).eval();
+    }
+
+    MeasurementVector measurement;
+    measurement << points[index].position.x, points[index].position.y, points[index].position.z;
+    const MeasurementCov meas_cov = measurement_covariance(points[index], var_rphi, var_r, var_z);
+    const MeasurementVector meas_residual = measurement - hmat * pred_state;
+    const MeasurementCov innovation = hmat * pred_cov * hmat.transpose() + meas_cov;
+    const MeasurementCov innovation_inv =
+        innovation.completeOrthogonalDecomposition().solve(MeasurementCov::Identity());
+    const double step_chi2 =
+        (meas_residual.transpose() * innovation_inv * meas_residual)(0, 0);
+
+    if (config.collect_innovation_components)
+    {
+      const MeasurementCov local_rotation = measurement_local_rotation(points[index]);
+      const MeasurementVector local_residual = local_rotation * meas_residual;
+      const MeasurementCov predicted_position_cov = hmat * pred_cov * hmat.transpose();
+      const MeasurementCov local_prediction_cov =
+          local_rotation * predicted_position_cov * local_rotation.transpose();
+      const MeasurementCov local_innovation =
+          local_rotation * innovation * local_rotation.transpose();
+
+      const double prediction_sigma_r = covariance_sigma(local_prediction_cov, 0);
+      const double prediction_sigma_rphi = covariance_sigma(local_prediction_cov, 1);
+      const double prediction_sigma_z = covariance_sigma(local_prediction_cov, 2);
+      const double innovation_sigma_r = covariance_sigma(local_innovation, 0);
+      const double innovation_sigma_rphi = covariance_sigma(local_innovation, 1);
+      const double innovation_sigma_z = covariance_sigma(local_innovation, 2);
+      const MeasurementVector whitened = whiten_innovation(local_innovation, local_residual);
+
+      // The current seed is a global helix fit, so every measurement contributes
+      // to it. This marker will distinguish bootstrap seed points once the seed
+      // is restricted to an initial consecutive subset.
+      result.measurement_in_seed.push_back(1U);
+      result.innovation_residual_r.push_back(local_residual(0));
+      result.innovation_residual_rphi.push_back(local_residual(1));
+      result.innovation_residual_z.push_back(local_residual(2));
+      result.prediction_sigma_r.push_back(prediction_sigma_r);
+      result.prediction_sigma_rphi.push_back(prediction_sigma_rphi);
+      result.prediction_sigma_z.push_back(prediction_sigma_z);
+      result.innovation_sigma_r.push_back(innovation_sigma_r);
+      result.innovation_sigma_rphi.push_back(innovation_sigma_rphi);
+      result.innovation_sigma_z.push_back(innovation_sigma_z);
+      result.innovation_rho_r_rphi.push_back(
+          covariance_correlation(local_innovation, 0, 1,
+                                 innovation_sigma_r, innovation_sigma_rphi));
+      result.innovation_rho_r_z.push_back(
+          covariance_correlation(local_innovation, 0, 2,
+                                 innovation_sigma_r, innovation_sigma_z));
+      result.innovation_rho_rphi_z.push_back(
+          covariance_correlation(local_innovation, 1, 2,
+                                 innovation_sigma_rphi, innovation_sigma_z));
+      result.innovation_whitened_0.push_back(whitened(0));
+      result.innovation_whitened_1.push_back(whitened(1));
+      result.innovation_whitened_2.push_back(whitened(2));
+    }
+
+    const Eigen::Matrix<double, 6, 3> gain = pred_cov * hmat.transpose() * innovation_inv;
+    state = pred_state + gain * meas_residual;
+    state(Phi) = normalize_phi(state(Phi));
+    cov = (eye - gain * hmat) * pred_cov * (eye - gain * hmat).transpose() +
+          gain * meas_cov * gain.transpose();
+    cov = 0.5 * (cov + cov.transpose()).eval();
+
+    result.measurement_chi2.push_back(step_chi2);
+    result.measurement_used.push_back(1U);
+    ++result.naccepted;
+    chi2 += step_chi2;
+    ndof += 3;
+
+    states_predicted[index] = pred_state;
+    covs_predicted[index] = pred_cov;
+    transport[index] = fmat;
+    states_filtered[index] = state;
+    covs_filtered[index] = cov;
+  }
+
+  std::vector<StateVector> states_smoothed = states_filtered;
+  std::vector<StateMatrix> covs_smoothed = covs_filtered;
+  for (std::size_t next_index = npoints - 1; next_index > 0; --next_index)
+  {
+    const std::size_t index = next_index - 1;
+    const StateMatrix pred_inv = covs_predicted[next_index]
+                                     .completeOrthogonalDecomposition()
+                                     .solve(StateMatrix::Identity());
+    const StateMatrix smoother_gain =
+        covs_filtered[index] *
+        transport[next_index].transpose() *
+        pred_inv;
+    const StateVector smooth_residual = residual(states_smoothed[next_index],
+                                                 states_predicted[next_index]);
+    states_smoothed[index] = states_filtered[index] + smoother_gain * smooth_residual;
+    states_smoothed[index](Phi) = normalize_phi(states_smoothed[index](Phi));
+    covs_smoothed[index] =
+        covs_filtered[index] +
+        smoother_gain *
+            (covs_smoothed[next_index] - covs_predicted[next_index]) *
+            smoother_gain.transpose();
+    covs_smoothed[index] =
+        0.5 * (covs_smoothed[index] +
+               covs_smoothed[index].transpose())
+                  .eval();
+  }
+
+  result.states_filtered.reserve(npoints);
+  result.covs_filtered.reserve(npoints);
+  result.states_smoothed.reserve(npoints);
+  result.covs_smoothed.reserve(npoints);
+  for (std::size_t index = 0; index < npoints; ++index)
+  {
+    result.states_filtered.push_back(to_array(states_filtered[index]));
+    result.covs_filtered.push_back(to_array(covs_filtered[index]));
+    result.states_smoothed.push_back(to_array(states_smoothed[index]));
+    result.covs_smoothed.push_back(to_array(covs_smoothed[index]));
+  }
+
+  result.chi2 = chi2;
+  result.ndof = ndof - StateDim;
+  copy_rkn_diagnostics();
+  result.success = true;
+  result.message = "ok";
+  return true;
+}
+
+TpcTrackVec3 TpcTrackKalmanFitter::state_position(const std::array<double, StateDim> &state)
+{
+  return {state[X], state[Y], state[Z]};
+}
+
+TpcTrackVec3 TpcTrackKalmanFitter::state_momentum(const std::array<double, StateDim> &state)
+{
+  const double qop_t = state[QOverPt];
+  const double pt = (std::abs(qop_t) < 1.0e-12) ? 1.0e12 : 1.0 / std::abs(qop_t);
+  return {
+      pt * std::cos(state[Phi]),
+      pt * std::sin(state[Phi]),
+      pt * state[TanLambda]};
+}
+
+TpcTrackVec3 TpcTrackKalmanFitter::state_tangent(const std::array<double, StateDim> &state)
+{
+  return {
+      std::cos(state[Phi]),
+      std::sin(state[Phi]),
+      state[TanLambda]};
+}
+
+std::array<double, TpcTrackKalmanFitter::StateDim> TpcTrackKalmanFitter::propagation_state(
+    const TpcKalmanResult &fit,
+    const TpcTrackVec3 & /*reference_vertex*/)
+{
+  if (!fit.success || fit.states_smoothed.empty())
+  {
+    return {};
+  }
+
+  if (fit.charge == 0)
+  {
+    return fit.states_smoothed.front();
+  }
+
+  const double charge_sign = static_cast<double>((fit.charge > 0) ? 1 : -1);
+  const double physical_qop_sign = -charge_sign;
+  const double sequence_qop = fit.states_smoothed.front()[QOverPt];
+  const bool sequence_runs_against_physical = sequence_qop * physical_qop_sign < 0.0;
+
+  // The fitted states are assumed to be in a continuous along-track sequence.
+  // Charge fixes only which end of that sequence is the physical initial point;
+  // do not use the reference vertex or any transverse-distance heuristic here.
+  auto state = sequence_runs_against_physical ? fit.states_smoothed.back()
+                                              : fit.states_smoothed.front();
+
+  const double qop_t = state[QOverPt];
+  if (std::abs(qop_t) < 1.0e-12)
+  {
+    return state;
+  }
+
+  const double pt = 1.0 / std::abs(qop_t);
+  const double fit_omega = kCurvaturePerCm * fit.bfield_t * qop_t;
+  if (std::abs(fit_omega) < 1.0e-12)
+  {
+    return state;
+  }
+
+  const double fit_center_x = state[X] - std::sin(state[Phi]) / fit_omega;
+  const double fit_center_y = state[Y] + std::cos(state[Phi]) / fit_omega;
+
+  // Internal convention: omega = 0.003 * B * qop_t.  For a physical charge in
+  // a solenoidal field this corresponds to qop_t = -charge / pT.  The Kalman
+  // fit itself may have the opposite sign if the input point order was reversed,
+  // so choose the tangent direction that preserves the fitted circle center.
+  const double physical_qop_t = -charge_sign / pt;
+  const double physical_omega = kCurvaturePerCm * fit.bfield_t * physical_qop_t;
+  if (std::abs(physical_omega) < 1.0e-12)
+  {
+    return state;
+  }
+
+  auto center_distance2 = [&](const double phi)
+  {
+    const double cx = state[X] - std::sin(phi) / physical_omega;
+    const double cy = state[Y] + std::cos(phi) / physical_omega;
+    return square(cx - fit_center_x) + square(cy - fit_center_y);
+  };
+
+  const double phi_keep = normalize_phi(state[Phi]);
+  const double phi_flip = normalize_phi(state[Phi] + kPi);
+  if (center_distance2(phi_flip) < center_distance2(phi_keep))
+  {
+    state[Phi] = phi_flip;
+    state[TanLambda] *= -1.0;
+  }
+  else
+  {
+    state[Phi] = phi_keep;
+  }
+  state[QOverPt] = physical_qop_t;
+  return state;
+}
+
+std::array<double, TpcTrackKalmanFitter::StateDim> TpcTrackKalmanFitter::propagate_state(
+    const std::array<double, StateDim> &state,
+    const double ds_cm,
+    const TpcKalmanConfig &config,
+    const double mass_gev)
+{
+  const StateVector input = to_eigen(state);
+  if (config.magnetic_field == nullptr && config.analytic_uniform_propagation)
+  {
+    return to_array(propagate_uniform_bz(input, ds_cm, config.bfield_t, config, mass_gev));
+  }
+  return to_array(propagate_rkn4(input, ds_cm, config, mass_gev));
+}
+
+std::pair<double, double> TpcTrackKalmanFitter::dca_to_vertex(const TpcKalmanResult &fit,
+                                                              const TpcTrackVec3 &vertex,
+                                                              const TpcKalmanConfig *input_config)
+{
+  if (!fit.success || fit.states_smoothed.empty())
+  {
+    return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+  }
+
+  const auto state_array = propagation_state(fit, vertex);
+  const StateVector state = to_eigen(state_array);
+  const double omega = omega_from_state(state, fit.bfield_t);
+  if (std::abs(omega) < 1.0e-10)
+  {
+    return TpcTrackHelixFitter::line_dca_to_vertex(state_position(state_array),
+                                                   state_momentum(state_array),
+                                                   vertex);
+  }
+
+  const double radius = 1.0 / omega;
+  const double center_x = state(X) - std::sin(state(Phi)) / omega;
+  const double center_y = state(Y) + std::cos(state(Phi)) / omega;
+  const double vx = vertex.x - center_x;
+  const double vy = vertex.y - center_y;
+  const double distance_to_center = std::sqrt(vx * vx + vy * vy);
+  double theta_closest = std::atan2(state(Y) - center_y, state(X) - center_x);
+  double dca_xy = std::abs(radius);
+  if (distance_to_center > 0.0)
+  {
+    const double closest_x = center_x + std::abs(radius) * vx / distance_to_center;
+    const double closest_y = center_y + std::abs(radius) * vy / distance_to_center;
+    const double theta0 = std::atan2(state(Y) - center_y, state(X) - center_x);
+    const double theta_raw = std::atan2(closest_y - center_y, closest_x - center_x);
+    theta_closest = theta0 + normalize_phi(theta_raw - theta0);
+    dca_xy = std::abs(distance_to_center - std::abs(radius));
+  }
+
+  const double theta0 = std::atan2(state(Y) - center_y, state(X) - center_x);
+  const double dtheta = normalize_phi(theta_closest - theta0);
+  const double s_cm = dtheta / omega;
+  TpcKalmanConfig config = input_config != nullptr ? *input_config : TpcKalmanConfig{};
+  config.bfield_t = fit.bfield_t;
+  config.magnetic_field = fit.magnetic_field;
+  config.analytic_uniform_propagation = fit.analytic_uniform_propagation;
+  const auto closest = propagate_state(state_array, s_cm, config, fit.mass_gev);
+  return {dca_xy, std::abs(closest[Z] - vertex.z)};
+}

--- a/offline/packages/tpctrackreco/TpcTrackKalmanFitter.h
+++ b/offline/packages/tpctrackreco/TpcTrackKalmanFitter.h
@@ -1,0 +1,46 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCTRACKKALMANFITTER_H
+#define TPCTRACKRECO_TPCTRACKKALMANFITTER_H
+
+#include "TpcTrackFit.h"
+
+#include <array>
+#include <utility>
+#include <vector>
+
+class TpcTrackKalmanFitter
+{
+ public:
+  enum StateIndex
+  {
+    X = 0,
+    Y = 1,
+    Z = 2,
+    Phi = 3,
+    QOverPt = 4,
+    TanLambda = 5,
+    StateDim = 6
+  };
+
+  static bool fit(const std::vector<TpcTrackPoint> &points,
+                  int charge,
+                  const TpcKalmanConfig &config,
+                  TpcKalmanResult &result,
+                  double mass_gev = 0.13957039);
+
+  static TpcTrackVec3 state_position(const std::array<double, StateDim> &state);
+  static TpcTrackVec3 state_momentum(const std::array<double, StateDim> &state);
+  static TpcTrackVec3 state_tangent(const std::array<double, StateDim> &state);
+  static std::array<double, StateDim> propagation_state(const TpcKalmanResult &fit,
+                                                        const TpcTrackVec3 &reference_vertex);
+  static std::array<double, StateDim> propagate_state(const std::array<double, StateDim> &state,
+                                                      double ds_cm,
+                                                      const TpcKalmanConfig &config,
+                                                      double mass_gev = 0.13957039);
+  static std::pair<double, double> dca_to_vertex(const TpcKalmanResult &fit,
+                                                 const TpcTrackVec3 &vertex,
+                                                 const TpcKalmanConfig *config = nullptr);
+};
+
+#endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds reusable TPC-only track-fitting utilities to `tpctrackreco` and a
Fun4All V0 reconstruction and diagnostics module to `TrackingDiagnostics`.

The new functionality includes:

- Common TPC track point, state, helix, fit-result, and configuration types.
- A standalone TPC helix fitter supporting:
  - configurable point ordering, including looper-aware ordering;
  - least-squares and high-momentum curvature-refined circle fits;
  - charge-consistent track orientation;
  - track-to-vertex DCA calculations;
  - bounded two-track PCA searches anchored to the measured TPC trajectory.
- A standalone six-parameter TPC Kalman fitter using
  `(x, y, z, phi, q/pT, tan(lambda))`, with:
  - forward filtering and backward smoothing;
  - configurable local `(r, rphi, z)` measurement uncertainties;
  - analytic propagation in a uniform solenoidal field;
  - numerical propagation through a `PHField` field map;
  - configurable process noise, multiple scattering, and energy loss;
  - DCA and two-track PCA extrapolation;
  - optional per-measurement innovation diagnostics.
- `TpcV0CandidateTree`, a Fun4All diagnostics module that:
  - consumes TPC pattern-recognition cluster and track containers;
  - supports helix fitting, Kalman fitting, and upstream fitted-track states;
  - reconstructs two-track V0 candidates;
  - writes track, pair, fit-quality, residual, invariant-mass, and
    Armenteros-Podolanski observables;
  - optionally writes same-sign pairs and simulation-truth diagnostics;
  - provides configurable track and pair preselection.

The existing tracking workflow is unchanged unless the new module is explicitly
registered and configured.



[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

- Companion macros PR: planned; link will be added when opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Adds reusable TPC-only track-fitting utilities and an opt-in Fun4All module for reconstructing and diagnosing two-track V0 candidates, enabling detailed tracking QA without changing existing workflows.

## Key Changes

- Added configurable TPC helix fitting, point ordering, DCA, and helix/line PCA utilities.
- Added six-parameter TPC Kalman fitting with:
  - Uniform-field or field-map propagation
  - Adaptive integration and process-noise options
  - Material effects and energy loss
  - Forward filtering, smoothing, and innovation diagnostics
- Added `TpcV0CandidateTree` for:
  - Track and pair preselection, including optional same-sign pairs
  - Helix, Kalman, or no-fit modes
  - V0, invariant-mass, Armenteros-Podolanski, fit-quality, residual, and truth observables
  - Optional cluster-residual and simulation-truth trees
- Updated build configurations and library dependencies.

## Potential Risk Areas

- New ROOT tree schemas and diagnostic outputs may require downstream consumer updates.
- Complex fitting and propagation logic could affect reconstruction quality, numerical stability, and runtime, especially with field maps or large candidate samples.
- Output-file and module state management should be reviewed for concurrent or repeated use; thread-safety is not established.
- AI-generated summaries can contain inaccuracies; implementation details and behavior should be verified against the source and physics validation results.

## Possible Future Improvements

- Add focused unit tests and physics validation for helix, Kalman, PCA, DCA, and V0 observables.
- Provide companion macros and documented configuration examples.
- Benchmark field-map propagation and candidate-pair performance.
- Define and version output tree schemas and add regression tests for diagnostic content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->