### PR TITLE
add 3GeV pythia jets/photonjets to CreateFileList.pl

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -35,7 +35,9 @@ my %exclude_these = (
     "DST_JOBA" => "Test PanDa",
     "DST_MDC2_GLOBAL" => "Test PanDa",
     "DST_PASS1_CLUSTERS" => "Test PanDa",
-    "DST_RECO_CLUSTER" => "Test PanDa"
+    "DST_RECO_CLUSTER" => "Test PanDa",
+    "DST_CALO_NOZERO" => "obsolete",
+    "DST_CALO_WAVEFORM" => "obsolete"
     );
 
 my %proddesc = (
@@ -89,7 +91,9 @@ my %proddesc = (
     "48" => "JS pythia8 Jet ptmin = 8 GeV",
     "49" => "JS pythia8 Jet ptmin = 80 GeV",
     "50" => "JS pythia8 Detroit eta ptmin = 3 GeV",
-    "51" => "JS pythia8 Detroit eta ptmin = 8 GeV"
+    "51" => "JS pythia8 Detroit eta ptmin = 8 GeV",
+    "52" => "JS pythia8 Jet ptmin = 3 GeV",
+    "53" => "JS pythia8 Photonjet ptmin = 3 GeV"
     );
 
 my %pileupdesc = (
@@ -1501,6 +1505,82 @@ if (defined $prodtype)
     {
         $embedok = 1;
 	$filenamestring = "pythia8_Eta8";
+	if (! defined $nopileup)
+	{
+	    if (defined $embed)
+	    {
+		if ($embed eq "pau")
+		{
+		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm%s",$filenamestring, $pAu_pileupstring);
+		}
+		elsif ($embed eq "central")
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		elsif ($embed eq "oo")
+		{
+		    $filenamestring = sprintf("%s_sHijing_OO_0_15fm%s",$filenamestring, $OO_pileupstring);
+		}
+		else
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_20fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+	    }
+	    else
+	    {
+		$filenamestring = sprintf("%s%s",$filenamestring,$pp_pileupstring);
+	    }
+	}
+        $pileupstring = $pp_pileupstring;
+	&commonfiletypes();
+    }
+    elsif ($prodtype == 52)
+    {
+        $embedok = 1;
+	$filenamestring = "pythia8_Jet3";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
+	if (! defined $nopileup)
+	{
+	    if (defined $embed)
+	    {
+		if ($embed eq "pau")
+		{
+		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm%s",$filenamestring, $pAu_pileupstring);
+		}
+		elsif ($embed eq "central")
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_488fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+		elsif ($embed eq "oo")
+		{
+		    $filenamestring = sprintf("%s_sHijing_OO_0_15fm%s",$filenamestring, $OO_pileupstring);
+		}
+		else
+		{
+		    $filenamestring = sprintf("%s_sHijing_0_20fm%s",$filenamestring, $AuAu_pileupstring);
+		}
+	    }
+	    else
+	    {
+		$filenamestring = sprintf("%s%s",$filenamestring,$pp_pileupstring);
+	    }
+	}
+        $pileupstring = $pp_pileupstring;
+	&commonfiletypes();
+    }
+    elsif ($prodtype == 53)
+    {
+        $embedok = 1;
+	$filenamestring = "pythia8_PhotonJet3";
+	if (defined $double)
+	{
+	    $doubleok = 1;
+	    $filenamestring = sprintf("%s_pythia8_Detroit",$filenamestring);
+	}
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the new 3GeV jets/photonjets as type 52,53 to CreateFileList.pl. jenkins does not check this, skipping it: [skip-ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Add file-list support for the new 3 GeV Pythia jets and photonjets datasets. This enables `CreateFileList.pl` to process production types 52 and 53.

## Key changes

- Add production type 52 for 3 GeV jets.
- Add production type 53 for 3 GeV photon jets.
- Support pileup, embedding, and double-interaction filename variants.
- Remove obsolete `DST_CALO_NOZERO` and `DST_CALO_WAVEFORM` entries from the exclusion list.
- Make no public API or exported-entity changes.

## Potential risk areas

- File matching may produce incomplete or incorrect lists if new filename variants differ from the implemented patterns.
- The obsolete exclusion-list changes may alter file selection for existing workflows.
- No reconstruction, I/O format, thread-safety, or performance changes are expected.
- CI does not validate this functionality because Jenkins skips it.

## Possible future improvements

- Add automated tests for production types 52 and 53.
- Add representative filename fixtures for pileup, embedding, and double-interaction cases.
- Verify the updated exclusion list against current production outputs.

AI-generated summaries can contain mistakes. Review the implementation and validate the filename patterns against production data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->