### PR TITLE
Added some variables to MbdTrackerVertex ttree

### DIFF
--- a/calibrations/mbd/Makefile.am
+++ b/calibrations/mbd/Makefile.am
@@ -24,7 +24,8 @@ libmbdcalib_la_LIBADD = \
   -lSubsysReco \
   -lglobalvertex_io \
   -lffarawobjects \
-  -lffaobjects
+  -lffaobjects \
+  -lmbd
 
 BUILT_SOURCES = testexternals.cc
 

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -105,7 +105,7 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
   SvtxVertexMap *m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   GlobalVertexMap *globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
 
-  if (!m_dst_mbdvertexmap || !m_dst_vertexmap || !globalvertexmap || !mbdout)
+  if ( !m_dst_mbdvertexmap || !m_dst_vertexmap || !globalvertexmap )
   {
     std::cout << PHWHERE << " missing required vertex node(s)" << std::endl;
     return Fun4AllReturnCodes::DISCARDEVENT;
@@ -123,8 +123,8 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
   }
   else
   {
-    _nMBD[0] = std::numeric_limits<Short_t>::quiet_NaN();
-    _nMBD[1] = std::numeric_limits<Short_t>::quiet_NaN();
+    _nMBD[0] = 0;
+    _nMBD[1] = 0;
     _qMBD[0] = std::numeric_limits<Float_t>::quiet_NaN();
     _qMBD[1] = std::numeric_limits<Float_t>::quiet_NaN();
   }

--- a/calibrations/mbd/MbdTrackVertex.cc
+++ b/calibrations/mbd/MbdTrackVertex.cc
@@ -9,6 +9,7 @@
 #include <ffarawobjects/Gl1Packet.h>
 
 #include <ffaobjects/EventHeader.h>
+#include <ffaobjects/RunHeader.h>
 
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
@@ -16,6 +17,8 @@
 #include <globalvertex/MbdVertexMap.h>
 #include <globalvertex/SvtxVertex.h>
 #include <globalvertex/SvtxVertexMap.h>
+
+#include <mbd/MbdOut.h>
 
 constexpr GlobalVertex::VTXTYPE trkType = GlobalVertex::SVTX;
 constexpr GlobalVertex::VTXTYPE mbdType = GlobalVertex::MBD;
@@ -42,12 +45,17 @@ int MbdTrackVertex::Init(PHCompositeNode * /*topNode*/)
     outTree->OptimizeBaskets();
     outTree->SetAutoSave(-5e6);
 
+    outTree->Branch("run", &_run, "run/I");
     outTree->Branch("evt", &_evt, "evt/I");
     outTree->Branch("mbdz", &_mbdVertex, "mbdz/F");
     outTree->Branch("trkz", &_trackerVertex, "trkz/F");
-    outTree->Branch("ntrks", &_nTracks, "ntrks/i");
     outTree->Branch("nbz", &_nMBDVertex, "nbz/i");
     outTree->Branch("ntz", &_nTRKVertex, "ntz/i");
+    outTree->Branch("ntrks", &_nTracks, "ntrks/i");
+    outTree->Branch("bns", &_nMBD[0], "bns/S");
+    outTree->Branch("bnn", &_nMBD[1], "bnn/S");
+    outTree->Branch("bqs", &_qMBD[0], "bqs/F");
+    outTree->Branch("bqn", &_qMBD[1], "bqn/F");
   }
 
   // h_mbdtrkz: dz = _mbdVertex - trackerVertex, range (-15,15) cm, 0.25 cm bins → 120 bins
@@ -69,6 +77,9 @@ int MbdTrackVertex::Init(PHCompositeNode * /*topNode*/)
 //____________________________________________________________________________..
 int MbdTrackVertex::process_event(PHCompositeNode *topNode)
 {
+  RunHeader *runheader = findNode::getClass<RunHeader>(topNode, "RunHeader");
+  _run = runheader ? runheader->get_RunNumber() : -1;
+
   EventHeader *eventheader = findNode::getClass<EventHeader>(topNode, "EventHeader");
   _evt = eventheader ? eventheader->get_EvtSequence() : -1;
 
@@ -89,11 +100,12 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
     }
   }
 
+  MbdOut *mbdout = findNode::getClass<MbdOut>(topNode, "MbdOut");
   MbdVertexMap *m_dst_mbdvertexmap = findNode::getClass<MbdVertexMap>(topNode, "MbdVertexMap");
   SvtxVertexMap *m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-
   GlobalVertexMap *globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
-  if (!m_dst_mbdvertexmap || !m_dst_vertexmap || !globalvertexmap)
+
+  if (!m_dst_mbdvertexmap || !m_dst_vertexmap || !globalvertexmap || !mbdout)
   {
     std::cout << PHWHERE << " missing required vertex node(s)" << std::endl;
     return Fun4AllReturnCodes::DISCARDEVENT;
@@ -101,6 +113,21 @@ int MbdTrackVertex::process_event(PHCompositeNode *topNode)
 
   _mbdVertex = _trackerVertex = std::numeric_limits<float>::quiet_NaN();
   _nTracks = _nMBDVertex = _nTRKVertex = std::numeric_limits<unsigned int>::quiet_NaN();
+
+  if ( mbdout )
+  {
+    _nMBD[0] = mbdout->get_npmt(0);
+    _nMBD[1] = mbdout->get_npmt(1);
+    _qMBD[0] = mbdout->get_q(0);
+    _qMBD[1] = mbdout->get_q(1);
+  }
+  else
+  {
+    _nMBD[0] = std::numeric_limits<Short_t>::quiet_NaN();
+    _nMBD[1] = std::numeric_limits<Short_t>::quiet_NaN();
+    _qMBD[0] = std::numeric_limits<Float_t>::quiet_NaN();
+    _qMBD[1] = std::numeric_limits<Float_t>::quiet_NaN();
+  }
 
   _hasMBD = false;
   _hasTRK = false;

--- a/calibrations/mbd/MbdTrackVertex.h
+++ b/calibrations/mbd/MbdTrackVertex.h
@@ -50,19 +50,23 @@ class MbdTrackVertex : public SubsysReco
   THnSparseF* h2_mbdtrkz {nullptr};
   std::string outFileName = "mbdtrk_vertex.root";
 
-  Float_t _mbdVertex {std::numeric_limits<float>::quiet_NaN()};
-  Float_t _trackerVertex {std::numeric_limits<float>::quiet_NaN()};
-  UInt_t  _nTracks {std::numeric_limits<unsigned int>::quiet_NaN()};
-  UInt_t  _nMBDVertex {std::numeric_limits<unsigned int>::quiet_NaN()};
-  UInt_t  _nTRKVertex {std::numeric_limits<unsigned int>::quiet_NaN()};
-
   bool _hasMBD {false};
   bool _hasTRK {false};
 
+  // Tree variables
+  Int_t    _run {0};
+  Int_t    _evt {0};
+  Float_t  _mbdVertex {std::numeric_limits<float>::quiet_NaN()};
+  Float_t  _trackerVertex {std::numeric_limits<float>::quiet_NaN()};
+  UInt_t   _nMBDVertex {0};
+  UInt_t   _nTRKVertex {0};
+  UInt_t   _nTracks {0};
+  Short_t  _nMBD[2] {0};
+  Float_t  _qMBD[2] {0};
+
   bool _treeflag {true};
   uint64_t _gl1_trigmask {0};
-  int _counter{0};
-  int _evt{0};
+  int _counter {0};
 };
 
 #endif // MBDTRACKVERTEX_H


### PR DESCRIPTION
[comment]: Some variables were added to a ttree that is used for doing the mbd-track vertex matching calibration.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Adds run/event metadata and MBD observables to the `MbdTrackerVertex` TTree for MBD–track vertex matching calibration.

## Key Changes

- Adds run number, MBD counts, and MBD charge branches.
- Reads `RunHeader`, `MbdOut`, and required vertex-map nodes during event processing.
- Handles unavailable MBD values using quiet NaNs.
- Links the calibration library against `libmbd`.

## Potential Risk Areas

- Extends the TTree schema, requiring downstream calibration readers to accommodate new branches.
- Events missing newly required nodes are now discarded.
- No significant thread-safety or performance concerns are apparent.

## Possible Future Improvements

- Document the updated TTree schema and compatibility expectations.
- Add validation or regression tests for missing nodes and NaN-valued MBD observables.
- Confirm downstream consumers handle the revised branch ordering and types.

This summary is based on AI-generated change descriptions; details should be verified against the implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->