### PR TITLE
Add B=0 to the gas tables.

### DIFF
--- a/offline/packages/PHGarfield/GasModel.cc
+++ b/offline/packages/PHGarfield/GasModel.cc
@@ -1,8 +1,11 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <filesystem>
 
 #include <Garfield/MediumMagboltz.hh>
+
+namespace fs = std::filesystem;
 
 //------------------------------------------------------------
 //  This standalone executable makes gas calculations for
@@ -41,6 +44,15 @@ int main(int argc, char* argv[])
   const int nA = std::atoi(argv[9]);
 
   const std::string output_file(argv[10]);
+
+
+  // A final output file means this grid point was already completed.
+  if (fs::exists(output_file))
+    {
+      std::cout << "Output file already exists: " << output_file
+		<< "\nSkipping calculation." << std::endl;
+      return 0;
+    }
 
   std::cout << "E grid: "
             << Emin << " -> " << Emax

--- a/offline/packages/PHGarfield/MergeGasFiles.cc
+++ b/offline/packages/PHGarfield/MergeGasFiles.cc
@@ -8,18 +8,21 @@
 #include <map>
 #include <regex>
 #include <set>
+#include <vector>
 #include <sstream>
 #include <string>
 #include <utility>
 
 namespace fs = std::filesystem;
-std::string mergedName(const std::string& path, unsigned int eindex);
+std::string mergedName (const std::string& path, unsigned int eindex);
 
 bool searchAndUnpackDirectory(
     const std::string& directoryPath,
     std::set<unsigned int>& Eindices,
     std::set<unsigned int>& Bindices,
-    std::map<std::pair<unsigned int, unsigned int>, std::string>& FileList);
+    std::map<std::pair<unsigned int, unsigned int>, std::string>& FileList,
+    std::set<unsigned int>& Zindices,
+    std::map<unsigned int, std::string>& ZeroFileList );
 
 int main(int argc, char* argv[])
 {
@@ -36,11 +39,16 @@ int main(int argc, char* argv[])
     const std::string path = argv[1];
     const std::string output = path + "/" + argv[2];
 
+    const std::string FIELD_ON  = path + "/MAGNETIC_FIELD_ON.gas";
+    const std::string FIELD_OFF = path + "/MAGNETIC_FIELD_OFF.gas";
+
     std::set<unsigned int> Eindices;
     std::set<unsigned int> Bindices;
     std::map<std::pair<unsigned int, unsigned int>, std::string> FileList;
+    std::set<unsigned int> Zindices;
+    std::map<unsigned int, std::string> ZeroFileList;
 
-    if (!searchAndUnpackDirectory(path, Eindices, Bindices, FileList))
+    if (!searchAndUnpackDirectory(path, Eindices, Bindices, FileList, Zindices, ZeroFileList))
     {
       std::cerr << PHWHERE << " Imperfect directory." << std::endl;
       return 1;
@@ -48,6 +56,7 @@ int main(int argc, char* argv[])
 
     Garfield::MediumMagboltz gas;
 
+    //  For each E, loop over all B to make merged files for a single E
     for (const auto Eindex : Eindices)
     {
       bool firstB = true;
@@ -92,8 +101,8 @@ int main(int argc, char* argv[])
                 << nA.size() << " Angles." << std::endl;
     }
 
+    //  For each E, merge all the Field-on files...
     bool firstE = true;
-
     for (const auto Eindex : Eindices)
     {
       // if (Eindex > 10) {break;}
@@ -116,20 +125,84 @@ int main(int argc, char* argv[])
       }
     }
 
-    std::cout << "Writing final file " << output << std::endl;
-    gas.WriteGasFile(output);
+    std::cout << "Writing field-on file " << FIELD_ON << std::endl;
+    gas.WriteGasFile(FIELD_ON);
 
     std::vector<double> nE;
     std::vector<double> nB;
     std::vector<double> nA;
     gas.GetFieldGrid(nE, nB, nA);
 
-    std::cout << "Final Gas File created: " << output
+    std::cout << "Field-on Gas File created: " << FIELD_ON
               << " with Grid Dimensions: "
               << nE.size() << " E-fields, "
               << nB.size() << " B-fields, "
               << nA.size() << " Angles." << std::endl;
 
+    //  For each E, merge the Zero Files
+    firstE = true;
+    for (const auto Eindex : Zindices)
+    {
+      // if (Eindex > 10) {break;}
+      const auto it = ZeroFileList.find(Eindex);
+      if (it == ZeroFileList.end())
+	{
+	  std::cerr << PHWHERE << " Missing zero file for E=" << Eindex
+		    << std::endl;
+	  return 1;
+	}
+      
+      const std::string& zeroFile = it->second;
+      //const std::string zeroFile = zeroName(path, Eindex);
+
+      if (!fs::exists(zeroFile))
+      {
+        std::cerr << PHWHERE << " Missing zero file " << zeroFile << std::endl;
+        return 1;
+      }
+
+      if (firstE)
+      {
+        gas.LoadGasFile(zeroFile);
+        firstE = false;
+      }
+      else
+      {
+        gas.MergeGasFile(zeroFile, true);
+      }
+    }
+
+    std::cout << "Writing field-off file " << FIELD_OFF << std::endl;
+    gas.WriteGasFile(FIELD_OFF);
+
+    nE.clear();
+    nB.clear();
+    nA.clear();
+    gas.GetFieldGrid(nE, nB, nA);
+
+    std::cout << "Field-off Gas File created: " << FIELD_OFF
+              << " with Grid Dimensions: "
+              << nE.size() << " E-fields, "
+              << nB.size() << " B-fields, "
+              << nA.size() << " Angles." << std::endl;
+
+
+    //  Now merge the field on with the field off and we shall be finally finished.
+    gas.LoadGasFile (FIELD_ON);
+    gas.MergeGasFile(FIELD_OFF, true);
+    gas.WriteGasFile(output);
+
+    nE.clear();
+    nB.clear();
+    nA.clear();
+    gas.GetFieldGrid(nE, nB, nA);
+    
+    std::cout << "FINAL Gas File created: " << output
+              << " with Grid Dimensions: "
+              << nE.size() << " E-fields, "
+              << nB.size() << " B-fields, "
+              << nA.size() << " Angles." << std::endl;
+    
     return 0;
   }
 
@@ -145,7 +218,7 @@ int main(int argc, char* argv[])
   }
 }
 
-bool searchAndUnpackDirectory(const std::string& directoryPath, std::set<unsigned int>& Eindices, std::set<unsigned int>& Bindices, std::map<std::pair<unsigned int, unsigned int>, std::string>& FileList)
+bool searchAndUnpackDirectory(const std::string& directoryPath, std::set<unsigned int>& Eindices, std::set<unsigned int>& Bindices, std::map<std::pair<unsigned int, unsigned int>, std::string>& FileList, std::set<unsigned int>& Zindices , std::map<unsigned int, std::string>& ZeroFileList)
 {
   // Check if the directory exists and is valid
   if (!fs::exists(directoryPath) || !fs::is_directory(directoryPath))
@@ -154,9 +227,9 @@ bool searchAndUnpackDirectory(const std::string& directoryPath, std::set<unsigne
     return false;
   }
 
+  //  First we shall fill the normal field on files...
   std::regex filePattern(R"(^E([0-9]{3})_B([0-9]{3})\.gas$)");
   std::smatch matchResults;
-
   // Iterate through all items in the directory
   for (const auto& entry : fs::directory_iterator(directoryPath))
   {
@@ -207,6 +280,54 @@ bool searchAndUnpackDirectory(const std::string& directoryPath, std::set<unsigne
   std::cout << "Electric field indices 0 --> " << maxE << std::endl;
   std::cout << "Magnetic field indices 0 --> " << maxB << std::endl;
 
+  //  Next we shall fill the zero field on files...
+  std::regex filePatternZERO(R"(^ZERO_E([0-9]{3})\.gas$)");
+  //std::smatch matchResults;
+  // Iterate through all items in the directory
+  for (const auto& entry : fs::directory_iterator(directoryPath))
+  {
+    // Only process regular files
+    if (entry.is_regular_file())
+    {
+      std::string filename = entry.path().filename().string();
+
+      // Check if the filename matches our target pattern
+      if (std::regex_match(filename, matchResults, filePatternZERO))
+      {
+        // matchResults[1] contains the string after 'E'
+        // std::stoul automatically handles leading zeros
+        unsigned int zValue = std::stoul(matchResults[1].str());
+        Zindices.insert(zValue);
+        ZeroFileList[zValue] = entry.path().string();
+      }
+    }
+  }
+
+  // Validate the results.
+  if (Zindices.empty())
+  {
+    return false;
+  }
+
+  if (Zindices != Eindices)
+    {
+      std::cerr << "Error: zero-field and field-on E grids do not match."
+		<< std::endl;
+      return false;
+    }
+  
+  unsigned int maxZ = *Zindices.rbegin();
+  for (unsigned int i = 0; i <= maxE; i++)
+  {
+    if (!ZeroFileList.contains(i))
+      {
+        return false;
+      }
+  }
+
+  std::cout << "   *** Gas ZERO File List Valid ***" << std::endl;
+  std::cout << "Electric field indices 0 --> " << maxZ << std::endl;
+  
   return true;
 }
 
@@ -218,3 +339,4 @@ std::string mergedName(const std::string& path, unsigned int eindex)
        << ".gas";
   return name.str();
 }
+

--- a/offline/packages/PHGarfield/PHGarfield.cc
+++ b/offline/packages/PHGarfield/PHGarfield.cc
@@ -97,6 +97,7 @@ int PHGarfield::InitRun(PHCompositeNode* /*topNode*/)
 
   // Here we fetch the gas from the CDB
   std::string gasfile = m_cdb->getUrl("PHGARFIELD_GAS");
+  //std::string gasfile("/gpfs/mnt/gpfs02/sphenix/user/hemmick/gasfiles_20260804/Ar75_CF20_iso5.gas");  // for testing only...
   if (gasfile.empty() || !fs::exists(gasfile))
   {
     std::cerr << PHWHERE << " Missing CDB gasfile: " << gasfile << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [*] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <This adds B=0 to the gas file making process.> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <N/A> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Add `B=0` support to gas-table generation. This requires matching updates in the macros repository.

## Key Changes

- Skip gas-table generation when the requested output file already exists.
- Discover, validate, and aggregate `ZERO_E###.gas` files.
- Merge field-on and field-off gas data into the final output.
- Report grid dimensions and fail when zero-field data is missing or inconsistent.
- Add a commented test gas-file path for development use.

## Potential Risk Areas

- The merged gas-file format and zero-field data validation may affect downstream consumers.
- Existing output-file checks can skip regeneration when a file is stale or incomplete.
- Additional file-system operations may affect performance and error handling.
- Reconstruction behavior may change when `B=0` tables are used.
- The updated interface requires synchronized changes in the macros repository.
- AI-generated summaries can contain mistakes. Review the implementation and generated files against the expected gas-table format before merging.

## Possible Future Improvements

- Validate output-file completeness instead of checking only file existence.
- Add automated tests for missing, mismatched, and valid zero-field inputs.
- Add an explicit development configuration for selecting test gas files.
- Document the required macros repository changes and the merged file format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->