### PR TITLE
Fix tpctrackreco

### DIFF
--- a/offline/packages/tpctrackreco/IdealPadMap.h
+++ b/offline/packages/tpctrackreco/IdealPadMap.h
@@ -1,5 +1,7 @@
-#ifndef IDEALPADMAP_H
-#define IDEALPADMAP_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_IDEALPADMAP_H
+#define TPCTRACKRECO_IDEALPADMAP_H
 
 #include <array>
 #include <string>

--- a/offline/packages/tpctrackreco/Makefile.am
+++ b/offline/packages/tpctrackreco/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS = \
   -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include \
   -fopenmp
+
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
@@ -66,27 +67,8 @@ ROOTDICTS = \
   Tpc_PolyTrackv1_Dict.cc
 
 pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-  Tpc_AssembledTrack_Dict_rdict.pcm \
-  Tpc_AssembledTrackContainer_Dict_rdict.pcm \
-  Tpc_AssembledTrackContainerv1_Dict_rdict.pcm \
-  Tpc_AssembledTrackv1_Dict_rdict.pcm \
-  Tpc_ModuleTrack_Dict_rdict.pcm \
-  Tpc_ModuleTrackContainer_Dict_rdict.pcm \
-  Tpc_ModuleTrackContainerv1_Dict_rdict.pcm \
-  Tpc_ModuleTrackv1_Dict_rdict.pcm \
-  Tpc_PolyCluster_Dict_rdict.pcm \
-  Tpc_PolyClusterContainer_Dict_rdict.pcm \
-  Tpc_PolyClusterContainerv1_Dict_rdict.pcm \
-  Tpc_PolyClusterv1_Dict_rdict.pcm \
-  Tpc_PolyTrack_Dict_rdict.pcm \
-  Tpc_PolyTrackContainer_Dict_rdict.pcm \
-  Tpc_PolyTrackContainerv1_Dict_rdict.pcm \
-  Tpc_PolyTrackVertex_Dict_rdict.pcm \
-  Tpc_PolyTrackVertexContainer_Dict_rdict.pcm \
-  Tpc_PolyTrackVertexContainerv1_Dict_rdict.pcm \
-  Tpc_PolyTrackVertexv1_Dict_rdict.pcm \
-  Tpc_PolyTrackv1_Dict_rdict.pcm
+# more elegant way to create pcm files (without listing them)
+nobase_dist_pcm_DATA = $(ROOTDICTS:.cc=_rdict.pcm)
 
 libtpctrackreco_la_SOURCES = \
   Tpc_ModuleTrackReco.cc \
@@ -135,7 +117,7 @@ libtpctrackreco_la_LIBADD = \
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 
 #just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrack.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrack.h
@@ -24,7 +24,6 @@ class Tpc_AssembledTrack : public PHObject
   {
     os << "Tpc_AssembledTrack base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   // --- Identity ---

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrack.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrack.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCASSEMBLEDTRACK_H
+#define TPCTRACKRECO_TPCASSEMBLEDTRACK_H
 
 #include <phool/PHObject.h>
 #include <trackbase/TrkrDefs.h>
@@ -136,3 +139,4 @@ class Tpc_AssembledTrack : public PHObject
  private:
   ClassDefOverride(Tpc_AssembledTrack, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackContainer.h
@@ -19,7 +19,6 @@ class Tpc_AssembledTrackContainer : public PHObject
   {
     os << "Tpc_AssembledTrackContainer base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int size() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackContainer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCASSEMBLEDTRACKCONTAINER_H
+#define TPCTRACKRECO_TPCASSEMBLEDTRACKCONTAINER_H
 
 #include <phool/PHObject.h>
 
@@ -27,3 +30,4 @@ class Tpc_AssembledTrackContainer : public PHObject
  private:
   ClassDefOverride(Tpc_AssembledTrackContainer, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackContainerv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_AssembledTrackContainerv1.h"
 #include "Tpc_AssembledTrack.h"
 
-ClassImp(Tpc_AssembledTrackContainerv1)
 
     Tpc_AssembledTrackContainerv1::Tpc_AssembledTrackContainerv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackContainerv1.cc
@@ -1,8 +1,7 @@
 #include "Tpc_AssembledTrackContainerv1.h"
 #include "Tpc_AssembledTrack.h"
 
-
-    Tpc_AssembledTrackContainerv1::Tpc_AssembledTrackContainerv1()
+Tpc_AssembledTrackContainerv1::Tpc_AssembledTrackContainerv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackContainerv1.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackContainerv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCASSEMBLEDTRACKCONTAINERV1_H
+#define TPCTRACKRECO_TPCASSEMBLEDTRACKCONTAINERV1_H
 
 #include "Tpc_AssembledTrackContainer.h"
 
@@ -45,3 +48,4 @@ class Tpc_AssembledTrackContainerv1 : public Tpc_AssembledTrackContainer
 
   ClassDefOverride(Tpc_AssembledTrackContainerv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackReco.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackReco.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCASSEMBLEDTRACKRECO_H
+#define TPCTRACKRECO_TPCASSEMBLEDTRACKRECO_H
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
@@ -273,3 +276,4 @@ class Tpc_AssembledTrackReco : public SubsysReco
   std::vector<unsigned long long> m_tree_hit_hitsetkey;
   std::vector<unsigned long long> m_tree_hit_hitkey;
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_AssembledTrackv1.h"
 
-
-    Tpc_AssembledTrackv1::Tpc_AssembledTrackv1()
+Tpc_AssembledTrackv1::Tpc_AssembledTrackv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.cc
@@ -1,6 +1,5 @@
 #include "Tpc_AssembledTrackv1.h"
 
-ClassImp(Tpc_AssembledTrackv1)
 
     Tpc_AssembledTrackv1::Tpc_AssembledTrackv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.h
@@ -210,6 +210,6 @@ class Tpc_AssembledTrackv1 : public Tpc_AssembledTrack
   std::vector<unsigned int> m_source_sectors;
   std::vector<HitIndex> m_hit_indices;
 
-  ClassDefOverride(Tpc_AssembledTrackv1, 2)
+  ClassDefOverride(Tpc_AssembledTrackv1, 1)
 };
 #endif

--- a/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.h
+++ b/offline/packages/tpctrackreco/Tpc_AssembledTrackv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCASSEMBLEDTRACKV1_H
+#define TPCTRACKRECO_TPCASSEMBLEDTRACKV1_H
 
 #include "Tpc_AssembledTrack.h"
 
@@ -209,3 +212,4 @@ class Tpc_AssembledTrackv1 : public Tpc_AssembledTrack
 
   ClassDefOverride(Tpc_AssembledTrackv1, 2)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_FittingTools.h
+++ b/offline/packages/tpctrackreco/Tpc_FittingTools.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCFITTINGTOOLS_H
+#define TPCTRACKRECO_TPCFITTINGTOOLS_H
 
 #include <vector>
 
@@ -104,3 +107,4 @@ class Tpc_FittingTools
   static bool fit(const std::vector<Point>& points, FitResult& fit);
   static bool fitLine3D(const std::vector<Point>& points, FitResult& fit);
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrack.h
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrack.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCMODULETRACK_H
+#define TPCTRACKRECO_TPCMODULETRACK_H
 
 #include <trackbase/TrkrDefs.h>
 
@@ -22,7 +25,6 @@ class Tpc_ModuleTrack : public PHObject
   {
     os << "Tpc_ModuleTrack base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   // --- Identity ---
@@ -73,5 +75,6 @@ class Tpc_ModuleTrack : public PHObject
   }
 
  private:
-  ClassDefOverride(Tpc_ModuleTrack, 1)
+  ClassDefOverride(Tpc_ModuleTrack, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackContainer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCMODULETRACKCONTAINER_H
+#define TPCTRACKRECO_TPCMODULETRACKCONTAINER_H
 
 #include <phool/PHObject.h>
 
@@ -31,3 +34,4 @@ class Tpc_ModuleTrackContainer : public PHObject
  private:
   ClassDefOverride(Tpc_ModuleTrackContainer, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackContainer.h
@@ -21,7 +21,6 @@ class Tpc_ModuleTrackContainer : public PHObject
   {
     os << "Tpc_ModuleTrackContainer base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int size() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackContainerv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_ModuleTrackContainerv1.h"
 #include "Tpc_ModuleTrack.h"
 
-ClassImp(Tpc_ModuleTrackContainerv1)
 
     Tpc_ModuleTrackContainerv1::Tpc_ModuleTrackContainerv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackContainerv1.cc
@@ -1,8 +1,7 @@
 #include "Tpc_ModuleTrackContainerv1.h"
 #include "Tpc_ModuleTrack.h"
 
-
-    Tpc_ModuleTrackContainerv1::Tpc_ModuleTrackContainerv1()
+Tpc_ModuleTrackContainerv1::Tpc_ModuleTrackContainerv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackContainerv1.h
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackContainerv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCMODULETRACKCONTAINERV1_H
+#define TPCTRACKRECO_TPCMODULETRACKCONTAINERV1_H
 
 #include "Tpc_ModuleTrackContainer.h"
 
@@ -46,3 +49,4 @@ class Tpc_ModuleTrackContainerv1 : public Tpc_ModuleTrackContainer
 
   ClassDefOverride(Tpc_ModuleTrackContainerv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackReco.h
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackReco.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCMODULETRACKRECO_H
+#define TPCTRACKRECO_TPCMODULETRACKRECO_H
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
@@ -268,3 +271,4 @@ class Tpc_ModuleTrackReco : public SubsysReco
   std::vector<unsigned long long> m_tree_hit_hitsetkey;
   std::vector<unsigned long long> m_tree_hit_hitkey;
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_ModuleTrackv1.h"
 
-
-    Tpc_ModuleTrackv1::Tpc_ModuleTrackv1()
+Tpc_ModuleTrackv1::Tpc_ModuleTrackv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackv1.cc
@@ -1,6 +1,5 @@
 #include "Tpc_ModuleTrackv1.h"
 
-ClassImp(Tpc_ModuleTrackv1)
 
     Tpc_ModuleTrackv1::Tpc_ModuleTrackv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackv1.h
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCMODULETRACKV1_H
+#define TPCTRACKRECO_TPCMODULETRACKV1_H
 
 #include "Tpc_ModuleTrack.h"
 
@@ -86,3 +89,4 @@ class Tpc_ModuleTrackv1 : public Tpc_ModuleTrack
 
   ClassDefOverride(Tpc_ModuleTrackv1, 3)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyCluster.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyCluster.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYCLUSTER_H
+#define TPCTRACKRECO_TPCPOLYCLUSTER_H
 
 #include <phool/PHObject.h>
 #include <trackbase/TrkrDefs.h>
@@ -70,3 +73,4 @@ class Tpc_PolyCluster : public PHObject
  private:
   ClassDefOverride(Tpc_PolyCluster, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyCluster.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyCluster.h
@@ -20,7 +20,6 @@ class Tpc_PolyCluster : public PHObject
   {
     os << "Tpc_PolyCluster base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   using HitIndex = std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>;

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterContainer.h
@@ -19,7 +19,6 @@ class Tpc_PolyClusterContainer : public PHObject
   {
     os << "Tpc_PolyClusterContainer base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int size() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterContainer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYCLUSTERCONTAINER_H
+#define TPCTRACKRECO_TPCPOLYCLUSTERCONTAINER_H
 
 #include <phool/PHObject.h>
 
@@ -27,3 +30,4 @@ class Tpc_PolyClusterContainer : public PHObject
  private:
   ClassDefOverride(Tpc_PolyClusterContainer, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterContainerv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_PolyClusterContainerv1.h"
 #include "Tpc_PolyCluster.h"
 
-ClassImp(Tpc_PolyClusterContainerv1)
 
     Tpc_PolyClusterContainerv1::Tpc_PolyClusterContainerv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterContainerv1.cc
@@ -1,8 +1,7 @@
 #include "Tpc_PolyClusterContainerv1.h"
 #include "Tpc_PolyCluster.h"
 
-
-    Tpc_PolyClusterContainerv1::Tpc_PolyClusterContainerv1()
+Tpc_PolyClusterContainerv1::Tpc_PolyClusterContainerv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterContainerv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterContainerv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYCLUSTERCONTAINERV1_H
+#define TPCTRACKRECO_TPCPOLYCLUSTERCONTAINERV1_H
 
 #include "Tpc_PolyClusterContainer.h"
 
@@ -36,3 +39,4 @@ class Tpc_PolyClusterContainerv1 : public Tpc_PolyClusterContainer
 
   ClassDefOverride(Tpc_PolyClusterContainerv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYCLUSTERIZER_H
+#define TPCTRACKRECO_TPCPOLYCLUSTERIZER_H
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
@@ -127,3 +130,4 @@ class Tpc_PolyClusterizer : public SubsysReco
   std::array<double, 3> m_tpcMove{{0.0, 0.0, 0.0}};                                             //{{-0.16775, -0.0337, -0.71365}};
   std::array<std::array<double, 3>, 2> m_tpcRotations{{{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}}};  //{{{{0.0, 0.01485 / 10.0, 0.0}}, {{0.0298 / 8.0, 0.0, 0.0}}}};
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterv1.cc
@@ -2,7 +2,6 @@
 
 #include <cmath>
 
-ClassImp(Tpc_PolyClusterv1)
 
     Tpc_PolyClusterv1::Tpc_PolyClusterv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterv1.cc
@@ -2,8 +2,7 @@
 
 #include <cmath>
 
-
-    Tpc_PolyClusterv1::Tpc_PolyClusterv1()
+Tpc_PolyClusterv1::Tpc_PolyClusterv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYCLUSTERV1_H
+#define TPCTRACKRECO_TPCPOLYCLUSTERV1_H
 
 #include "Tpc_PolyCluster.h"
 
@@ -92,3 +95,4 @@ class Tpc_PolyClusterv1 : public Tpc_PolyCluster
 
   ClassDefOverride(Tpc_PolyClusterv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrack.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrack.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACK_H
+#define TPCTRACKRECO_TPCPOLYTRACK_H
 
 #include <phool/PHObject.h>
 
@@ -54,3 +57,4 @@ class Tpc_PolyTrack : public PHObject
  private:
   ClassDefOverride(Tpc_PolyTrack, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrack.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrack.h
@@ -17,7 +17,6 @@ class Tpc_PolyTrack : public PHObject
   {
     os << "Tpc_PolyTrack base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int get_event() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackContainer.h
@@ -19,7 +19,6 @@ class Tpc_PolyTrackContainer : public PHObject
   {
     os << "Tpc_PolyTrackContainer base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int size() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackContainer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKCONTAINER_H
+#define TPCTRACKRECO_TPCPOLYTRACKCONTAINER_H
 
 #include <phool/PHObject.h>
 
@@ -27,3 +30,4 @@ class Tpc_PolyTrackContainer : public PHObject
  private:
   ClassDefOverride(Tpc_PolyTrackContainer, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackContainerv1.cc
@@ -1,8 +1,7 @@
 #include "Tpc_PolyTrackContainerv1.h"
 #include "Tpc_PolyTrack.h"
 
-
-    Tpc_PolyTrackContainerv1::Tpc_PolyTrackContainerv1()
+Tpc_PolyTrackContainerv1::Tpc_PolyTrackContainerv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackContainerv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_PolyTrackContainerv1.h"
 #include "Tpc_PolyTrack.h"
 
-ClassImp(Tpc_PolyTrackContainerv1)
 
     Tpc_PolyTrackContainerv1::Tpc_PolyTrackContainerv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackContainerv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackContainerv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKCONTAINERV1_H
+#define TPCTRACKRECO_TPCPOLYTRACKCONTAINERV1_H
 
 #include "Tpc_PolyTrackContainer.h"
 
@@ -36,3 +39,4 @@ class Tpc_PolyTrackContainerv1 : public Tpc_PolyTrackContainer
 
   ClassDefOverride(Tpc_PolyTrackContainerv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackReco.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackReco.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKRECO_H
+#define TPCTRACKRECO_TPCPOLYTRACKRECO_H
 
 #include "Tpc_FittingTools.h"
 
@@ -54,3 +57,4 @@ class Tpc_PolyTrackReco : public SubsysReco
   double m_magneticFieldTesla{1.4};
   FitMode m_fitMode{FitMode::Helix};
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertex.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertex.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKVERTEX_H
+#define TPCTRACKRECO_TPCPOLYTRACKVERTEX_H
 
 #include <phool/PHObject.h>
 
@@ -42,3 +45,4 @@ class Tpc_PolyTrackVertex : public PHObject
  private:
   ClassDefOverride(Tpc_PolyTrackVertex, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertex.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertex.h
@@ -17,7 +17,6 @@ class Tpc_PolyTrackVertex : public PHObject
   {
     os << "Tpc_PolyTrackVertex base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int get_track_id() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainer.h
@@ -19,7 +19,6 @@ class Tpc_PolyTrackVertexContainer : public PHObject
   {
     os << "Tpc_PolyTrackVertexContainer base class" << std::endl;
   }
-  void Reset() override {}
   int isValid() const override { return 0; }
 
   virtual unsigned int size() const { return 0; }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKVERTEXCONTAINER_H
+#define TPCTRACKRECO_TPCPOLYTRACKVERTEXCONTAINER_H
 
 #include <phool/PHObject.h>
 
@@ -41,3 +44,4 @@ class Tpc_PolyTrackVertexContainer : public PHObject
  private:
   ClassDefOverride(Tpc_PolyTrackVertexContainer, 0)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainerv1.cc
@@ -1,8 +1,7 @@
 #include "Tpc_PolyTrackVertexContainerv1.h"
 #include "Tpc_PolyTrackVertex.h"
 
-
-    Tpc_PolyTrackVertexContainerv1::Tpc_PolyTrackVertexContainerv1()
+Tpc_PolyTrackVertexContainerv1::Tpc_PolyTrackVertexContainerv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainerv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainerv1.cc
@@ -1,7 +1,6 @@
 #include "Tpc_PolyTrackVertexContainerv1.h"
 #include "Tpc_PolyTrackVertex.h"
 
-ClassImp(Tpc_PolyTrackVertexContainerv1)
 
     Tpc_PolyTrackVertexContainerv1::Tpc_PolyTrackVertexContainerv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainerv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexContainerv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKVERTEXCONTAINERV1_H
+#define TPCTRACKRECO_TPCPOLYTRACKVERTEXCONTAINERV1_H
 
 #include "Tpc_PolyTrackVertexContainer.h"
 
@@ -49,3 +52,4 @@ class Tpc_PolyTrackVertexContainerv1 : public Tpc_PolyTrackVertexContainer
 
   ClassDefOverride(Tpc_PolyTrackVertexContainerv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKVERTEXER_H
+#define TPCTRACKRECO_TPCPOLYTRACKVERTEXER_H
 
 #include <fun4all/SubsysReco.h>
 
@@ -65,3 +68,4 @@ class Tpc_PolyTrackVertexer : public SubsysReco
   double m_collisionZSeparation{10.0};
   double m_magneticFieldTesla{1.4};
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexv1.cc
@@ -2,7 +2,6 @@
 
 #include <cmath>
 
-ClassImp(Tpc_PolyTrackVertexv1)
 
     Tpc_PolyTrackVertexv1::Tpc_PolyTrackVertexv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexv1.cc
@@ -2,8 +2,7 @@
 
 #include <cmath>
 
-
-    Tpc_PolyTrackVertexv1::Tpc_PolyTrackVertexv1()
+Tpc_PolyTrackVertexv1::Tpc_PolyTrackVertexv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackVertexv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackVertexv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKVERTEXV1_H
+#define TPCTRACKRECO_TPCPOLYTRACKVERTEXV1_H
 
 #include "Tpc_PolyTrackVertex.h"
 
@@ -51,3 +54,4 @@ class Tpc_PolyTrackVertexv1 : public Tpc_PolyTrackVertex
 
   ClassDefOverride(Tpc_PolyTrackVertexv1, 1)
 };
+#endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackv1.cc
@@ -3,8 +3,7 @@
 #include <cmath>
 #include <limits>
 
-
-    Tpc_PolyTrackv1::Tpc_PolyTrackv1()
+Tpc_PolyTrackv1::Tpc_PolyTrackv1()
 {
   Reset();
 }

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackv1.cc
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <limits>
 
-ClassImp(Tpc_PolyTrackv1)
 
     Tpc_PolyTrackv1::Tpc_PolyTrackv1()
 {

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackv1.h
@@ -82,6 +82,6 @@ class Tpc_PolyTrackv1 : public Tpc_PolyTrack
   double m_dedx{0.0};
   std::vector<double> m_cov;
 
-  ClassDefOverride(Tpc_PolyTrackv1, 2)
+  ClassDefOverride(Tpc_PolyTrackv1, 1)
 };
 #endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackv1.h
@@ -1,4 +1,7 @@
-#pragma once
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef TPCTRACKRECO_TPCPOLYTRACKV1_H
+#define TPCTRACKRECO_TPCPOLYTRACKV1_H
 
 #include "Tpc_PolyTrack.h"
 
@@ -81,3 +84,4 @@ class Tpc_PolyTrackv1 : public Tpc_PolyTrack
 
   ClassDefOverride(Tpc_PolyTrackv1, 2)
 };
+#endif

--- a/offline/packages/tpctrackreco/configure.ac
+++ b/offline/packages/tpctrackreco/configure.ac
@@ -20,6 +20,8 @@ if test $ac_cv_prog_gxx = yes; then
      CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wshadow -Werror"
 fi
 
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -44,7 +44,7 @@ struct ActsAborter
 
     /// Check that we are in the proper layer and that we've also reached
     /// a sensitive surface
-    if (layerno == abortlayer and volumeno == abortvolume and sensitive != 0)
+    if (layerno == abortlayer && volumeno == abortvolume && sensitive != 0)
     { return true; }
 
     return false;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
CINT was missing parameters which lead to include files not being found. While at it - remove empty Reset() method in virtual base classes - this can suppress warnings which point out we have a severe problem (look at the recent centrality issue). Replace #pragma once by standard include guards. #pragma once has caused problems in the past - not sure if this is still an issue but until this is proven to work (with cling and the root prompt) in all cases - let's leave it as standard include guards. Remove obsolete ClassImps (they were needed to generate the ancient root html documentation about 15 years ago). It's a new package - let's start the classdef versions at 1 (for the virtual base class it should be zero - no streamer)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context
Fix `tpctrackreco` ROOT dictionary generation by ensuring the CINT/Cling invocation gets the missing include-handling parameters, while also modernizing/cleaning up ROOT metadata and header conventions. (AI-generated change summaries can contain mistakes—use best judgment when reviewing.)

## Key changes
- Build/dictionary generation
  - Added `CINTDEFS` in `offline/packages/tpctrackreco/configure.ac` and substituted it into the `rootcint` command via `offline/packages/tpctrackreco/Makefile.am` (including `-noIncludePaths` and `-inlineInputHeader`) to improve header/include resolution during dictionary generation.
- ROOT class metadata / dictionary hygiene
  - Removed obsolete `ClassImp(...)` declarations from multiple `*v1.cc` files.
  - Updated `ClassDefOverride(..., version)` values across the affected track/cluster classes (setting non-streamed virtual-base classes to version `0`, and adjusting streamed classes’ versions as needed).
- Header and interface cleanup
  - Replaced `#pragma once` with conventional include guards across the `tpctrackreco` headers.
  - Removed empty `Reset() override {}` stubs from virtual/base-like classes so `identify(...)` flows directly to the next relevant interface method.

- Related small fix
  - `offline/packages/trackreco/ActsPropagator.cc`: replaced `and` with `&&` in the abort condition logic.

## Potential risk areas
- ROOT dictionary generation and serialization/IO compatibility (changes to dictionary build inputs and ROOT class versioning can require validation with existing schemas/data).
- Behavioral/API impact from removing previously empty `Reset()` overrides (even if trivial, this can affect callers via the type hierarchy).
- Build-system and ROOT codegen correctness (the `CINTDEFS` wiring affects dictionary generation only, but should be checked in CI or a dictionary build).
- Reconstruction behavior should be unchanged for `tpctrackreco`, but the small `ActsPropagator.cc` operator-token change should still be covered by existing tests.

## Possible future improvements
- Add automated checks that dictionary generation succeeds and that ROOT schema compatibility holds across class-version changes.
- Add lightweight regression tests covering the reconstruction paths that consume these track/cluster objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->