### PR TITLE
Handle TPC survey geometry properly in reconstruction

### DIFF
--- a/offline/QA/Tracking/TpcSeedsQA.cc
+++ b/offline/QA/Tracking/TpcSeedsQA.cc
@@ -73,7 +73,7 @@ int TpcSeedsQA::InitRun(PHCompositeNode *topNode)
   // global position wrapper
   m_globalPositionWrapper.loadNodes(topNode);
 
-  m_clusterMover.initialize_geometry(g4geom, actsgeom);
+  m_clusterMover.initialize_geometry(g4geom, actsgeom, topNode);
   m_clusterMover.set_verbosity(0);
 
   auto *hm = QAHistManagerDef::getHistoManager();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1035,17 +1035,11 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
 
 void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* track,
                                            const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global,
+					   const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_moved,
                                            PHCompositeNode* topNode)
 {
   auto *clustermap = findNode::getClass<TrkrClusterContainer>(topNode, m_clusterContainerName);
   auto *geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-
-  auto global_moved = global;  // if use transient transforms for distortion correction
-  if (m_use_clustermover)
-  {
-    // move the corrected cluster positions back to the original readout surface
-    global_moved = m_clusterMover.processTrack(global);
-  }
 
   ActsTransformations transformer;
   TrkrCluster* cluster = clustermap->findCluster(ckey);
@@ -1056,6 +1050,8 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   {
     auto thiskey = pair.first;
     clusglob = pair.second;
+    // unsigned int layer = TrkrDefs::getLayer(thiskey);
+    // std::cout << "global: " << layer << " ckey " << ckey << std::endl; 
     if (thiskey == ckey)
     {
       break;
@@ -1067,6 +1063,8 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   {
     auto thiskey = pair.first;
     clusglob_moved = pair.second;
+    //  unsigned int layer = TrkrDefs::getLayer(thiskey);
+    // std::cout << "global moved: " << layer << " ckey " << ckey << std::endl; 
     if (thiskey == ckey)
     {
       break;
@@ -1413,9 +1411,10 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
 
 void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey,  // SvtxTrack* track,
                                               const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global,
+					      const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_moved,
                                               PHCompositeNode* topNode)
 {
-  // The input map global contains the corrected cluster positions - NOT moved back to the surfacer.
+  // The input map global contains the corrected cluster positions - NOT moved back to the surface.
   // When filling the residualtree:
   //    clusgx etc are the corrected - but not moved back to the surface - cluster positions
   //    clugxideal etc are the completely uncorrected cluster positions - they do not even have crossing corrections
@@ -1424,13 +1423,6 @@ void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey,  // SvtxTr
 
   auto *clustermap = findNode::getClass<TrkrClusterContainer>(topNode, m_clusterContainerName);
   auto *geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-
-  auto global_moved = global;
-  if (m_use_clustermover)
-  {
-    // move the corrected cluster positions back to the original readout surface
-    global_moved = m_clusterMover.processTrack(global);
-  }
 
   TrkrCluster* cluster = clustermap->findCluster(ckey);
 
@@ -2248,13 +2240,14 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
       global_raw.emplace_back(ckey, global);
     }
 
-    // move the cluster positions back to the original readout surface in the fillClusterBranchesKF method
+    // Call clusterMover for the entire track
+    auto global_moved = m_clusterMover.processTrack(global_raw);
 
     if (!m_doAlignment)
     {
       for (const auto& ckey : get_cluster_keys(track))
       {
-        fillClusterBranchesKF(ckey, track, global_raw, topNode);
+	fillClusterBranchesKF(ckey, track, global_raw, global_moved, topNode);
       }
     }
 
@@ -2273,7 +2266,7 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
         {
           auto ckey = state->get_cluster_key();
 
-          fillClusterBranchesKF(ckey, track, global_raw, topNode);
+	  fillClusterBranchesKF(ckey, track, global_raw, global_moved, topNode);
 
           const auto& globderivs = state->get_global_derivative_matrix();
           const auto& locderivs = state->get_local_derivative_matrix();
@@ -2630,8 +2623,10 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
       maxR = std::max<double>(r(global.x(), global.y()), maxR);
     }
     m_tracklength = maxR - minR;
-    // ---- we move the global positions back to the surface in fillClusterBranchesSeeds
 
+    // Call clusterMover for the entire track
+    auto global_moved = m_clusterMover.processTrack(global_raw);
+    
     if (!m_doAlignment)
     {
       std::vector<TrkrDefs::cluskey> keys;
@@ -2648,11 +2643,11 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
         // this corrects the cluster positions and fits them, to fill the helical fit parameters
         //  that are used to calculate the "state" positions
         circleFitClusters(keys, clustermap, m_crossing);
-      }
+      }        
 
       for (const auto& ckey : get_cluster_keys(track))
       {
-        fillClusterBranchesSeeds(ckey, global_raw, topNode);
+	fillClusterBranchesSeeds(ckey, global_raw, global_moved, topNode);
       }
     }
 
@@ -2671,7 +2666,7 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
         {
           auto ckey = state->get_cluster_key();
 
-          fillClusterBranchesSeeds(ckey, global_raw, topNode);
+	  fillClusterBranchesSeeds(ckey, global_raw, global_moved, topNode);
 
           const auto& globderivs = state->get_global_derivative_matrix();
           const auto& locderivs = state->get_local_derivative_matrix();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -120,7 +120,7 @@ int TrackResiduals::InitRun(PHCompositeNode* topNode)
   auto *tpccellgeo = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
 
   auto *geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-  m_clusterMover.initialize_geometry(tpccellgeo, geometry);
+  m_clusterMover.initialize_geometry(tpccellgeo, geometry, topNode);
   m_clusterMover.set_verbosity(0);
 
   auto *se = Fun4AllServer::instance();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -79,10 +79,12 @@ class TrackResiduals : public SubsysReco
   void fillResidualTreeKF(PHCompositeNode *topNode);
   void fillResidualTreeSeeds(PHCompositeNode *topNode);
   void fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack *track,
-                             const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> &global_moved,
+                             const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> &global,
+			     const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_moved,
                              PHCompositeNode *topNode);
   void fillClusterBranchesSeeds(TrkrDefs::cluskey ckey,  // SvtxTrack* track,
                                 const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> &global,
+				const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_moved,
                                 PHCompositeNode *topNode);
   void lineFitClusters(std::vector<TrkrDefs::cluskey> &keys, TrkrClusterContainer *clusters, const short int &crossing);
   void circleFitClusters(std::vector<TrkrDefs::cluskey> &keys, TrkrClusterContainer *clusters, const short int &crossing);

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -8,9 +8,21 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <trackbase/TrackFitUtils.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrCluster.h>
 
 #include <g4detectors/PHG4TpcGeom.h>
 #include <g4detectors/PHG4TpcGeomContainer.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
 #include <climits>
 #include <cmath>
 #include <iostream>
@@ -45,8 +57,10 @@ TpcClusterMover::TpcClusterMover()
   }
 }
 
-void TpcClusterMover::initialize_geometry(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry)
+void TpcClusterMover::initialize_geometry(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry, PHCompositeNode* topNode)
 {
+  _topNode = topNode;
+  
   if (_verbosity > 0)
   {
     std::cout << "TpcClusterMover: Getting ActsGeometry, and getting layer radii for Tpc from cell geometry object" << std::endl;
@@ -76,7 +90,9 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
 {
   // Get the global positions of the TPC clusters for this track, already corrected for distortions, and move them to the surfaces
   // The input object contains all clusters for the track in world coordinates
-  // The surface radii are in envelope coordinates, we transform the positions to envelope coordinates
+  // The surface radii are in global coordinates. Needed bexcause we are dealing with aligned surfaces
+
+  auto *cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
   
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_moved;
 
@@ -89,8 +105,7 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     if (trkrid == TrkrDefs::tpcId)
     {
       tpc_cluskey_vec.push_back(ckey);
-      Acts::Vector3 env_global = _tGeometry->transformTpcWorldToEnvelope(global);
-      tpc_global_vec.push_back(env_global);
+      tpc_global_vec.push_back(global);
     }
     else
     {
@@ -122,13 +137,20 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     unsigned int layer = TrkrDefs::getLayer(cluskey);
     Acts::Vector3 global = tpc_global_vec[i];
 
+    // get target surface radius in global coordinates
+    TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
+    auto cluster = cluster_map->findCluster(cluskey);
+    auto surfMaps = _tGeometry->maps();
+    auto surface = surfMaps.getSurface(cluskey, cluster);
+    auto surfcent = surface->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // the aligned geometry
+    
+    double target_radius = sqrt(surfcent[0]*surfcent[0]+surfcent[1]*surfcent[1]);	    
     // get circle position at target surface radius
-    double target_radius = layer_radius[layer - 7];
     int ret = get_circle_circle_intersection(target_radius, R, X0, Y0, global[0], global[1], _x_proj, _y_proj);
     if (ret == Fun4AllReturnCodes::ABORTEVENT)
-    {
-      continue;  // skip to next cluster
-    }
+      {
+	continue;  // skip to next cluster
+      }
     // z projection is unique
     _z_proj = B + A * target_radius;
 
@@ -150,19 +172,25 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     // now move the cluster to the surface radius
     // we keep the cluster key fixed, change the surface if necessary
 
-    Acts::Vector3 env_global_new(xnew, ynew, znew);
-    // now we transform back to global coordinates and add the new position and surface to the return object
-    Acts::Vector3 global_new = _tGeometry->transformTpcEnvelopeToWorld(env_global_new);
-    global_moved.emplace_back(cluskey, global_new);
+    Acts::Vector3 global_new(xnew, ynew, znew);
 
-    if (_verbosity > 2)
-    {
-      std::cout << "Cluster " << cluskey << " xstart " << _x_start << " xproj " << _x_proj << " ystart " << _y_start << " yproj " << _y_proj
-                << " zstart " << _z_start << " zproj " << _z_proj << std::endl;
-      std::cout << " layer " << layer << " layer radius " << target_radius << " cluster radius " << cluster_radius << std::endl;
-      std::cout << "  global in " << global[0] << "  " << global[1] << "  " << global[2] << std::endl;
-      std::cout << "  global new " << global_new[0] << "  " << global_new[1] << "  " << global_new[2] << std::endl;
-    }
+    // Check if the subsurface changed
+    TrkrDefs::subsurfkey new_subsurfkey = 0;
+    auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
+    
+    if(_verbosity > 2 && layer == 28)
+      {
+	unsigned int sskey = cluster->getSubSurfKey();
+	double new_radius = sqrt(xnew*xnew+ynew*ynew);
+	std::cout << "   layer " << layer << " clusterkey " << cluskey << " hitsetkey " << hkey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
+	std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2]  << " clus_radius " << cluster_radius <<  " target radius " << target_radius << std::endl;
+	std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2]  << " global_new radius " << new_radius << std::endl;
+	std::cout << "        xstart " << _x_start << " xproj " << _x_proj << " ystart " << _y_start << " yproj " << _y_proj << " zstart " << _z_start << " zproj " << _z_proj << std::endl;
+	std::cout << "        phi_in      " << atan2(global[1], global[0]) << " phi_moved " << atan2(global_new[1], global_new[0]) << std::endl;
+      }
+    
+    // now we add the new position and surface to the return object
+    global_moved.emplace_back(cluskey, global_new); 
   }
 
   return global_moved;

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -90,10 +90,11 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
 {
   // Get the global positions of the TPC clusters for this track, already corrected for distortions, and move them to the surfaces
   // The input object contains all clusters for the track in world coordinates
-  // The surface radii are in global coordinates. Needed bexcause we are dealing with aligned surfaces
+  // The surface radii are in global coordinates. Needed because we are dealing with aligned surfaces
 
   auto *cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
-  
+  auto surfMaps = _tGeometry->maps();
+    
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_moved;
 
   std::vector<Acts::Vector3> tpc_global_vec;
@@ -134,13 +135,10 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   for (unsigned int i = 0; i < tpc_global_vec.size(); ++i)
   {
     TrkrDefs::cluskey cluskey = tpc_cluskey_vec[i];
-    unsigned int layer = TrkrDefs::getLayer(cluskey);
     Acts::Vector3 global = tpc_global_vec[i];
 
     // get target surface radius in global coordinates
-    TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
     auto cluster = cluster_map->findCluster(cluskey);
-    auto surfMaps = _tGeometry->maps();
     auto surface = surfMaps.getSurface(cluskey, cluster);
     auto surfcent = surface->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // the aligned geometry
     
@@ -170,23 +168,28 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     double znew = global[2] - (_z_start - _z_proj);
 
     // now move the cluster to the surface radius
-    // we keep the cluster key fixed, change the surface if necessary
+    // we keep the cluster key fixed, change the surface later if necessary
 
     Acts::Vector3 global_new(xnew, ynew, znew);
 
-    // Check if the subsurface changed
-    TrkrDefs::subsurfkey new_subsurfkey = 0;
-    auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
-    
-    if(_verbosity > 2 && layer == 28)
+    if(_verbosity > 2)
       {
-	unsigned int sskey = cluster->getSubSurfKey();
-	double new_radius = sqrt(xnew*xnew+ynew*ynew);
-	std::cout << "   layer " << layer << " clusterkey " << cluskey << " hitsetkey " << hkey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
-	std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2]  << " clus_radius " << cluster_radius <<  " target radius " << target_radius << std::endl;
-	std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2]  << " global_new radius " << new_radius << std::endl;
-	std::cout << "        xstart " << _x_start << " xproj " << _x_proj << " ystart " << _y_start << " yproj " << _y_proj << " zstart " << _z_start << " zproj " << _z_proj << std::endl;
-	std::cout << "        phi_in      " << atan2(global[1], global[0]) << " phi_moved " << atan2(global_new[1], global_new[0]) << std::endl;
+	unsigned int layer = TrkrDefs::getLayer(cluskey);
+	if(layer == 28)
+	  {
+	    unsigned int sskey = cluster->getSubSurfKey();
+	    double new_radius = sqrt(xnew*xnew+ynew*ynew);
+	    // Check if the subsurface changed
+	    TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
+	    TrkrDefs::subsurfkey new_subsurfkey = 0;
+	    auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
+	    
+	    std::cout << "   layer " << layer << " clusterkey " << cluskey << " hitsetkey " << hkey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
+	    std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2]  << " clus_radius " << cluster_radius <<  " target radius " << target_radius << std::endl;
+	    std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2]  << " global_new radius " << new_radius << std::endl;
+	    std::cout << "        xstart " << _x_start << " xproj " << _x_proj << " ystart " << _y_start << " yproj " << _y_proj << " zstart " << _z_start << " zproj " << _z_proj << std::endl;
+	    std::cout << "        phi_in      " << atan2(global[1], global[0]) << " phi_moved " << atan2(global_new[1], global_new[0]) << std::endl;
+	  }
       }
     
     // now we add the new position and surface to the return object

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -93,6 +93,12 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   // The surface radii are in global coordinates. Needed because we are dealing with aligned surfaces
 
   auto *cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
+  if(!cluster_map)
+    {
+      std::cout << PHWHERE << " Did not find TRKR_CLUSTER node, quit." << std::endl;
+	exit(1);
+    }
+
   auto surfMaps = _tGeometry->maps();
     
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_moved;
@@ -138,8 +144,10 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     Acts::Vector3 global = tpc_global_vec[i];
 
     // get target surface radius in global coordinates
-    auto cluster = cluster_map->findCluster(cluskey);
+    auto *cluster = cluster_map->findCluster(cluskey);
+    if(!cluster) { continue; }
     auto surface = surfMaps.getSurface(cluskey, cluster);
+    if(!surface) { continue; }
     auto surfcent = surface->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // the aligned geometry
     
     double target_radius = sqrt(surfcent[0]*surfcent[0]+surfcent[1]*surfcent[1]);	    

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 class PHG4TpcGeomContainer;
-
+class PHCompositeNode;
 class TpcClusterMover
 {
  public:
@@ -24,7 +24,7 @@ class TpcClusterMover
 
   //! Updates the assumed default geometry below to that contained in the
   //! cell geo
-  void initialize_geometry(PHG4TpcGeomContainer *cellgeo, ActsGeometry *tGeometry);
+  void initialize_geometry(PHG4TpcGeomContainer *cellgeo, ActsGeometry *tGeometry, PHCompositeNode *topNode);
 
  private:
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y) const;
@@ -49,7 +49,9 @@ class TpcClusterMover
 
   int _verbosity = 0;
 
- ActsGeometry *_tGeometry  = nullptr;
+  ActsGeometry *_tGeometry  = nullptr;
+  PHCompositeNode* _topNode = nullptr;
+  
 };
 
 #endif

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -876,16 +876,15 @@ namespace
     {
       env_clusz = -env_clusz;
     }
+
     const double phi_cov = (iphi2_sum / adc_sum - square(clusiphi)) * pow(my_data.layergeom->get_phistep(), 2);
     const double t_cov = t2_sum / adc_sum - square(clust);
 
-    // get_tpc_surface_from_coords expects a world global position
-    Acts::Vector3 env_global(env_clusx, env_clusy, env_clusz);
-    Acts::Vector3 global = my_data.tGeometry->transformTpcEnvelopeToWorld(env_global);
+    Acts::Vector3 env_pos(env_clusx, env_clusy, env_clusz);
     TrkrDefs::subsurfkey subsurfkey = 0;
-    Surface surface = my_data.tGeometry->get_tpc_surface_from_coords(
+    Surface surface = my_data.tGeometry->get_clusterizer_tpc_surface(
         tpcHitSetKey,
-        global,
+        env_pos,
         subsurfkey);
 
     if (!surface)
@@ -917,9 +916,9 @@ namespace
     // Equivalent charge per T bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
 
     /// convert to Acts units
-    global *= Acts::UnitConstants::cm;
+    env_pos *= Acts::UnitConstants::cm;
     // std::cout << "transform" << std::endl;
-    Acts::Vector3 local = surface->localToGlobalTransform(my_data.tGeometry->geometry().getGeoContext()).inverse() * global;
+    Acts::Vector3 local = surface->localToGlobalTransform(my_data.tGeometry->geometry().getGeoContext()).inverse() * env_pos;
     local /= Acts::UnitConstants::cm;
     // std::cout << "done transform" << std::endl;
     //  we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
@@ -2155,3 +2154,4 @@ void TpcClusterizer::makeChannelMask(hitMaskTpcSet &aMask, const std::string &db
   }
 
 }
+

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -30,7 +30,6 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
 
-//#include <g4detectors/PHG4TpcGeomv1.h>
 #include <g4detectors/PHG4TpcGeom.h>
 #include <g4detectors/PHG4TpcGeomContainer.h>
 

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -914,12 +914,12 @@ namespace
     // To get equivalent charge per T bin, so that summing ADC input voltage over all T bins returns total input charge, divide voltages by 2.4 for 80 ns SAMPA
     // Equivalent charge per T bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
 
-    /// convert to Acts units
-    env_pos *= Acts::UnitConstants::cm;
-    // std::cout << "transform" << std::endl;
-    Acts::Vector3 local = surface->localToGlobalTransform(my_data.tGeometry->geometry().getGeoContext()).inverse() * env_pos;
+    // convert envelope coords to simulation geometry coords - note alignment is turned off here
+    auto simgeom_pos = my_data.tGeometry->transformTpcEnvelopeToWorld(env_pos);    
+    simgeom_pos *= Acts::UnitConstants::cm;  // convert to Acts units
+    Acts::Vector3 local = surface->localToGlobalTransform(my_data.tGeometry->geometry().getGeoContext()).inverse() * simgeom_pos;
     local /= Acts::UnitConstants::cm;
-    // std::cout << "done transform" << std::endl;
+
     //  we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
 
     TrkrCluster *clus_base = nullptr;

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -111,18 +111,6 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
 
   auto surface = m_surfMaps.getSurface(key, cluster);
 
-  unsigned int sskey = cluster->getSubSurfKey();
-  unsigned int layer = TrkrDefs::getLayer(key);
-  unsigned int side = TpcDefs::getSide(key);
-  unsigned int sector = TpcDefs::getSectorId(key);
-  //  std::cout << " getGlobalPositionTpc transform for layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey << " is: " << std::endl
-  //	    <<  surface->localToGlobalTransform(m_tGeometry.getGeoContext()).matrix()
-  //	    << std::endl;
-  alignmentTransformationContainer::use_alignment = false;
-  Acts::Vector3 ideal_center = surface->center(m_tGeometry.getGeoContext()) * 0.1;
- alignmentTransformationContainer::use_alignment = true;  
-  Acts::Vector3 sensorCenter = surface->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
-  
   if (!surface)
   {
     std::cerr << "Couldn't identify cluster surface. Returning NAN"
@@ -135,23 +123,33 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
 
   Acts::Vector2 local = getLocalCoords(key, cluster);  // no crossing correction here
 
-  alignmentTransformationContainer::use_alignment = false;
   glob = surface->localToGlobal(m_tGeometry.getGeoContext(),
                                 local * Acts::UnitConstants::cm,
                                 Acts::Vector3(1, 1, 1));
-  alignmentTransformationContainer::use_alignment = true;  
   glob /= Acts::UnitConstants::cm;
 
+  /*
+    // Leaving this here for now, since it gives comprehensive diagnostic info 
 
-  // std::cout << "  local " << local << std::endl;
-  // std::cout << "  glob " << glob << std::endl;
+    unsigned int sskey = cluster->getSubSurfKey();
+    unsigned int layer = TrkrDefs::getLayer(key);
+    unsigned int side = TpcDefs::getSide(key);
+    unsigned int sector = TpcDefs::getSectorId(key);
 
-  std::cout << "  layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey
+    alignmentTransformationContainer::use_alignment = false;
+    Acts::Vector3 ideal_center = surface->center(m_tGeometry.getGeoContext()) * 0.1;
+    alignmentTransformationContainer::use_alignment = true;  
+    
+    Acts::Vector3 env_center = m_tpc_world_envelope_transform * ideal_center;
+    Acts::Vector3 sensorCenter = surface->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
+
+    std::cout << "  layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey
 	    << "  aligned global: " << glob[0] << "  " << glob[1] << "  " << glob[2]  
 	    << "  aligned surf: " << sensorCenter[0] << "  " << sensorCenter[1] << "  " << sensorCenter[2]
     	    << "  ideal surf: " << ideal_center[0] << "  " << ideal_center[1] << "  " << ideal_center[2]
+	    << "  env surf: " << env_center[0] << "  " << env_center[1] << "  " << env_center[2]
 	    << std::endl;
-
+  */
   
   return glob;
 }
@@ -187,7 +185,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   // convert global to mm for consistency with surface centers
   cluster *= 10.0;
   
-  // Apparently, tilting the TPC leads to the surfaces not being sorted in phi in the outer layers
+  // Apparently, tilting the TPC leads to the surfaces not being sorted in phi in some layers
   // just test all surfaces in each layer for now
   double min_dphi = 999.0;
   unsigned int min_surf_index = 999;
@@ -202,9 +200,9 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
       if(surf_side != side) { continue; }
       
       // the cluster coordinates are in the sPHENIX frame, where the TPC is tilted and alignment
-      // transforms are implemented on a module by module basis. We must convert the cluster  to tpc
-      // envelope coordinates, where we know where everything is.
-      //      transform:  cluster_aligned->local->cluster_noalign->envelope
+      // transforms are implemented. We must convert the cluster  to tpc envelope coordinates,
+      // where we know where the fake surfaces are located.
+      //    so, transform:  cluster_aligned->local->cluster_noalign->envelope
       
       Acts::Vector3 local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (cluster);
       // transform local to unaligned geometry (simulation) global
@@ -251,29 +249,15 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
     Acts::Vector3 clus_envelope,
     TrkrDefs::subsurfkey& subsurfkey) const
 {
-  // This method finds the subsurface for the clusterizer
+  // This method finds the subsurface for the clusterizer so the key can be added to the cluster
   // The input cluster position is in envelope coordinates
 
   unsigned int layer = TrkrDefs::getLayer(hitsetkey);
   unsigned int side = TpcDefs::getSide(hitsetkey);
   unsigned int sector = TpcDefs::getSectorId(hitsetkey);
 
-  //  std::cout << " get_clusterizer_tpc_surface: layer " << layer << " side " << side << " sector " << sector << std::endl;
-  
   double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
   
-    if(clus_envelope[2] == 0.0)
-    {
-      if(side == 0)
-	{
-	  clus_envelope[2] = -10.0;
-	}
-      else
-	{
-	  clus_envelope[2] = 10.0;
-	}
-    }
-
   // returns an iterator to all of the surfaces for this layer
   auto mapIter = m_surfMaps.m_tpcSurfaceMap.find(layer);
 
@@ -323,6 +307,7 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
       if(surf_center_noalign.z() > 0.0) { surf_side = 1; }
       if(surf_side != side) { continue; }
 
+      
       // transform simulation geometry global to envelope coords
       Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center_noalign/10.0) * 10.0;    // transform uses cm
       double surf_phi_envelope = atan2(surf_center_envelope[1], surf_center_envelope[0]);  
@@ -337,16 +322,6 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
   
   surf_index = min_surf_index;
   subsurfkey = min_surf_index;
-
-  /*
-  if(hitsetkey == 35588608)
-    {
-      std::cout << " Cluster surface finder: " << " hitsetkey " << hitsetkey << " layer " << layer << " side " << side << " sskey " << surf_index << std::endl;
-      auto surfcenter = surf_vec[surf_index]->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
-      double surf_radius = sqrt(surfcenter[0]*surfcenter[0] + surfcenter[1]*surfcenter[1]);
-      std::cout << "      center: " << surfcenter[0] << "  " << surfcenter[1] << "  " << surfcenter[2] << " radius " << surf_radius << std::endl;
-    }
-  */
   
   if(min_dphi > surfStepPhi)
     {
@@ -359,7 +334,7 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
 		<< " hitsetkey " << hitsetkey << std::endl;
       return nullptr;
     }
-
+  
   return surf_vec[surf_index];
 }
 

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -150,18 +150,17 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
 
 Surface ActsGeometry::get_tpc_surface_from_coords(
     TrkrDefs::hitsetkey hitsetkey,
-    Acts::Vector3 world,
+    Acts::Vector3 cluster,
     TrkrDefs::subsurfkey& subsurfkey) const
 {
-  // Assume that the world coordinates are in the sPHENIX frame, where the TPC is tilted
-  // We convert the position to tpc envelope coordinates, where we know where everything is
-  Acts::Vector3 world_envelope = transformTpcWorldToEnvelope(world);
-  double world_phi = atan2(world_envelope[1], world_envelope[0]);
+  // This method finds the subsurface for global cluster positions
 
   unsigned int layer = TrkrDefs::getLayer(hitsetkey);
   unsigned int side = TpcDefs::getSide(hitsetkey);
   unsigned int sector = TpcDefs::getSectorId(hitsetkey);
- 
+
+  double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
+	
   // returns an iterator to all of the surfaces for this layer
   auto mapIter = m_surfMaps.m_tpcSurfaceMap.find(layer);
 
@@ -175,113 +174,177 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   const auto& surf_vec = mapIter->second;
   unsigned int surf_index = 999;
 
+  // convert global to mm for consistency with surface centers
+  cluster *= 10.0;
+  
   // Apparently, tilting the TPC leads to the surfaces not being sorted in phi in the outer layers
   // just test all surfaces in each layer for now
+  double min_dphi = 999.0;
+  unsigned int min_surf_index = 999;
   for(unsigned int isurf = 0; isurf < surf_vec.size(); ++isurf)
     {
       Surface this_surf = surf_vec[isurf];
-      auto surf_center = this_surf->center(m_tGeometry.getGeoContext());
-      surf_center /= 10.0;   // convert from mm to cm
-      //this surface center includes the TPC tilt used in PHG4TpcDetector construction, transform it to tpc envelope coordinates
-      Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center);
-      double surf_phi = atan2(surf_center_envelope[1], surf_center_envelope[0]);  
-      double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
 
-      const double dphi = std::atan2(std::sin(world_phi - surf_phi), std::cos(world_phi - surf_phi));
-      if (std::abs(dphi) <= surfStepPhi / 2.0)
+      // the cluster coordinates are in the sPHENIX frame, where the TPC is tilted and where alignment
+      // transforms are implemented on a module by module basis. We must convert the cluster  to tpc
+      // envelope coordinates, where we know where everything is.
+      //      transform:  cluster_aligned->local->cluster_noalign->envelope
+      
+      Acts::Vector3 local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (cluster);
+      // transform local to unaligned geometry global
+      alignmentTransformationContainer::use_alignment = false;
+      Acts::Vector3 cluster_noalign = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()) * (local);   
+      auto surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
+      alignmentTransformationContainer::use_alignment = true;
+
+      // transform simulation geometry global to envelope coords
+      Acts::Vector3 cluster_envelope = transformTpcWorldToEnvelope(cluster_noalign/10.0) * 10.0;  // transform needs cm
+      Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center_noalign/10.0) * 10.0;  
+
+      if(surf_center_envelope.z() < 0 && side != 0) { continue; }
+      if(surf_center_envelope.z() > 0 && side != 1) { continue; }
+
+      double cluster_phi_envelope = atan2(cluster_envelope[1], cluster_envelope[0]);
+      double surf_phi_envelope = atan2(surf_center_envelope[1], surf_center_envelope[0]);
+      const double dphi = std::atan2(std::sin(cluster_phi_envelope - surf_phi_envelope), std::cos(cluster_phi_envelope - surf_phi_envelope));
+      
+      if(std::abs(dphi) < min_dphi)
 	{
-	  if(surf_center_envelope.z() < 0 && side != 0) { continue; }
-	  if(surf_center_envelope.z() > 0 && side != 1) { continue; }
-	  surf_index = isurf;
-	  subsurfkey = isurf;
-	  break;
-	}            
-    }  
-
-  if(surf_index == 999)
+	  min_dphi = std::abs(dphi);
+	  min_surf_index = isurf;
+	}
+    }
+  
+  surf_index = min_surf_index;
+  subsurfkey = min_surf_index;
+  
+  if(min_dphi > surfStepPhi)
     {
-    std::cout << "Error: surface not found in ActsGeometry::get_tpc_surface_from_coords "
-              << " layer " << layer << " side " << side << " sector " << sector
-	      << " world_phi (deg) " << world_phi* 180.0/M_PI
-	      << "  world[0]  " << world[0] << " world[1] " << world[1]
-	      << " hitsetkey " << hitsetkey << std::endl;
+      // too large to be due to cluster uncertainty
+      std::cout << "Error: surface not found in ActsGeometry::get_tpc_surface_from_coords "
+		<< " layer " << layer << " side " << side << " sector " << sector
+		<< " min_dphi " << min_dphi << " min_surf_index " << min_surf_index
+		<< " cluster[0]  " << cluster[0] << " cluster[1] " << cluster[1] << " cluster[2] " << cluster[2] << " mm "
+		<< " cluster phi " << atan2(cluster[1],cluster[0])
+		<< " hitsetkey " << hitsetkey << std::endl;
+      return nullptr;
+    }
+  
+  return surf_vec[surf_index];
+}
+
+Surface ActsGeometry::get_clusterizer_tpc_surface(
+    TrkrDefs::hitsetkey hitsetkey,
+    Acts::Vector3 clus_envelope,
+    TrkrDefs::subsurfkey& subsurfkey) const
+{
+  // This method finds the subsurface for the clusterizer
+  // The input cluster position is in envelope coordinates
+
+  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+  unsigned int side = TpcDefs::getSide(hitsetkey);
+  unsigned int sector = TpcDefs::getSectorId(hitsetkey);
+
+  double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
+  
+    if(clus_envelope[2] == 0.0)
+    {
+      if(side == 0)
+	{
+	  clus_envelope[2] = -10.0;
+	}
+      else
+	{
+	  clus_envelope[2] = 10.0;
+	}
+    }
+
+  // returns an iterator to all of the surfaces for this layer
+  auto mapIter = m_surfMaps.m_tpcSurfaceMap.find(layer);
+
+  if (mapIter == m_surfMaps.m_tpcSurfaceMap.end())
+  {
+    std::cout << "Error: hitsetkey not found in ActsGeometry::get_tpc_surface_from_coords, hitsetkey = "
+              << hitsetkey << std::endl;
     return nullptr;
+  }
+
+  const auto& surf_vec = mapIter->second;
+  unsigned int surf_index = 999;
+
+  // convert position to mm for consistency with surfaces
+  clus_envelope *= 10.0;
+
+  double clus_phi_envelope = atan2(clus_envelope[1], clus_envelope[0]);
+      
+  // Apparently, tilting the TPC leads to the surfaces not being sorted in phi in the outer layers
+  // just test all surfaces in each layer for now
+  double min_dphi = 999.0;
+  unsigned int min_surf_index = 999;
+  for(unsigned int isurf = 0; isurf < surf_vec.size(); ++isurf)
+    {
+      Surface this_surf = surf_vec[isurf];
+      
+      // get the surface center before alignment
+      // leave the alignment flag the way you found it!
+      Acts::Vector3 surf_center_noalign(0,0,0);
+      Acts::Vector3 surf_center_local(0,0,0);
+      if(alignmentTransformationContainer::use_alignment)
+	{
+	  alignmentTransformationContainer::use_alignment = false;
+	  surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
+	  surf_center_local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (surf_center_noalign);
+	  alignmentTransformationContainer::use_alignment = true;	  
+	}
+      else
+	{
+	  // this will be the case when called from the clusterizer
+	  surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
+	  surf_center_local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (surf_center_noalign);
+	}
+ 
+      // transform simulation geometry global to envelope coords
+      Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center_noalign/10.0) * 10.0;    // transform uses cm
+      double surf_phi_envelope = atan2(surf_center_envelope[1], surf_center_envelope[0]);  
+      
+      if(surf_center_envelope.z() < 0 && side != 0) { continue; }
+      if(surf_center_envelope.z() > 0 && side != 1) { continue; }
+            
+      const double dphi = std::atan2(std::sin(clus_phi_envelope - surf_phi_envelope), std::cos(clus_phi_envelope - surf_phi_envelope));
+
+      if(std::abs(dphi) < min_dphi)
+	{
+	  min_dphi = std::abs(dphi);
+	  min_surf_index = isurf;
+	}
+    }
+  
+  surf_index = min_surf_index;
+  subsurfkey = min_surf_index;
+
+  /*
+  if(hitsetkey == 35588608)
+    {
+      std::cout << " Cluster surface finder: " << " hitsetkey " << hitsetkey << " layer " << layer << " side " << side << " sskey " << surf_index << std::endl;
+      auto surfcenter = surf_vec[surf_index]->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
+      double surf_radius = sqrt(surfcenter[0]*surfcenter[0] + surfcenter[1]*surfcenter[1]);
+      std::cout << "      center: " << surfcenter[0] << "  " << surfcenter[1] << "  " << surfcenter[2] << " radius " << surf_radius << std::endl;
+    }
+  */
+  
+  if(min_dphi > surfStepPhi)
+    {
+      // too large to be due to cluster uncertainty
+      std::cout << "Error: surface not found in ActsGeometry::get_tpc_surface_from_coords "
+		<< " layer " << layer << " side " << side << " sector " << sector
+		<< " min_dphi " << min_dphi << " min_surf_index " << min_surf_index
+		<< " cluster[0]  " << clus_envelope[0] << " cluster[1] " << clus_envelope[1] << " cluster[2] " << clus_envelope[2] << " mm "
+		<< " cluster phi " << atan2(clus_envelope[1],clus_envelope[0])
+		<< " hitsetkey " << hitsetkey << std::endl;
+      return nullptr;
     }
 
   return surf_vec[surf_index];
-  
-  /*
-  // Predict which surface index this phi and side will correspond to
-  // assumes that the vector elements are ordered positive z, -pi to pi, then negative z, -pi to pi
-  // we use TPC side from the hitsetkey, since z can be either sign in north and south, depending on crossing
-  double fraction = (world_phi + M_PI) / (2.0 * M_PI);
-
-  double rounded_nsurf = std::round((double) (surf_vec.size() / 2) * fraction - 0.5);  // NOLINT
-  unsigned int nsurfm = (unsigned int) rounded_nsurf;
- std::cout << " surf_vec.size " << surf_vec.size() << " rounded_nsurf " << rounded_nsurf << " initial nsurfm " << nsurfm << std::endl;
-  
-  if (side == 0)
-  {
-    nsurfm += surf_vec.size() / 2;
-  }
-  unsigned int nsurf = nsurfm % surf_vec.size();
-  Surface this_surf = surf_vec[nsurf];
-  auto surf_center = this_surf->center(m_tGeometry.getGeoContext());
-  surf_center /= 10.0;   // convert from mm to cm
-  //this surface center is from the default geometry, which includes the TPC tilt used in PHG4TpcDetector construction
-  // transform it to tpc envelope coordinates
-  Acts::Vector3 surf_center_envelope = m_tpc_world_envelope_transform * surf_center;
-
-  double surf_phi = atan2(surf_center_envelope[1], surf_center_envelope[0]);  
-  double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
-  
-  if ((world_phi > surf_phi - surfStepPhi / 2.0) && (world_phi < surf_phi + surfStepPhi / 2.0))
-  {
-    surf_index = nsurf;
-    subsurfkey = nsurf;
-    std::cout << "success, found nsurf = " << nsurf << std::endl;
-  }
-  else
-  {
-    // check for the periodic boundary condition
-    auto firstsurf = *surf_vec.begin();
-    auto firstsurfcenter = firstsurf->center(m_tGeometry.getGeoContext());
-    firstsurfcenter /= 10.0;
-    auto firstsurfcenter_envelope = m_tpc_world_envelope_transform * firstsurfcenter;
-    double firstsurf_phi = atan2(firstsurfcenter_envelope[1], firstsurfcenter_envelope[0]);
-    if (world_phi < -M_PI)
-    {
-      world_phi += 2.0 * M_PI;
-    }
-    //check a few surfaces around this one
-    for( int i = -1; i <= 1; i++)
-    {
-      if(i==0) // already tried this one
-      {
-        continue;
-      }
-      unsigned int new_nsurf = (nsurf+i) % surf_vec.size();
-      this_surf = surf_vec[new_nsurf];
-      surf_center = this_surf->center(m_tGeometry.getGeoContext());
-      surf_center /= 10.0;
-      surf_center_envelope = m_tpc_world_envelope_transform * surf_center;
-      surf_phi = atan2(surf_center_envelope[1], surf_center_envelope[0]);
-      double this_philow =  surf_phi - surfStepPhi / 2.0;
-      double this_phihigh =  surf_phi + surfStepPhi / 2.0;
-      
-      if ((world_phi > this_philow) && (world_phi < this_phihigh))
-      {
-	std::cout << "success, found nsurf = " << new_nsurf << std::endl;	
-        surf_index = new_nsurf;
-        subsurfkey = new_nsurf;
-        return surf_vec[surf_index];
-      }
-    }
-    return nullptr;
-  }
-  */
-  
-
 }
 
 //________________________________________________________________________________________________

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -111,17 +111,17 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
 
   auto surface = m_surfMaps.getSurface(key, cluster);
 
-  /*
-  std::cout << " getGlobalPositionTpc transform is: " << std::endl
-	    <<  surface->transform(m_tGeometry.getGeoContext()).matrix()
-	    << std::endl;
+  unsigned int sskey = cluster->getSubSurfKey();
+  unsigned int layer = TrkrDefs::getLayer(key);
+  unsigned int side = TpcDefs::getSide(key);
+  unsigned int sector = TpcDefs::getSectorId(key);
+  //  std::cout << " getGlobalPositionTpc transform for layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey << " is: " << std::endl
+  //	    <<  surface->localToGlobalTransform(m_tGeometry.getGeoContext()).matrix()
+  //	    << std::endl;
   alignmentTransformationContainer::use_alignment = false;
   Acts::Vector3 ideal_center = surface->center(m_tGeometry.getGeoContext()) * 0.1;
-  alignmentTransformationContainer::use_alignment = true;  
+ alignmentTransformationContainer::use_alignment = true;  
   Acts::Vector3 sensorCenter = surface->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
-  std::cout << "  ideal surface center: " << ideal_center << std::endl;
-  std::cout << "  aligned surface center: " << sensorCenter << std::endl;
-  */
   
   if (!surface)
   {
@@ -134,15 +134,23 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
   }
 
   Acts::Vector2 local = getLocalCoords(key, cluster);  // no crossing correction here
-  
+
+  alignmentTransformationContainer::use_alignment = false;
   glob = surface->localToGlobal(m_tGeometry.getGeoContext(),
                                 local * Acts::UnitConstants::cm,
                                 Acts::Vector3(1, 1, 1));
+  alignmentTransformationContainer::use_alignment = true;  
   glob /= Acts::UnitConstants::cm;
 
 
   // std::cout << "  local " << local << std::endl;
   // std::cout << "  glob " << glob << std::endl;
+
+  std::cout << "  layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey
+	    << "  aligned global: " << glob[0] << "  " << glob[1] << "  " << glob[2]  
+	    << "  aligned surf: " << sensorCenter[0] << "  " << sensorCenter[1] << "  " << sensorCenter[2]
+    	    << "  ideal surf: " << ideal_center[0] << "  " << ideal_center[1] << "  " << ideal_center[2]
+	    << std::endl;
 
   
   return glob;
@@ -159,6 +167,8 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   unsigned int side = TpcDefs::getSide(hitsetkey);
   unsigned int sector = TpcDefs::getSectorId(hitsetkey);
 
+  //    std::cout << " get_tpc_surface_from_coords: layer " << layer << " side " << side << " sector " << sector << std::endl;
+    
   double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
 	
   // returns an iterator to all of the surfaces for this layer
@@ -185,13 +195,19 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
     {
       Surface this_surf = surf_vec[isurf];
 
-      // the cluster coordinates are in the sPHENIX frame, where the TPC is tilted and where alignment
+      // quick check to eliminate wrong side surfaces 
+      auto surf_center_test = this_surf->center(m_tGeometry.getGeoContext());
+      unsigned int surf_side = 0;
+      if(surf_center_test.z() > 0.0) { surf_side = 1; }
+      if(surf_side != side) { continue; }
+      
+      // the cluster coordinates are in the sPHENIX frame, where the TPC is tilted and alignment
       // transforms are implemented on a module by module basis. We must convert the cluster  to tpc
       // envelope coordinates, where we know where everything is.
       //      transform:  cluster_aligned->local->cluster_noalign->envelope
       
       Acts::Vector3 local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (cluster);
-      // transform local to unaligned geometry global
+      // transform local to unaligned geometry (simulation) global
       alignmentTransformationContainer::use_alignment = false;
       Acts::Vector3 cluster_noalign = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()) * (local);   
       auto surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
@@ -200,10 +216,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
       // transform simulation geometry global to envelope coords
       Acts::Vector3 cluster_envelope = transformTpcWorldToEnvelope(cluster_noalign/10.0) * 10.0;  // transform needs cm
       Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center_noalign/10.0) * 10.0;  
-
-      if(surf_center_envelope.z() < 0 && side != 0) { continue; }
-      if(surf_center_envelope.z() > 0 && side != 1) { continue; }
-
+      
       double cluster_phi_envelope = atan2(cluster_envelope[1], cluster_envelope[0]);
       double surf_phi_envelope = atan2(surf_center_envelope[1], surf_center_envelope[0]);
       const double dphi = std::atan2(std::sin(cluster_phi_envelope - surf_phi_envelope), std::cos(cluster_phi_envelope - surf_phi_envelope));
@@ -245,6 +258,8 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
   unsigned int side = TpcDefs::getSide(hitsetkey);
   unsigned int sector = TpcDefs::getSectorId(hitsetkey);
 
+  //  std::cout << " get_clusterizer_tpc_surface: layer " << layer << " side " << side << " sector " << sector << std::endl;
+  
   double surfStepPhi = m_tGeometry.tpcSurfStepPhi;
   
     if(clus_envelope[2] == 0.0)
@@ -302,14 +317,15 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
 	  surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
 	  surf_center_local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (surf_center_noalign);
 	}
- 
+
+      // eliminate wrong side surfaces 
+      unsigned int surf_side = 0;
+      if(surf_center_noalign.z() > 0.0) { surf_side = 1; }
+      if(surf_side != side) { continue; }
+
       // transform simulation geometry global to envelope coords
       Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center_noalign/10.0) * 10.0;    // transform uses cm
       double surf_phi_envelope = atan2(surf_center_envelope[1], surf_center_envelope[0]);  
-      
-      if(surf_center_envelope.z() < 0 && side != 0) { continue; }
-      if(surf_center_envelope.z() > 0 && side != 1) { continue; }
-            
       const double dphi = std::atan2(std::sin(clus_phi_envelope - surf_phi_envelope), std::cos(clus_phi_envelope - surf_phi_envelope));
 
       if(std::abs(dphi) < min_dphi)

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -128,28 +128,31 @@ Acts::Vector3 ActsGeometry::getGlobalPositionTpc(TrkrDefs::cluskey key, TrkrClus
                                 Acts::Vector3(1, 1, 1));
   glob /= Acts::UnitConstants::cm;
 
-  /*
-    // Leaving this here for now, since it gives comprehensive diagnostic info 
+  bool debugging = false;
+  if(debugging)
+    {
+      // Leaving this here for now, since it gives comprehensive diagnostic info 
+      
+      unsigned int sskey = cluster->getSubSurfKey();
+      unsigned int layer = TrkrDefs::getLayer(key);
+      unsigned int side = TpcDefs::getSide(key);
+      unsigned int sector = TpcDefs::getSectorId(key);
 
-    unsigned int sskey = cluster->getSubSurfKey();
-    unsigned int layer = TrkrDefs::getLayer(key);
-    unsigned int side = TpcDefs::getSide(key);
-    unsigned int sector = TpcDefs::getSectorId(key);
-
-    alignmentTransformationContainer::use_alignment = false;
-    Acts::Vector3 ideal_center = surface->center(m_tGeometry.getGeoContext()) * 0.1;
-    alignmentTransformationContainer::use_alignment = true;  
-    
-    Acts::Vector3 env_center = m_tpc_world_envelope_transform * ideal_center;
-    Acts::Vector3 sensorCenter = surface->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
-
-    std::cout << "  layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey
-	    << "  aligned global: " << glob[0] << "  " << glob[1] << "  " << glob[2]  
-	    << "  aligned surf: " << sensorCenter[0] << "  " << sensorCenter[1] << "  " << sensorCenter[2]
-    	    << "  ideal surf: " << ideal_center[0] << "  " << ideal_center[1] << "  " << ideal_center[2]
-	    << "  env surf: " << env_center[0] << "  " << env_center[1] << "  " << env_center[2]
-	    << std::endl;
-  */
+      bool align_flag = alignmentTransformationContainer::use_alignment;
+      alignmentTransformationContainer::use_alignment = false;
+      Acts::Vector3 ideal_center = surface->center(m_tGeometry.getGeoContext()) * 0.1;
+      if(align_flag) {alignmentTransformationContainer::use_alignment = true; }
+      
+      Acts::Vector3 env_center = m_tpc_world_envelope_transform * ideal_center;
+      Acts::Vector3 sensorCenter = surface->center(m_tGeometry.getGeoContext()) * 0.1;  // cm
+      
+      std::cout << "  layer " << layer << " side " << side << " sector " << sector << " sskey " << sskey
+		<< "  aligned global: " << glob[0] << "  " << glob[1] << "  " << glob[2]  
+		<< "  aligned surf: " << sensorCenter[0] << "  " << sensorCenter[1] << "  " << sensorCenter[2]
+		<< "  ideal surf: " << ideal_center[0] << "  " << ideal_center[1] << "  " << ideal_center[2]
+		<< "  env surf: " << env_center[0] << "  " << env_center[1] << "  " << env_center[2]
+		<< std::endl;
+    }
   
   return glob;
 }
@@ -206,11 +209,15 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
       
       Acts::Vector3 local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (cluster);
       // transform local to unaligned geometry (simulation) global
+      bool align_flag = alignmentTransformationContainer::use_alignment;
       alignmentTransformationContainer::use_alignment = false;
       Acts::Vector3 cluster_noalign = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()) * (local);   
       auto surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
-      alignmentTransformationContainer::use_alignment = true;
-
+      if(align_flag)
+	{
+	  alignmentTransformationContainer::use_alignment = true;
+	}
+      
       // transform simulation geometry global to envelope coords
       Acts::Vector3 cluster_envelope = transformTpcWorldToEnvelope(cluster_noalign/10.0) * 10.0;  // transform needs cm
       Acts::Vector3 surf_center_envelope = transformTpcWorldToEnvelope(surf_center_noalign/10.0) * 10.0;  
@@ -297,7 +304,7 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
 	}
       else
 	{
-	  // this will be the case when called from the clusterizer
+	  // this will be the case when called from the clusterizer, leave it alone 
 	  surf_center_noalign = this_surf->center(m_tGeometry.getGeoContext());
 	  surf_center_local = this_surf->localToGlobalTransform(m_tGeometry.getGeoContext()).inverse() * (surf_center_noalign);
 	}
@@ -326,7 +333,7 @@ Surface ActsGeometry::get_clusterizer_tpc_surface(
   if(min_dphi > surfStepPhi)
     {
       // too large to be due to cluster uncertainty
-      std::cout << "Error: surface not found in ActsGeometry::get_tpc_surface_from_coords "
+      std::cout << "Error: surface not found in ActsGeometry::get_clusterizer_tpc_surface "
 		<< " layer " << layer << " side " << side << " sector " << sector
 		<< " min_dphi " << min_dphi << " min_surf_index " << min_surf_index
 		<< " cluster[0]  " << clus_envelope[0] << " cluster[1] " << clus_envelope[1] << " cluster[2] " << clus_envelope[2] << " mm "

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -73,12 +73,12 @@ class ActsGeometry
 
   Surface get_tpc_surface_from_coords(
       TrkrDefs::hitsetkey hitsetkey,
-      Acts::Vector3 world,
+      Acts::Vector3 cluster,
       TrkrDefs::subsurfkey& subsurfkey) const ;
 
   Surface get_clusterizer_tpc_surface(
       TrkrDefs::hitsetkey hitsetkey,
-      Acts::Vector3 cluslocal,
+      Acts::Vector3 clus_envelope,
       TrkrDefs::subsurfkey& subsurfkey) const;
     
   Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation) const;

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -76,6 +76,11 @@ class ActsGeometry
       Acts::Vector3 world,
       TrkrDefs::subsurfkey& subsurfkey) const ;
 
+  Surface get_clusterizer_tpc_surface(
+      TrkrDefs::hitsetkey hitsetkey,
+      Acts::Vector3 cluslocal,
+      TrkrDefs::subsurfkey& subsurfkey) const;
+    
   Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation) const;
 
   Acts::Vector3 transformTpcWorldToEnvelope(const Acts::Vector3& world) const ;

--- a/offline/packages/trackbase/ActsSurfaceMaps.cc
+++ b/offline/packages/trackbase/ActsSurfaceMaps.cc
@@ -7,6 +7,7 @@
 #include "ActsSurfaceMaps.h"
 #include "InttDefs.h"
 #include "MvtxDefs.h"
+#include "TpcDefs.h"
 #include "TrkrCluster.h"
 
 #include <Acts/Definitions/Units.hpp>
@@ -112,7 +113,7 @@ Surface ActsSurfaceMaps::getTpcSurface(TrkrDefs::hitsetkey hitsetkey,
 {
   unsigned int layer = TrkrDefs::getLayer(hitsetkey);
   const auto iter = m_tpcSurfaceMap.find(layer);
-
+   
   if (iter != m_tpcSurfaceMap.end())
   {
     auto surfvec = iter->second;

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -34,7 +34,7 @@
 
 void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 {
-  localVerbosity = 0;
+  localVerbosity = 1;
   // The default is to use translation parameters that are in global coordinates
   std::cout << "AlignmentTransformation: use INTT survey geometry = " << use_intt_survey_geometry << std::endl;
   std::cout << "AlignmentTransformation: localVerbosity = " << localVerbosity << std::endl;
@@ -291,9 +291,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		zcenter *= -1;
 	      }
 	    Acts::Vector3 env_pos(radius*std::cos(phis), radius * std::sin(phis), zcenter);
-	    Acts::Vector3 world_pos = m_tGeometry->transformTpcEnvelopeToWorld(env_pos);
 	    unsigned short  sskey = 999;
-	    Surface this_surf = m_tGeometry->get_tpc_surface_from_coords(this_hitsetkey, world_pos, sskey);
+	    Surface this_surf = m_tGeometry->get_clusterizer_tpc_surface(this_hitsetkey, env_pos, sskey);
 	    if(sskey == 999 || !this_surf)
 	      {
 		std::cout << PHWHERE << "Failed to get surface for layer " << this_layer << " side " << side << " sector " << sector << "  quit!" << std::endl;
@@ -301,8 +300,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	      }
 	    /*
 	    std::cout << " layer " << this_layer << " radius " << radius << " phis " << phis << " min_phi " << min_phi << " max_phi " << max_phi
-		      << " side " << side << " sector " << sector << " world " << world_pos.x() << "  " << world_pos.y() << "  " << world_pos.z()
-		      <<"  world_radius " << sqrt(world_pos.x() * world_pos.x() + world_pos.y() * world_pos.y())
+		      << " side " << side << " sector " << sector << " env_pos " << env_pos.x() << "  " << env_pos.y() << "  " << env_pos_pos.z()
+		      <<"  world_radius " << sqrt(env_pos.x() * env_pos.x() + env_pos.y() * env_pos.y())
 		      << " sskey " << sskey << std::endl;
 	    */
 
@@ -710,32 +709,42 @@ void AlignmentTransformation::extractModuleCenterPositions()
 double AlignmentTransformation::extractModuleCenter(TrkrDefs::hitsetkey hitsetkey, double sectorphi)
 {
   // We want the module center position from the ideal geometry in the tpc envelope frame
-
+  
   // the radius and z are not used, only the phi value
   double x = std::cos(sectorphi + 0.01) * 10.0;
   double y = std::sin(sectorphi + 0.01) * 10.0;
-  double z = 0.0;
+  double z = 10.0;
+  unsigned int side = TpcDefs::getSide(hitsetkey);
+  if(side ==0)
+    {
+      z = -10.0;
+    }
 
-  Acts::Vector3 world(x, y, z);
+  Acts::Vector3 world_envelope(x, y, z);
   TrkrDefs::subsurfkey subsurfkey = 0;
 
-  //   std::cout << "extractModuleCenter: sectorphi " << sectorphi << " world " << world(0) << "  " << world(1) << "  " << world(2) << std::endl;
+  //  std::cout << "extractModuleCenter: sectorphi " << sectorphi << " world_envelope " << world_envelope(0) << "  " << world_envelope(1) << "  " << world_envelope(2) << std::endl;
 
   // Note: the "world" position here is in pre-tilt tpc envelope coordinates, not global coordinates
-  // But, get_tpc_surface_from_coords() expects a global position as input, so we convert to world coordinates
-  Acts::Vector3 world_envelope = m_tGeometry->transformTpcEnvelopeToWorld(world);
-  Surface surface = m_tGeometry->get_tpc_surface_from_coords(hitsetkey, world_envelope, subsurfkey);
+  Surface surface = m_tGeometry->get_clusterizer_tpc_surface(hitsetkey, world_envelope, subsurfkey);     
   if (!surface)
   {
     std::cout << PHWHERE << "Failed to find surface, quit " << std::endl;
     exit(1);
   }
 
-  Eigen::Vector3d surf_center = surface->center(m_tGeometry->geometry().getGeoContext());
+  Acts::GeometryIdentifier id = surface->geometryId();
+  //std::cout << " subsurfkey " << subsurfkey << " id " << id << std::endl;
+
+  Acts::Vector3 surf_center = surface->center(m_tGeometry->geometry().getGeoContext());
   surf_center /= 10.0;  // convert from mm to cm
+
   // convert to tpc envelope coords
   Acts::Vector3 surf_center_envelope = m_tGeometry->transformTpcWorldToEnvelope(surf_center);
+ 
   double surf_radius = std::sqrt(surf_center_envelope[0] * surf_center_envelope[0] + surf_center_envelope[1] * surf_center_envelope[1]);
+
+  //std::cout << " surf radius = " << surf_radius << std::endl;
 
   return surf_radius;
 }

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -724,7 +724,7 @@ double AlignmentTransformation::extractModuleCenter(TrkrDefs::hitsetkey hitsetke
     exit(1);
   }
 
-  Acts::GeometryIdentifier id = surface->geometryId();
+  // Acts::GeometryIdentifier id = surface->geometryId();
   //std::cout << " subsurfkey " << subsurfkey << " id " << id << std::endl;
 
   Acts::Vector3 surf_center = surface->center(m_tGeometry->geometry().getGeoContext());

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -263,14 +263,11 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 
       unsigned int side = TpcDefs::getSide(hitsetkey);
       unsigned int sector = TpcDefs::getSectorId(hitsetkey);
-      //      std::cout << "New module hitsetkey " << hitsetkey << "test_layer " << test_layer <<  " side " << side << " sector " << sector << " nlayers " << nlayers << " layer_begin " << layer_begin << std::endl;
 
       // loop over layers in module
       for (unsigned int this_layer = layer_begin; this_layer < layer_begin + nlayers; ++this_layer)
       {
         TrkrDefs::hitsetkey this_hitsetkey = TpcDefs::genHitSetKey(this_layer, sector, side);
-
-	//   std::cout << " *** module hitsetkey " << hitsetkey << " this_hitsetkey " << this_hitsetkey << " this layer " << this_layer << " side " << side << " sector " << sector << std::endl;
 
 	// Each TPC hitsetkey has 12 fake surfaces associated with it
 	// We want to make a transform for every fake surface in this hitsetkey
@@ -298,12 +295,6 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		std::cout << PHWHERE << "Failed to get surface for layer " << this_layer << " side " << side << " sector " << sector << "  quit!" << std::endl;
 		exit(1);
 	      }
-	    /*
-	    std::cout << " layer " << this_layer << " radius " << radius << " phis " << phis << " min_phi " << min_phi << " max_phi " << max_phi
-		      << " side " << side << " sector " << sector << " env_pos " << env_pos.x() << "  " << env_pos.y() << "  " << env_pos_pos.z()
-		      <<"  world_radius " << sqrt(env_pos.x() * env_pos.x() + env_pos.y() * env_pos.y())
-		      << " sskey " << sskey << std::endl;
-	    */
 
 	    Eigen::Vector3d localFrameTranslation(0, 0, 0);
 	    use_module_tilt = false;
@@ -317,9 +308,6 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		double this_radius = std::sqrt(this_center_envelope[0] * this_center_envelope[0] + this_center_envelope[1] * this_center_envelope[1]);
 		float moduleRadius = TpcModuleRadii[side][sector][this_region];                                     // radius of the center of the module in cm
 		localFrameTranslation = getTpcLocalFrameTranslation(moduleRadius, this_radius, sensorAngles) * 10;  // cm to mm
-
-		std::cout << "      mod tilt: ModuleRadius " << moduleRadius << " this_layer " << this_layer << " this_radius " << this_radius
-			  << " sensorAngles " << sensorAngles[0] << "  " << sensorAngles[1] << "  " << sensorAngles[2] << std::endl;
 
 		// set this flag for later use
 		use_module_tilt = true;

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -34,7 +34,7 @@
 
 void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 {
-  localVerbosity = 1;
+  localVerbosity = 0;
   // The default is to use translation parameters that are in global coordinates
   std::cout << "AlignmentTransformation: use INTT survey geometry = " << use_intt_survey_geometry << std::endl;
   std::cout << "AlignmentTransformation: localVerbosity = " << localVerbosity << std::endl;
@@ -285,7 +285,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	  {
 	    double phis = min_phi + is*dphi + dphi/2.0;
 	    double radius = layergeom->get_radius();
-	    double zcenter = 51.0;
+	    double zcenter = 51.0;  // not used, make something up
 	    if(side == 0)
 	      {
 		zcenter *= -1;
@@ -317,6 +317,9 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		double this_radius = std::sqrt(this_center_envelope[0] * this_center_envelope[0] + this_center_envelope[1] * this_center_envelope[1]);
 		float moduleRadius = TpcModuleRadii[side][sector][this_region];                                     // radius of the center of the module in cm
 		localFrameTranslation = getTpcLocalFrameTranslation(moduleRadius, this_radius, sensorAngles) * 10;  // cm to mm
+
+		std::cout << "      mod tilt: ModuleRadius " << moduleRadius << " this_layer " << this_layer << " this_radius " << this_radius
+			  << " sensorAngles " << sensorAngles[0] << "  " << sensorAngles[1] << "  " << sensorAngles[2] << std::endl;
 
 		// set this flag for later use
 		use_module_tilt = true;
@@ -717,7 +720,7 @@ double AlignmentTransformation::extractModuleCenter(TrkrDefs::hitsetkey hitsetke
   unsigned int side = TpcDefs::getSide(hitsetkey);
   if(side ==0)
     {
-      z = -10.0;
+      z = -10.0;  // not used, just make something up
     }
 
   Acts::Vector3 world_envelope(x, y, z);

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -313,7 +313,7 @@ namespace TrackAnalysisUtils
     auto* geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
     auto* tpccellgeo = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
     TpcClusterMover mover;
-    mover.initialize_geometry(tpccellgeo, geometry);
+    mover.initialize_geometry(tpccellgeo, geometry, topNode);
     mover.set_verbosity(0);
 
     std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_raw;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -911,9 +911,11 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
     for (auto &j : surfaceVector)
     {
       auto surf = j->getSharedPtr();
+      alignmentTransformationContainer::use_alignment = false;  // we want the unaligned center
       auto vec3d = surf->center(m_geoCtxt);
+      alignmentTransformationContainer::use_alignment = true;
       vec3d /= 10.0;
-      auto vec3d_envelope = m_tpc_world_envelope_transform * vec3d;  // needs to be in TPC envelope coordinates due to tilt in sims
+      auto vec3d_envelope = m_tpc_world_envelope_transform * vec3d;  // needs to be in TPC envelope coordinates due to tilt, displacement,  in sims
 
       std::vector<double> world_center = {vec3d_envelope(0),
                                           vec3d_envelope(1),
@@ -923,22 +925,19 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
       unsigned int layer = TrkrDefs::getLayer(hitsetkey);
       // unsigned int sector = TpcDefs::getSectorId(hitsetkey);
       // unsigned int side = TpcDefs::getSide(hitsetkey);
+
       // If there is already an entry for this hitsetkey, add the surface
       // to its corresponding vector
-      // std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
       std::map<unsigned int, std::vector<Surface>>::iterator mapIter;
-      // mapIter = m_clusterSurfaceMapTpcEdit.find(hitsetkey);
       mapIter = m_clusterSurfaceMapTpcEdit.find(layer);
 
       if (mapIter != m_clusterSurfaceMapTpcEdit.end())
       {
-	//std::cout << "  Adding surface to map with layer " << layer << " side " << side << " sector " << sector << std::endl;
         mapIter->second.push_back(surf);
       }
       else
       {
         // Otherwise make a new map entry
-	//	std::cout << "Starting new surfvec for layer " << layer << " side " << side << " sector " << sector << std::endl;
         std::vector<Surface> dumvec;
         dumvec.push_back(surf);
         std::pair<unsigned int, std::vector<Surface>> tmp =

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -360,6 +360,11 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
        ++clusIter)
   {
     auto key = *clusIter;
+
+    unsigned int test_layer = TrkrDefs::getLayer(key);    
+    const unsigned int trkrid = TrkrDefs::getTrkrId(key);
+    //    std::cout << "   SL 1:  layer " << test_layer << " cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
+    
     auto* cluster = clusterContainer->findCluster(key);
     if (!cluster)
     {
@@ -374,6 +379,8 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       continue;
     }
 
+    //    std::cout << "   SL 2:  layer " << test_layer << " cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
+	
     /// Make a safety check for clusters that couldn't be attached
     /// to a surface
     auto surf = tGeometry->maps().getSurface(key, cluster);
@@ -382,11 +389,12 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       continue;
     }
 
-    const unsigned int trkrid = TrkrDefs::getTrkrId(key);
+    //    unsigned int test_layer = TrkrDefs::getLayer(key);    
+    // const unsigned int trkrid = TrkrDefs::getTrkrId(key);
 
     if (m_verbosity > 1)
     {
-      std::cout << "    Cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
+      std::cout << "   SL:  layer " << test_layer << " cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
     }
 
     // For the TPC, cluster z has to be corrected for the crossing z offset, distortion, and TOF z offset

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -53,7 +53,7 @@ namespace
 void MakeSourceLinks::initialize(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry, PHCompositeNode *topNode)
 {
   // get the TPC layer radii from the geometry object
-  if (cellgeo && tGeometry)
+  if (cellgeo && tGeometry && topNode)
   {
     _clusterMover.initialize_geometry(cellgeo, tGeometry, topNode);
   }

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -50,12 +50,12 @@ namespace
 
 }  // namespace
 
-void MakeSourceLinks::initialize(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry)
+void MakeSourceLinks::initialize(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry, PHCompositeNode *topNode)
 {
   // get the TPC layer radii from the geometry object
   if (cellgeo && tGeometry)
   {
-    _clusterMover.initialize_geometry(cellgeo, tGeometry);
+    _clusterMover.initialize_geometry(cellgeo, tGeometry, topNode);
   }
 }
 
@@ -449,6 +449,7 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
 
     auto* cluster = clusterContainer->findCluster(cluskey);
     Surface surf = tGeometry->maps().getSurface(cluskey, cluster);
+
     if (std::isnan(global.x()) || std::isnan(global.y()))
     {
       std::cout << "MakeSourceLinks::getSourceLinksClusterMover - invalid position"
@@ -470,6 +471,14 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
       TrkrDefs::subsurfkey new_subsurfkey = 0;
       surf = tGeometry->get_tpc_surface_from_coords(hitsetkey, global, new_subsurfkey);
+
+      if(m_verbosity > 2 && (int) TrkrDefs::getLayer(cluskey) == 28)
+	{
+	  if(new_subsurfkey - cluster->getSubSurfKey() != 0)
+	    {
+	      std::cout << "        ********  surf sskey changed from " << cluster->getSubSurfKey() << " to " << new_subsurfkey << std::endl;
+	    }
+	}
     }
 
     if (!surf)

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -360,10 +360,6 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
        ++clusIter)
   {
     auto key = *clusIter;
-
-    unsigned int test_layer = TrkrDefs::getLayer(key);    
-    const unsigned int trkrid = TrkrDefs::getTrkrId(key);
-    //    std::cout << "   SL 1:  layer " << test_layer << " cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
     
     auto* cluster = clusterContainer->findCluster(key);
     if (!cluster)
@@ -379,8 +375,6 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       continue;
     }
 
-    //    std::cout << "   SL 2:  layer " << test_layer << " cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
-	
     /// Make a safety check for clusters that couldn't be attached
     /// to a surface
     auto surf = tGeometry->maps().getSurface(key, cluster);
@@ -389,18 +383,11 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       continue;
     }
 
-    //    unsigned int test_layer = TrkrDefs::getLayer(key);    
-    // const unsigned int trkrid = TrkrDefs::getTrkrId(key);
-
-    if (m_verbosity > 1)
-    {
-      std::cout << "   SL:  layer " << test_layer << " cluster key " << key << " trkrid " << trkrid << " crossing " << crossing << std::endl;
-    }
-
     // For the TPC, cluster z has to be corrected for the crossing z offset, distortion, and TOF z offset
     // we do this locally here and do not modify the cluster, since the cluster may be associated with multiple silicon tracks
     const Acts::Vector3 global = globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, crossing);
 
+    const unsigned int trkrid = TrkrDefs::getTrkrId(key);
     if (trkrid == TrkrDefs::tpcId)
     {
       if (m_verbosity > 2)
@@ -443,8 +430,6 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
   // loop over global positions returned by cluster mover
   for (auto&& [cluskey, global] : global_moved)
   {
-    // std::cout << "Global moved: " << global.x() << "  " <<  global.y() << "  " << global.z() << std::endl;
-
     if (m_ignoreLayer.contains(TrkrDefs::getLayer(cluskey)))
     {
       if (m_verbosity > 3)

--- a/offline/packages/trackreco/MakeSourceLinks.h
+++ b/offline/packages/trackreco/MakeSourceLinks.h
@@ -31,6 +31,7 @@ class TrkrCluster;
 class TrkrClusterContainer;
 class TpcGlobalPositionWrapper;
 class TrackSeed;
+class PHCompositeNode;
 
 /**
    This class contains the code that generates Acts source links and makes the modified GeoContext
@@ -42,7 +43,7 @@ class MakeSourceLinks
  public:
   MakeSourceLinks() = default;
 
-  void initialize(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry);
+  void initialize(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry, PHCompositeNode * topNode);
 
   void setVerbosity(int verbosity) { m_verbosity = verbosity; }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -186,6 +186,8 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+  _topNode = topNode;
+  
   if (Verbosity() > 1)
   {
     std::cout << "Finish PHActsTrkFitter Setup" << std::endl;
@@ -436,7 +438,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       SourceLinkVec sourceLinks;
 
       MakeSourceLinks makeSourceLinks;
-      makeSourceLinks.initialize(_tpccellgeo, m_tGeometry);
+      makeSourceLinks.initialize(_tpccellgeo, m_tGeometry, _topNode);
       makeSourceLinks.setVerbosity(Verbosity());
       makeSourceLinks.set_pp_mode(m_pp_mode);
       makeSourceLinks.set_cluster_edge_rejection(m_cluster_edge_rejection);

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -41,6 +41,7 @@ class TrackSeedContainer;
 class TrkrClusterContainer;
 class SvtxAlignmentStateMap;
 class PHG4TpcGeomContainer;
+class PHCompositeNode;
 
 using SourceLink = ActsSourceLink;
 using FitResult = ActsTrackFittingAlgorithm::TrackFitterResult;
@@ -307,6 +308,7 @@ class PHActsTrkFitter : public SubsysReco
 
   std::vector<const Acts::Surface*> m_materialSurfaces = {};
 
+  PHCompositeNode *_topNode;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -327,7 +327,7 @@ class PHActsTrkFitter : public SubsysReco
 
   std::vector<const Acts::Surface*> m_materialSurfaces = {};
 
-  PHCompositeNode *_topNode;
+  PHCompositeNode *_topNode = nullptr;
 };
 
 #endif

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -128,6 +128,7 @@ namespace
   inline double get_phi(const Acts::Vector3& position)
   {
     double phi = std::atan2(position.y(), position.x());
+
     if (phi < 0)
     {
       phi += 2. * M_PI;
@@ -214,6 +215,13 @@ int PHCASeeding::InitializeGeometry(PHCompositeNode* topNode)
 
 Acts::Vector3 PHCASeeding::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster* cluster) const
 {
+
+  Acts::Vector3 global =  _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
+
+  // translate tpc center to zero for seeding
+  //  Acts::Vector3 tpc_survey_center(-1.6775/10.0, -0.336/10.0, -7.1365/10.0);
+  Acts::Vector3 tpc_survey_center(0.0, 0.0, 0.0);
+  Acts::Vector3 envelope_global = global - tpc_survey_center;
   /*
   unsigned int layer =  TrkrDefs::getLayer(key);
   unsigned int side =  TpcDefs::getSide(key);
@@ -223,9 +231,15 @@ Acts::Vector3 PHCASeeding::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster*
 	    << " side " << side
 	    << " sector " << sector
 	    << " subsurfkey " << cluster->getSubSurfKey()
+	    << " global " << global[0] << "  " << global[1] << "  " << global[2]
+	    << " envelope global " << envelope_global[0] << "  " << envelope_global[1] << "  " << envelope_global[2]
 	    << std::endl;
   */
-  return _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
+  return envelope_global;
+
+  
+  //  return _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
+  
 }
 
 void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& rtree, double phimin, double z_min, double phimax, double z_max, std::vector<pointKey>& returned_values) const

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -215,31 +215,7 @@ int PHCASeeding::InitializeGeometry(PHCompositeNode* topNode)
 
 Acts::Vector3 PHCASeeding::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster* cluster) const
 {
-
-  Acts::Vector3 global =  _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
-
-  // translate tpc center to zero for seeding
-  //  Acts::Vector3 tpc_survey_center(-1.6775/10.0, -0.336/10.0, -7.1365/10.0);
-  Acts::Vector3 tpc_survey_center(0.0, 0.0, 0.0);
-  Acts::Vector3 envelope_global = global - tpc_survey_center;
-  /*
-  unsigned int layer =  TrkrDefs::getLayer(key);
-  unsigned int side =  TpcDefs::getSide(key);
-  unsigned int sector =  TpcDefs::getSectorId(key);
-  std::cout << " _pp_mode = " << _pp_mode
-	    << " layer " << layer
-	    << " side " << side
-	    << " sector " << sector
-	    << " subsurfkey " << cluster->getSubSurfKey()
-	    << " global " << global[0] << "  " << global[1] << "  " << global[2]
-	    << " envelope global " << envelope_global[0] << "  " << envelope_global[1] << "  " << envelope_global[2]
-	    << std::endl;
-  */
-  return envelope_global;
-
-  
-  //  return _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
-  
+  return _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
 }
 
 void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& rtree, double phimin, double z_min, double phimax, double z_max, std::vector<pointKey>& returned_values) const

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -169,6 +169,8 @@ int PHCosmicsTrkFitter::InitRun(PHCompositeNode* topNode)
     std::cout << "Finish PHCosmicsTrkFitter Setup" << std::endl;
   }
 
+  m_topNode = topNode;
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -297,7 +299,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     SourceLinkVec sourceLinks;
 
     MakeSourceLinks makeSourceLinks;
-    makeSourceLinks.initialize(_tpccellgeo, m_tGeometry);
+    makeSourceLinks.initialize(_tpccellgeo, m_tGeometry, m_topNode);
     makeSourceLinks.setVerbosity(Verbosity());
     makeSourceLinks.set_pp_mode(false);
 

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -32,6 +32,7 @@ class TrackSeedContainer;
 class TrkrClusterContainer;
 class SvtxAlignmentStateMap;
 class PHG4TpcGeomContainer;
+class PHCompositeNode;
 
 class TFile;
 class TTree;
@@ -236,6 +237,8 @@ class PHCosmicsTrkFitter : public SubsysReco
   void clearVectors();
   void fillVectors(TrackSeed* tpcseed, TrackSeed* siseed);
   ClusterErrorPara m_clusErrPara;
+
+  PHCompositeNode *m_topNode;
 };
 
 #endif

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -238,7 +238,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   void fillVectors(TrackSeed* tpcseed, TrackSeed* siseed);
   ClusterErrorPara m_clusErrPara;
 
-  PHCompositeNode *m_topNode;
+  PHCompositeNode *m_topNode = nullptr;
 };
 
 #endif

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -430,6 +430,16 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 Acts::Vector3 PHSimpleKFProp::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster* cluster) const
 {
   // get global position from Acts transform
+
+  /*
+  Acts::Vector3 global = _pp_mode ?
+    m_tgeometry->getGlobalPosition(key, cluster):
+    m_globalPositionWrapper.getGlobalPositionDistortionCorrected( key, cluster, 0 );    
+  // convert to envelope coordinates
+  Acts::Vector3 envelope_global = m_tgeometry->transformTpcWorldToEnvelope(global);
+  return envelope_global;
+  */
+  
   return _pp_mode ?
     m_tgeometry->getGlobalPosition(key, cluster):
     m_globalPositionWrapper.getGlobalPositionDistortionCorrected( key, cluster, 0 );

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -430,15 +430,6 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 Acts::Vector3 PHSimpleKFProp::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster* cluster) const
 {
   // get global position from Acts transform
-
-  /*
-  Acts::Vector3 global = _pp_mode ?
-    m_tgeometry->getGlobalPosition(key, cluster):
-    m_globalPositionWrapper.getGlobalPositionDistortionCorrected( key, cluster, 0 );    
-  // convert to envelope coordinates
-  Acts::Vector3 envelope_global = m_tgeometry->transformTpcWorldToEnvelope(global);
-  return envelope_global;
-  */
   
   return _pp_mode ?
     m_tgeometry->getGlobalPosition(key, cluster):


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR properly accounts for the alignment corrections during data reconstruction when the TPC survey geometry is implemented (tilt and displacement). The TPC subsurface finding for clusters now converts the cluster position to local coordinates, transforms it to "simulation global" coordinates with the pre-alignment (simulated geometry) transforms, then transforms the simulation global coordinates into the TPC enevelope frame. In the TPC envelope frame the TPC geometry object knows where the surfaces are.

An important note is that the subsurface keys are stored in the cluster object by TpcClusterizer. When the TPC survey geometry is implemented, the subsurface keys no longer have the same binding as they do for the ideal TPC geometry. This causes the seeding to be given wrong global positions in some layers. So reconstructing clusters produced with the ideal TPC geometry using the survey geometry does not work properly. If the survey geometry is used in reconstruction, the TPC clustering has to be redone. 

The code in this PR was tested on raw hits files, using the "tpcSurvey" CDB tag.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

Update TPC reconstruction to correctly apply survey-geometry alignment corrections (including tilt and displacement). This is needed so reconstructed cluster positions and their association to the correct TPC surfaces remain consistent when running with survey geometry rather than ideal geometry.

## Key Changes

- Implemented alignment-aware TPC surface matching by selecting the best surface via minimum wrapped-phi differences, with supporting envelope-coordinate surface lookups.
- Extended/added geometry utilities to support envelope-frame inputs during surface selection (e.g., `get_clusterizer_tpc_surface`), and refined alignment-handling so surface selection respects (and preserves) the enabled/disabled alignment state.
- Updated TPC cluster relocation to use aligned-surface geometry in global coordinates:
  - `TpcClusterMover::initialize_geometry` now takes `PHCompositeNode* topNode` so the mover can access the `TrkrClusterContainer`.
  - `processTrack` computes and stores “moved” cluster global positions based on aligned-surface centers, with added robustness checks for missing nodes/surfaces.
- Reworked residual/sourcing workflows to avoid inconsistent recomputation of moved positions:
  - `TrackResiduals` now computes moved global cluster positions once per track via `m_clusterMover.processTrack(...)`, then passes them into `fillClusterBranchesKF` / `fillClusterBranchesSeeds` via a new `global_moved` parameter.
  - `MakeSourceLinks` and track fitters now accept/pass `topNode` so source-link construction can also use the moved cluster/global position logic.
- Updated supporting geometry-map building so hitset/layer mapping is derived from geometry computed with appropriate alignment-state handling.

## Potential Risk Areas

- **Reconstruction behavior changes:** survey geometry alignment alters cluster-to-surface associations, which can propagate to subsurface keys, seeding behavior, and fitted track parameters.
- **Reclustering requirement:** because alignment can change how subsurface keys bind to “ideal” geometry, clusters may need to be reclustered when using survey geometry to avoid incorrect seeding in some layers.
- **Performance:** additional surface scanning/lookup and per-track moved-position computation may increase runtime.
- **Thread-safety / object lifetime:** passing/storing `PHCompositeNode*` and geometry/mover state should be reviewed for safety in multi-threaded workflows (assuming pointer usage is read-only after init).

## Possible Future Improvements

- Add/extend dedicated tests to cover survey-geometry vs ideal-geometry regressions, and explicitly validate the reclustering requirement across layers.
- Remove temporary diagnostics and any defensive/diagnostic branches after broader validation.
- Benchmark surface-lookup and cluster-movement performance, and consider caching strategies for repeated surface matching.
- Consolidate subsurface-key update/reclustering logic so subsurface keys are consistently refreshed rather than temporarily preserved while moved positions are derived.

*AI-generated summaries can contain mistakes—please verify the described behavior against the implementation and the reconstruction outputs for the intended production configurations (including the required reclustering step when survey geometry is used).*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->