### PR TITLE
fix: verbosity

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1012,7 +1012,7 @@ SurfacePtrVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
   {
     const ActsSourceLink asl = sl.get<ActsSourceLink>();
     const auto* const surf = m_tGeometry->geometry().tGeometry->findSurface(asl.geometryId());
-    //   std::cout << "sl: " <<  surf->geometryId() << std::endl;
+    //std::cout << "sl: " <<  surf->geometryId() << std::endl;
     surfaces.push_back(surf);
   }
 
@@ -1055,15 +1055,19 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
     /// Implement a check to ensure surfaces are sorted
     if (nextVolume == thisVolume)
     {
+      
       //    if (nextLayer < thisLayer)
       if (nextRadius < thisRadius)
       {
+        if(Verbosity() > 0)
+        {
         std::cout
             << "PHActsTrkFitter::checkSurfaceVec - "
             << "Surface not in order... removing surface"
             << surface->geometryId() << " with radius " << thisRadius << std::endl;
             std::cout << "   approach " << nextSurface->geometryId().approach() << " volume " << nextSurface->geometryId().volume() << " layer " << nextSurface->geometryId().layer() << std::endl;
         std::cout << "    Next surface is " << nextSurface->geometryId() << " with radius " << nextRadius << std::endl;
+        }
         surfaces.erase(surfaces.begin() + i);
 
         /// Subtract one so we don't skip a surface


### PR DESCRIPTION
This print statement is wrapped into a verbosity call after the surface check was fixed last week to handle approach surfaces. This should not actually print at all but some logs show that it is because there are cases where track seeds have multiple clusters on the same layer. My understanding was that the CAseeder did not allow for that but we need to double check.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context
Reduce unexpected diagnostic output observed when track seeds contain multiple clusters on the same layer, following the prior approach-surface check fix. Further verification of CAseeder behavior is still needed.

## Key Changes
- Gate the out-of-order surface diagnostic print behind `Verbosity() > 0`.
- Preserve existing surface-removal and reconstruction logic.
- Reformat a commented-out debug statement only.

## Potential Risk Areas
- No intended reconstruction, I/O, thread-safety, or performance changes.
- Reduced diagnostics at default verbosity may make related CAseeder issues less visible.

## Possible Future Improvements
- Verify why multiple clusters can occur on the same layer.
- Add targeted tests or structured diagnostics for this condition.

AI-generated summaries can contain mistakes; use best judgment when reviewing the implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->