### PR TITLE
Acts extrapolation

### DIFF
--- a/offline/packages/trackbase_historic/ActsTransformations.cc
+++ b/offline/packages/trackbase_historic/ActsTransformations.cc
@@ -299,27 +299,28 @@ void ActsTransformations::fillSvtxTrackStates(
     { return true; }
 
     // only fill for state vectors with proper smoothed parameters
-    if( !state.hasSmoothed()) { return true;
-  }
+    if( !state.hasSmoothed()) { return true;  }
 
-  // create svtx state vector with relevant pathlength
-  const float pathlength = state.pathLength() / Acts::UnitConstants::cm;
+    // create svtx state vector with relevant pathlength
+    const float pathlength = state.pathLength() / Acts::UnitConstants::cm;
 
-  // get smoothed fitted parameters
-  const Acts::BoundTrackParameters params(
-    state.referenceSurface().getSharedPtr(),
-    state.smoothed(),
-    state.smoothedCovariance(),
-    Acts::ParticleHypothesis::pion());
+    // get smoothed fitted parameters
+    const Acts::BoundTrackParameters params(
+      state.referenceSurface().getSharedPtr(),
+      state.smoothed(),
+      state.smoothedCovariance(),
+      Acts::ParticleHypothesis::pion());
 
-  // get source link and key
-  const auto sourceLink = state.getUncalibratedSourceLink().template get<ActsSourceLink>();
-  const auto key = sourceLink.cluskey();
+    // get source link and key
+    const auto sourceLink = state.getUncalibratedSourceLink().template get<ActsSourceLink>();
+    const auto key = sourceLink.cluskey();
 
-  // add track state
-  addTrackState( svtxTrack,key,pathlength,params, geoContext );
+    // add track state
+    addTrackState( svtxTrack,key,pathlength,params, geoContext );
 
-  return true; });
+    return true;
+  });
+
 }
 
 //_______________________________________________________________________________________________________

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -17,40 +17,56 @@
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Definitions/Units.hpp>
 
-/// local aborter class, used to tell acts to end track propagation when a given layer is used
-/** for the time being, the class is defined locally only, because it has no usage outside of ActsPropagator */
-struct ActsAborter
+namespace
 {
 
-  /// (ACTS) layer id at which propagation should stop
-  unsigned int abortlayer = std::numeric_limits<unsigned int>::max();
-
-  /// (ACTS) voulme id at which propagation should stop
-  unsigned int abortvolume = std::numeric_limits<unsigned int>::max();
-
-  /// called at each extrapolation step, by acts, to verify whether to stop propagation or not
-  template <typename propagator_state_t, typename stepper_t, typename navigator_t>
-    bool checkAbort(
-    propagator_state_t& state, const stepper_t& /*stepper*/,
-    const navigator_t& navigator, const Acts::Logger& /*logger*/) const
+  /// local aborter class, used to tell acts to end track propagation when a given layer is used
+  /** for the time being, the class is defined locally only, because it has no usage outside of ActsPropagator */
+  struct ActsAborter
   {
 
-    if (!navigator.currentSurface(state.navigation))
-    { return false; }
+    /// (ACTS) layer id at which propagation should stop
+    unsigned int abortlayer = std::numeric_limits<unsigned int>::max();
 
-    const auto& volumeno = state.navigation.currentSurface->geometryId().volume();
-    const auto& layerno = state.navigation.currentSurface->geometryId().layer();
-    const auto& sensitive = state.navigation.currentSurface->geometryId().sensitive();
+    /// (ACTS) voulme id at which propagation should stop
+    unsigned int abortvolume = std::numeric_limits<unsigned int>::max();
 
-    /// Check that we are in the proper layer and that we've also reached
-    /// a sensitive surface
-    if (layerno == abortlayer && volumeno == abortvolume && sensitive != 0)
-    { return true; }
+    /// called at each extrapolation step, by acts, to verify whether to stop propagation or not
+    template <typename propagator_state_t, typename stepper_t, typename navigator_t>
+      bool checkAbort(
+      propagator_state_t& state, const stepper_t& /*stepper*/,
+      const navigator_t& navigator, const Acts::Logger& /*logger*/) const
+    {
 
-    return false;
-  }
+      if (!navigator.currentSurface(state.navigation))
+      { return false; }
 
-};
+      const auto& volumeno = state.navigation.currentSurface->geometryId().volume();
+      const auto& layerno = state.navigation.currentSurface->geometryId().layer();
+      const auto& sensitive = state.navigation.currentSurface->geometryId().sensitive();
+
+      /// Check that we are in the proper layer and that we've also reached
+      /// a sensitive surface
+      if (layerno == abortlayer && volumeno == abortvolume && sensitive != 0)
+      { return true; }
+
+      return false;
+    }
+
+  };
+
+  // some definition for maping acts volume/layer to sphenix layer
+  constexpr unsigned int kFirstMvtxLayer = 0;
+  constexpr unsigned int kFirstInttLayer = 3;
+  constexpr unsigned int kFirstTpcLayer = 7;
+  constexpr unsigned int kFirstTpotLayer = 55;
+
+  constexpr unsigned int kMvtxVolumeId =  10;
+  constexpr unsigned int kInttVolumeId =  12;
+  constexpr unsigned int kTpcVolumeId =  14;
+  constexpr unsigned int kTpotVolumeId =  16;
+
+}
 
 //____________________________________________________________________
 ActsPropagator::SurfacePtr
@@ -294,9 +310,9 @@ ActsPropagator::SphenixPropagator ActsPropagator::makePropagator( Acts::Logging:
 }
 
 //____________________________________________________________________
-bool ActsPropagator::checkLayer(const unsigned int& sphenixlayer,
+bool ActsPropagator::checkLayer(const unsigned int sphenixlayer,
                                 unsigned int& actsvolume,
-                                unsigned int& actslayer)
+                                unsigned int& actslayer) const
 {
   /*
    * Acts geometry is defined in terms of volumes and layers. Within a volume
@@ -305,32 +321,33 @@ bool ActsPropagator::checkLayer(const unsigned int& sphenixlayer,
    * So we convert the sPHENIX layer number here to the Acts volume and
    * layer number that can interpret where to navigate to in the propagation.
    * The only exception is the TPOT, which is interpreted as a single layer.
+   * TODO: this is all hardcoded. should at least use properly defined constexpr variables. Ideally build on the fly
    */
 
   /// mvtx
-  if (sphenixlayer < 3)
+  if (sphenixlayer < kFirstInttLayer)
   {
-    actsvolume = 10;
+    actsvolume = kMvtxVolumeId;
     actslayer = (sphenixlayer + 1) * 2;
   }
 
   /// intt
-  else if (sphenixlayer < 7)
+  else if (sphenixlayer < kFirstTpcLayer)
   {
-    actsvolume = 12;
-    actslayer = ((sphenixlayer - 3) + 1) * 2;
+    actsvolume = kInttVolumeId;
+    actslayer = ((sphenixlayer - kFirstInttLayer) + 1) * 2;
   }
 
   /// tpc
-  else if (sphenixlayer < 55)
+  else if (sphenixlayer < kFirstTpotLayer)
   {
-    actsvolume = 14;
-    actslayer = ((sphenixlayer - 7) + 1) * 2;
+    actsvolume = kTpcVolumeId;
+    actslayer = ((sphenixlayer - kFirstTpcLayer) + 1) * 2;
   }
   /// tpot only has one layer in Acts geometry
   else
   {
-    actsvolume = 16;
+    actsvolume = kTpotVolumeId;
     actslayer = 2;
   }
 
@@ -362,6 +379,51 @@ bool ActsPropagator::checkLayer(const unsigned int& sphenixlayer,
   }
 
   return true;
+}
+
+//____________________________________________________________________
+bool ActsPropagator::checkSphenixLayer( const unsigned int actsvolume, const unsigned int actslayer, unsigned int& sphenixlayer ) const
+{
+
+  /*
+   * Acts geometry is defined in terms of volumes and layers. Within a volume
+   * layers always begin at 2 and iterate in 2s, i.e. the MVTX is defined as a
+   * volume and the 3 layers are identifiable as 2, 4, and 6.
+   * So we convert the sPHENIX layer number here to the Acts volume and
+   * layer number that can interpret where to navigate to in the propagation.
+   * The only exception is the TPOT, which is interpreted as a single layer.
+   * TODO: this is all hardcoded. should at least use properly defined constexpr variables. Ideally build on the fly
+   */
+
+  if( actsvolume == kMvtxVolumeId )
+  {
+    // mvtx
+    sphenixlayer = (actslayer/2)-1;
+    return (sphenixlayer<kFirstInttLayer);
+  }
+
+  if( actsvolume == kInttVolumeId )
+  {
+    // intt
+    sphenixlayer = (actslayer/2)+kFirstInttLayer-1;
+    return (sphenixlayer>=kFirstInttLayer && sphenixlayer<kFirstTpcLayer);
+  }
+
+  if( actsvolume == kTpcVolumeId )
+  {
+    // tpc
+    sphenixlayer = (actslayer/2)+kFirstTpcLayer-1;
+    return (sphenixlayer>=kFirstTpcLayer&&sphenixlayer<kFirstTpotLayer);
+  }
+
+  if( actsvolume == kTpotVolumeId )
+  {
+    // TPOT
+    sphenixlayer = (actslayer/2) + kFirstTpotLayer - 1;
+    return (sphenixlayer>=kFirstTpotLayer);
+  }
+
+  return false;
 }
 
 //____________________________________________________________________

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -321,7 +321,6 @@ bool ActsPropagator::checkLayer(const unsigned int sphenixlayer,
    * So we convert the sPHENIX layer number here to the Acts volume and
    * layer number that can interpret where to navigate to in the propagation.
    * The only exception is the TPOT, which is interpreted as a single layer.
-   * TODO: this is all hardcoded. should at least use properly defined constexpr variables. Ideally build on the fly
    */
 
   /// mvtx
@@ -382,7 +381,7 @@ bool ActsPropagator::checkLayer(const unsigned int sphenixlayer,
 }
 
 //____________________________________________________________________
-bool ActsPropagator::checkSphenixLayer( const unsigned int actsvolume, const unsigned int actslayer, unsigned int& sphenixlayer ) const
+bool ActsPropagator::checkSphenixLayer( const unsigned int actsvolume, const unsigned int actslayer, unsigned int& sphenixlayer )
 {
 
   /*
@@ -392,7 +391,6 @@ bool ActsPropagator::checkSphenixLayer( const unsigned int actsvolume, const uns
    * So we convert the sPHENIX layer number here to the Acts volume and
    * layer number that can interpret where to navigate to in the propagation.
    * The only exception is the TPOT, which is interpreted as a single layer.
-   * TODO: this is all hardcoded. should at least use properly defined constexpr variables. Ideally build on the fly
    */
 
   if( actsvolume == kMvtxVolumeId )

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -56,7 +56,7 @@ namespace
   };
 
   // some definition for maping acts volume/layer to sphenix layer
-  constexpr unsigned int kFirstMvtxLayer = 0;
+  /* constexpr unsigned int kFirstMvtxLayer = 0; */
   constexpr unsigned int kFirstInttLayer = 3;
   constexpr unsigned int kFirstTpcLayer = 7;
   constexpr unsigned int kFirstTpotLayer = 55;
@@ -183,8 +183,12 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params, const u
   options.direction = direction;
 
   auto result = propagator.propagate(params, options);
-  if (result.ok()) { return Acts::Result<BoundTrackParamPair>::success({result.value().pathLength,*result.value().endParameters}); }
-  else { return result.error(); }
+  if( result.ok() && result.value().endParameters )
+  {
+    return Acts::Result<BoundTrackParamPair>::success({result.value().pathLength,*result.value().endParameters});
+  }
+
+  return result.error();
 
 }
 

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -183,17 +183,9 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params, const u
   options.direction = direction;
 
   auto result = propagator.propagate(params, options);
+  if (result.ok()) { return Acts::Result<BoundTrackParamPair>::success({result.value().pathLength,*result.value().endParameters}); }
+  else { return result.error(); }
 
-  if (result.ok())
-  {
-    auto finalparams = *result.value().endParameters; // NOLINT(bugprone-unchecked-optional-access)
-    auto pathlength = result.value().pathLength;
-    auto pair = std::make_pair(pathlength, finalparams);
-
-    return Acts::Result<BoundTrackParamPair>::success(pair);
-  }
-
-  return result.error();
 }
 
 //____________________________________________________________________

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -44,7 +44,7 @@ struct ActsAborter
 
     /// Check that we are in the proper layer and that we've also reached
     /// a sensitive surface
-    if (layerno == abortlayer and volumeno == abortvolume and sensitive != 0)
+    if (layerno == abortlayer && volumeno == abortvolume && sensitive != 0)
     { return true; }
 
     return false;
@@ -138,8 +138,7 @@ ActsPropagator::makeTrackParams(SvtxTrack* track,
 
 //____________________________________________________________________
 ActsPropagator::BTPPairResult
-ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params,
-                               const unsigned int sphenixLayer)
+ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params, const unsigned int sphenixLayer, Acts::Direction direction )
 {
   unsigned int actsvolume = 0;
   unsigned int actslayer = 0;
@@ -151,7 +150,8 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params,
     printTrackParams(params);
   }
 
-  auto propagator = makePropagator();
+  const Acts::Logging::Level loglevel = (m_verbosity > 3) ? Acts::Logging::VERBOSE : Acts::Logging::FATAL;
+  auto propagator = makePropagator(loglevel);
 
   // create propagator options with proper aborter
   using actor_list_t = Acts::ActorList<ActsAborter>;
@@ -164,6 +164,7 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params,
   // initialize aborter
   options.actorList.get<ActsAborter>().abortlayer = actslayer;
   options.actorList.get<ActsAborter>().abortvolume = actsvolume;
+  options.direction = direction;
 
   auto result = propagator.propagate(params, options);
 
@@ -188,7 +189,8 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params, const S
     printTrackParams(params);
   }
 
-  auto propagator = makePropagator();
+  const Acts::Logging::Level loglevel = (m_verbosity > 3) ? Acts::Logging::VERBOSE:Acts::Logging::FATAL;
+  auto propagator = makePropagator( loglevel );
 
   SphenixPropagator::Options options(m_geometry->geometry().getGeoContext(), m_geometry->geometry().magFieldContext);
 
@@ -209,8 +211,7 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params, const S
 
 //____________________________________________________________________
 ActsPropagator::BTPPairResult
-ActsPropagator::propagateTrackFast(const Acts::BoundTrackParameters& params,
-                                   const SurfacePtr& surface)
+ActsPropagator::propagateTrackFast(const Acts::BoundTrackParameters& params, const SurfacePtr& surface)
 {
   if (m_verbosity > 1)
   {
@@ -263,7 +264,7 @@ ActsPropagator::FastPropagator ActsPropagator::makeFastPropagator()
 }
 
 //____________________________________________________________________
-ActsPropagator::SphenixPropagator ActsPropagator::makePropagator()
+ActsPropagator::SphenixPropagator ActsPropagator::makePropagator( Acts::Logging::Level logLevel)
 {
   auto field = m_geometry->geometry().magField;
 
@@ -277,7 +278,6 @@ ActsPropagator::SphenixPropagator ActsPropagator::makePropagator()
   Stepper stepper(field);
 
   // create mavigation logger
-  const Acts::Logging::Level logLevel = (m_verbosity > 3) ? Acts::Logging::VERBOSE:Acts::Logging::FATAL;
   std::shared_ptr<const Acts::Logger> navlogger = Acts::getDefaultLogger("ActsPropagator::NAVIGATION", logLevel);
 
   // create navigator

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -61,16 +61,15 @@ class ActsPropagator
   /// and GeV. For an example of how to unpack this, see
   /// PHActsTrackProjection::propagateTrack and
   /// PHActsTrackProjection::updateSvtxTrack
-  BTPPairResult propagateTrack(const Acts::BoundTrackParameters& params,
-                                       const unsigned int sphenixLayer);
-  BTPPairResult propagateTrack(const Acts::BoundTrackParameters& params,
-                                       const SurfacePtr& surface);
+  BTPPairResult propagateTrack(const Acts::BoundTrackParameters&, const unsigned int /*layer*/, Acts::Direction = Acts::Direction::Positive());
+
+  BTPPairResult propagateTrack(const Acts::BoundTrackParameters&, const SurfacePtr&);
+
   /// The following function takes the track parameters at the vertex and
   /// propagates them in isolation to the requested surface, i.e. it does
   /// NOT stop at each layer in the sPHENIX detector on the way to the
   /// target surface
-  BTPPairResult propagateTrackFast(const Acts::BoundTrackParameters& params,
-                                           const SurfacePtr& surface);
+  BTPPairResult propagateTrackFast(const Acts::BoundTrackParameters&, const SurfacePtr&);
 
   bool checkLayer(const unsigned int& sphenixlayer,
                   unsigned int& actsvolume,
@@ -79,7 +78,11 @@ class ActsPropagator
   void setConstFieldValue(float field) { m_fieldval = field; }
   void constField() { m_constField = true; }
   void setOverstepLimit(const double overstep) { m_overstepLimit = overstep; }
-  SphenixPropagator makePropagator();
+
+  // create propagator
+  SphenixPropagator makePropagator( Acts::Logging::Level = Acts::Logging::FATAL);
+
+  // create propagator
   FastPropagator makeFastPropagator();
 
  private:

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -39,19 +39,22 @@ class ActsPropagator
   using FastPropagator = Acts::Propagator<Stepper>;
   using SphenixPropagator = Acts::Propagator<Stepper, Acts::Navigator>;
 
-  ActsPropagator() {}
+  // default constructor
+  ActsPropagator() = default;
+
+  // constructor with gemotry pointer
   ActsPropagator(ActsGeometry* geometry)
     : m_geometry(geometry)
-  {
-  }
-  ~ActsPropagator() {}
+  {}
 
   /// Helper functions for creating needed input for track propagation
   /// functions below
   SurfacePtr makeVertexSurface(const SvtxVertex* vertex);
+
   SurfacePtr makeVertexSurface(const Acts::Vector3& vertex);
-  BoundTrackParamResult makeTrackParams(SvtxTrack* track,
-					SvtxVertexMap* vertexMap);
+
+  BoundTrackParamResult makeTrackParams(SvtxTrack* track, SvtxVertexMap* vertexMap);
+
   BoundTrackParamResult makeTrackParams(SvtxTrackState* state,
 					int trackCharge,
 					SurfacePtr surf);
@@ -71,9 +74,16 @@ class ActsPropagator
   /// target surface
   BTPPairResult propagateTrackFast(const Acts::BoundTrackParameters&, const SurfacePtr&);
 
-  bool checkLayer(const unsigned int& sphenixlayer,
-                  unsigned int& actsvolume,
-                  unsigned int& actslayer);
+  /// get acts volume and layer from sphenix layer. Returns true on success
+  bool checkLayer(
+    const unsigned int sphenixlayer,
+    unsigned int& actsvolume,
+    unsigned int& actslayer) const;
+
+  /// get sphenix layer from acts volume and layer from sphenix layer. Returns true on success
+  /** this is the opposite transformation as checkLayer */
+  bool checkSphenixLayer( const unsigned int /*actsvolume*/, const unsigned int /*actslayer*/, unsigned int& /*sphenixlayer*/ ) const;
+
   void verbosity(int verb) { m_verbosity = verb; }
   void setConstFieldValue(float field) { m_fieldval = field; }
   void constField() { m_constField = true; }

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -82,7 +82,7 @@ class ActsPropagator
 
   /// get sphenix layer from acts volume and layer from sphenix layer. Returns true on success
   /** this is the opposite transformation as checkLayer */
-  bool checkSphenixLayer( const unsigned int /*actsvolume*/, const unsigned int /*actslayer*/, unsigned int& /*sphenixlayer*/ ) const;
+  static bool checkSphenixLayer( const unsigned int /*actsvolume*/, const unsigned int /*actslayer*/, unsigned int& /*sphenixlayer*/ );
 
   void verbosity(int verb) { m_verbosity = verb; }
   void setConstFieldValue(float field) { m_fieldval = field; }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -185,6 +185,51 @@ namespace
     }
   };
 
+
+  // calculate average track parameters
+  /* return the first, forward parameters in case of failure */
+  [[maybe_unused]] Acts::BoundTrackParameters calculateAverageParameters( const Acts::BoundTrackParameters& forward, const Acts::BoundTrackParameters& backward )
+  {
+    // check that surfaces are identical
+    if( forward.referenceSurface() != backward.referenceSurface() )
+    {
+      std::cout << "PHActsTrkFitter::calculateAverageParameters - surfaces are different. not averaging" << std::endl;
+      return forward;
+    }
+
+    // check particle hypothesis
+    if( forward.particleHypothesis() != backward.particleHypothesis() )
+    {
+      std::cout << "PHActsTrkFitter::calculateAverageParameters - particle hypotheses are different. not averaging" << std::endl;
+      return forward;
+    }
+
+    // check covariance matrices
+    if( !forward.covariance() )
+    {
+      std::cout << "PHActsTrkFitter::calculateAverageParameters - invalid forward covariance. not averaging" << std::endl;
+      return forward;
+    }
+
+    // check covariance matrices
+    if( !backward.covariance() )
+    {
+      std::cout << "PHActsTrkFitter::calculateAverageParameters - invalid backward covariance. not averaging" << std::endl;
+      return forward;
+    }
+
+    // perform the averaging
+    const auto forwardCovInv = forward.covariance().value().inverse();
+    const auto backwardCovInv = backward.covariance().value().inverse();
+    const auto covInv = forwardCovInv+backwardCovInv;
+    const auto cov = covInv.inverse();
+
+    const auto parameters = cov*(forwardCovInv*forward.parameters() + backwardCovInv*backward.parameters());
+
+    // assign
+    return Acts::BoundTrackParameters(forward.referenceSurface().getSharedPtr(), parameters, cov, forward.particleHypothesis() );
+  }
+
 }  // namespace
 
 //___________________________________________________________________________
@@ -192,12 +237,13 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
 {}
 
+//___________________________________________________________________________
 int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
 {
-  if (Verbosity() > 1)
-  {
-    std::cout << "Setup PHActsTrkFitter" << std::endl;
-  }
+
+  std::cout << "PHActsTrkFitter::InitRun - m_fitSiliconMMs: " << m_fitSiliconMMs << std::endl;
+  std::cout << "PHActsTrkFitter::InitRun - m_useMicromegas: " << m_useMicromegas << std::endl;
+  std::cout << "PHActsTrkFitter::InitRun - m_extrapolation_mode: " << (int)(m_extrapolation_mode) << std::endl;
 
   if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
   {
@@ -993,13 +1039,13 @@ bool PHActsTrkFitter::getTrackFitResult(
     Trajectory::IndexedParameters indexedParams;
 
     // retrieve track parameters from fit result
-    Acts::BoundTrackParameters parameters = ActsExamples::TrackParameters(outtrack.referenceSurface().getSharedPtr(),
-                                                                          outtrack.parameters(), outtrack.covariance(), outtrack.particleHypothesis());
+    const Acts::BoundTrackParameters parameters(
+      outtrack.referenceSurface().getSharedPtr(),
+      outtrack.parameters(),
+      outtrack.covariance(),
+      outtrack.particleHypothesis());
 
-    indexedParams.emplace(
-        outtrack.tipIndex(),
-        ActsExamples::TrackParameters{outtrack.referenceSurface().getSharedPtr(),
-                                      outtrack.parameters(), outtrack.covariance(), outtrack.particleHypothesis()});
+    indexedParams.emplace( outtrack.tipIndex(),parameters );
 
     if (Verbosity() > 2)
     {
@@ -1217,9 +1263,7 @@ void PHActsTrkFitter::updateSvtxTrack(
 
   // create a state at pathlength = 0.0
   // This state holds the track parameters, which will be updated below
-  float pathlength = 0.0;
-  //  SvtxTrackState_v1 out(pathlength);
-  SvtxTrackState_v3 out(pathlength);
+  SvtxTrackState_v3 out( 0.0 );
   out.set_localX(0.0);
   out.set_localY(0.0);
   out.set_x(0.0);
@@ -1303,18 +1347,25 @@ void PHActsTrkFitter::updateSvtxTrack(
       }
 
       // get layer, propagate
+      /* this code is quite complicated. See to simplify */
       const auto layer = TrkrDefs::getLayer(cluskey);
+      auto extrapolate = [&]( ActsPropagator::BoundTrackParamPair p, uint8_t l, Acts::Direction direction )
+      {
+
+        const auto& [source_pathlength, source_param] = p;
+        auto result = propagator.propagateTrack(source_param, l, direction);
+        if( result.ok() )
+        {
+          const auto& [pathLength, trackStateParams] = result.value();
+          transformer.addTrackState(track, cluskey, (source_pathlength+pathLength)/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
+        }
+      };
 
       if( m_extrapolation_mode == ExtrapolationMode::Default )
       {
 
-        auto result = propagator.propagateTrack(params, layer, Acts::Direction::Positive() );
-        if( result.ok() )
-        {
-          // get path length and extrapolated parameters
-          const auto& [pathLength, trackStateParams] = result.value();
-          transformer.addTrackState(track, cluskey, pathLength/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
-        }
+        // extrapolate from track parameters
+        extrapolate( {0,params}, layer, Acts::Direction::Positive() );
 
       } else {
 
@@ -1325,31 +1376,51 @@ void PHActsTrkFitter::updateSvtxTrack(
         // forward extrapolation
         if( m_extrapolation_mode == ExtrapolationMode::Forward && nearest_params_forward )
         {
-          // get source pathlength and parameters
-          const auto& [source_pathlength, source_param] = *nearest_params_forward;
-          auto result = propagator.propagateTrack(source_param, layer, Acts::Direction::Positive() );
-          if( result.ok() )
-          {
-            // get extrapolation pathlength and extrapolated parameters
-            const auto& [pathLength, trackStateParams] = result.value();
-            transformer.addTrackState(track, cluskey, (source_pathlength+pathLength)/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
-          }
+          // extrapolate from nearest forward parameters
+          extrapolate( nearest_params_forward.value(), layer, Acts::Direction::Positive() );
         }
 
         // forward extrapolation
         if( m_extrapolation_mode == ExtrapolationMode::Backward && nearest_params_backward )
         {
-          // get source pathlength and parameters
-          const auto& [source_pathlength, source_param] = *nearest_params_backward;
-          auto result = propagator.propagateTrack(source_param, layer, Acts::Direction::Backward() );
-          if( result.ok() )
+          // extrapolate from nearest backward parameters
+          extrapolate( nearest_params_backward.value(), layer, Acts::Direction::Negative() );
+        }
+
+        // bidirectional extrapolation
+        if( m_extrapolation_mode == ExtrapolationMode::Bidirectional && ( nearest_params_forward || nearest_params_backward ) )
+        {
+
+          if( nearest_params_forward && nearest_params_backward )
           {
-            // get extrapolation pathlength and extrapolated parameters
-            const auto& [pathLength, trackStateParams] = result.value();
-            transformer.addTrackState(track, cluskey, (source_pathlength+pathLength)/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
+
+            const auto result_forward = propagator.propagateTrack(nearest_params_forward.value().second, layer, Acts::Direction::Positive());
+            const auto result_backward = propagator.propagateTrack(nearest_params_backward.value().second, layer, Acts::Direction::Negative());
+
+            if( result_forward.ok() && result_backward.ok() )
+            {
+              // calculate pathlenght (using the forward extrapolation only) and the weighted average track parameters
+              const auto pathlength = nearest_params_forward.value().first + result_forward.value().first;
+              const auto averaged_param = calculateAverageParameters( result_forward.value().second, result_backward.value().second );
+
+              // assign
+              transformer.addTrackState(track, cluskey, pathlength/Acts::UnitConstants::cm, averaged_param, m_transient_geocontext);
+            }
+
+          } else if( nearest_params_forward ) {
+
+            // extrapolate from nearest forward parameters
+            extrapolate( nearest_params_forward.value(), layer, Acts::Direction::Positive() );
+
+          } else {
+
+            // extrapolate from nearest backward parameters
+            extrapolate( nearest_params_backward.value(), layer, Acts::Direction::Negative() );
+
           }
         }
       }
+
     }
 
   }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -57,6 +57,10 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
+#include <trackbase/alignmentTransformationContainer.h>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
 #include <cmath>
 #include <filesystem>
 #include <iostream>
@@ -181,10 +185,7 @@ namespace
 
 }  // namespace
 
-#include <trackbase/alignmentTransformationContainer.h>
-#include <Eigen/Dense>
-#include <Eigen/Geometry>
-
+//___________________________________________________________________________
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
 {}
@@ -1292,80 +1293,6 @@ void PHActsTrkFitter::updateSvtxTrack(
     // acts propagator
     ActsPropagator propagator(m_tGeometry);
 
-    // find Acts track state closest to the TPC and create the corresponding parameter
-    ActsTrackFittingAlgorithm::TrackParameters nearest_params_forward = params;
-    bool found_forward = false;
-    mj.visitBackwards(trackTip, [&nearest_params_forward, &found_forward](const auto& state)
-    {
-      /// Only fill the track states with non-outlier measurement
-      if (!state.typeFlags().isMeasurement())
-      { return true; }
-
-      // only fill for state vectors with proper smoothed parameters
-      if( !state.hasSmoothed()) { return true;  }
-
-      // create svtx state vector with relevant pathlength
-      const float pathlength_local = state.pathLength() / Acts::UnitConstants::cm;
-      if( pathlength_local > 20. ) return true;
-
-      // get sphenix layer from acst volume and layer
-      unsigned int sphenixlayer = 0;
-      if( ActsPropagator().checkSphenixLayer(
-        state.referenceSurface().getSharedPtr()->geometryId().volume(),
-        state.referenceSurface().getSharedPtr()->geometryId().layer(),
-        sphenixlayer ) )
-      { std::cout << "PHActsTrkFitter::updateSvtxTrack - layer: " << (int) sphenixlayer << std::endl; }
-
-      // get smoothed fitted parameters
-      nearest_params_forward = Acts::BoundTrackParameters(
-        state.referenceSurface().getSharedPtr(),
-        state.smoothed(),
-        state.smoothedCovariance(),
-        Acts::ParticleHypothesis::pion());
-      found_forward = true;
-
-      return false;
-    });
-
-    // find Acts track state closest to the TPC and create the corresponding parameter
-    ActsTrackFittingAlgorithm::TrackParameters nearest_params_backward = params;
-    bool found_backward = false;
-    mj.visitBackwards(trackTip, [&nearest_params_backward, &found_backward](const auto& state)
-    {
-      /// Only fill the track states with non-outlier measurement
-      if (!state.typeFlags().isMeasurement())
-      { return true; }
-
-      // only fill for state vectors with proper smoothed parameters
-      if( !state.hasSmoothed()) { return true;  }
-
-      // create svtx state vector with relevant pathlength
-      const float pathlength_local = state.pathLength() / Acts::UnitConstants::cm;
-      if( pathlength_local > 50 )
-      {
-        // get smoothed fitted parameters and store
-        nearest_params_backward = Acts::BoundTrackParameters(
-          state.referenceSurface().getSharedPtr(),
-          state.smoothed(),
-          state.smoothedCovariance(),
-          Acts::ParticleHypothesis::pion());
-        found_backward = true;
-
-        // get sphenix layer from acst volume and layer
-        unsigned int sphenixlayer = 0;
-        if( ActsPropagator().checkSphenixLayer(
-          state.referenceSurface().getSharedPtr()->geometryId().volume(),
-          state.referenceSurface().getSharedPtr()->geometryId().layer(),
-          sphenixlayer ) )
-        { std::cout << "PHActsTrkFitter::updateSvtxTrack - layer: " << (int) sphenixlayer << std::endl; }
-
-        return true;
-      } else {
-        // stop here
-        return false;
-      }
-
-    });
 
     // loop over cluster keys associated to TPC seed
     for (auto key_iter = seed->begin_cluster_keys(); key_iter != seed->end_cluster_keys(); ++key_iter)
@@ -1412,16 +1339,18 @@ void PHActsTrkFitter::updateSvtxTrack(
         }
       }
 
-      if( found_forward )
+      // forward extrapolation
+      const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
+      if( nearest_params_forward )
       {
-        // forward extrapolation
-        extrapolate_parameters( nearest_params_forward );
+        extrapolate_parameters( *nearest_params_forward );
       }
 
-      if( found_backward )
+      // backward extrapolation
+      const auto& nearest_params_backward = find_nearest_params_after( mj, trackTip, layer );
+      if( nearest_params_backward )
       {
-        // backward extrapolation
-        extrapolate_parameters( nearest_params_backward, Acts::Direction::Negative() );
+        extrapolate_parameters( *nearest_params_backward, Acts::Direction::Negative() );
       }
 
       std::cout << std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1305,99 +1305,53 @@ void PHActsTrkFitter::updateSvtxTrack(
       // get layer, propagate
       const auto layer = TrkrDefs::getLayer(cluskey);
 
-//       if( m_extrapolation_mode == ExtrapolationMode::Default )
-//       {
-//
-//         auto result = propagator.propagateTrack(params, layer, Acts::Direction::Positive() );
-//         if( result.ok() )
-//         {
-//           // get path length and extrapolated parameters
-//           auto& [pathLength, trackStateParams] = result.value();
-//           pathLength /= Acts::UnitConstants::cm;
-//           transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
-//         }
-//
-//       } else {
-//
-//         // get before and after nearesst parameters
-//         const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
-//         const auto& nearest_params_backward = find_nearest_params_after( mj, trackTip, layer );
-//
-//         // forward extrapolation
-//         if( m_extrapolation_mode == ExtrapolationMode::Forward && nearest_params_forward )
-//         {
-//           auto result = propagator.propagateTrack(*nearest_params_forward, layer, Acts::Direction::Positive() );
-//           if( result.ok() )
-//           {
-//             // get path length and extrapolated parameters
-//             auto& [pathLength, trackStateParams] = result.value();
-//             pathLength /= Acts::UnitConstants::cm;
-//             transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
-//           }
-//         }
-//
-//         // backward extrapolation
-//         if( m_extrapolation_mode == ExtrapolationMode::Backward && nearest_params_backward )
-//         {
-//           auto result = propagator.propagateTrack(*nearest_params_backward, layer, Acts::Direction::Positive() );
-//           if( result.ok() )
-//           {
-//             // get path length and extrapolated parameters
-//             auto& [pathLength, trackStateParams] = result.value();
-//             pathLength /= Acts::UnitConstants::cm;
-//             transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
-//           }
-//         }
-//       }
-
-      // extrapolate track parameter
-      auto extrapolate_parameters = [this, &propagator, &layer]( const ActsPropagator::BoundTrackParamPair& p, Acts::Direction direction = Acts::Direction::Positive() )
+      if( m_extrapolation_mode == ExtrapolationMode::Default )
       {
 
-        auto result = propagator.propagateTrack(p.second, layer, direction);
-        if (result.ok())
-        {
-          auto& [pathLength, trackStateParams] = result.value();
-          const auto global = trackStateParams.position(m_transient_geocontext);
-          std::cout << "PHActsTrkFitter::updateSvtxTrack - extrapolated: ("
-            << global.x() / Acts::UnitConstants::cm << ", "
-            << global.y() / Acts::UnitConstants::cm << ", "
-            << global.z() / Acts::UnitConstants::cm << ")"
-            << " pathlength: " << pathLength+p.first
-            << std::endl;
-        }
-
-        return result;
-      };
-
-      {
-        auto result = extrapolate_parameters( {0,params} );
+        auto result = propagator.propagateTrack(params, layer, Acts::Direction::Positive() );
         if( result.ok() )
         {
           // get path length and extrapolated parameters
-          auto& [pathLength, trackStateParams] = result.value();
-          pathLength /= Acts::UnitConstants::cm;
-          transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
+          const auto& [pathLength, trackStateParams] = result.value();
+          transformer.addTrackState(track, cluskey, pathLength/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
+        }
+
+      } else {
+
+        // get before and after nearesst parameters
+        const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
+        const auto& nearest_params_backward = find_nearest_params_after( mj, trackTip, layer );
+
+        // forward extrapolation
+        if( m_extrapolation_mode == ExtrapolationMode::Forward && nearest_params_forward )
+        {
+          // get source pathlength and parameters
+          const auto& [source_pathlength, source_param] = *nearest_params_forward;
+          auto result = propagator.propagateTrack(source_param, layer, Acts::Direction::Positive() );
+          if( result.ok() )
+          {
+            // get extrapolation pathlength and extrapolated parameters
+            const auto& [pathLength, trackStateParams] = result.value();
+            transformer.addTrackState(track, cluskey, (source_pathlength+pathLength)/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
+          }
+        }
+
+        // forward extrapolation
+        if( m_extrapolation_mode == ExtrapolationMode::Backward && nearest_params_backward )
+        {
+          // get source pathlength and parameters
+          const auto& [source_pathlength, source_param] = *nearest_params_backward;
+          auto result = propagator.propagateTrack(source_param, layer, Acts::Direction::Backward() );
+          if( result.ok() )
+          {
+            // get extrapolation pathlength and extrapolated parameters
+            const auto& [pathLength, trackStateParams] = result.value();
+            transformer.addTrackState(track, cluskey, (source_pathlength+pathLength)/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
+          }
         }
       }
-
-      // forward extrapolation
-      const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
-      if( nearest_params_forward )
-      {
-        extrapolate_parameters( *nearest_params_forward );
-      }
-
-      // backward extrapolation
-      const auto& nearest_params_backward = find_nearest_params_after( mj, trackTip, layer );
-      if( nearest_params_backward )
-      {
-        extrapolate_parameters( *nearest_params_backward, Acts::Direction::Negative() );
-      }
-
-      std::cout << std::endl;
-
     }
+
   }
 
   // also propagate to Micromegas if not used for the fit

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -222,7 +222,19 @@ namespace
     const auto forwardCovInv = forward.covariance().value().inverse();
     const auto backwardCovInv = backward.covariance().value().inverse();
     const auto covInv = forwardCovInv+backwardCovInv;
+    if (!covInv.allFinite() || std::abs(covInv.determinant()) < std::numeric_limits<double>::epsilon())
+    {
+      std::cout << "PHActsTrkFitter::calculateAverageParameters - combined information matrix is singular. not averaging" << std::endl;
+      return forward;
+    }
+
     const auto cov = covInv.inverse();
+    if (!cov.allFinite())
+    {
+      std::cout << "PHActsTrkFitter::calculateAverageParameters - averaged covariance is not finite. not averaging" << std::endl;
+      return forward;
+    }
+
     const auto parameters = cov*(forwardCovInv*forward.parameters() + backwardCovInv*backward.parameters());
 
     // assign

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -223,7 +223,6 @@ namespace
     const auto backwardCovInv = backward.covariance().value().inverse();
     const auto covInv = forwardCovInv+backwardCovInv;
     const auto cov = covInv.inverse();
-
     const auto parameters = cov*(forwardCovInv*forward.parameters() + backwardCovInv*backward.parameters());
 
     // assign
@@ -1418,12 +1417,14 @@ void PHActsTrkFitter::updateSvtxTrack(
             extrapolate( nearest_params_backward.value(), layer, Acts::Direction::Negative() );
 
           }
-        }
-      }
 
-    }
+        } // bidirectional extrapolation
 
-  }
+      } // forward/backward or bidirectional extrapolation
+
+    } // cluster loop
+
+  } // silicon-MM fitting.
 
   // also propagate to Micromegas if not used for the fit
   /* this is be used to get unbiased residuals in TPOT */

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -69,11 +69,116 @@ namespace
   {
     return !(std::isnan(vec.x()) || std::isnan(vec.y()) || std::isnan(vec.z()));
   }
+
+  // square
   template <class T>
   inline T square(const T& x)
   {
     return x * x;
   }
+
+  // find nearest parameter in trajectory before a given sPhenix layer
+  [[maybe_unused]] std::optional<Acts::BoundTrackParameters> find_nearest_params_before(
+    const Acts::VectorMultiTrajectory& traj,
+    const size_t trackTip,
+    const unsigned int layer )
+  {
+    bool found = false;
+    auto s = traj.getTrackState(trackTip);
+    traj.visitBackwards(trackTip, [&found, &s, &layer](const auto& state )
+    {
+      /// Only fill the track states with non-outlier measurement
+      if (!state.typeFlags().isMeasurement()) {return true;}
+
+      // only fill for state vectors with proper smoothed parameters
+      if( !state.hasSmoothed()) {return true;}
+
+      // get sphenix layer from acst volume and layer
+      unsigned int currentLayer = 0;
+      if( !ActsPropagator::checkSphenixLayer(
+        state.referenceSurface().getSharedPtr()->geometryId().volume(),
+        state.referenceSurface().getSharedPtr()->geometryId().layer(),
+        currentLayer ) ) { return true; }
+
+      // check layer
+      if( currentLayer >= layer ) { return true; }
+
+      // found correct state
+      /* store and abort loop */
+      s = state;
+      found = true;
+      return false;
+
+    });
+
+    if( found )
+    {
+
+      // get smoothed fitted parameters
+      return Acts::BoundTrackParameters(
+        s.referenceSurface().getSharedPtr(),
+        s.smoothed(),
+        s.smoothedCovariance(),
+        Acts::ParticleHypothesis::pion());
+
+    } else {
+
+      return std::nullopt;
+
+    }
+  };
+
+  // find nearest parameter in trajectory after a given sPhenix layer
+  [[maybe_unused]] std::optional<Acts::BoundTrackParameters> find_nearest_params_after(
+    const Acts::VectorMultiTrajectory& traj,
+    const size_t trackTip,
+    const unsigned int layer )
+  {
+    bool found = false;
+    auto s = traj.getTrackState(trackTip);
+    traj.visitBackwards(trackTip, [&found, &s, &layer](const auto& state )
+    {
+      /// Only fill the track states with non-outlier measurement
+      if (!state.typeFlags().isMeasurement()) {return true;}
+
+      // only fill for state vectors with proper smoothed parameters
+      if( !state.hasSmoothed()) {return true;}
+
+      // get sphenix layer from acst volume and layer
+      unsigned int currentLayer = 0;
+      if( !ActsPropagator::checkSphenixLayer(
+        state.referenceSurface().getSharedPtr()->geometryId().volume(),
+        state.referenceSurface().getSharedPtr()->geometryId().layer(),
+        currentLayer ) ) { return true; }
+
+      // check layer
+      if( currentLayer > layer ) {
+        s = state;
+        found = true;
+        return true;
+      } else {
+        return false;
+      }
+
+    });
+
+    if( found )
+    {
+
+      // get smoothed fitted parameters
+      return Acts::BoundTrackParameters(
+        s.referenceSurface().getSharedPtr(),
+        s.smoothed(),
+        s.smoothedCovariance(),
+        Acts::ParticleHypothesis::pion());
+
+    } else {
+
+      return std::nullopt;
+
+    }
+  };
+
 }  // namespace
 
 #include <trackbase/alignmentTransformationContainer.h>
@@ -82,8 +187,7 @@ namespace
 
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
-{
-}
+{}
 
 int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
 {
@@ -941,7 +1045,7 @@ bool PHActsTrkFitter::getTrackFitResult(
     {
       h_updateTime->Fill(updateTime);
     }
-    
+
     if (m_actsEvaluator)
     {
       m_evaluator->evaluateTrackFit(tracks, trackTips, indexedParams, track,
@@ -1030,18 +1134,18 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
 
   for (unsigned int i = 0; i < surfaces.size() - 1; i++)
   {
-    
+
     const auto& surface = surfaces.at(i);
     if (std::find(m_materialSurfaces.begin(), m_materialSurfaces.end(), surface) != m_materialSurfaces.end())
     {
       continue;
     }
- 
+
     const auto thisVolume = surface->geometryId().volume();
 
     const Acts::Vector3 this_center = surface->center(m_tGeometry->geometry().getGeoContext());
     double thisRadius = sqrt(this_center.x()*this_center.x()+this_center.y()*this_center.y());
-    
+
     const auto* nextSurface = surfaces.at(i + 1);
     const auto nextVolume = nextSurface->geometryId().volume();
 
@@ -1052,6 +1156,7 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
     {
       continue;
     }
+
     /// Implement a check to ensure surfaces are sorted
     if (nextVolume == thisVolume)
     {
@@ -1124,8 +1229,7 @@ void PHActsTrkFitter::updateSvtxTrack(
   out.set_z(0.0);
   track->insert_state(&out);
 
-  auto trajState =
-      Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
+  auto trajState = Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
 
   const auto& params = paramsMap.find(trackTip)->second;
 
@@ -1135,7 +1239,7 @@ void PHActsTrkFitter::updateSvtxTrack(
   track->set_z(params.position(m_transient_geocontext)(2) / Acts::UnitConstants::cm);
 
   auto* seed = track->get_tpc_seed();
-  
+
   if(!m_forceSiOnlyFit)
   {
     track->set_px(params.momentum()(0));
@@ -1182,11 +1286,86 @@ void PHActsTrkFitter::updateSvtxTrack(
 
   // in using silicon mm fit also extrapolate track parameters to all TPC surfaces with clusters
   // get all tpc clusters
-  
+
   if (m_fitSiliconMMs && seed)
   {
     // acts propagator
     ActsPropagator propagator(m_tGeometry);
+
+    // find Acts track state closest to the TPC and create the corresponding parameter
+    ActsTrackFittingAlgorithm::TrackParameters nearest_params_forward = params;
+    bool found_forward = false;
+    mj.visitBackwards(trackTip, [&nearest_params_forward, &found_forward](const auto& state)
+    {
+      /// Only fill the track states with non-outlier measurement
+      if (!state.typeFlags().isMeasurement())
+      { return true; }
+
+      // only fill for state vectors with proper smoothed parameters
+      if( !state.hasSmoothed()) { return true;  }
+
+      // create svtx state vector with relevant pathlength
+      const float pathlength_local = state.pathLength() / Acts::UnitConstants::cm;
+      if( pathlength_local > 20. ) return true;
+
+      // get sphenix layer from acst volume and layer
+      unsigned int sphenixlayer = 0;
+      if( ActsPropagator().checkSphenixLayer(
+        state.referenceSurface().getSharedPtr()->geometryId().volume(),
+        state.referenceSurface().getSharedPtr()->geometryId().layer(),
+        sphenixlayer ) )
+      { std::cout << "PHActsTrkFitter::updateSvtxTrack - layer: " << (int) sphenixlayer << std::endl; }
+
+      // get smoothed fitted parameters
+      nearest_params_forward = Acts::BoundTrackParameters(
+        state.referenceSurface().getSharedPtr(),
+        state.smoothed(),
+        state.smoothedCovariance(),
+        Acts::ParticleHypothesis::pion());
+      found_forward = true;
+
+      return false;
+    });
+
+    // find Acts track state closest to the TPC and create the corresponding parameter
+    ActsTrackFittingAlgorithm::TrackParameters nearest_params_backward = params;
+    bool found_backward = false;
+    mj.visitBackwards(trackTip, [&nearest_params_backward, &found_backward](const auto& state)
+    {
+      /// Only fill the track states with non-outlier measurement
+      if (!state.typeFlags().isMeasurement())
+      { return true; }
+
+      // only fill for state vectors with proper smoothed parameters
+      if( !state.hasSmoothed()) { return true;  }
+
+      // create svtx state vector with relevant pathlength
+      const float pathlength_local = state.pathLength() / Acts::UnitConstants::cm;
+      if( pathlength_local > 50 )
+      {
+        // get smoothed fitted parameters and store
+        nearest_params_backward = Acts::BoundTrackParameters(
+          state.referenceSurface().getSharedPtr(),
+          state.smoothed(),
+          state.smoothedCovariance(),
+          Acts::ParticleHypothesis::pion());
+        found_backward = true;
+
+        // get sphenix layer from acst volume and layer
+        unsigned int sphenixlayer = 0;
+        if( ActsPropagator().checkSphenixLayer(
+          state.referenceSurface().getSharedPtr()->geometryId().volume(),
+          state.referenceSurface().getSharedPtr()->geometryId().layer(),
+          sphenixlayer ) )
+        { std::cout << "PHActsTrkFitter::updateSvtxTrack - layer: " << (int) sphenixlayer << std::endl; }
+
+        return true;
+      } else {
+        // stop here
+        return false;
+      }
+
+    });
 
     // loop over cluster keys associated to TPC seed
     for (auto key_iter = seed->begin_cluster_keys(); key_iter != seed->end_cluster_keys(); ++key_iter)
@@ -1202,18 +1381,51 @@ void PHActsTrkFitter::updateSvtxTrack(
 
       // get layer, propagate
       const auto layer = TrkrDefs::getLayer(cluskey);
-      auto result = propagator.propagateTrack(params, layer);
-      if (!result.ok())
+
+      // extrapolate track parameter
+      auto extrapolate_parameters = [this, &propagator, &layer]( const ActsTrackFittingAlgorithm::TrackParameters& p, Acts::Direction direction = Acts::Direction::Positive() )
       {
-        continue;
+
+        auto result = propagator.propagateTrack(p, layer, direction);
+        if (result.ok())
+        {
+          auto& [pathLength, trackStateParams] = result.value();
+          const auto global = trackStateParams.position(m_transient_geocontext);
+          std::cout << "PHActsTrkFitter::updateSvtxTrack - extrapolated: ("
+            << global.x() / Acts::UnitConstants::cm << ", "
+            << global.y() / Acts::UnitConstants::cm << ", "
+            << global.z() / Acts::UnitConstants::cm << ")"
+            << std::endl;
+        }
+
+        return result;
+      };
+
+      {
+        auto result = extrapolate_parameters( params );
+        if( result.ok() )
+        {
+          // get path length and extrapolated parameters
+          auto& [pathLength, trackStateParams] = result.value();
+          pathLength /= Acts::UnitConstants::cm;
+          transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
+        }
       }
 
-      // get path length and extrapolated parameters
-      auto& [pathLength, trackStateParams] = result.value();
-      pathLength /= Acts::UnitConstants::cm;
+      if( found_forward )
+      {
+        // forward extrapolation
+        extrapolate_parameters( nearest_params_forward );
+      }
 
-      // create track state and add to track
-      transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
+      if( found_backward )
+      {
+        // backward extrapolation
+        extrapolate_parameters( nearest_params_backward, Acts::Direction::Negative() );
+      }
+
+      std::cout << std::endl;
+
     }
   }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -82,7 +82,7 @@ namespace
   }
 
   // find nearest parameter in trajectory before a given sPhenix layer
-  [[maybe_unused]] std::optional<Acts::BoundTrackParameters> find_nearest_params_before(
+  [[maybe_unused]] std::optional<ActsPropagator::BoundTrackParamPair> find_nearest_params_before(
     const Acts::VectorMultiTrajectory& traj,
     const size_t trackTip,
     const unsigned int layer )
@@ -119,11 +119,12 @@ namespace
     {
 
       // get smoothed fitted parameters
-      return Acts::BoundTrackParameters(
+      Acts::BoundTrackParameters p(
         s.referenceSurface().getSharedPtr(),
         s.smoothed(),
         s.smoothedCovariance(),
         Acts::ParticleHypothesis::pion());
+      return std::make_pair( s.pathLength(), p );
 
     } else {
 
@@ -133,7 +134,7 @@ namespace
   };
 
   // find nearest parameter in trajectory after a given sPhenix layer
-  [[maybe_unused]] std::optional<Acts::BoundTrackParameters> find_nearest_params_after(
+  [[maybe_unused]] std::optional<ActsPropagator::BoundTrackParamPair> find_nearest_params_after(
     const Acts::VectorMultiTrajectory& traj,
     const size_t trackTip,
     const unsigned int layer )
@@ -170,11 +171,12 @@ namespace
     {
 
       // get smoothed fitted parameters
-      return Acts::BoundTrackParameters(
+      Acts::BoundTrackParameters p(
         s.referenceSurface().getSharedPtr(),
         s.smoothed(),
         s.smoothedCovariance(),
         Acts::ParticleHypothesis::pion());
+      return std::make_pair( s.pathLength(), p );
 
     } else {
 
@@ -258,19 +260,12 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
 
   if (m_timeAnalysis)
   {
-    m_timeFile = new TFile(std::string(Name() + ".root").c_str(),
-                           "RECREATE");
-    h_eventTime = new TH1F("h_eventTime", ";time [ms]",
-                           100000, 0, 10000);
-    h_fitTime = new TH2F("h_fitTime", ";p_{T} [GeV];time [ms]",
-                         80, 0, 40, 100000, 0, 1000);
-    h_updateTime = new TH1F("h_updateTime", ";time [ms]",
-                            100000, 0, 1000);
-
-    h_rotTime = new TH1F("h_rotTime", ";time [ms]",
-                         100000, 0, 1000);
-    h_stateTime = new TH1F("h_stateTime", ";time [ms]",
-                           100000, 0, 1000);
+    m_timeFile = new TFile(std::string(Name() + ".root").c_str(), "RECREATE");
+    h_eventTime = new TH1F("h_eventTime", ";time [ms]", 100000, 0, 10000);
+    h_fitTime = new TH2F("h_fitTime", ";p_{T} [GeV];time [ms]", 80, 0, 40, 100000, 0, 1000);
+    h_updateTime = new TH1F("h_updateTime", ";time [ms]", 100000, 0, 1000);
+    h_rotTime = new TH1F("h_rotTime", ";time [ms]", 100000, 0, 1000);
+    h_stateTime = new TH1F("h_stateTime", ";time [ms]", 100000, 0, 1000);
   }
 
   if (m_actsEvaluator)
@@ -624,7 +619,9 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
         // add tpc sourcelinks to silicon source links
         sourceLinks.insert(sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end());
       }
+
       Acts::GeometryContext geoContext{m_alignmentTransformationMapTransient};
+
       // copy transient map for this track into transient geoContext
       m_transient_geocontext = geoContext;
 
@@ -1293,7 +1290,6 @@ void PHActsTrkFitter::updateSvtxTrack(
     // acts propagator
     ActsPropagator propagator(m_tGeometry);
 
-
     // loop over cluster keys associated to TPC seed
     for (auto key_iter = seed->begin_cluster_keys(); key_iter != seed->end_cluster_keys(); ++key_iter)
     {
@@ -1309,11 +1305,56 @@ void PHActsTrkFitter::updateSvtxTrack(
       // get layer, propagate
       const auto layer = TrkrDefs::getLayer(cluskey);
 
+//       if( m_extrapolation_mode == ExtrapolationMode::Default )
+//       {
+//
+//         auto result = propagator.propagateTrack(params, layer, Acts::Direction::Positive() );
+//         if( result.ok() )
+//         {
+//           // get path length and extrapolated parameters
+//           auto& [pathLength, trackStateParams] = result.value();
+//           pathLength /= Acts::UnitConstants::cm;
+//           transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
+//         }
+//
+//       } else {
+//
+//         // get before and after nearesst parameters
+//         const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
+//         const auto& nearest_params_backward = find_nearest_params_after( mj, trackTip, layer );
+//
+//         // forward extrapolation
+//         if( m_extrapolation_mode == ExtrapolationMode::Forward && nearest_params_forward )
+//         {
+//           auto result = propagator.propagateTrack(*nearest_params_forward, layer, Acts::Direction::Positive() );
+//           if( result.ok() )
+//           {
+//             // get path length and extrapolated parameters
+//             auto& [pathLength, trackStateParams] = result.value();
+//             pathLength /= Acts::UnitConstants::cm;
+//             transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
+//           }
+//         }
+//
+//         // backward extrapolation
+//         if( m_extrapolation_mode == ExtrapolationMode::Backward && nearest_params_backward )
+//         {
+//           auto result = propagator.propagateTrack(*nearest_params_backward, layer, Acts::Direction::Positive() );
+//           if( result.ok() )
+//           {
+//             // get path length and extrapolated parameters
+//             auto& [pathLength, trackStateParams] = result.value();
+//             pathLength /= Acts::UnitConstants::cm;
+//             transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
+//           }
+//         }
+//       }
+
       // extrapolate track parameter
-      auto extrapolate_parameters = [this, &propagator, &layer]( const ActsTrackFittingAlgorithm::TrackParameters& p, Acts::Direction direction = Acts::Direction::Positive() )
+      auto extrapolate_parameters = [this, &propagator, &layer]( const ActsPropagator::BoundTrackParamPair& p, Acts::Direction direction = Acts::Direction::Positive() )
       {
 
-        auto result = propagator.propagateTrack(p, layer, direction);
+        auto result = propagator.propagateTrack(p.second, layer, direction);
         if (result.ok())
         {
           auto& [pathLength, trackStateParams] = result.value();
@@ -1322,6 +1363,7 @@ void PHActsTrkFitter::updateSvtxTrack(
             << global.x() / Acts::UnitConstants::cm << ", "
             << global.y() / Acts::UnitConstants::cm << ", "
             << global.z() / Acts::UnitConstants::cm << ")"
+            << " pathlength: " << pathLength+p.first
             << std::endl;
         }
 
@@ -1329,7 +1371,7 @@ void PHActsTrkFitter::updateSvtxTrack(
       };
 
       {
-        auto result = extrapolate_parameters( params );
+        auto result = extrapolate_parameters( {0,params} );
         if( result.ok() )
         {
           // get path length and extrapolated parameters

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -126,11 +126,10 @@ namespace
         Acts::ParticleHypothesis::pion());
       return std::make_pair( s.pathLength(), p );
 
-    } else {
-
-      return std::nullopt;
-
     }
+
+    return std::nullopt;
+
   };
 
   // find nearest parameter in trajectory after a given sPhenix layer
@@ -161,9 +160,9 @@ namespace
         s = state;
         found = true;
         return true;
-      } else {
-        return false;
       }
+
+      return false;
 
     });
 
@@ -178,11 +177,9 @@ namespace
         Acts::ParticleHypothesis::pion());
       return std::make_pair( s.pathLength(), p );
 
-    } else {
-
-      return std::nullopt;
-
     }
+
+    return std::nullopt;
   };
 
 
@@ -1360,7 +1357,7 @@ void PHActsTrkFitter::updateSvtxTrack(
       // get layer, propagate
       /* this code is quite complicated. See to simplify */
       const auto layer = TrkrDefs::getLayer(cluskey);
-      auto extrapolate = [&]( ActsPropagator::BoundTrackParamPair p, uint8_t l, Acts::Direction direction )
+      auto extrapolate = [&]( const ActsPropagator::BoundTrackParamPair& p, uint8_t l, Acts::Direction direction )
       {
 
         const auto& [source_pathlength, source_param] = p;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -155,7 +155,21 @@ class PHActsTrkFitter : public SubsysReco
   void setTrkrClusterContainerName(const std::string& name) { m_clusterContainerName = name; }
   void setDirectNavigation(bool flag) { m_directNavigation = flag; }
   void setClusterEdgeRejection(int edge ) { m_cluster_edge_rejection = edge; }
- private:
+
+  /// extrapolation mode
+  enum class ExtrapolationMode
+  {
+    Default, // the default extrapolation mode, using fitter track parameters at origin
+    Forward, // uses the track state vector closest to the requested layer, before
+    Backward, // uses the track state vector closest to the requested layer, after
+    Both // uses the weighted average of forward and backward extrapolation
+  };
+
+  /// extrapolation mode
+  void setExtrapolationMode( const ExtrapolationMode value )
+  { m_extrapolation_mode = value; }
+
+  private:
   /// Get all the nodes
   int getNodes(PHCompositeNode* topNode);
 
@@ -257,7 +271,11 @@ class PHActsTrkFitter : public SubsysReco
   // name of TRKR_CLUSTER container
   std::string m_clusterContainerName = "TRKR_CLUSTER";
 
+  /// true if clusters on edge are removed from the fit
   int m_cluster_edge_rejection = 0;
+
+  /// extrapolation mode
+  ExtrapolationMode m_extrapolation_mode = ExtrapolationMode::Default;
 
   //!@name evaluator
   //@{

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -78,16 +78,16 @@ class PHActsTrkFitter : public SubsysReco
   }
 
   /// FOR ALIGNMENT STUDIES ONLY, USE AT OWN RISK. With direct navigation, force a fit with only silicon hits and a full
-  /// matched (si+tpc track seed). This requires a standard track fit to be run first, followed by refit configured with 
+  /// matched (si+tpc track seed). This requires a standard track fit to be run first, followed by refit configured with
   /// the option below. NOTE this uses the TPC track seed pT for the final pT value, to compensate for poor pt resolution
-  /// with the silicon seeds only. 
+  /// with the silicon seeds only.
   void forceSiOnlyFit(bool forceSiOnlyFit)
   {
     m_forceSiOnlyFit = forceSiOnlyFit;
   }
 
   /// FOR ALIGNMENT STUDIES ONLY, USE AT OWN RISK. With direct navigation, force a fit with only tpc hits and a full
-  /// matched (si+tpc track seed). This requires a standard track fit to be run first, followed by refit configured with 
+  /// matched (si+tpc track seed). This requires a standard track fit to be run first, followed by refit configured with
   /// the option below. NOTE this has poor pointing as the Si is not used for an initial guess of the track pointing
   void forceTpcOnlyFit(bool forceTpcOnlyFit)
   {
@@ -225,7 +225,6 @@ class PHActsTrkFitter : public SubsysReco
   /// Boolean to use normal tracking geometry navigator or the
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs = false;
-
   bool m_forceSiOnlyFit = false;
   bool m_forceTpcOnlyFit = false;
 
@@ -245,6 +244,7 @@ class PHActsTrkFitter : public SubsysReco
   /// Flag for pp running
   bool m_pp_mode = false;
 
+  /// direct navigation, in acts
   bool m_directNavigation = true;
 
   // do we have a constant field
@@ -258,6 +258,7 @@ class PHActsTrkFitter : public SubsysReco
   std::string m_clusterContainerName = "TRKR_CLUSTER";
 
   int m_cluster_edge_rejection = 0;
+
   //!@name evaluator
   //@{
   bool m_actsEvaluator = false;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -161,8 +161,7 @@ class PHActsTrkFitter : public SubsysReco
   {
     Default, // the default extrapolation mode, using fitter track parameters at origin
     Forward, // uses the track state vector closest to the requested layer, before
-    Backward, // uses the track state vector closest to the requested layer, after
-    Both // uses the weighted average of forward and backward extrapolation
+    Backward // uses the track state vector closest to the requested layer, after
   };
 
   /// extrapolation mode

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -161,7 +161,8 @@ class PHActsTrkFitter : public SubsysReco
   {
     Default, // the default extrapolation mode, using fitter track parameters at origin
     Forward, // uses the track state vector closest to the requested layer, before
-    Backward // uses the track state vector closest to the requested layer, after
+    Backward, // uses the track state vector closest to the requested layer, after
+    Bidirectional // uses the weighted average of the forward and backward extrapolation, when available
   };
 
   /// extrapolation mode

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -474,8 +474,8 @@ void PHGenFitTrkFitter::set_use_micromegas(bool value)
   m_use_micromegas = value;
 
   // disable the two micromegas layers from the fit
-  disable_layer(55, value);
-  disable_layer(56, value);
+  disable_layer(55, !value);
+  disable_layer(56, !value);
 
 }
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -468,6 +468,17 @@ void PHGenFitTrkFitter::set_fit_silicon_mms(bool value)
   }
 }
 
+//______________________________________________________
+void PHGenFitTrkFitter::set_use_micromegas(bool value)
+{
+  m_use_micromegas = value;
+
+  // disable the two micromegas layers from the fit
+  disable_layer(55, value);
+  disable_layer(56, value);
+
+}
+
 /*
  * GetNodes():
  *  Get all the all the required nodes off the node tree

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -132,10 +132,7 @@ class PHGenFitTrkFitter : public SubsysReco
   void set_fit_silicon_mms(bool);
 
   /// require micromegas in SiliconMM fits
-  void set_use_micromegas(bool value)
-  {
-    m_use_micromegas = value;
-  }
+  void set_use_micromegas(bool);
 
   void set_svtx_seed_map_name(const std::string &name) {_seedMap_name = name;}
   void set_svtx_track_map_name(const std::string &name) {_trackMap_name = name;}


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR improves acts extrapolation in the TPC for measuring distortion corrections, ultimately aligning the code to what is done in GENFIT. 
4 extrapolation modes are introduced: 
1/ default - the current setup which uses the track parameters at origin for extrapolating
2/ forward - uses the track parameters closest, before the target extrapolation layer (in the TPC case this is the last layer of the INTT)
3/ bacward - uses the track parameters closest, after the target extrapolation layer, with backward extrapolation (in the TPC case this is the first TPOT layer, if available).
4/ bidirectional - uses the weighted average of the above two. This is consistent with what is done with GENFIT. 

For now the default is still 1/ so there should be no change to the users. 
I'll make a presentation at tomorrows Tracking meeting. (July 28)
Overall performances are illustrated in the plot below:
<img width="776" height="557" alt="image" src="https://github.com/user-attachments/assets/4643d048-3bbe-416f-bf98-eb86d4e99d21" />

In addition: changed the meaning of "set_use_micromegas" in the GENFIT track fitter, to make it consistant with ACTS. 
When micromegas are not used, the corresponding clusters do not participate to the fit at all, whether present or not. 
@yuxdPKU this is redundant with a change you discussed last week and which you wanted to commit. 
Sorry if this create conflicts; I needed this for my tests. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Improve ACTS extrapolation for TPC distortion-correction measurements by adding mode options (matching GENFIT behavior more closely) while keeping the existing default behavior unchanged.

## Key changes

- Introduced four ACTS silicon-MM extrapolation modes in the TPC fitting flow:
  - **Default:** unchanged behavior using track parameters at the origin.
  - **Forward / Backward:** extrapolate using the nearest smoothed trajectory parameters before/after the target layer (with backward propagation in the backward mode).
  - **Bidirectional:** combine successful forward and backward results via a weighted average of parameters (with validation of surface/hypothesis and finite/valid covariance inputs) and consistent path-length handling.
- Updated ACTS propagation plumbing to support directional propagation and clearer layer/volume mapping:
  - `ActsPropagator::propagateTrack` now takes an `Acts::Direction`.
  - Centralized logging-level selection and refactored SPhenix↔ACTS layer/volume mapping with range-checked reverse mapping.
- Updated GENFIT Micromegas handling to exclude Micromegas from the fit when disabled:
  - Added/implemented `PHGenFitTrkFitter::set_use_micromegas(bool)` to disable the relevant Micromegas fit layers when `false`.
- Additional refactors/cleanup:
  - Minor formatting/initialization and internal construction changes (no intended logic changes) in related ACTS transformation/fitter code paths.

## Potential risk areas

- **Reconstruction behavior changes:** non-default extrapolation modes can alter fitted track states/resolutions; bidirectional mode introduces additional propagation attempts and parameter/path-length averaging.
- **Layer/volume mapping correctness:** updated ACTS↔SPhenix layer mapping and the new reverse mapping helper must be validated for all relevant geometries.
- **Performance/edge cases:** bidirectional mode performs extra propagation/averaging, which may increase runtime and fail more often in pathological configurations.
- **Thread-safety:** if extrapolation mode or Micromegas settings are modified concurrently with reconstruction, behavior may be sensitive (best validated in the actual job model).
- **No I/O format changes** are indicated by the provided changes.

## Possible future improvements

- Add targeted validation for:
  - propagation success/failure rates by mode,
  - bidirectional averaging correctness (including covariance validity paths),
  - and mapping consistency across detector regions.
- Benchmark runtime impact across modes and confirm stability on large datasets.
- Provide documentation on recommended mode selection for distortion-correction workflows.

*AI-generated summaries can contain mistakes; please use best judgment and validate against the actual code changes and physics/regression tests.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->