### PR TITLE
Acts extrapolation

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -341,7 +341,7 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
   }
 
   _topNode = topNode;
-  
+
   if (Verbosity() > 1)
   {
     std::cout << "Finish PHActsTrkFitter Setup" << std::endl;
@@ -1361,7 +1361,6 @@ void PHActsTrkFitter::updateSvtxTrack(
       }
 
       // get layer, propagate
-      /* this code is quite complicated. See to simplify */
       const auto layer = TrkrDefs::getLayer(cluskey);
       auto extrapolate = [&]( const ActsPropagator::BoundTrackParamPair& p, uint8_t l, Acts::Direction direction )
       {
@@ -1383,7 +1382,7 @@ void PHActsTrkFitter::updateSvtxTrack(
 
       } else {
 
-        // get before and after nearesst parameters
+        // get before and after nearest parameters
         const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
         const auto& nearest_params_backward = find_nearest_params_after( mj, trackTip, layer );
 
@@ -1451,6 +1450,7 @@ void PHActsTrkFitter::updateSvtxTrack(
     // loop over cluster keys associated to TPC seed
     for (auto key_iter = seed->begin_cluster_keys(); key_iter != seed->end_cluster_keys(); ++key_iter)
     {
+      // cluster key
       const auto& cluskey = *key_iter;
 
       // make sure cluster is from Micromegas (TPOT)
@@ -1458,23 +1458,61 @@ void PHActsTrkFitter::updateSvtxTrack(
       if (detId != TrkrDefs::micromegasId)
       { continue; }
 
+      // layer
+      const auto layer = TrkrDefs::getLayer(cluskey);
+
       // get corresponding surface
       const auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
       const auto surface = m_tGeometry->maps().getMMSurface(hitsetkey);
       if (!surface) { continue; }
 
-      // propagate
-      auto result = propagator.propagateTrack(params, surface);
-      if (!result.ok()) { continue; }
+      // surface extrapolation
+      auto extrapolate = [&]( const ActsPropagator::BoundTrackParamPair& p, const Surface& s)
+      {
 
-      // get path length and extrapolated parameters
-      auto& [pathLength, trackStateParams] = result.value();
-      pathLength /= Acts::UnitConstants::cm;
+        const auto& [source_pathlength, source_param] = p;
+        auto result = propagator.propagateTrack(source_param, s);
+        if( result.ok() )
+        {
+          const auto& [pathLength, trackStateParams] = result.value();
+          transformer.addTrackState(track, cluskey, (source_pathlength+pathLength)/Acts::UnitConstants::cm, trackStateParams, m_transient_geocontext);
+        }
+      };
 
-      // create track state and add to track
-      transformer.addTrackState(track, cluskey, pathLength, trackStateParams, m_transient_geocontext);
-    }
-  }
+      switch( m_extrapolation_mode )
+      {
+        case ExtrapolationMode::Default:
+        {
+
+          // extrapolate from track parameters
+          extrapolate( {0,params}, surface );
+          break;
+        }
+
+        case ExtrapolationMode::Forward:
+        case ExtrapolationMode::Bidirectional:
+        {
+          // find nearest parameters before TPOT
+          const auto& nearest_params_forward = find_nearest_params_before( mj, trackTip, layer );
+
+          // perform extrapolation
+          if( nearest_params_forward )
+          {
+            // extrapolate from nearest forward parameters
+            extrapolate( nearest_params_forward.value(), surface );
+          }
+          break;
+        }
+
+        case ExtrapolationMode::Backward:
+        {
+          // cannot use backward extrapolation to TPOT since this is the outermost detector.
+          // doing nothing
+          break;
+        }
+      } // extrapolation mode
+    } // cluster loop
+  } // check on TPOT enabled
 
   trackStateTimer.stop();
   auto stateTime = trackStateTimer.get_accumulated_time();

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -276,7 +276,7 @@ class PHActsTrkFitter : public SubsysReco
   int m_cluster_edge_rejection = 0;
 
   /// extrapolation mode
-  ExtrapolationMode m_extrapolation_mode = ExtrapolationMode::Default;
+  ExtrapolationMode m_extrapolation_mode = ExtrapolationMode::Bidirectional;
 
   //!@name evaluator
   //@{


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
this changes the default extrapolation mode in ACTS to bidirectional, consistently with genfit and following presentation at https://indico.bnl.gov/event/33420/contributions/126451/attachments/71737/122952/acts_extrapolation.pdf
Also implements forward extrapolation when extrapolating to TPOT.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Align the default ACTS extrapolation behavior with GenFit and the referenced presentation, while ensuring TPOT track states are extrapolated in the forward direction.

## Key Changes

- Set the default `PHActsTrkFitter` extrapolation mode to bidirectional.
- Refactor TPOT track-state propagation to support extrapolation-mode-specific behavior.
- Use forward extrapolation for forward and bidirectional modes.
- Skip TPOT extrapolation in backward-only mode.
- Add surface validity checks and path-length handling for propagated track states.
- Clean up minor whitespace and comments.

## Potential Risk Areas

- Reconstruction behavior may change due to the new default extrapolation mode and TPOT propagation logic.
- Additional propagation and trajectory handling could affect performance.
- No IO format or thread-safety changes are expected.

## Possible Future Improvements

- Add targeted tests covering all extrapolation modes and TPOT surface edge cases.
- Benchmark propagation performance and validate track-quality changes against reference samples.

*AI-generated summaries can contain mistakes; the implementation should be reviewed against the source changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->