### PR TITLE
Genfit extrapolation

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -822,8 +822,6 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
   double du2 = gf_state_beam_line_ca->getCov()[3][3];
   double dv2 = gf_state_beam_line_ca->getCov()[4][4];
-  // std::cout << PHWHERE << "        u " << u << " v " << v << " du2 " << du2 << " dv2 " << dv2 << " dvr2 " << dvr2 << std::endl;
-  // delete gf_state_beam_line_ca;
 
   // create new track
   auto out_track = std::make_shared<SvtxTrack_v4>(*svtx_track);
@@ -981,26 +979,24 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       continue;
     }
 
-    std::optional<genfit::MeasuredStateOnPlane> gf_state;
+    std::optional<genfit::MeasuredStateOnPlane> gf_state{};
     try
     {
-      *gf_state = kfi->getFittedState(true);
+      gf_state = kfi->getFittedState();
     }
     catch (...)
     {
       if (Verbosity() >= 1)
-        LogWarning("Exrapolation failed!");
-    }
-    if (!gf_state)
-    {
-      if (Verbosity() >= 1)
-        LogWarning("Exrapolation failed!");
+      { LogWarning("Exrapolation failed!"); }
       continue;
     }
 
-    // calculate path length
-    auto temp = gf_state.value();
-    const float pathlength = -temp.extrapolateToPoint(vertex_position);
+//     // calculate path length by extrapolating backward to vertex position
+//     auto temp = gf_state.value();
+//     const float pathlength = -temp.extrapolateToPoint(vertex_position);
+
+    genfit::MeasuredStateOnPlane temp;
+    float pathlength = -phgf_track->extrapolateToPoint(temp, vertex_position, id);
 
     // create new svtx state and add to track
     auto state = create_track_state(pathlength, gf_state.value());
@@ -1031,7 +1027,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       // get position
       const auto globalPosition = m_globalPositionWrapper.getGlobalPositionDistortionCorrected( cluster_key, cluster, crossing );
       const TVector3 pos_A(globalPosition.x(), globalPosition.y(), globalPosition.z() );
-      const float r_cluster = std::sqrt( square(globalPosition.x()) + square(globalPosition.y()) );
+      const auto r_cluster = get_r(globalPosition.x(),globalPosition.y());
 
       // loop over states
       /* find first state whose radius is larger than that of cluster if any */
@@ -1051,21 +1047,17 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         }
         catch (...)
         {
-          if (Verbosity())
-          {
-            LogWarning("Failed to get kf fitted state");
-          }
+          if (Verbosity()) { LogWarning("Failed to get kf fitted state"); }
+          continue;
         }
 
-        if (!gf_state) continue;
-
-        float r_track = std::sqrt(square(gf_state->getPos().x()) + square(gf_state->getPos().y()));
+        const auto r_track = get_r( gf_state->getPos().x(), gf_state->getPos().y());
         if (r_track > r_cluster) break;
       }
 
       // forward extrapolation
-      std::optional<genfit::MeasuredStateOnPlane> gf_state_forward;
-      std::optional<genfit::MeasuredStateOnPlane> gf_state_backward;
+      std::optional<genfit::MeasuredStateOnPlane> gf_state_forward{};
+      std::optional<genfit::MeasuredStateOnPlane> gf_state_backward{};
 
       float pathlength_forward = 0;
       float pathlength_backward = 0;
@@ -1080,7 +1072,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
         auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-        *gf_state_forward = kfi->getFittedState();
+        gf_state_forward = kfi->getFittedState();
         pathlength_forward = gf_state_forward->extrapolateToPoint( pos_A );
 
         auto tmp = kfi->getFittedState();
@@ -1104,7 +1096,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
           if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
           auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-          *gf_state_backward = kfi->getFittedState();
+          gf_state_backward = kfi->getFittedState();
 
           pathlength_backward = gf_state_backward->extrapolateToPoint( pos_A );
 
@@ -1140,17 +1132,18 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
         if( gf_state_forward && gf_state_backward )
         {
+          try {
+            // extrapolate backward state to the same plane as forward
+            gf_state_backward->extrapolateToPlane(gf_state_forward->getPlane());
 
-          // extrapolate backward state to the same plane as forward
-          gf_state_backward->extrapolateToPlane(gf_state_forward->getPlane());
+            // calculate weighted average
+            auto gf_state = genfit::calcAverageState(gf_state_forward.value(), gf_state_backward.value());
 
-          // calculate weighted average
-          auto gf_state = genfit::calcAverageState(gf_state_forward.value(), gf_state_backward.value());
-
-          // assign to track
-          auto state = create_track_state(pathlength_forward, gf_state);
-          state.set_cluskey(cluster_key);
-          out_track->insert_state(&state);
+            // assign to track
+            auto state = create_track_state(pathlength_forward, gf_state);
+            state.set_cluskey(cluster_key);
+            out_track->insert_state(&state);
+          } catch( ... ) {}
 
         } else if( gf_state_forward ) {
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1029,140 +1029,160 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       const TVector3 pos_A(globalPosition.x(), globalPosition.y(), globalPosition.z() );
       const auto r_cluster = get_r(globalPosition.x(),globalPosition.y());
 
-      // loop over states
-      /* find first state whose radius is larger than that of cluster if any */
-      unsigned int id = id_min;
-      for (; id < gftrack->getNumPointsWithMeasurement(); ++id)
+      if( m_extrapolation_mode == ExtrapolationMode::Default )
       {
-        auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
-        if (!trpoint) continue;
+          try
+          {
+            // copy state vector and extrapolate to cluster
+            auto tmp = *gf_state_vertex_ca;
+            auto pathlength = tmp.extrapolateToPoint(pos_A);
 
-        auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-        if (!kfi) continue;
+            // create state and assign
+            auto state = create_track_state(pathlength, tmp );
+            state.set_cluskey(cluster_key);
+            out_track->insert_state(&state);
 
-        std::optional<genfit::MeasuredStateOnPlane> gf_state;
-        try
-        {
-          gf_state = kfi->getFittedState();
-        }
-        catch (...)
-        {
-          if (Verbosity()) { LogWarning("Failed to get kf fitted state"); }
-          continue;
-        }
+          } catch(...) {}
 
-        const auto r_track = get_r( gf_state->getPos().x(), gf_state->getPos().y());
-        if (r_track > r_cluster) break;
-      }
+      } else {
 
-      // forward extrapolation
-      std::optional<genfit::MeasuredStateOnPlane> gf_state_forward{};
-      std::optional<genfit::MeasuredStateOnPlane> gf_state_backward{};
-
-      float pathlength_forward = 0;
-      float pathlength_backward = 0;
-
-      // first point is previous, if valid
-      if (id > 0) { id_min = id - 1; }
-
-      // extrapolate forward
-      try
-      {
-        auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
-        if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
-
-        auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-        gf_state_forward = kfi->getFittedState();
-        pathlength_forward = gf_state_forward->extrapolateToPoint( pos_A );
-
-        auto tmp = kfi->getFittedState();
-        pathlength_forward -= tmp.extrapolateToPoint(vertex_position);
-      }
-      catch (...)
-      {
-        if (Verbosity())
-        { std::cout << "PHGenFitTrkFitter::MakeSvtxTrack - Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
-
-        gf_state_forward = std::nullopt;
-      }
-
-      // extrapolate backward if possible
-      if (id > 0 && id < gftrack->getNumPointsWithMeasurement() )
-      {
-
-        try
+        // loop over states
+        /* find first state whose radius is larger than that of cluster if any */
+        unsigned int id = id_min;
+        for (; id < gftrack->getNumPointsWithMeasurement(); ++id)
         {
           auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
+          if (!trpoint) continue;
+
+          auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+          if (!kfi) continue;
+
+          std::optional<genfit::MeasuredStateOnPlane> gf_state;
+          try
+          {
+            gf_state = kfi->getFittedState();
+          }
+          catch (...)
+          {
+            if (Verbosity()) { LogWarning("Failed to get kf fitted state"); }
+            continue;
+          }
+
+          const auto r_track = get_r( gf_state->getPos().x(), gf_state->getPos().y());
+          if (r_track > r_cluster) break;
+        }
+
+        // forward extrapolation
+        std::optional<genfit::MeasuredStateOnPlane> gf_state_forward{};
+        std::optional<genfit::MeasuredStateOnPlane> gf_state_backward{};
+
+        float pathlength_forward = 0;
+        float pathlength_backward = 0;
+
+        // first point is previous, if valid
+        if (id > 0) { id_min = id - 1; }
+
+        // extrapolate forward
+        try
+        {
+          auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
           if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
           auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-          gf_state_backward = kfi->getFittedState();
-
-          pathlength_backward = gf_state_backward->extrapolateToPoint( pos_A );
+          gf_state_forward = kfi->getFittedState();
+          pathlength_forward = gf_state_forward->extrapolateToPoint( pos_A );
 
           auto tmp = kfi->getFittedState();
-          pathlength_backward -= tmp.extrapolateToPoint(vertex_position);
+          pathlength_forward -= tmp.extrapolateToPoint(vertex_position);
         }
         catch (...)
         {
           if (Verbosity())
           { std::cout << "PHGenFitTrkFitter::MakeSvtxTrack - Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
 
-          gf_state_backward = std::nullopt;
+          gf_state_forward = std::nullopt;
         }
-      }
 
-      // update state
-      if( m_extrapolation_mode == ExtrapolationMode::Forward && gf_state_forward )
-      {
-
-        // create new svtx state and add to track
-        auto state = create_track_state(pathlength_forward, gf_state_forward.value());
-        state.set_cluskey(cluster_key);
-        out_track->insert_state(&state);
-
-      } else if( m_extrapolation_mode == ExtrapolationMode::Backward && gf_state_backward ) {
-
-        // create new svtx state and add to track
-        auto state = create_track_state(pathlength_backward, gf_state_backward.value());
-        state.set_cluskey(cluster_key);
-        out_track->insert_state(&state);
-
-      } else if( m_extrapolation_mode == ExtrapolationMode::Bidirectional && ( gf_state_forward || gf_state_backward ) ) {
-
-        if( gf_state_forward && gf_state_backward )
+        // extrapolate backward if possible
+        if (id > 0 && id < gftrack->getNumPointsWithMeasurement() )
         {
-          try {
-            // extrapolate backward state to the same plane as forward
-            gf_state_backward->extrapolateToPlane(gf_state_forward->getPlane());
 
-            // calculate weighted average
-            auto gf_state = genfit::calcAverageState(gf_state_forward.value(), gf_state_backward.value());
+          try
+          {
+            auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
+            if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
-            // assign to track
-            auto state = create_track_state(pathlength_forward, gf_state);
-            state.set_cluskey(cluster_key);
-            out_track->insert_state(&state);
-          } catch( ... ) {}
+            auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+            gf_state_backward = kfi->getFittedState();
 
-        } else if( gf_state_forward ) {
+            pathlength_backward = gf_state_backward->extrapolateToPoint( pos_A );
 
-          // fall back to forward extrapolation
+            auto tmp = kfi->getFittedState();
+            pathlength_backward -= tmp.extrapolateToPoint(vertex_position);
+          }
+          catch (...)
+          {
+            if (Verbosity())
+            { std::cout << "PHGenFitTrkFitter::MakeSvtxTrack - Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
+
+            gf_state_backward = std::nullopt;
+          }
+        }
+
+        // update state
+        if( m_extrapolation_mode == ExtrapolationMode::Forward && gf_state_forward )
+        {
+
           // create new svtx state and add to track
           auto state = create_track_state(pathlength_forward, gf_state_forward.value());
           state.set_cluskey(cluster_key);
           out_track->insert_state(&state);
 
-        } else {
+        } else if( m_extrapolation_mode == ExtrapolationMode::Backward && gf_state_backward ) {
 
-          // fall back to backward extrapolation
           // create new svtx state and add to track
           auto state = create_track_state(pathlength_backward, gf_state_backward.value());
           state.set_cluskey(cluster_key);
           out_track->insert_state(&state);
 
-        }
-      } // test extrapolation mode
+        } else if( m_extrapolation_mode == ExtrapolationMode::Bidirectional && ( gf_state_forward || gf_state_backward ) ) {
+
+          if( gf_state_forward && gf_state_backward )
+          {
+            try {
+              // extrapolate backward state to the same plane as forward
+              gf_state_backward->extrapolateToPlane(gf_state_forward->getPlane());
+
+              // calculate weighted average
+              auto gf_state = genfit::calcAverageState(gf_state_forward.value(), gf_state_backward.value());
+
+              // assign to track
+              auto state = create_track_state(pathlength_forward, gf_state);
+              state.set_cluskey(cluster_key);
+              out_track->insert_state(&state);
+            } catch( ... ) {}
+
+          } else if( gf_state_forward ) {
+
+            // fall back to forward extrapolation
+            // create new svtx state and add to track
+            auto state = create_track_state(pathlength_forward, gf_state_forward.value());
+            state.set_cluskey(cluster_key);
+            out_track->insert_state(&state);
+
+          } else {
+
+            // fall back to backward extrapolation
+            // create new svtx state and add to track
+            auto state = create_track_state(pathlength_backward, gf_state_backward.value());
+            state.set_cluskey(cluster_key);
+            out_track->insert_state(&state);
+
+          }
+        } // test extrapolation mode
+
+      }
+
     } // loop over clusters
   } // check on disabled layers
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -95,8 +95,6 @@ namespace genfit
 #define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
 #define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
 
-using namespace std;
-
 //______________________________________________________
 namespace
 {
@@ -152,12 +150,25 @@ namespace
     return out;
   }
 
+  //______________________________________________________________________
+  // acts vector printout
   [[maybe_unused]] std::ostream& operator<<(std::ostream& out, const Acts::Vector3& vector)
   {
     out << "(" << vector.x() << ", " << vector.y() << ", " << vector.z() << ")";
     return out;
   }
 
+  //______________________________________________________________________
+  // genfit state vector printout
+  [[maybe_unused]] std::ostream& operator<<(std::ostream& out, const genfit::MeasuredStateOnPlane& state )
+  {
+    out
+      << "position (" << state.getPos().x() << ", " << state.getPos().y() << ", " << state.getPos().z() << ") "
+      << "radius " << get_r(  state.getPos().x(), state.getPos().y() );
+    return out;
+  }
+  //______________________________________________________________________
+  // convert local vector to global coordinates using a given surface and acts geometry
   TVector3 get_world_from_local_vect( ActsGeometry* geometry, Surface surface, const TVector3& local_vect )
   {
 
@@ -180,7 +191,7 @@ namespace
 /*
  * Constructor
  */
-PHGenFitTrkFitter::PHGenFitTrkFitter(const string& name)
+PHGenFitTrkFitter::PHGenFitTrkFitter(const std::string& name)
   : SubsysReco(name)
 {
 }
@@ -286,10 +297,10 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
   }
 
   // stands for Refit_GenFit_Tracks
-  vector<genfit::Track*> rf_gf_tracks;
-  vector<std::shared_ptr<PHGenFit::Track> > rf_phgf_tracks;
+  std::vector<genfit::Track*> rf_gf_tracks;
+  std::vector<std::shared_ptr<PHGenFit::Track> > rf_phgf_tracks;
 
-  map<unsigned int, unsigned int> svtxtrack_genfittrack_map;
+  std::map<unsigned int, unsigned int> svtxtrack_genfittrack_map;
 
   for (const auto& [key, svtx_track] : *m_trackMap)
   {
@@ -297,7 +308,7 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
 
     if (Verbosity() > 10)
     {
-      cout << "   process SVTXTrack " << key << endl;
+      std::cout << "   process SVTXTrack " << key << std::endl;
       svtx_track->identify();
     }
 
@@ -315,11 +326,12 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
         rf_gf_tracks.push_back(rf_phgf_track->getGenFitTrack());
       }
 
-      if (Verbosity() > 10) cout << "Done refitting input track" << svtx_track->get_id() << " or rf_phgf_track " << rf_phgf_tracks.size() << endl;
+      if (Verbosity() > 10)
+      { std::cout << "Done refitting input track" << svtx_track->get_id() << " or rf_phgf_track " << rf_phgf_tracks.size() << std::endl; }
     }
     else if (Verbosity() >= 1)
     {
-      cout << "failed refitting input track# " << key << endl;
+      std::cout << "failed refitting input track# " << key << std::endl;
     }
   }
 
@@ -391,7 +403,7 @@ int PHGenFitTrkFitter::CreateNodes(PHCompositeNode* topNode)
   auto dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
+    std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
   PHNodeIterator iter_dst(dstNode);
@@ -404,7 +416,7 @@ int PHGenFitTrkFitter::CreateNodes(PHCompositeNode* topNode)
     dstNode->addNode(svtx_node);
     if (Verbosity())
     {
-      cout << "SVTX node added" << endl;
+      std::cout << "SVTX node added" << std::endl;
     }
   }
 
@@ -514,7 +526,7 @@ int PHGenFitTrkFitter::GetNodes(PHCompositeNode* topNode)
 
   if (!m_clustermap)
   {
-    cout << PHWHERE << "PHGenFitTrkFitter::GetNodes - TRKR_CLUSTER node not found on node tree" << endl;
+    std::cout << PHWHERE << "PHGenFitTrkFitter::GetNodes - TRKR_CLUSTER node not found on node tree" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -546,7 +558,7 @@ int PHGenFitTrkFitter::GetNodes(PHCompositeNode* topNode)
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, _trackMap_name);
   if (!m_trackMap && _event < 2)
   {
-    cout << "PHGenFitTrkFitter::GetNodes - SvtxTrackMap node not found on node tree" << endl;
+    std::cout << "PHGenFitTrkFitter::GetNodes - SvtxTrackMap node not found on node tree" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -569,7 +581,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
   // std::shared_ptr<PHGenFit::Track> empty_track(nullptr);
   if (!intrack)
   {
-    cerr << PHWHERE << " Input SvtxTrack is nullptr!" << endl;
+    std::cerr << PHWHERE << " Input SvtxTrack is nullptr!" << std::endl;
     return nullptr;
   }
 
@@ -627,7 +639,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     if (Verbosity() > 10)
     {
       const int layer_out = TrkrDefs::getLayer(cluster_key);
-      cout << "    Layer " << layer_out << " cluster " << cluster_key << " radius " << r << endl;
+      std::cout << "    Layer " << layer_out << " cluster " << cluster_key << " radius " << r << std::endl;
     }
   }
 
@@ -756,12 +768,13 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
   }
 
   if (Verbosity() > 10)
-    cout << " track->getChisq() " << track->get_chi2() << " get_ndf " << track->get_ndf()
-         << " mom.X " << track->get_mom().X()
-         << " mom.Y " << track->get_mom().Y()
-         << " mom.Z " << track->get_mom().Z()
-         << endl;
-
+  {
+    std::cout << " track->getChisq() " << track->get_chi2() << " get_ndf " << track->get_ndf()
+      << " mom.X " << track->get_mom().X()
+      << " mom.Y " << track->get_mom().Y()
+      << " mom.Z " << track->get_mom().Z()
+      << std::endl;
+  }
   return track;
 }
 
@@ -808,7 +821,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
   double du2 = gf_state_beam_line_ca->getCov()[3][3];
   double dv2 = gf_state_beam_line_ca->getCov()[4][4];
-  // cout << PHWHERE << "        u " << u << " v " << v << " du2 " << du2 << " dv2 " << dv2 << " dvr2 " << dvr2 << endl;
+  // std::cout << PHWHERE << "        u " << u << " v " << v << " du2 " << du2 << " dv2 " << dv2 << " dvr2 " << dvr2 << std::endl;
   // delete gf_state_beam_line_ca;
 
   // create new track
@@ -907,37 +920,15 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
     if (Verbosity() > 30)
     {
-      cout << " vn.X " << vn.X() << " vn.Y " << vn.Y() << " vn.Z " << vn.Z() << endl;
-      cout << " pos_in.X " << pos_in[0][0] << " pos_in.Y " << pos_in[1][0] << " pos_in.Z " << pos_in[2][0] << endl;
-      cout << " pos_out.X " << pos_out[0][0] << " pos_out.Y " << pos_out[1][0] << " pos_out.Z " << pos_out[2][0] << endl;
+      std::cout << " vn.X " << vn.X() << " vn.Y " << vn.Y() << " vn.Z " << vn.Z() << std::endl;
+      std::cout << " pos_in.X " << pos_in[0][0] << " pos_in.Y " << pos_in[1][0] << " pos_in.Z " << pos_in[2][0] << std::endl;
+      std::cout << " pos_out.X " << pos_out[0][0] << " pos_out.Y " << pos_out[1][0] << " pos_out.Z " << pos_out[2][0] << std::endl;
     }
 
     dca3d_xy = pos_out[0][0];
     dca3d_z = pos_out[2][0];
     dca3d_xy_error = sqrt(cov_out[0][0]);
     dca3d_z_error = sqrt(cov_out[2][2]);
-
-#ifdef _DEBUG_
-    cout << __LINE__ << ": Vertex: ----------------" << endl;
-    vertex_position.Print();
-    vertex_cov.Print();
-
-    cout << __LINE__ << ": State: ----------------" << endl;
-    state6.Print();
-    cov6.Print();
-
-    cout << __LINE__ << ": Mean: ----------------" << endl;
-    pos_in.Print();
-    cout << "===>" << endl;
-    pos_out.Print();
-
-    cout << __LINE__ << ": Cov: ----------------" << endl;
-    cov_in.Print();
-    cout << "===>" << endl;
-    cov_out.Print();
-
-    cout << endl;
-#endif
   }
   catch (...)
   {
@@ -973,10 +964,6 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       out_track->set_error(i, j, cov[i][j]);
     }
   }
-
-#ifdef _DEBUG_
-  cout << __LINE__ << endl;
-#endif
 
   const auto gftrack = phgf_track->getGenFitTrack();
   const auto rep = gftrack->getCardinalRep();
@@ -1025,14 +1012,6 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
     out_track->insert_state(&state);
 
-#ifdef _DEBUG_
-    cout
-        << __LINE__
-        << ": " << id
-        << ": " << pathlength << " => "
-        << sqrt(square(state->get_x()) + square(state->get_y()))
-        << endl;
-#endif
   }
 
   // loop over clusters, check if layer is disabled, include extrapolated SvtxTrackState
@@ -1091,66 +1070,79 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
       // forward extrapolation
       genfit::MeasuredStateOnPlane gf_state;
+      genfit::MeasuredStateOnPlane gf_state_forward;
+      genfit::MeasuredStateOnPlane gf_state_backward;
+
+      float pathlength_forward = 0;
+      float pathlength_backward = 0;
       float pathlength = 0;
 
       // first point is previous, if valid
-      if (id > 0) id_min = id - 1;
+      if (id > 0) { id_min = id - 1; }
 
-      if( m_extrapolation_mode == ExtrapolationMode::Bidirectional || m_extrapolation_mode == ExtrapolationMode::Forward )
+      // extrapolate forward
+      try
       {
-        // extrapolate forward
-        try
-        {
-          auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
-          if (!trpoint) continue;
+        auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
+        if (!trpoint) continue;
 
-          auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-          gf_state = *kfi->getForwardUpdate();
-          pathlength = gf_state.extrapolateToPoint( pos_A );
-          auto tmp = *kfi->getBackwardUpdate();
-          pathlength -= tmp.extrapolateToPoint(vertex_position);
-        }
-        catch (...)
-        {
-          if (Verbosity())
-          {
-            std::cerr << PHWHERE << "Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl;
-          }
-          continue;
-        }
+        auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+        gf_state_forward = kfi->getFittedState();
+        // gf_state_forward = *kfi->getForwardUpdate();
+        pathlength_forward = gf_state_forward.extrapolateToPoint( pos_A );
+
+        auto tmp = *kfi->getBackwardUpdate();
+        pathlength_forward -= tmp.extrapolateToPoint(vertex_position);
       }
-
-      // if no track state was found after current, abort backward extrapolation
-      if( m_extrapolation_mode == ExtrapolationMode::Backward && (id >= gftrack->getNumPointsWithMeasurement() || id<=0 ) )
-      { continue; }
+      catch (...)
+      {
+        if (Verbosity())
+        { std::cerr << PHWHERE << "Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
+        continue;
+      }
 
       // also extrapolate backward from next state if any
       // and take the weighted average between both points
-      if (id > 0 && id < gftrack->getNumPointsWithMeasurement() &&
-        ( m_extrapolation_mode == ExtrapolationMode::Bidirectional || m_extrapolation_mode == ExtrapolationMode::Backward ))
+      if (id > 0 && id < gftrack->getNumPointsWithMeasurement() )
       {
+
         try
         {
           auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
           if (!trpoint) continue;
 
           auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-          genfit::KalmanFittedStateOnPlane gf_state_backward = *kfi->getBackwardUpdate();
+          // gf_state_backward = *kfi->getBackwardUpdate();
+          gf_state_backward = kfi->getFittedState();
 
-          // assign backward extrapolation as state
-          if( m_extrapolation_mode == ExtrapolationMode::Backward )
-          {
-            gf_state = gf_state_backward;
-            pathlength = gf_state.extrapolateToPoint( pos_A );
-            auto tmp = *kfi->getBackwardUpdate();
-            pathlength -= tmp.extrapolateToPoint(vertex_position);
-          }
+          pathlength_backward = gf_state_backward.extrapolateToPoint( pos_A );
+          auto tmp = *kfi->getBackwardUpdate();
+          pathlength_backward -= tmp.extrapolateToPoint(vertex_position);
 
-          // calculate the mean value
-          if( m_extrapolation_mode == ExtrapolationMode::Bidirectional )
+          switch( m_extrapolation_mode )
           {
-            gf_state_backward.extrapolateToPlane(gf_state.getPlane());
-            gf_state = genfit::calcAverageState(gf_state, gf_state_backward);
+
+            case ExtrapolationMode::Forward:
+            {
+              gf_state = gf_state_forward;
+              pathlength = pathlength_forward;
+              break;
+            }
+
+            case ExtrapolationMode::Backward:
+            {
+              gf_state = gf_state_backward;
+              pathlength = pathlength_backward;
+              break;
+            }
+
+            case ExtrapolationMode::Bidirectional:
+            {
+              gf_state_backward.extrapolateToPlane(gf_state_forward.getPlane());
+              gf_state = genfit::calcAverageState(gf_state_forward, gf_state_backward);
+              pathlength = pathlength_forward;
+            }
+
           }
 
         }
@@ -1162,6 +1154,18 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
           }
           continue;
         }
+
+      } else {
+
+        // do nothing if extrapolating backward
+        if( m_extrapolation_mode == ExtrapolationMode::Backward )
+        { continue; }
+
+        // no backward point found
+        // use forward extrapolation
+        gf_state = gf_state_forward;
+        pathlength = pathlength_forward;
+
       }
 
       // create new svtx state and add to track

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -170,7 +170,7 @@ namespace
   }
   //______________________________________________________________________
   // convert local vector to global coordinates using a given surface and acts geometry
-  TVector3 get_world_from_local_vect( ActsGeometry* geometry, Surface surface, const TVector3& local_vect )
+  TVector3 get_world_from_local_vect( ActsGeometry* geometry, const Surface& surface, const TVector3& local_vect )
   {
 
     // get global vector from local, using ACTS surface
@@ -401,7 +401,7 @@ int PHGenFitTrkFitter::CreateNodes(PHCompositeNode* topNode)
   // create nodes...
   PHNodeIterator iter(topNode);
 
-  auto dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  auto* dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
     std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
@@ -426,7 +426,7 @@ int PHGenFitTrkFitter::CreateNodes(PHCompositeNode* topNode)
   if (!m_trackMap)
   {
     m_trackMap = new SvtxTrackMap_v2;
-    auto node = new PHIODataNode<PHObject>(m_trackMap, _trackMap_name, "PHObject");
+    auto* node = new PHIODataNode<PHObject>(m_trackMap, _trackMap_name, "PHObject");
     svtx_node->addNode(node);
   }
 
@@ -960,11 +960,11 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
     }
   }
 
-  const auto gftrack = phgf_track->getGenFitTrack();
-  const auto rep = gftrack->getCardinalRep();
+  const auto* gftrack = phgf_track->getGenFitTrack();
+  const auto* rep = gftrack->getCardinalRep();
   for (unsigned int id = 0; id < gftrack->getNumPointsWithMeasurement(); ++id)
   {
-    auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, gftrack->getCardinalRep());
+    auto* trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, gftrack->getCardinalRep());
 
     if (!trpoint)
     {
@@ -972,7 +972,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       continue;
     }
 
-    auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+    auto* kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
     if (!kfi)
     {
       if (Verbosity() > 1) LogWarning("!kfi");
@@ -1042,7 +1042,10 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
             state.set_cluskey(cluster_key);
             out_track->insert_state(&state);
 
-          } catch(...) {}
+          } catch(...) {
+            if( Verbosity() )
+            { LogWarning("extrapolateToPoint failed!"); }
+          }
 
       } else {
 
@@ -1051,11 +1054,11 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         unsigned int id = id_min;
         for (; id < gftrack->getNumPointsWithMeasurement(); ++id)
         {
-          auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
-          if (!trpoint) continue;
+          auto* trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
+          if (!trpoint) { continue; }
 
-          auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-          if (!kfi) continue;
+          auto* kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+          if (!kfi) { continue; }
 
           std::optional<genfit::MeasuredStateOnPlane> gf_state;
           try
@@ -1069,7 +1072,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
           }
 
           const auto r_track = get_r( gf_state->getPos().x(), gf_state->getPos().y());
-          if (r_track > r_cluster) break;
+          if (r_track > r_cluster) { break; }
         }
 
         // forward extrapolation
@@ -1085,10 +1088,10 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         // extrapolate forward
         try
         {
-          auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
+          auto* trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
           if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
-          auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+          auto* kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
           gf_state_forward = kfi->getFittedState();
           pathlength_forward = gf_state_forward->extrapolateToPoint( pos_A );
 
@@ -1106,13 +1109,12 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         // extrapolate backward if possible
         if (id > 0 && id < gftrack->getNumPointsWithMeasurement() )
         {
-
           try
           {
-            auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
+            auto* trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
             if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
-            auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+            auto* kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
             gf_state_backward = kfi->getFittedState();
 
             pathlength_backward = gf_state_backward->extrapolateToPoint( pos_A );
@@ -1160,7 +1162,10 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
               auto state = create_track_state(pathlength_forward, gf_state);
               state.set_cluskey(cluster_key);
               out_track->insert_state(&state);
-            } catch( ... ) {}
+            } catch( ... ) {
+              if( Verbosity() )
+              { LogWarning("extrapolateToPoint failed!"); }
+            }
 
           } else if( gf_state_forward ) {
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1120,6 +1120,10 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         }
       }
 
+      // if no track state was found after current, abort backward extrapolation
+      if( m_extrapolation_mode == ExtrapolationMode::Backward && id >= gftrack->getNumPointsWithMeasurement() )
+      { continue; }
+
       // also extrapolate backward from next state if any
       // and take the weighted average between both points
       if (id > 0 && id < gftrack->getNumPointsWithMeasurement() &&

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1121,7 +1121,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       }
 
       // if no track state was found after current, abort backward extrapolation
-      if( m_extrapolation_mode == ExtrapolationMode::Backward && id >= gftrack->getNumPointsWithMeasurement() )
+      if( m_extrapolation_mode == ExtrapolationMode::Backward && (id >= gftrack->getNumPointsWithMeasurement() || id<=0 ) )
       { continue; }
 
       // also extrapolate backward from next state if any

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -975,7 +975,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
     auto* kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
     if (!kfi)
     {
-      if (Verbosity() > 1) LogWarning("!kfi");
+      if (Verbosity() > 1) { LogWarning("!kfi"); }
       continue;
     }
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1096,30 +1096,35 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       // first point is previous, if valid
       if (id > 0) id_min = id - 1;
 
-      // extrapolate forward
-      try
+      if( m_extrapolation_mode == ExtrapolationMode::Bidirectional || m_extrapolation_mode == ExtrapolationMode::Forward )
       {
-        auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
-        if (!trpoint) continue;
-
-        auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-        gf_state = *kfi->getForwardUpdate();
-        pathlength = gf_state.extrapolateToPoint( pos_A );
-        auto tmp = *kfi->getBackwardUpdate();
-        pathlength -= tmp.extrapolateToPoint(vertex_position);
-      }
-      catch (...)
-      {
-        if (Verbosity())
+        // extrapolate forward
+        try
         {
-          std::cerr << PHWHERE << "Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl;
+          auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
+          if (!trpoint) continue;
+
+          auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
+          gf_state = *kfi->getForwardUpdate();
+          pathlength = gf_state.extrapolateToPoint( pos_A );
+          auto tmp = *kfi->getBackwardUpdate();
+          pathlength -= tmp.extrapolateToPoint(vertex_position);
         }
-        continue;
+        catch (...)
+        {
+          if (Verbosity())
+          {
+            std::cerr << PHWHERE << "Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl;
+          }
+          continue;
+        }
       }
 
       // also extrapolate backward from next state if any
       // and take the weighted average between both points
-      if (id > 0 && id < gftrack->getNumPointsWithMeasurement())
+      if (id > 0 && id < gftrack->getNumPointsWithMeasurement() &&
+        ( m_extrapolation_mode == ExtrapolationMode::Bidirectional || m_extrapolation_mode == ExtrapolationMode::Backward ))
+      {
         try
         {
           auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
@@ -1127,8 +1132,23 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
           auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
           genfit::KalmanFittedStateOnPlane gf_state_backward = *kfi->getBackwardUpdate();
-          gf_state_backward.extrapolateToPlane(gf_state.getPlane());
-          gf_state = genfit::calcAverageState(gf_state, gf_state_backward);
+
+          // assign backward extrapolation as state
+          if( m_extrapolation_mode == ExtrapolationMode::Backward )
+          {
+            gf_state = gf_state_backward;
+            pathlength = gf_state.extrapolateToPoint( pos_A );
+            auto tmp = *kfi->getBackwardUpdate();
+            pathlength -= tmp.extrapolateToPoint(vertex_position);
+          }
+
+          // calculate the mean value
+          if( m_extrapolation_mode == ExtrapolationMode::Bidirectional )
+          {
+            gf_state_backward.extrapolateToPlane(gf_state.getPlane());
+            gf_state = genfit::calcAverageState(gf_state, gf_state_backward);
+          }
+
         }
         catch (...)
         {
@@ -1138,6 +1158,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
           }
           continue;
         }
+      }
 
       // create new svtx state and add to track
       auto state = create_track_state(pathlength, &gf_state);

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -82,6 +82,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -114,22 +115,22 @@ namespace
   }
 
   // convert gf state to SvtxTrackState_v2
-  SvtxTrackState_v2 create_track_state(float pathlength, const genfit::MeasuredStateOnPlane* gf_state)
+  SvtxTrackState_v2 create_track_state(float pathlength, const genfit::MeasuredStateOnPlane& gf_state)
   {
     SvtxTrackState_v2 out(pathlength);
-    out.set_x(gf_state->getPos().x());
-    out.set_y(gf_state->getPos().y());
-    out.set_z(gf_state->getPos().z());
+    out.set_x(gf_state.getPos().x());
+    out.set_y(gf_state.getPos().y());
+    out.set_z(gf_state.getPos().z());
 
-    out.set_px(gf_state->getMom().x());
-    out.set_py(gf_state->getMom().y());
-    out.set_pz(gf_state->getMom().z());
+    out.set_px(gf_state.getMom().x());
+    out.set_py(gf_state.getMom().y());
+    out.set_pz(gf_state.getMom().z());
 
     for (int i = 0; i < 6; i++)
     {
       for (int j = i; j < 6; j++)
       {
-        out.set_error(i, j, gf_state->get6DCov()[i][j]);
+        out.set_error(i, j, gf_state.get6DCov()[i][j]);
       }
     }
 
@@ -864,10 +865,6 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
   const auto pos = gf_state_vertex_ca->getPos();
   const auto cov = gf_state_vertex_ca->get6DCov();
 
-  //	genfit::MeasuredStateOnPlane* gf_state_vertex_ca =
-  //			phgf_track->extrapolateToLine(vertex_position,
-  //					TVector3(0., 0., 1.));
-
   u = gf_state_vertex_ca->getState()[3];
   v = gf_state_vertex_ca->getState()[4];
 
@@ -969,7 +966,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
   const auto rep = gftrack->getCardinalRep();
   for (unsigned int id = 0; id < gftrack->getNumPointsWithMeasurement(); ++id)
   {
-    genfit::TrackPoint* trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, gftrack->getCardinalRep());
+    auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, gftrack->getCardinalRep());
 
     if (!trpoint)
     {
@@ -984,11 +981,10 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       continue;
     }
 
-    const genfit::MeasuredStateOnPlane* gf_state = nullptr;
+    std::optional<genfit::MeasuredStateOnPlane> gf_state;
     try
     {
-      // this works because KalmanFitterInfo returns a const reference to internal object and not a temporary object
-      gf_state = &kfi->getFittedState(true);
+      *gf_state = kfi->getFittedState(true);
     }
     catch (...)
     {
@@ -1001,15 +997,14 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         LogWarning("Exrapolation failed!");
       continue;
     }
-    genfit::MeasuredStateOnPlane temp;
-    float pathlength = -phgf_track->extrapolateToPoint(temp, vertex_position, id);
+
+    // calculate path length
+    auto temp = gf_state.value();
+    const float pathlength = -temp.extrapolateToPoint(vertex_position);
 
     // create new svtx state and add to track
-    auto state = create_track_state(pathlength, gf_state);
-
-    // get matching cluster key from phgf_track and assign to state
+    auto state = create_track_state(pathlength, gf_state.value());
     state.set_cluskey(phgf_track->get_cluster_keys()[id]);
-
     out_track->insert_state(&state);
 
   }
@@ -1049,10 +1044,10 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
         auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
         if (!kfi) continue;
 
-        const genfit::MeasuredStateOnPlane* gf_state = nullptr;
+        std::optional<genfit::MeasuredStateOnPlane> gf_state;
         try
         {
-          gf_state = &kfi->getFittedState(true);
+          gf_state = kfi->getFittedState();
         }
         catch (...)
         {
@@ -1069,13 +1064,11 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       }
 
       // forward extrapolation
-      genfit::MeasuredStateOnPlane gf_state;
-      genfit::MeasuredStateOnPlane gf_state_forward;
-      genfit::MeasuredStateOnPlane gf_state_backward;
+      std::optional<genfit::MeasuredStateOnPlane> gf_state_forward;
+      std::optional<genfit::MeasuredStateOnPlane> gf_state_backward;
 
       float pathlength_forward = 0;
       float pathlength_backward = 0;
-      float pathlength = 0;
 
       // first point is previous, if valid
       if (id > 0) { id_min = id - 1; }
@@ -1084,96 +1077,101 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       try
       {
         auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id_min, rep);
-        if (!trpoint) continue;
+        if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
         auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-        gf_state_forward = kfi->getFittedState();
-        // gf_state_forward = *kfi->getForwardUpdate();
-        pathlength_forward = gf_state_forward.extrapolateToPoint( pos_A );
+        *gf_state_forward = kfi->getFittedState();
+        pathlength_forward = gf_state_forward->extrapolateToPoint( pos_A );
 
-        auto tmp = *kfi->getBackwardUpdate();
+        auto tmp = kfi->getFittedState();
         pathlength_forward -= tmp.extrapolateToPoint(vertex_position);
       }
       catch (...)
       {
         if (Verbosity())
-        { std::cerr << PHWHERE << "Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
-        continue;
+        { std::cout << "PHGenFitTrkFitter::MakeSvtxTrack - Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
+
+        gf_state_forward = std::nullopt;
       }
 
-      // also extrapolate backward from next state if any
-      // and take the weighted average between both points
+      // extrapolate backward if possible
       if (id > 0 && id < gftrack->getNumPointsWithMeasurement() )
       {
 
         try
         {
           auto trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, rep);
-          if (!trpoint) continue;
+          if( !trpoint ) { throw std::logic_error( "invalid argument" ); }
 
           auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
-          // gf_state_backward = *kfi->getBackwardUpdate();
-          gf_state_backward = kfi->getFittedState();
+          *gf_state_backward = kfi->getFittedState();
 
-          pathlength_backward = gf_state_backward.extrapolateToPoint( pos_A );
-          auto tmp = *kfi->getBackwardUpdate();
+          pathlength_backward = gf_state_backward->extrapolateToPoint( pos_A );
+
+          auto tmp = kfi->getFittedState();
           pathlength_backward -= tmp.extrapolateToPoint(vertex_position);
-
-          switch( m_extrapolation_mode )
-          {
-
-            case ExtrapolationMode::Forward:
-            {
-              gf_state = gf_state_forward;
-              pathlength = pathlength_forward;
-              break;
-            }
-
-            case ExtrapolationMode::Backward:
-            {
-              gf_state = gf_state_backward;
-              pathlength = pathlength_backward;
-              break;
-            }
-
-            case ExtrapolationMode::Bidirectional:
-            {
-              gf_state_backward.extrapolateToPlane(gf_state_forward.getPlane());
-              gf_state = genfit::calcAverageState(gf_state_forward, gf_state_backward);
-              pathlength = pathlength_forward;
-            }
-
-          }
-
         }
         catch (...)
         {
           if (Verbosity())
-          {
-            std::cerr << PHWHERE << "Failed to backward extrapolate from id " << id << " to disabled layer " << layer << std::endl;
-          }
-          continue;
+          { std::cout << "PHGenFitTrkFitter::MakeSvtxTrack - Failed to forward extrapolate from id " << id_min << " to disabled layer " << layer << std::endl; }
+
+          gf_state_backward = std::nullopt;
         }
-
-      } else {
-
-        // do nothing if extrapolating backward
-        if( m_extrapolation_mode == ExtrapolationMode::Backward )
-        { continue; }
-
-        // no backward point found
-        // use forward extrapolation
-        gf_state = gf_state_forward;
-        pathlength = pathlength_forward;
-
       }
 
-      // create new svtx state and add to track
-      auto state = create_track_state(pathlength, &gf_state);
-      state.set_cluskey(cluster_key);
-      out_track->insert_state(&state);
-    }
-  }
+      // update state
+      if( m_extrapolation_mode == ExtrapolationMode::Forward && gf_state_forward )
+      {
+
+        // create new svtx state and add to track
+        auto state = create_track_state(pathlength_forward, gf_state_forward.value());
+        state.set_cluskey(cluster_key);
+        out_track->insert_state(&state);
+
+      } else if( m_extrapolation_mode == ExtrapolationMode::Backward && gf_state_backward ) {
+
+        // create new svtx state and add to track
+        auto state = create_track_state(pathlength_backward, gf_state_backward.value());
+        state.set_cluskey(cluster_key);
+        out_track->insert_state(&state);
+
+      } else if( m_extrapolation_mode == ExtrapolationMode::Bidirectional && ( gf_state_forward || gf_state_backward ) ) {
+
+        if( gf_state_forward && gf_state_backward )
+        {
+
+          // extrapolate backward state to the same plane as forward
+          gf_state_backward->extrapolateToPlane(gf_state_forward->getPlane());
+
+          // calculate weighted average
+          auto gf_state = genfit::calcAverageState(gf_state_forward.value(), gf_state_backward.value());
+
+          // assign to track
+          auto state = create_track_state(pathlength_forward, gf_state);
+          state.set_cluskey(cluster_key);
+          out_track->insert_state(&state);
+
+        } else if( gf_state_forward ) {
+
+          // fall back to forward extrapolation
+          // create new svtx state and add to track
+          auto state = create_track_state(pathlength_forward, gf_state_forward.value());
+          state.set_cluskey(cluster_key);
+          out_track->insert_state(&state);
+
+        } else {
+
+          // fall back to backward extrapolation
+          // create new svtx state and add to track
+          auto state = create_track_state(pathlength_backward, gf_state_backward.value());
+          state.set_cluskey(cluster_key);
+          out_track->insert_state(&state);
+
+        }
+      } // test extrapolation mode
+    } // loop over clusters
+  } // check on disabled layers
 
   // printout all track state
   if (Verbosity())

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -145,6 +145,7 @@ class PHGenFitTrkFitter : public SubsysReco
   /// extrapolation mode
   enum class ExtrapolationMode
   {
+    Default, // use track parameters at vertex for the extrapolation
     Forward, // uses the track state vector closest to the requested layer, before
     Backward, // uses the track state vector closest to the requested layer, before
     Bidirectional // uses the weighted average of the forward and backward extrapolation, when available

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -147,7 +147,7 @@ class PHGenFitTrkFitter : public SubsysReco
   {
     Default, // use track parameters at vertex for the extrapolation
     Forward, // uses the track state vector closest to the requested layer, before
-    Backward, // uses the track state vector closest to the requested layer, before
+    Backward, // uses the track state vector closest to the requested layer, after
     Bidirectional // uses the weighted average of the forward and backward extrapolation, when available
   };
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -142,7 +142,20 @@ class PHGenFitTrkFitter : public SubsysReco
   void disableAverageCorr() { m_disable_average_corr = true; }
   void disableFluctuationCorr() { m_disable_fluctuation_corr = true; }
 
- private:
+  /// extrapolation mode
+  enum class ExtrapolationMode
+  {
+    Forward, // uses the track state vector closest to the requested layer, before
+    Backward, // uses the track state vector closest to the requested layer, before
+    Bidirectional // uses the weighted average of the forward and backward extrapolation, when available
+  };
+
+  /// extrapolation mode
+  void setExtrapolationMode( const ExtrapolationMode value )
+  { m_extrapolation_mode = value; }
+
+  private:
+
   //! Event counter
   int _event = 0;
 
@@ -218,6 +231,10 @@ class PHGenFitTrkFitter : public SubsysReco
   bool m_disable_static_corr = false;
   bool m_disable_average_corr = false;
   bool m_disable_fluctuation_corr = false;
+
+  /// extrapolation mode
+  ExtrapolationMode m_extrapolation_mode = ExtrapolationMode::Bidirectional;
+
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This aligns GENFIT extrapolation modes to that in ACTS, introducing 
- Default (using track parameters at origin)
- Forward
- Backward
- Bidirectional. 
The latter is the default, and what was used until now. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation
Bring GENFIT disabled-layer extrapolation in line with ACTS by adding selectable extrapolation modes, while keeping the previous bidirectional behavior as the default (new, non-breaking feature).

## Key changes
- Added `PHGenFitTrkFitter::ExtrapolationMode` (`Default`, `Forward`, `Backward`, `Bidirectional`) and a `setExtrapolationMode(...)` setter; internal default remains `ExtrapolationMode::Bidirectional`.
- Reworked disabled-layer extrapolation in `MakeSvtxTrack` around `m_extrapolation_mode`, with directional candidate state retrieval using `std::optional`.
- Implemented mode-specific logic:
  - `Default`: extrapolate using track parameters at the origin/vertex.
  - `Forward`/`Backward`: use the closest state before/after the target layer, respectively.
  - `Bidirectional`: align backward to the forward plane and (when both directions succeed) create an averaged-state; otherwise explicitly fall back to the single successful direction.
- Improved robustness of GenFit fitted-state handling/state construction:
  - Switched state extraction to `std::optional` patterns with `try/catch`.
  - Updated helper usage to pass fitted state by value (removing pointer-based fitted state retrieval).
- Refactor/cleanup: removed `using namespace std` and standardized to `std::` qualification; updated/refined logging and refit/extrapolation failure messages.

## Potential risk areas
- **Reconstruction behavior:** Extrapolated disabled-layer Svtx states will change depending on the configured mode, especially for `Bidirectional` (may require both directions to succeed).
- **Performance:** `Bidirectional` can increase extrapolation work versus single-direction modes.
- **Failure/edge cases:** New optional/fallback logic and plane alignment could impact rare geometries/topologies or cases where one direction intermittently fails.
- **Thread-safety/configuration:** `m_extrapolation_mode` is mutable state on the fitter instance; concurrent reuse with different settings could be problematic.

## Possible future improvements
- Add validation tests that compare `Default`/`Forward`/`Backward`/`Bidirectional` behavior (including fallback/averaging) against ACTS-style expectations.
- Benchmark performance impact across representative track samples and disabled-layer patterns.
- Document recommended mode usage and expected physics differences, with reference studies.

*Note:* This summary is based on repository change indicators provided and may contain mistakes; please use best judgment and verify the exact runtime behavior with the corresponding unit/integration tests or reference studies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->