### PR TITLE
Update TpcClusterMover to handle two cases for TRKR_CLUSTER node name.

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -92,11 +92,15 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   // The input object contains all clusters for the track in world coordinates
   // The surface radii are in global coordinates. Needed because we are dealing with aligned surfaces
 
-  auto *cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
+  auto *cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER_SEED");
   if(!cluster_map)
     {
-      std::cout << PHWHERE << " Did not find TRKR_CLUSTER node, quit." << std::endl;
-	exit(1);
+      cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
+      if(!cluster_map)
+	{
+	  std::cout << PHWHERE << " Did not find TRKR_CLUSTER_SEED or TRKR_CLUSTER nodes, quit." << std::endl;
+	  exit(1);
+	}
     }
 
   auto surfMaps = _tGeometry->maps();


### PR DESCRIPTION
[comment]: <This PR updates the TpcClusterMover to handle two cases for the TRKR_CLUSTER node name.> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Support both `TRKR_CLUSTER_SEED` and `TRKR_CLUSTER` node names without changing public interfaces.

## Key changes

- `processTrack` checks for `TRKR_CLUSTER_SEED` first.
- It falls back to `TRKR_CLUSTER` when `TRKR_CLUSTER_SEED` is unavailable.
- It reports an error only when neither container exists.

## Potential risks

- No I/O format changes are expected.
- Reconstruction behavior can change when only `TRKR_CLUSTER` is present.
- No thread-safety or significant performance impact is expected.

## Possible future improvements

- Add tests for both node names and for the missing-container case.
- Document the supported node-name behavior.

AI-generated summaries can contain mistakes. Contributors should verify the implementation and test behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->