### PR TITLE
Update cluster subsurface key in cluster mover

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -184,13 +184,28 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
 
     Acts::Vector3 global_new(xnew, ynew, znew);
 
+    bool update_sskey = true;
+    if(update_sskey)
+      {
+	unsigned int sskey = cluster->getSubSurfKey();
+
+	TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
+	TrkrDefs::subsurfkey new_subsurfkey = 0;
+	auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
+	if(new_subsurfkey != sskey)
+	  {
+	    // std::cout << "    updating cluster subsurfkey from " << sskey << " to " << new_subsurfkey << std::endl;
+	    cluster->setSubSurfKey(new_subsurfkey);
+	  }
+      }
+    
     if(_verbosity > 2)
       {
 	unsigned int layer = TrkrDefs::getLayer(cluskey);
 	if(layer == 28)
 	  {
 	    unsigned int sskey = cluster->getSubSurfKey();
-	    double new_radius = sqrt(xnew*xnew+ynew*ynew);
+	      double new_radius = sqrt(xnew*xnew+ynew*ynew);
 	    // Check if the subsurface changed
 	    TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
 	    TrkrDefs::subsurfkey new_subsurfkey = 0;

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -192,7 +192,7 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
 	TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
 	TrkrDefs::subsurfkey new_subsurfkey = 0;
 	auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
-	if(new_subsurfkey != sskey)
+	if( new_surf && (new_subsurfkey != sskey) )
 	  {
 	    // std::cout << "    updating cluster subsurfkey from " << sskey << " to " << new_subsurfkey << std::endl;
 	    cluster->setSubSurfKey(new_subsurfkey);

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -377,6 +377,12 @@ namespace TrackAnalysisUtils
         TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
         TrkrDefs::subsurfkey new_sskey = 0;
         surf = geometry->get_tpc_surface_from_coords(hitsetkey, clusglob_moved, new_sskey);
+	if (!surf)
+	  {
+	    std::cout << PHWHERE << " WARNING: failed to find moved-cluster surface for "
+		      << ckey << std::endl;
+	    continue;
+	  }
 	if(new_sskey != sskey)
 	  {
 	    // ClusterMover should have updated the subsurface key, so this should not happen

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -370,13 +370,18 @@ namespace TrackAnalysisUtils
       }
       Surface surf = geometry->maps().getSurface(ckey, cluster);
       Surface surf_ideal = geometry->maps().getSurface(ckey, cluster);  // Unchanged by distortion corrections
-      // if this is a TPC cluster, the crossing correction may have moved it across the central membrane, check the surface
       auto trkrid = TrkrDefs::getTrkrId(ckey);
       if (trkrid == TrkrDefs::tpcId)
       {
+	TrkrDefs::subsurfkey sskey = cluster->getSubSurfKey();
         TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
-        TrkrDefs::subsurfkey new_subsurfkey = 0;
-        surf = geometry->get_tpc_surface_from_coords(hitsetkey, clusglob_moved, new_subsurfkey);
+        TrkrDefs::subsurfkey new_sskey = 0;
+        surf = geometry->get_tpc_surface_from_coords(hitsetkey, clusglob_moved, new_sskey);
+	if(new_sskey != sskey)
+	  {
+	    // ClusterMover should have updated the subsurface key, so this should not happen
+	    std::cout << PHWHERE << " WARNING: subsurface key change from " << sskey << " to " << new_sskey << std::endl;
+	  }
       }
 
       auto loc = geometry->getLocalCoords(ckey, cluster, track->get_crossing());

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -440,6 +440,7 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       continue;
     }
 
+    // clustermover updates the subsurface key after moving the clusters to the surface, so this is safe
     auto* cluster = clusterContainer->findCluster(cluskey);
     Surface surf = tGeometry->maps().getSurface(cluskey, cluster);
 
@@ -452,7 +453,6 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
                 << std::endl;
     }
 
-    // if this is a TPC cluster, the crossing correction may have moved it across the central membrane, check the surface
     auto trkrid = TrkrDefs::getTrkrId(cluskey);
     if (trkrid == TrkrDefs::tpcId)
     {
@@ -460,26 +460,11 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       {
         continue;
       }
-
-      TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
-      TrkrDefs::subsurfkey new_subsurfkey = 0;
-      surf = tGeometry->get_tpc_surface_from_coords(hitsetkey, global, new_subsurfkey);
-
-      if(m_verbosity > 2 && (int) TrkrDefs::getLayer(cluskey) == 28)
-	{
-	  if(new_subsurfkey - cluster->getSubSurfKey() != 0)
-	    {
-	      std::cout << "        ********  surf sskey changed from " << cluster->getSubSurfKey() << " to " << new_subsurfkey << std::endl;
-	    }
-	}
     }
-
+    
     if (!surf)
     {
-      if (m_verbosity > 2)
-      {
-        std::cout << "MakeSourceLinks::getSourceLinksClusterMover -  Failed to find surface for cluskey " << cluskey << std::endl;
-      }
+      std::cout << "MakeSourceLinks::getSourceLinksClusterMover -  Failed to find surface for cluskey " << cluskey << std::endl;
       continue;
     }
 


### PR DESCRIPTION
When TpcClusterMover puts a TPC cluster on a subsurface other than the original one, update the subsurface key stored in the cluster object. Ensures that the cluster always associates to the correct surface.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Keep moved TPC clusters associated with the correct subsurface.

## Key changes

- Update the cluster subsurface key when movement changes its mapped subsurface.
- Reuse the updated key in diagnostics.
- Warn when cluster and position-derived subsurface keys differ or surface resolution fails.
- Retain the initially mapped surface during source-link creation.
- Apply TPC edge rejection before surface validation.

## Potential risk areas

- Reconstruction behavior changes for clusters that cross subsurface boundaries.
- Additional warnings may increase log volume.
- No intended I/O format, public interface, thread-safety, or major performance changes.

## Possible future improvements

- Add unit and integration tests for subsurface-boundary crossings.
- Define handling for unresolved or inconsistent TPC surfaces.
- Measure source-link and surface-resolution performance with representative workloads.

AI-generated summaries can contain errors. Contributors should verify these points against the implementation and reconstruction tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->