### PR TITLE
use DST#Sync for unsplit TTree to read sync object

### DIFF
--- a/offline/framework/ffaobjects/SyncDefs.h
+++ b/offline/framework/ffaobjects/SyncDefs.h
@@ -9,7 +9,9 @@ namespace syncdefs
 {
   // __attribute__((unused)) prevents compiler from flagging variable as unused
   static const int NUM_SYNC_VARS __attribute__((unused)) = 4;
-  static const char *SYNCVARS[] __attribute__((unused)) = {"eventcounter", "eventnumber", "runnumber", "segmentnumber"};
+// Sync object in old split TTree
+//  static const char *SYNCVARS[] __attribute__((unused)) = {"eventcounter", "eventnumber", "runnumber", "segmentnumber"};
+  static const char *SYNCVARS[] __attribute__((unused)) = {"DST#Sync"}; // TBranch name of sync object in unsplit TTree
   static const std::string SYNCNODENAME __attribute__((unused)) = "Sync";
 }  // namespace syncdefs
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
For unsplit TTrees the sync object branch handling changes. In split ttrees we have to enable the reading of the "eventcounter", "eventnumber", "runnumber", "segmentnumber" branches. For unsplit TTrees this changes to "DST#Sync". That's low level and only needed if we disable reading certain branches to speed up i/o or suppress some objects from being read from the DST

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Fix synchronization-object reads for unsplit TTrees when selective branch reading is enabled. This supports improved I/O performance and suppression of DST objects.

## Key changes

- Update `syncdefs::SYNCVARS` to use the unsplit `"DST#Sync"` branch.
- Preserve `eventcounter`, `eventnumber`, `runnumber`, and `segmentnumber` for split TTrees.

## Potential risk areas

- Verify synchronization reads for both split and unsplit TTree formats.
- Confirm that reconstruction behavior remains unchanged.
- Measure I/O performance when branches are selectively disabled.
- Check for thread-safety issues in downstream branch handling.

## Possible future improvements

- Add regression tests for selective branch reads in both TTree formats.
- Document the branch-selection behavior and format requirements.

AI-generated summaries can contain mistakes. Review the implementation and tests before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->