### PR TITLE
Update JetCalib with new pT + EMCal fraction + z-vertex + jet eta dep…

### DIFF
--- a/offline/packages/jetbase/JetCalib.cc
+++ b/offline/packages/jetbase/JetCalib.cc
@@ -22,11 +22,11 @@
 #include <TF1.h>
 #include <TFile.h>
 #include <TH2.h>
-#include <TString.h>  // for Form
 
 #include <algorithm>  // for std::max, std::min
 #include <cmath>
 #include <iostream>  // for operator<<, basic_ostream
+#include <string>
 
 JetCalib::JetCalib(const std::string &name)
   : SubsysReco(name)
@@ -97,25 +97,29 @@ int JetCalib::initEMfracCalib()
   }
 
   int r_index = (int) (jet_radius * 10 + 0.1);
+  const std::string r_suffix = "_r0" + std::to_string(r_index);
+  const std::string jes_name = "h2d_jes_calib" + r_suffix;
+  const std::string zeta_name = "h2_zeta_corr" + r_suffix;
+  const std::string noz_name = "f_zeta_noz_corr" + r_suffix;
 
   // First-pass map (required).
-  m_JesCalibMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(Form("h2d_jes_calib_r0%d", r_index)));
+  m_JesCalibMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(jes_name.c_str()));
   if (!m_JesCalibMap)
   {
-    std::cout << "JetCalib::initEMfracCalib() : Could not find first-pass calibration map h2d_jes_calib_r0" << r_index << "!" << std::endl;
+    std::cout << "JetCalib::initEMfracCalib() : Could not find first-pass calibration map " << jes_name << "!" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
   // Residual (z-vertex, eta) correction (map + no-vertex function).
   if (m_ApplyResidualCalib)
   {
-    m_ZetaCorrMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(Form("h2_zeta_corr_r0%d", r_index)));
-    m_NozCorrFunc = dynamic_cast<TF1 *>(m_JetCalibFile->Get(Form("f_zeta_noz_corr_r0%d", r_index)));
+    m_ZetaCorrMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(zeta_name.c_str()));
+    m_NozCorrFunc = dynamic_cast<TF1 *>(m_JetCalibFile->Get(noz_name.c_str()));
     if (!m_ZetaCorrMap || !m_NozCorrFunc)
     {
       std::cout << "JetCalib::initEMfracCalib() : Could not find residual correction ("
-                << (m_ZetaCorrMap ? "" : Form("h2_zeta_corr_r0%d ", r_index))
-                << (m_NozCorrFunc ? "" : Form("f_zeta_noz_corr_r0%d", r_index))
+                << (m_ZetaCorrMap ? std::string() : zeta_name + " ")
+                << (m_NozCorrFunc ? std::string() : noz_name)
                 << "); residual correction disabled." << std::endl;
       m_ZetaCorrMap = nullptr;
       m_NozCorrFunc = nullptr;
@@ -397,9 +401,15 @@ std::string JetCalib::fetchCalibDir(const char *calibType)
 void JetCalib::getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit)
 {
   // Calorimeter half-lengths [cm] and radii [cm].
-  const float minz_EM = -130.23, maxz_EM = 130.23, radius_EM = 93.5;
-  const float minz_IH = -170.299, maxz_IH = 170.299, radius_IH = 127.503;
-  const float minz_OH = -301.683, maxz_OH = 301.683, radius_OH = 225.87;
+  const float minz_EM = -130.23;
+  const float maxz_EM = 130.23;
+  const float radius_EM = 93.5;
+  const float minz_IH = -170.299;
+  const float maxz_IH = 170.299;
+  const float radius_IH = 127.503;
+  const float minz_OH = -301.683;
+  const float maxz_OH = 301.683;
+  const float radius_OH = 225.87;
 
   float emcal_min = std::asinh((minz_EM - zvrtx) / radius_EM);
   float emcal_max = std::asinh((maxz_EM - zvrtx) / radius_EM);
@@ -422,22 +432,10 @@ float JetCalib::interpolateClamped(TH2 *h2, double x, double y)
   double x_hi = xa->GetBinCenter(xa->GetNbins());
   double y_lo = ya->GetBinCenter(1);
   double y_hi = ya->GetBinCenter(ya->GetNbins());
-  if (x < x_lo)
-  {
-    x = x_lo;
-  }
-  if (x > x_hi)
-  {
-    x = x_hi;
-  }
-  if (y < y_lo)
-  {
-    y = y_lo;
-  }
-  if (y > y_hi)
-  {
-    y = y_hi;
-  }
+  x = std::max(x, x_lo);
+  x = std::min(x, x_hi);
+  y = std::max(y, y_lo);
+  y = std::min(y, y_hi);
   return h2->Interpolate(x, y);
 }
 
@@ -512,7 +510,9 @@ float JetCalib::getResidualScale(float zvrtx, bool hasVertex, float eta) const
 // Legacy method helpers (per-(z bin, eta bin) TF1 corrections versus pT).
 // ---------------------------------------------------------------------------
 
-static int getZvrtxBin(float zvrtx)
+namespace
+{
+int getZvrtxBin(float zvrtx)
 {
   if (zvrtx >= -60.0 && zvrtx < -30.0)
   {
@@ -538,7 +538,7 @@ static int getZvrtxBin(float zvrtx)
   return 0;  // Default case, should not happen
 }
 
-static int getEtaBin(int zvrtxbin, float eta, float jet_radius)
+int getEtaBin(int zvrtxbin, float eta, float jet_radius)
 {
   float eta_low = 0;
   float eta_high = 0;
@@ -581,6 +581,7 @@ static int getEtaBin(int zvrtxbin, float eta, float jet_radius)
 
   return 3;  // threshold3 to inf
 }
+}  // namespace
 
 float JetCalib::doCalibration(const std::vector<std::vector<TF1 *>> &JetCalibFunc, float jetPt, float zvrtx, float eta) const
 {

--- a/offline/packages/jetbase/JetCalib.cc
+++ b/offline/packages/jetbase/JetCalib.cc
@@ -1,14 +1,9 @@
 #include "JetCalib.h"
 
+#include "Jet.h"
 #include "JetContainerv1.h"
 
-#include <cdbobjects/CDBTF.h>  // for CDBTF1
-
 #include <ffamodules/CDBInterface.h>
-#include <ffaobjects/EventHeader.h>
-
-#include <globalvertex/GlobalVertex.h>
-#include <globalvertex/GlobalVertexMap.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
@@ -20,18 +15,17 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>
-#include <phool/recoConsts.h>
 
+#include <TAxis.h>
 #include <TF1.h>
-#include <TSystem.h>
+#include <TFile.h>
+#include <TH2.h>
+#include <TString.h>  // for Form
 
-#include <boost/format.hpp>
-
+#include <algorithm>  // for std::max, std::min
 #include <cmath>
-#include <cstdlib>    // for exit
-#include <exception>  // for exception
-#include <iostream>   // for operator<<, basic_ostream
-#include <stdexcept>  // for runtime_error
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, basic_ostream
 
 JetCalib::JetCalib(const std::string &name)
   : SubsysReco(name)
@@ -44,6 +38,11 @@ JetCalib::JetCalib(const std::string &name)
 
 JetCalib::~JetCalib()
 {
+  if (m_JetCalibFile)
+  {
+    m_JetCalibFile->Close();
+    delete m_JetCalibFile;
+  }
   if (Verbosity() > 0)
   {
     std::cout << "JetCalib::~JetCalib() : Calling dtor." << std::endl;
@@ -55,117 +54,53 @@ int JetCalib::InitRun(PHCompositeNode *topNode)
   // Create calib jet node.
   CreateNodeTree(topNode);
 
-  // Load calibration file and function.
-  if (fetchCalibDir("Default").empty())
+  // Locate the calibration file: local override first, otherwise the CDB payload.
+  std::string calibFile = m_calibFileOverride.empty() ? fetchCalibDir("Default") : m_calibFileOverride;
+  if (calibFile.empty())
   {
     std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : No default calibration available! Will apply calib factor 1." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
   }
-  else
+
+  m_JetCalibFile = TFile::Open(calibFile.c_str(), "READ");
+  if (!m_JetCalibFile || m_JetCalibFile->IsZombie())
   {
-    m_JetCalibFile = new CDBTF(fetchCalibDir("Default"));
-    if (m_JetCalibFile)
+    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not open calibration file " << calibFile << "!" << std::endl;
+    exit(1);
+  }
+
+  int r_index = (int) (jet_radius * 10 + 0.1);
+
+  // First-pass map (required).
+  m_JesCalibMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(Form("h2d_jes_calib_r0%d", r_index)));
+  if (!m_JesCalibMap)
+  {
+    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find first-pass calibration map h2d_jes_calib_r0" << r_index << "!" << std::endl;
+    exit(1);
+  }
+
+  // Residual (z-vertex, eta) correction (map + no-vertex function).
+  if (m_ApplyResidualCalib)
+  {
+    m_ZetaCorrMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(Form("h2_zeta_corr_r0%d", r_index)));
+    m_NozCorrFunc = dynamic_cast<TF1 *>(m_JetCalibFile->Get(Form("f_zeta_noz_corr_r0%d", r_index)));
+    if (!m_ZetaCorrMap || !m_NozCorrFunc)
     {
-      m_JetCalibFile->LoadCalibrations();
-      std::string JetCalibFunc_name = "JES_Calib_Func_R0" + std::to_string((int)(jet_radius * 10));
-      if (!ApplyZvrtxDependentCalib && !ApplyEtaDependentCalib)
-      {
-        int nZvrtxBins = 1;
-        int nEtaBins = 1;
-        m_JetCalibFunc.resize(nZvrtxBins);
-        for (auto &row : m_JetCalibFunc)
-        {
-          row.resize(nEtaBins, nullptr);
-        }
-        TF1 *func_temp = m_JetCalibFile->getTF(JetCalibFunc_name + "_Default");
-        if (!func_temp)
-        {
-          std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find calibration function: " << JetCalibFunc_name << "_Default" << std::endl;
-          exit(1);
-        }
-        m_JetCalibFunc[0][0] = func_temp;
-      }
-      else if (ApplyZvrtxDependentCalib && !ApplyEtaDependentCalib)
-      {
-        int nZvrtxBins = 5;
-        int nEtaBins = 1;
-        m_JetCalibFunc.resize(nZvrtxBins);
-        for (auto &row : m_JetCalibFunc)
-        {
-          row.resize(nEtaBins, nullptr);
-        }
-        for (int iz = 0; iz < nZvrtxBins; ++iz)
-        {
-          TF1 *func_temp = m_JetCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz));
-          if (!func_temp)
-          {
-            std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
-            exit(1);
-          }
-          m_JetCalibFunc[iz][0] = func_temp;
-        }
-      }
-      else if (ApplyEtaDependentCalib)
-      {
-        if (!ApplyZvrtxDependentCalib)
-        {
-          std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Must apply Zvrtx dependent calibration to apply eta dependent calibration. Applying Zvrtx + eta dependent calibration." << std::endl;
-        }
-        int nZvrtxBins = 5;
-        int nEtaBins = 4;
-        m_JetCalibFunc.resize(nZvrtxBins);
-        for (auto &row : m_JetCalibFunc)
-        {
-          row.resize(nEtaBins, nullptr);
-        }
-        for (int iz = 0; iz < nZvrtxBins; ++iz)
-        {
-          if (iz < 3 && jet_radius <= 0.4) {
-            for (int ieta = 0; ieta < nEtaBins; ++ieta)
-            {
-              TF1 *func_temp = m_JetCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz) + "_Eta" + std::to_string(ieta));
-              if (!func_temp)
-              {
-                std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << "_Eta" << ieta << std::endl;
-                exit(1);
-              }
-              m_JetCalibFunc[iz][ieta] = func_temp;
-            }
-          }
-          else if (iz < 3 && jet_radius > 0.4)
-          {
-            for (int ieta = 0; ieta < nEtaBins; ++ieta)
-            {
-              TF1 *func_temp = m_JetCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz));
-              if (!func_temp)
-              {
-                std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
-                exit(1);
-              }
-              m_JetCalibFunc[iz][ieta] = func_temp;
-            }
-          }
-          else
-          {
-            TF1 *func_temp = m_JetCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz));
-            if (!func_temp)
-            {
-              std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
-              exit(1);
-            }
-            m_JetCalibFunc[iz][0] = func_temp;
-          }
-        }
-      }
-    }
-    else
-    {
-      std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not open calibration file!" << std::endl;
+      std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find residual correction ("
+                << (m_ZetaCorrMap ? "" : Form("h2_zeta_corr_r0%d ", r_index))
+                << (m_NozCorrFunc ? "" : Form("f_zeta_noz_corr_r0%d", r_index))
+                << "); residual correction disabled." << std::endl;
+      m_ZetaCorrMap = nullptr;
+      m_NozCorrFunc = nullptr;
+      m_ApplyResidualCalib = false;
     }
   }
 
   if (Verbosity() > 0)
   {
-    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) - InitRun with inputNode: " << m_inputNode << " outputNode: " << m_outputNode << std::endl;
+    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) - InitRun with inputNode: " << m_inputNode
+              << " outputNode: " << m_outputNode << " calibFile: " << calibFile
+              << " residual: " << (m_ApplyResidualCalib ? "on" : "off") << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -185,48 +120,30 @@ int JetCalib::process_event(PHCompositeNode *topNode)
     std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : Calib jet node not found! Cannot apply calibration." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  GlobalVertexMap *vertexmap = nullptr;
-  if (ApplyZvrtxDependentCalib)
+
+  // z-vertex for the residual correction: taken from the raw jet container, i.e.
+  // the vertex that was ACTUALLY USED in the jet reconstruction (recorded from the
+  // jet inputs) -- not re-fetched from the GlobalVertexMap, which may differ from
+  // what the jets were built with. Events whose jets carry no z-vertex
+  // (has_zvertex() false) take the no-vertex correction path; get_vertex_z()
+  // alone cannot distinguish them, since the jet reco falls back to z = 0.
+  float zvertex = 0;
+  bool hasVertex = false;
+  if (m_ApplyResidualCalib)
   {
-    vertexmap = findNode::getClass<GlobalVertexMap>(topNode, m_zvrtxNode);
-    if (!vertexmap)
+    hasVertex = _raw_jets->has_zvertex();
+    if (hasVertex)
     {
-      std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : GlobalVertexMap node not found! Cannot apply Z-vertex dependent calibration." << std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
-  }
-  // Get z-vertex if needed.
-  float zvertex = -999.0;
-  if (ApplyZvrtxDependentCalib)
-  {
-    if (!vertexmap->empty())
-    {
-      GlobalVertex *vtx = vertexmap->begin()->second;
-      auto mbdStartIter = vtx->find_vertexes(GlobalVertex::MBD);
-      auto mbdEndIter = vtx->end_vertexes();
-      for (auto iter = mbdStartIter; iter != mbdEndIter; ++iter)
+      zvertex = _raw_jets->get_vertex_z();
+      if (!std::isfinite(zvertex))
       {
-        const auto &[type, vertexVec] = *iter;
-        if (type != GlobalVertex::MBD)
-        {
-          continue;
-        }
-        for (const auto *vertex : vertexVec)
-        {
-          if (!vertex)
-          {
-            continue;
-          }
-          zvertex = vertex->get_z();
-        }
+        hasVertex = false;
+        zvertex = 0;
       }
     }
-    else
+    if (!hasVertex && Verbosity() > 0)
     {
-      if (Verbosity() > 0)
-      {
-        std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : GlobalVertexMap is empty." << std::endl;
-      }
+      std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : jets reconstructed without a z-vertex; applying the no-vertex correction." << std::endl;
     }
   }
 
@@ -237,8 +154,25 @@ int JetCalib::process_event(PHCompositeNode *topNode)
     float pt = jet->get_pt();
     float eta = jet->get_eta();
     float phi = jet->get_phi();
+    float emfrac = jet->get_emcal_frac();
 
-    float calib_pt = doCalibration(m_JetCalibFunc, pt, zvertex, eta);
+    float calib_pt = pt;
+    if (m_JesCalibMap && std::isfinite(emfrac))
+    {
+      calib_pt = getFirstPassPt(pt, emfrac);
+      if (m_ApplyResidualCalib)
+      {
+        calib_pt *= getResidualScale(zvertex, hasVertex, eta);
+      }
+    }
+    else if (m_JesCalibMap && !m_warnedNoEmFrac)
+    {
+      std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : Jet has no EMCal fraction stored"
+                << " (Jet::get_emcal_frac() is NaN; enable the calo fractions in the jet reco)."
+                << " Applying calib factor 1 to such jets." << std::endl;
+      m_warnedNoEmFrac = true;
+    }
+
     auto *calib_jet = _calib_jets->add_jet();
     calib_jet->set_px(calib_pt * std::cos(phi));
     calib_jet->set_py(calib_pt * std::sin(phi));
@@ -311,96 +245,118 @@ std::string JetCalib::fetchCalibDir(const char *calibType)
   return CDBInterface::instance()->getUrl(calibName);
 }
 
-int getZvrtxBin(float zvrtx)
+// z-corrected eta acceptance window: intersection of the EMCal/IHCal/OHCal reach as
+// seen from the vertex, padded inward by the jet radius. Must match the derivation.
+void JetCalib::getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit)
 {
-  if (zvrtx >= -60.0 && zvrtx < -30.0)
-  {
-    return 1;  // -60 to -30
-  }
-  if (zvrtx >= -30.0 && zvrtx < 30.0)
-  {
-    return 0;  // -30 to 30
-  }
-  if (zvrtx >= 30.0 && zvrtx < 60)
-  {
-    return 2;  // 30 to 60
-  }
-  if ((zvrtx < -60.0 && zvrtx >= -900) || (zvrtx >= 60.0 && zvrtx < 900))
-  {
-    return 3;  // -inf to -60 or 60 to inf
-  }
-  if (zvrtx < -900)
-  {
-    return 4;  // -999 no zvertex
-  }
+  // Calorimeter half-lengths [cm] and radii [cm].
+  const float minz_EM = -130.23, maxz_EM = 130.23, radius_EM = 93.5;
+  const float minz_IH = -170.299, maxz_IH = 170.299, radius_IH = 127.503;
+  const float minz_OH = -301.683, maxz_OH = 301.683, radius_OH = 225.87;
 
-  return 0;  // Default case, should not happen
+  float emcal_min = std::asinh((minz_EM - zvrtx) / radius_EM);
+  float emcal_max = std::asinh((maxz_EM - zvrtx) / radius_EM);
+  float ihcal_min = std::asinh((minz_IH - zvrtx) / radius_IH);
+  float ihcal_max = std::asinh((maxz_IH - zvrtx) / radius_IH);
+  float ohcal_min = std::asinh((minz_OH - zvrtx) / radius_OH);
+  float ohcal_max = std::asinh((maxz_OH - zvrtx) / radius_OH);
+
+  minlimit = std::max({emcal_min, ihcal_min, ohcal_min}) + radius;
+  maxlimit = std::min({emcal_max, ihcal_max, ohcal_max}) - radius;
 }
 
-int getEtaBin(int zvrtxbin, float eta, float jet_radius)
+// Bilinear interpolation with both coordinates clamped to the bin-center range
+// (TH2::Interpolate is undefined outside it).
+float JetCalib::interpolateClamped(TH2 *h2, double x, double y)
 {
-  float eta_low = 0;
-  float eta_high = 0;
-  if (zvrtxbin == 0)  // -30 < zvrtx < 30
+  TAxis *xa = h2->GetXaxis();
+  TAxis *ya = h2->GetYaxis();
+  double x_lo = xa->GetBinCenter(1);
+  double x_hi = xa->GetBinCenter(xa->GetNbins());
+  double y_lo = ya->GetBinCenter(1);
+  double y_hi = ya->GetBinCenter(ya->GetNbins());
+  if (x < x_lo)
   {
-    eta_low = -1.2 + jet_radius;
-    eta_high = 1.2 - jet_radius;
+    x = x_lo;
   }
-  else if (zvrtxbin == 1)  // -60 < zvrtx < -30
+  if (x > x_hi)
   {
-    eta_low = -0.95 + jet_radius;
-    eta_high = 1.25 - jet_radius;
+    x = x_hi;
   }
-  else if (zvrtxbin == 2)  // 30 < zvrtx < inf
+  if (y < y_lo)
   {
-    eta_low = -1.25 + jet_radius;
-    eta_high = 0.95 - jet_radius;
+    y = y_lo;
   }
-  else if (zvrtxbin == 3 || zvrtxbin == 4)
+  if (y > y_hi)
   {
-    return 0;
+    y = y_hi;
   }
-
-  float threshold1 = eta_low + ((eta_high - eta_low) / 4.0);
-  float threshold2 = eta_low + ((eta_high - eta_low) / 2.0);
-  float threshold3 = eta_low + (3.0 * (eta_high - eta_low) / 4.0);
-
-  if (eta < threshold1)
-  {
-    return 0;  // -inf to threshold1
-  }
-  if (eta < threshold2)
-  {
-    return 1;  // threshold1 to threshold2
-  }
-  if (eta < threshold3)
-  {
-    return 2;  // threshold2 to threshold3
-  }
-
-  return 3;  // threshold3 to inf
+  return h2->Interpolate(x, y);
 }
 
-float JetCalib::doCalibration(const std::vector<std::vector<TF1 *>> &JetCalibFunc, float jetPt, float zvrtx, float eta) const
+// First pass: calibrated (truth-equivalent) pT from the inverted (reco pT, EMCal
+// fraction) map.
+float JetCalib::getFirstPassPt(float jetPt, float emFrac) const
 {
-  float calib = jetPt;
-  int zvrtxbin = 0;
-  int etabin = 0;
-  if (ApplyZvrtxDependentCalib || ApplyEtaDependentCalib)
+  if (!m_JesCalibMap)
   {
-    zvrtxbin = getZvrtxBin(zvrtx);
-    if (ApplyEtaDependentCalib)
+    return jetPt;
+  }
+  float calibPt = interpolateClamped(m_JesCalibMap, jetPt, emFrac);
+  if (!std::isfinite(calibPt) || calibPt <= 0)
+  {
+    return jetPt;  // unpopulated map region (no inversion solution): leave uncalibrated
+  }
+  return calibPt;
+}
+
+// Residual (z-vertex, eta) scale factor. With a vertex: the (signed z, f) map;
+// without: the no-vertex function evaluated at f computed with z = 0.
+float JetCalib::getResidualScale(float zvrtx, bool hasVertex, float eta) const
+{
+  if (hasVertex)
+  {
+    if (!m_ZetaCorrMap)
     {
-      if (zvrtxbin < 3)
-      {
-        etabin = getEtaBin(zvrtxbin, eta, jet_radius);
-      }
-      else
-      {
-        etabin = 0;
-      }
+      return 1.0;
     }
+    float minlimit = 0;
+    float maxlimit = 0;
+    getEtaAcceptance(zvrtx, jet_radius, minlimit, maxlimit);
+    if (maxlimit <= minlimit)
+    {
+      return 1.0;  // acceptance closed at this z
+    }
+    double f = (eta - minlimit) / (double) (maxlimit - minlimit);
+    float scale = interpolateClamped(m_ZetaCorrMap, zvrtx, f);  // SIGNED z, no mirror
+    if (!std::isfinite(scale) || scale <= 0)
+    {
+      return 1.0;
+    }
+    return scale;
   }
-  calib = JetCalibFunc[zvrtxbin][etabin]->Eval(jetPt);
-  return calib;
+
+  // No reconstructed z-vertex: f at z = 0, 1D correction function.
+  if (!m_NozCorrFunc)
+  {
+    return 1.0;
+  }
+  float minlimit = 0;
+  float maxlimit = 0;
+  getEtaAcceptance(0.0, jet_radius, minlimit, maxlimit);
+  if (maxlimit <= minlimit)
+  {
+    return 1.0;
+  }
+  double f = (eta - minlimit) / (double) (maxlimit - minlimit);
+  if (f < 0 || f > 1)
+  {
+    return 1.0;  // outside the acceptance window
+  }
+  double scale = m_NozCorrFunc->Eval(f);
+  if (!std::isfinite(scale) || scale < 0.8 || scale > 1.2)
+  {
+    return 1.0;  // sanity guard
+  }
+  return (float) scale;
 }

--- a/offline/packages/jetbase/JetCalib.cc
+++ b/offline/packages/jetbase/JetCalib.cc
@@ -3,11 +3,8 @@
 #include "Jet.h"
 #include "JetContainerv1.h"
 
-<<<<<<< Updated upstream
-=======
 #include <cdbobjects/CDBTF.h>  // for CDBTF1 (legacy method)
 
->>>>>>> Stashed changes
 #include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -29,7 +26,6 @@
 
 #include <algorithm>  // for std::max, std::min
 #include <cmath>
-#include <cstdlib>   // for exit
 #include <iostream>  // for operator<<, basic_ostream
 
 JetCalib::JetCalib(const std::string &name)
@@ -48,6 +44,7 @@ JetCalib::~JetCalib()
     m_JetCalibFile->Close();
     delete m_JetCalibFile;
   }
+  delete m_LegacyCalibFile;
   if (Verbosity() > 0)
   {
     std::cout << "JetCalib::~JetCalib() : Calling dtor." << std::endl;
@@ -57,23 +54,13 @@ JetCalib::~JetCalib()
 int JetCalib::InitRun(PHCompositeNode *topNode)
 {
   // Create calib jet node.
-  CreateNodeTree(topNode);
-
-<<<<<<< Updated upstream
-  // Locate the calibration file: local override first, otherwise the CDB payload.
-  std::string calibFile = m_calibFileOverride.empty() ? fetchCalibDir("Default") : m_calibFileOverride;
-  if (calibFile.empty())
+  int ret = CreateNodeTree(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
   {
-    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : No default calibration available! Will apply calib factor 1." << std::endl;
-    return Fun4AllReturnCodes::EVENT_OK;
+    return ret;
   }
 
-  m_JetCalibFile = TFile::Open(calibFile.c_str(), "READ");
-  if (!m_JetCalibFile || m_JetCalibFile->IsZombie())
-  {
-    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not open calibration file " << calibFile << "!" << std::endl;
-=======
-  int ret = m_useEMfracCalib ? initEMfracCalib() : initLegacyCalib();
+  ret = m_useEMfracCalib ? initEMfracCalib() : initLegacyCalib();
   if (ret != Fun4AllReturnCodes::EVENT_OK)
   {
     return ret;
@@ -106,8 +93,7 @@ int JetCalib::initEMfracCalib()
   if (!m_JetCalibFile || m_JetCalibFile->IsZombie())
   {
     std::cout << "JetCalib::initEMfracCalib() : Could not open calibration file " << calibFile << "!" << std::endl;
->>>>>>> Stashed changes
-    exit(1);
+    return Fun4AllReturnCodes::ABORTRUN;
   }
 
   int r_index = (int) (jet_radius * 10 + 0.1);
@@ -116,12 +102,8 @@ int JetCalib::initEMfracCalib()
   m_JesCalibMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(Form("h2d_jes_calib_r0%d", r_index)));
   if (!m_JesCalibMap)
   {
-<<<<<<< Updated upstream
-    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find first-pass calibration map h2d_jes_calib_r0" << r_index << "!" << std::endl;
-=======
     std::cout << "JetCalib::initEMfracCalib() : Could not find first-pass calibration map h2d_jes_calib_r0" << r_index << "!" << std::endl;
->>>>>>> Stashed changes
-    exit(1);
+    return Fun4AllReturnCodes::ABORTRUN;
   }
 
   // Residual (z-vertex, eta) correction (map + no-vertex function).
@@ -131,11 +113,7 @@ int JetCalib::initEMfracCalib()
     m_NozCorrFunc = dynamic_cast<TF1 *>(m_JetCalibFile->Get(Form("f_zeta_noz_corr_r0%d", r_index)));
     if (!m_ZetaCorrMap || !m_NozCorrFunc)
     {
-<<<<<<< Updated upstream
-      std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find residual correction ("
-=======
       std::cout << "JetCalib::initEMfracCalib() : Could not find residual correction ("
->>>>>>> Stashed changes
                 << (m_ZetaCorrMap ? "" : Form("h2_zeta_corr_r0%d ", r_index))
                 << (m_NozCorrFunc ? "" : Form("f_zeta_noz_corr_r0%d", r_index))
                 << "); residual correction disabled." << std::endl;
@@ -147,12 +125,7 @@ int JetCalib::initEMfracCalib()
 
   if (Verbosity() > 0)
   {
-<<<<<<< Updated upstream
-    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) - InitRun with inputNode: " << m_inputNode
-              << " outputNode: " << m_outputNode << " calibFile: " << calibFile
-=======
     std::cout << "JetCalib::initEMfracCalib() : calibFile: " << calibFile
->>>>>>> Stashed changes
               << " residual: " << (m_ApplyResidualCalib ? "on" : "off") << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
@@ -192,7 +165,7 @@ int JetCalib::initLegacyCalib()
     if (!func_temp)
     {
       std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Default" << std::endl;
-      exit(1);
+      return Fun4AllReturnCodes::ABORTRUN;
     }
     m_JetCalibFunc[0][0] = func_temp;
   }
@@ -211,7 +184,7 @@ int JetCalib::initLegacyCalib()
       if (!func_temp)
       {
         std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
-        exit(1);
+        return Fun4AllReturnCodes::ABORTRUN;
       }
       m_JetCalibFunc[iz][0] = func_temp;
     }
@@ -221,6 +194,7 @@ int JetCalib::initLegacyCalib()
     if (!ApplyZvrtxDependentCalib)
     {
       std::cout << "JetCalib::initLegacyCalib() : Must apply Zvrtx dependent calibration to apply eta dependent calibration. Applying Zvrtx + eta dependent calibration." << std::endl;
+      ApplyZvrtxDependentCalib = true;
     }
     int nZvrtxBins = 5;
     int nEtaBins = 4;
@@ -239,7 +213,7 @@ int JetCalib::initLegacyCalib()
           if (!func_temp)
           {
             std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << "_Eta" << ieta << std::endl;
-            exit(1);
+            return Fun4AllReturnCodes::ABORTRUN;
           }
           m_JetCalibFunc[iz][ieta] = func_temp;
         }
@@ -252,7 +226,7 @@ int JetCalib::initLegacyCalib()
           if (!func_temp)
           {
             std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
-            exit(1);
+            return Fun4AllReturnCodes::ABORTRUN;
           }
           m_JetCalibFunc[iz][ieta] = func_temp;
         }
@@ -263,7 +237,7 @@ int JetCalib::initLegacyCalib()
         if (!func_temp)
         {
           std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
-          exit(1);
+          return Fun4AllReturnCodes::ABORTRUN;
         }
         m_JetCalibFunc[iz][0] = func_temp;
       }
@@ -289,21 +263,9 @@ int JetCalib::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-<<<<<<< Updated upstream
-  // z-vertex for the residual correction: taken from the raw jet container, i.e.
-  // the vertex that was ACTUALLY USED in the jet reconstruction (recorded from the
-  // jet inputs) -- not re-fetched from the GlobalVertexMap, which may differ from
-  // what the jets were built with. Events whose jets carry no z-vertex
-  // (has_zvertex() false) take the no-vertex correction path; get_vertex_z()
-  // alone cannot distinguish them, since the jet reco falls back to z = 0.
-  float zvertex = 0;
-  bool hasVertex = false;
-  if (m_ApplyResidualCalib)
-=======
   float zvertex = m_useEMfracCalib ? 0 : -999.0;
   bool hasVertex = false;
   if ((m_useEMfracCalib && m_ApplyResidualCalib) || (!m_useEMfracCalib && ApplyZvrtxDependentCalib))
->>>>>>> Stashed changes
   {
     hasVertex = _raw_jets->has_zvertex();
     if (hasVertex)
@@ -312,20 +274,12 @@ int JetCalib::process_event(PHCompositeNode *topNode)
       if (!std::isfinite(zvertex))
       {
         hasVertex = false;
-<<<<<<< Updated upstream
-        zvertex = 0;
-=======
         zvertex = m_useEMfracCalib ? 0 : -999.0;
->>>>>>> Stashed changes
       }
     }
     if (!hasVertex && Verbosity() > 0)
     {
-<<<<<<< Updated upstream
-      std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : jets reconstructed without a z-vertex; applying the no-vertex correction." << std::endl;
-=======
       std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : jets reconstructed without a z-vertex; applying the no-vertex treatment." << std::endl;
->>>>>>> Stashed changes
     }
   }
 
@@ -336,27 +290,7 @@ int JetCalib::process_event(PHCompositeNode *topNode)
     float pt = jet->get_pt();
     float eta = jet->get_eta();
     float phi = jet->get_phi();
-    float emfrac = jet->get_emcal_frac();
 
-    float calib_pt = pt;
-    if (m_JesCalibMap && std::isfinite(emfrac))
-    {
-      calib_pt = getFirstPassPt(pt, emfrac);
-      if (m_ApplyResidualCalib)
-      {
-        calib_pt *= getResidualScale(zvertex, hasVertex, eta);
-      }
-    }
-    else if (m_JesCalibMap && !m_warnedNoEmFrac)
-    {
-      std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : Jet has no EMCal fraction stored"
-                << " (Jet::get_emcal_frac() is NaN; enable the calo fractions in the jet reco)."
-                << " Applying calib factor 1 to such jets." << std::endl;
-      m_warnedNoEmFrac = true;
-    }
-
-<<<<<<< Updated upstream
-=======
     float calib_pt = pt;
     if (m_useEMfracCalib)
     {
@@ -382,7 +316,6 @@ int JetCalib::process_event(PHCompositeNode *topNode)
       calib_pt = doCalibration(m_JetCalibFunc, pt, zvertex, eta);
     }
 
->>>>>>> Stashed changes
     auto *calib_jet = _calib_jets->add_jet();
     calib_jet->set_px(calib_pt * std::cos(phi));
     calib_jet->set_py(calib_pt * std::sin(phi));
@@ -455,11 +388,6 @@ std::string JetCalib::fetchCalibDir(const char *calibType)
   return CDBInterface::instance()->getUrl(calibName);
 }
 
-<<<<<<< Updated upstream
-// z-corrected eta acceptance window: intersection of the EMCal/IHCal/OHCal reach as
-// seen from the vertex, padded inward by the jet radius. Must match the derivation.
-void JetCalib::getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit)
-=======
 // ---------------------------------------------------------------------------
 // EMfrac method helpers.
 // ---------------------------------------------------------------------------
@@ -585,120 +513,95 @@ float JetCalib::getResidualScale(float zvrtx, bool hasVertex, float eta) const
 // ---------------------------------------------------------------------------
 
 static int getZvrtxBin(float zvrtx)
->>>>>>> Stashed changes
 {
-  // Calorimeter half-lengths [cm] and radii [cm].
-  const float minz_EM = -130.23, maxz_EM = 130.23, radius_EM = 93.5;
-  const float minz_IH = -170.299, maxz_IH = 170.299, radius_IH = 127.503;
-  const float minz_OH = -301.683, maxz_OH = 301.683, radius_OH = 225.87;
+  if (zvrtx >= -60.0 && zvrtx < -30.0)
+  {
+    return 1;  // -60 to -30
+  }
+  if (zvrtx >= -30.0 && zvrtx < 30.0)
+  {
+    return 0;  // -30 to 30
+  }
+  if (zvrtx >= 30.0 && zvrtx < 60)
+  {
+    return 2;  // 30 to 60
+  }
+  if ((zvrtx < -60.0 && zvrtx >= -900) || (zvrtx >= 60.0 && zvrtx < 900))
+  {
+    return 3;  // -inf to -60 or 60 to inf
+  }
+  if (zvrtx < -900)
+  {
+    return 4;  // -999 no zvertex
+  }
 
-  float emcal_min = std::asinh((minz_EM - zvrtx) / radius_EM);
-  float emcal_max = std::asinh((maxz_EM - zvrtx) / radius_EM);
-  float ihcal_min = std::asinh((minz_IH - zvrtx) / radius_IH);
-  float ihcal_max = std::asinh((maxz_IH - zvrtx) / radius_IH);
-  float ohcal_min = std::asinh((minz_OH - zvrtx) / radius_OH);
-  float ohcal_max = std::asinh((maxz_OH - zvrtx) / radius_OH);
-
-  minlimit = std::max({emcal_min, ihcal_min, ohcal_min}) + radius;
-  maxlimit = std::min({emcal_max, ihcal_max, ohcal_max}) - radius;
+  return 0;  // Default case, should not happen
 }
 
-<<<<<<< Updated upstream
-// Bilinear interpolation with both coordinates clamped to the bin-center range
-// (TH2::Interpolate is undefined outside it).
-float JetCalib::interpolateClamped(TH2 *h2, double x, double y)
-=======
 static int getEtaBin(int zvrtxbin, float eta, float jet_radius)
->>>>>>> Stashed changes
 {
-  TAxis *xa = h2->GetXaxis();
-  TAxis *ya = h2->GetYaxis();
-  double x_lo = xa->GetBinCenter(1);
-  double x_hi = xa->GetBinCenter(xa->GetNbins());
-  double y_lo = ya->GetBinCenter(1);
-  double y_hi = ya->GetBinCenter(ya->GetNbins());
-  if (x < x_lo)
+  float eta_low = 0;
+  float eta_high = 0;
+  if (zvrtxbin == 0)  // -30 < zvrtx < 30
   {
-    x = x_lo;
+    eta_low = -1.2 + jet_radius;
+    eta_high = 1.2 - jet_radius;
   }
-  if (x > x_hi)
+  else if (zvrtxbin == 1)  // -60 < zvrtx < -30
   {
-    x = x_hi;
+    eta_low = -0.95 + jet_radius;
+    eta_high = 1.25 - jet_radius;
   }
-  if (y < y_lo)
+  else if (zvrtxbin == 2)  // 30 < zvrtx < inf
   {
-    y = y_lo;
+    eta_low = -1.25 + jet_radius;
+    eta_high = 0.95 - jet_radius;
   }
-  if (y > y_hi)
+  else if (zvrtxbin == 3 || zvrtxbin == 4)
   {
-    y = y_hi;
+    return 0;
   }
-  return h2->Interpolate(x, y);
+
+  float threshold1 = eta_low + ((eta_high - eta_low) / 4.0);
+  float threshold2 = eta_low + ((eta_high - eta_low) / 2.0);
+  float threshold3 = eta_low + (3.0 * (eta_high - eta_low) / 4.0);
+
+  if (eta < threshold1)
+  {
+    return 0;  // -inf to threshold1
+  }
+  if (eta < threshold2)
+  {
+    return 1;  // threshold1 to threshold2
+  }
+  if (eta < threshold3)
+  {
+    return 2;  // threshold2 to threshold3
+  }
+
+  return 3;  // threshold3 to inf
 }
 
-// First pass: calibrated (truth-equivalent) pT from the inverted (reco pT, EMCal
-// fraction) map.
-float JetCalib::getFirstPassPt(float jetPt, float emFrac) const
+float JetCalib::doCalibration(const std::vector<std::vector<TF1 *>> &JetCalibFunc, float jetPt, float zvrtx, float eta) const
 {
-  if (!m_JesCalibMap)
+  float calib = jetPt;
+  int zvrtxbin = 0;
+  int etabin = 0;
+  if (ApplyZvrtxDependentCalib || ApplyEtaDependentCalib)
   {
-    return jetPt;
-  }
-  float calibPt = interpolateClamped(m_JesCalibMap, jetPt, emFrac);
-  if (!std::isfinite(calibPt) || calibPt <= 0)
-  {
-    return jetPt;  // unpopulated map region (no inversion solution): leave uncalibrated
-  }
-  return calibPt;
-}
-
-// Residual (z-vertex, eta) scale factor. With a vertex: the (signed z, f) map;
-// without: the no-vertex function evaluated at f computed with z = 0.
-float JetCalib::getResidualScale(float zvrtx, bool hasVertex, float eta) const
-{
-  if (hasVertex)
-  {
-    if (!m_ZetaCorrMap)
+    zvrtxbin = getZvrtxBin(zvrtx);
+    if (ApplyEtaDependentCalib)
     {
-      return 1.0;
+      if (zvrtxbin < 3)
+      {
+        etabin = getEtaBin(zvrtxbin, eta, jet_radius);
+      }
+      else
+      {
+        etabin = 0;
+      }
     }
-    float minlimit = 0;
-    float maxlimit = 0;
-    getEtaAcceptance(zvrtx, jet_radius, minlimit, maxlimit);
-    if (maxlimit <= minlimit)
-    {
-      return 1.0;  // acceptance closed at this z
-    }
-    double f = (eta - minlimit) / (double) (maxlimit - minlimit);
-    float scale = interpolateClamped(m_ZetaCorrMap, zvrtx, f);  // SIGNED z, no mirror
-    if (!std::isfinite(scale) || scale <= 0)
-    {
-      return 1.0;
-    }
-    return scale;
   }
-
-  // No reconstructed z-vertex: f at z = 0, 1D correction function.
-  if (!m_NozCorrFunc)
-  {
-    return 1.0;
-  }
-  float minlimit = 0;
-  float maxlimit = 0;
-  getEtaAcceptance(0.0, jet_radius, minlimit, maxlimit);
-  if (maxlimit <= minlimit)
-  {
-    return 1.0;
-  }
-  double f = (eta - minlimit) / (double) (maxlimit - minlimit);
-  if (f < 0 || f > 1)
-  {
-    return 1.0;  // outside the acceptance window
-  }
-  double scale = m_NozCorrFunc->Eval(f);
-  if (!std::isfinite(scale) || scale < 0.8 || scale > 1.2)
-  {
-    return 1.0;  // sanity guard
-  }
-  return (float) scale;
+  calib = JetCalibFunc[zvrtxbin][etabin]->Eval(jetPt);
+  return calib;
 }

--- a/offline/packages/jetbase/JetCalib.cc
+++ b/offline/packages/jetbase/JetCalib.cc
@@ -3,6 +3,11 @@
 #include "Jet.h"
 #include "JetContainerv1.h"
 
+<<<<<<< Updated upstream
+=======
+#include <cdbobjects/CDBTF.h>  // for CDBTF1 (legacy method)
+
+>>>>>>> Stashed changes
 #include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -54,6 +59,7 @@ int JetCalib::InitRun(PHCompositeNode *topNode)
   // Create calib jet node.
   CreateNodeTree(topNode);
 
+<<<<<<< Updated upstream
   // Locate the calibration file: local override first, otherwise the CDB payload.
   std::string calibFile = m_calibFileOverride.empty() ? fetchCalibDir("Default") : m_calibFileOverride;
   if (calibFile.empty())
@@ -66,6 +72,41 @@ int JetCalib::InitRun(PHCompositeNode *topNode)
   if (!m_JetCalibFile || m_JetCalibFile->IsZombie())
   {
     std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not open calibration file " << calibFile << "!" << std::endl;
+=======
+  int ret = m_useEMfracCalib ? initEMfracCalib() : initLegacyCalib();
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) - InitRun with inputNode: " << m_inputNode
+              << " outputNode: " << m_outputNode
+              << " method: " << (m_useEMfracCalib ? "EMfrac" : "legacy") << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+// ---------------------------------------------------------------------------
+// EMfrac method initialization: CDB payload "JES_Calib_EMfrac" (or the local
+// file set with set_CalibFile), holding per-radius h2d_jes_calib_r0R,
+// h2_zeta_corr_r0R and f_zeta_noz_corr_r0R.
+// ---------------------------------------------------------------------------
+int JetCalib::initEMfracCalib()
+{
+  std::string calibFile = m_calibFileOverride.empty() ? fetchCalibDir("EMfrac") : m_calibFileOverride;
+  if (calibFile.empty())
+  {
+    std::cout << "JetCalib::initEMfracCalib() : No EMfrac calibration available! Will apply calib factor 1." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  m_JetCalibFile = TFile::Open(calibFile.c_str(), "READ");
+  if (!m_JetCalibFile || m_JetCalibFile->IsZombie())
+  {
+    std::cout << "JetCalib::initEMfracCalib() : Could not open calibration file " << calibFile << "!" << std::endl;
+>>>>>>> Stashed changes
     exit(1);
   }
 
@@ -75,7 +116,11 @@ int JetCalib::InitRun(PHCompositeNode *topNode)
   m_JesCalibMap = dynamic_cast<TH2 *>(m_JetCalibFile->Get(Form("h2d_jes_calib_r0%d", r_index)));
   if (!m_JesCalibMap)
   {
+<<<<<<< Updated upstream
     std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find first-pass calibration map h2d_jes_calib_r0" << r_index << "!" << std::endl;
+=======
+    std::cout << "JetCalib::initEMfracCalib() : Could not find first-pass calibration map h2d_jes_calib_r0" << r_index << "!" << std::endl;
+>>>>>>> Stashed changes
     exit(1);
   }
 
@@ -86,7 +131,11 @@ int JetCalib::InitRun(PHCompositeNode *topNode)
     m_NozCorrFunc = dynamic_cast<TF1 *>(m_JetCalibFile->Get(Form("f_zeta_noz_corr_r0%d", r_index)));
     if (!m_ZetaCorrMap || !m_NozCorrFunc)
     {
+<<<<<<< Updated upstream
       std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) : Could not find residual correction ("
+=======
+      std::cout << "JetCalib::initEMfracCalib() : Could not find residual correction ("
+>>>>>>> Stashed changes
                 << (m_ZetaCorrMap ? "" : Form("h2_zeta_corr_r0%d ", r_index))
                 << (m_NozCorrFunc ? "" : Form("f_zeta_noz_corr_r0%d", r_index))
                 << "); residual correction disabled." << std::endl;
@@ -98,10 +147,129 @@ int JetCalib::InitRun(PHCompositeNode *topNode)
 
   if (Verbosity() > 0)
   {
+<<<<<<< Updated upstream
     std::cout << "JetCalib::InitRun(PHCompositeNode *topNode) - InitRun with inputNode: " << m_inputNode
               << " outputNode: " << m_outputNode << " calibFile: " << calibFile
+=======
+    std::cout << "JetCalib::initEMfracCalib() : calibFile: " << calibFile
+>>>>>>> Stashed changes
               << " residual: " << (m_ApplyResidualCalib ? "on" : "off") << std::endl;
   }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy method initialization: CDB payload "JES_Calib_Default", holding
+// per-(z bin, eta bin) TF1 corrections versus pT.
+// ---------------------------------------------------------------------------
+int JetCalib::initLegacyCalib()
+{
+  if (fetchCalibDir("Default").empty())
+  {
+    std::cout << "JetCalib::initLegacyCalib() : No default calibration available! Will apply calib factor 1." << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  m_LegacyCalibFile = new CDBTF(fetchCalibDir("Default"));
+  if (!m_LegacyCalibFile)
+  {
+    std::cout << "JetCalib::initLegacyCalib() : Could not open calibration file!" << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  m_LegacyCalibFile->LoadCalibrations();
+  std::string JetCalibFunc_name = "JES_Calib_Func_R0" + std::to_string((int) (jet_radius * 10));
+  if (!ApplyZvrtxDependentCalib && !ApplyEtaDependentCalib)
+  {
+    int nZvrtxBins = 1;
+    int nEtaBins = 1;
+    m_JetCalibFunc.resize(nZvrtxBins);
+    for (auto &row : m_JetCalibFunc)
+    {
+      row.resize(nEtaBins, nullptr);
+    }
+    TF1 *func_temp = m_LegacyCalibFile->getTF(JetCalibFunc_name + "_Default");
+    if (!func_temp)
+    {
+      std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Default" << std::endl;
+      exit(1);
+    }
+    m_JetCalibFunc[0][0] = func_temp;
+  }
+  else if (ApplyZvrtxDependentCalib && !ApplyEtaDependentCalib)
+  {
+    int nZvrtxBins = 5;
+    int nEtaBins = 1;
+    m_JetCalibFunc.resize(nZvrtxBins);
+    for (auto &row : m_JetCalibFunc)
+    {
+      row.resize(nEtaBins, nullptr);
+    }
+    for (int iz = 0; iz < nZvrtxBins; ++iz)
+    {
+      TF1 *func_temp = m_LegacyCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz));
+      if (!func_temp)
+      {
+        std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
+        exit(1);
+      }
+      m_JetCalibFunc[iz][0] = func_temp;
+    }
+  }
+  else if (ApplyEtaDependentCalib)
+  {
+    if (!ApplyZvrtxDependentCalib)
+    {
+      std::cout << "JetCalib::initLegacyCalib() : Must apply Zvrtx dependent calibration to apply eta dependent calibration. Applying Zvrtx + eta dependent calibration." << std::endl;
+    }
+    int nZvrtxBins = 5;
+    int nEtaBins = 4;
+    m_JetCalibFunc.resize(nZvrtxBins);
+    for (auto &row : m_JetCalibFunc)
+    {
+      row.resize(nEtaBins, nullptr);
+    }
+    for (int iz = 0; iz < nZvrtxBins; ++iz)
+    {
+      if (iz < 3 && jet_radius <= 0.4)
+      {
+        for (int ieta = 0; ieta < nEtaBins; ++ieta)
+        {
+          TF1 *func_temp = m_LegacyCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz) + "_Eta" + std::to_string(ieta));
+          if (!func_temp)
+          {
+            std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << "_Eta" << ieta << std::endl;
+            exit(1);
+          }
+          m_JetCalibFunc[iz][ieta] = func_temp;
+        }
+      }
+      else if (iz < 3 && jet_radius > 0.4)
+      {
+        for (int ieta = 0; ieta < nEtaBins; ++ieta)
+        {
+          TF1 *func_temp = m_LegacyCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz));
+          if (!func_temp)
+          {
+            std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
+            exit(1);
+          }
+          m_JetCalibFunc[iz][ieta] = func_temp;
+        }
+      }
+      else
+      {
+        TF1 *func_temp = m_LegacyCalibFile->getTF(JetCalibFunc_name + "_Z" + std::to_string(iz));
+        if (!func_temp)
+        {
+          std::cout << "JetCalib::initLegacyCalib() : Could not find calibration function: " << JetCalibFunc_name << "_Z" << iz << std::endl;
+          exit(1);
+        }
+        m_JetCalibFunc[iz][0] = func_temp;
+      }
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -121,6 +289,7 @@ int JetCalib::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+<<<<<<< Updated upstream
   // z-vertex for the residual correction: taken from the raw jet container, i.e.
   // the vertex that was ACTUALLY USED in the jet reconstruction (recorded from the
   // jet inputs) -- not re-fetched from the GlobalVertexMap, which may differ from
@@ -130,6 +299,11 @@ int JetCalib::process_event(PHCompositeNode *topNode)
   float zvertex = 0;
   bool hasVertex = false;
   if (m_ApplyResidualCalib)
+=======
+  float zvertex = m_useEMfracCalib ? 0 : -999.0;
+  bool hasVertex = false;
+  if ((m_useEMfracCalib && m_ApplyResidualCalib) || (!m_useEMfracCalib && ApplyZvrtxDependentCalib))
+>>>>>>> Stashed changes
   {
     hasVertex = _raw_jets->has_zvertex();
     if (hasVertex)
@@ -138,12 +312,20 @@ int JetCalib::process_event(PHCompositeNode *topNode)
       if (!std::isfinite(zvertex))
       {
         hasVertex = false;
+<<<<<<< Updated upstream
         zvertex = 0;
+=======
+        zvertex = m_useEMfracCalib ? 0 : -999.0;
+>>>>>>> Stashed changes
       }
     }
     if (!hasVertex && Verbosity() > 0)
     {
+<<<<<<< Updated upstream
       std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : jets reconstructed without a z-vertex; applying the no-vertex correction." << std::endl;
+=======
+      std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : jets reconstructed without a z-vertex; applying the no-vertex treatment." << std::endl;
+>>>>>>> Stashed changes
     }
   }
 
@@ -173,6 +355,34 @@ int JetCalib::process_event(PHCompositeNode *topNode)
       m_warnedNoEmFrac = true;
     }
 
+<<<<<<< Updated upstream
+=======
+    float calib_pt = pt;
+    if (m_useEMfracCalib)
+    {
+      float emfrac = jet->get_emcal_frac();
+      if (m_JesCalibMap && std::isfinite(emfrac))
+      {
+        calib_pt = getFirstPassPt(pt, emfrac);
+        if (m_ApplyResidualCalib)
+        {
+          calib_pt *= getResidualScale(zvertex, hasVertex, eta);
+        }
+      }
+      else if (m_JesCalibMap && !m_warnedNoEmFrac)
+      {
+        std::cout << "JetCalib::process_event(PHCompositeNode *topNode) : Jet has no EMCal fraction stored"
+                  << " (Jet::get_emcal_frac() is NaN; enable the calo fractions in the jet reco)."
+                  << " Applying calib factor 1 to such jets." << std::endl;
+        m_warnedNoEmFrac = true;
+      }
+    }
+    else if (!m_JetCalibFunc.empty())
+    {
+      calib_pt = doCalibration(m_JetCalibFunc, pt, zvertex, eta);
+    }
+
+>>>>>>> Stashed changes
     auto *calib_jet = _calib_jets->add_jet();
     calib_jet->set_px(calib_pt * std::cos(phi));
     calib_jet->set_py(calib_pt * std::sin(phi));
@@ -245,6 +455,15 @@ std::string JetCalib::fetchCalibDir(const char *calibType)
   return CDBInterface::instance()->getUrl(calibName);
 }
 
+<<<<<<< Updated upstream
+// z-corrected eta acceptance window: intersection of the EMCal/IHCal/OHCal reach as
+// seen from the vertex, padded inward by the jet radius. Must match the derivation.
+void JetCalib::getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit)
+=======
+// ---------------------------------------------------------------------------
+// EMfrac method helpers.
+// ---------------------------------------------------------------------------
+
 // z-corrected eta acceptance window: intersection of the EMCal/IHCal/OHCal reach as
 // seen from the vertex, padded inward by the jet radius. Must match the derivation.
 void JetCalib::getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit)
@@ -268,6 +487,129 @@ void JetCalib::getEtaAcceptance(float zvrtx, float radius, float &minlimit, floa
 // Bilinear interpolation with both coordinates clamped to the bin-center range
 // (TH2::Interpolate is undefined outside it).
 float JetCalib::interpolateClamped(TH2 *h2, double x, double y)
+{
+  TAxis *xa = h2->GetXaxis();
+  TAxis *ya = h2->GetYaxis();
+  double x_lo = xa->GetBinCenter(1);
+  double x_hi = xa->GetBinCenter(xa->GetNbins());
+  double y_lo = ya->GetBinCenter(1);
+  double y_hi = ya->GetBinCenter(ya->GetNbins());
+  if (x < x_lo)
+  {
+    x = x_lo;
+  }
+  if (x > x_hi)
+  {
+    x = x_hi;
+  }
+  if (y < y_lo)
+  {
+    y = y_lo;
+  }
+  if (y > y_hi)
+  {
+    y = y_hi;
+  }
+  return h2->Interpolate(x, y);
+}
+
+// First pass: calibrated (truth-equivalent) pT from the inverted (reco pT, EMCal
+// fraction) map.
+float JetCalib::getFirstPassPt(float jetPt, float emFrac) const
+{
+  if (!m_JesCalibMap)
+  {
+    return jetPt;
+  }
+  float calibPt = interpolateClamped(m_JesCalibMap, jetPt, emFrac);
+  if (!std::isfinite(calibPt) || calibPt <= 0)
+  {
+    return jetPt;  // unpopulated map region (no inversion solution): leave uncalibrated
+  }
+  return calibPt;
+}
+
+// Residual (z-vertex, eta) scale factor. With a vertex: the (signed z, f) map;
+// without: the no-vertex function evaluated at f computed with z = 0.
+float JetCalib::getResidualScale(float zvrtx, bool hasVertex, float eta) const
+{
+  if (hasVertex)
+  {
+    if (!m_ZetaCorrMap)
+    {
+      return 1.0;
+    }
+    float minlimit = 0;
+    float maxlimit = 0;
+    getEtaAcceptance(zvrtx, jet_radius, minlimit, maxlimit);
+    if (maxlimit <= minlimit)
+    {
+      return 1.0;  // acceptance closed at this z
+    }
+    double f = (eta - minlimit) / (double) (maxlimit - minlimit);
+    float scale = interpolateClamped(m_ZetaCorrMap, zvrtx, f);  // SIGNED z, no mirror
+    if (!std::isfinite(scale) || scale <= 0)
+    {
+      return 1.0;
+    }
+    return scale;
+  }
+
+  // No reconstructed z-vertex: f at z = 0, 1D correction function.
+  if (!m_NozCorrFunc)
+  {
+    return 1.0;
+  }
+  float minlimit = 0;
+  float maxlimit = 0;
+  getEtaAcceptance(0.0, jet_radius, minlimit, maxlimit);
+  if (maxlimit <= minlimit)
+  {
+    return 1.0;
+  }
+  double f = (eta - minlimit) / (double) (maxlimit - minlimit);
+  if (f < 0 || f > 1)
+  {
+    return 1.0;  // outside the acceptance window
+  }
+  double scale = m_NozCorrFunc->Eval(f);
+  if (!std::isfinite(scale) || scale < 0.5 || scale > 2.0)
+  {
+    return 1.0;  // sanity guard
+  }
+  return (float) scale;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy method helpers (per-(z bin, eta bin) TF1 corrections versus pT).
+// ---------------------------------------------------------------------------
+
+static int getZvrtxBin(float zvrtx)
+>>>>>>> Stashed changes
+{
+  // Calorimeter half-lengths [cm] and radii [cm].
+  const float minz_EM = -130.23, maxz_EM = 130.23, radius_EM = 93.5;
+  const float minz_IH = -170.299, maxz_IH = 170.299, radius_IH = 127.503;
+  const float minz_OH = -301.683, maxz_OH = 301.683, radius_OH = 225.87;
+
+  float emcal_min = std::asinh((minz_EM - zvrtx) / radius_EM);
+  float emcal_max = std::asinh((maxz_EM - zvrtx) / radius_EM);
+  float ihcal_min = std::asinh((minz_IH - zvrtx) / radius_IH);
+  float ihcal_max = std::asinh((maxz_IH - zvrtx) / radius_IH);
+  float ohcal_min = std::asinh((minz_OH - zvrtx) / radius_OH);
+  float ohcal_max = std::asinh((maxz_OH - zvrtx) / radius_OH);
+
+  minlimit = std::max({emcal_min, ihcal_min, ohcal_min}) + radius;
+  maxlimit = std::min({emcal_max, ihcal_max, ohcal_max}) - radius;
+}
+
+<<<<<<< Updated upstream
+// Bilinear interpolation with both coordinates clamped to the bin-center range
+// (TH2::Interpolate is undefined outside it).
+float JetCalib::interpolateClamped(TH2 *h2, double x, double y)
+=======
+static int getEtaBin(int zvrtxbin, float eta, float jet_radius)
+>>>>>>> Stashed changes
 {
   TAxis *xa = h2->GetXaxis();
   TAxis *ya = h2->GetYaxis();

--- a/offline/packages/jetbase/JetCalib.h
+++ b/offline/packages/jetbase/JetCalib.h
@@ -6,19 +6,32 @@
 #include <fun4all/SubsysReco.h>
 
 #include <string>
+#include <vector>
 
 class PHCompositeNode;
 class TF1;
 class TFile;
 class TH2;
 
+<<<<<<< Updated upstream
 // Jet energy scale calibration:
+=======
+// Jet energy scale calibration. Two methods are available:
+//
+// EMfrac method (DEFAULT; CDB payload "JES_Calib_EMfrac"):
+>>>>>>> Stashed changes
 //   1) first pass: calibrated (truth-equivalent) pT read from a 2D map versus
 //      (reco pT, EMCal energy fraction), by clamped bilinear interpolation;
 //   2) residual correction: multiplicative scale factor versus (signed z-vertex,
 //      fractional eta position f within the z-corrected acceptance window);
 //      events without a reconstructed z-vertex instead use a 1D correction
 //      function versus f, with f computed at z = 0.
+<<<<<<< Updated upstream
+=======
+//
+// Legacy method (select with set_UseEMfracCalib(false); CDB payload
+// "JES_Calib_Default"): per-(z-vertex bin, eta bin) TF1 corrections versus pT.
+>>>>>>> Stashed changes
 
 class JetCalib : public SubsysReco
 {
@@ -30,16 +43,39 @@ class JetCalib : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int CreateNodeTree(PHCompositeNode *topNode);
 
+<<<<<<< Updated upstream
   // Setters.
   void set_InputNode(const std::string &inputNode) { m_inputNode = inputNode; }
   void set_OutputNode(const std::string &outputNode) { m_outputNode = outputNode; }
   void set_JetRadius(float radius) { jet_radius = radius; }
   void set_ApplyResidualCalib(bool apply) { m_ApplyResidualCalib = apply; }
   void set_CalibFile(const std::string &path) { m_calibFileOverride = path; }  // local file override (default: CDB)
+=======
+  // Setters (both methods).
+  void set_InputNode(const std::string &inputNode) { m_inputNode = inputNode; }
+  void set_OutputNode(const std::string &outputNode) { m_outputNode = outputNode; }
+  void set_JetRadius(float radius) { jet_radius = radius; }
+  // Method selection: true (default) = EMfrac method, false = legacy method.
+  void set_UseEMfracCalib(bool use) { m_useEMfracCalib = use; }
+
+  // Setters (EMfrac method).
+  void set_ApplyResidualCalib(bool apply) { m_ApplyResidualCalib = apply; }
+  void set_CalibFile(const std::string &path) { m_calibFileOverride = path; }  // local file override (default: CDB)
+
+  // Setters (legacy method).
+  void set_ApplyZvrtxDependentCalib(bool apply) { ApplyZvrtxDependentCalib = apply; }
+  void set_ApplyEtaDependentCalib(bool apply) { ApplyEtaDependentCalib = apply; }
+>>>>>>> Stashed changes
 
  private:
-  // Functions.
+  // Functions (common).
   static std::string fetchCalibDir(const char *calibType);
+<<<<<<< Updated upstream
+=======
+
+  // Functions (EMfrac method).
+  int initEMfracCalib();
+>>>>>>> Stashed changes
   // z-corrected eta acceptance window (intersection of EMCal/IHCal/OHCal reach,
   // padded inward by the jet radius); must match the derivation exactly.
   static void getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit);
@@ -47,20 +83,45 @@ class JetCalib : public SubsysReco
   static float interpolateClamped(TH2 *h2, double x, double y);
   float getFirstPassPt(float jetPt, float emFrac) const;
   float getResidualScale(float zvrtx, bool hasVertex, float eta) const;
+<<<<<<< Updated upstream
+=======
+
+  // Functions (legacy method).
+  int initLegacyCalib();
+  float doCalibration(const std::vector<std::vector<TF1 *>> &JetCalibFunc, float jetPt, float zvrtx, float eta) const;
+>>>>>>> Stashed changes
 
   // Input.
   std::string m_inputNode{"AntiKt_Tower_r04"};
   std::string m_outputNode{"AntiKt_Tower_r04_Calib"};
+<<<<<<< Updated upstream
   std::string m_calibFileOverride;      // if set, read this file instead of the CDB payload
   float jet_radius{0.4};                // Jet radius.
   bool m_ApplyResidualCalib{true};      // Apply the residual (z-vertex, eta) correction.
 
   // Calibration objects (for the configured radius).
+=======
+  std::string m_calibFileOverride;              // EMfrac method: if set, read this file instead of the CDB payload
+  float jet_radius{0.4};                        // Jet radius.
+  bool m_useEMfracCalib{true};                  // true = EMfrac method (default), false = legacy method
+  bool m_ApplyResidualCalib{true};              // EMfrac method: apply the residual (z-vertex, eta) correction.
+  bool ApplyZvrtxDependentCalib{true};          // Legacy method: apply Z-vertex dependent calibration.
+  bool ApplyEtaDependentCalib{true};            // Legacy method: apply eta dependent calibration.
+
+  // Calibration objects (EMfrac method, for the configured radius).
+>>>>>>> Stashed changes
   TFile *m_JetCalibFile{nullptr};
   TH2 *m_JesCalibMap{nullptr};   // h2d_jes_calib_r0R: truth-equivalent pT vs (reco pT, EMCal fraction)
   TH2 *m_ZetaCorrMap{nullptr};   // h2_zeta_corr_r0R: scale factor vs (signed z-vertex, f)
   TF1 *m_NozCorrFunc{nullptr};   // f_zeta_noz_corr_r0R: scale factor vs f (f at z = 0), no-vertex events
   bool m_warnedNoEmFrac{false};
+<<<<<<< Updated upstream
+=======
+
+  // Calibration objects (legacy method).
+  CDBTF *m_LegacyCalibFile{nullptr};
+  std::vector<std::vector<TF1 *>> m_JetCalibFunc{};
+>>>>>>> Stashed changes
 };
 
 #endif  // JETBASE_JETCALIB_H

--- a/offline/packages/jetbase/JetCalib.h
+++ b/offline/packages/jetbase/JetCalib.h
@@ -3,16 +3,22 @@
 #ifndef JETBASE_JETCALIB_H
 #define JETBASE_JETCALIB_H
 
-#include <calobase/TowerInfoContainer.h>
 #include <fun4all/SubsysReco.h>
 
-#include <iostream>
-#include <limits>
 #include <string>
 
-class CDBTF;
 class PHCompositeNode;
 class TF1;
+class TFile;
+class TH2;
+
+// Jet energy scale calibration:
+//   1) first pass: calibrated (truth-equivalent) pT read from a 2D map versus
+//      (reco pT, EMCal energy fraction), by clamped bilinear interpolation;
+//   2) residual correction: multiplicative scale factor versus (signed z-vertex,
+//      fractional eta position f within the z-corrected acceptance window);
+//      events without a reconstructed z-vertex instead use a 1D correction
+//      function versus f, with f computed at z = 0.
 
 class JetCalib : public SubsysReco
 {
@@ -24,30 +30,37 @@ class JetCalib : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int CreateNodeTree(PHCompositeNode *topNode);
 
-  // Getters.
+  // Setters.
   void set_InputNode(const std::string &inputNode) { m_inputNode = inputNode; }
   void set_OutputNode(const std::string &outputNode) { m_outputNode = outputNode; }
   void set_JetRadius(float radius) { jet_radius = radius; }
-  void set_ZvrtxNode(const std::string &zvrtxNode) { m_zvrtxNode = zvrtxNode; }
-  void set_ApplyZvrtxDependentCalib(bool apply) { ApplyZvrtxDependentCalib = apply; }
-  void set_ApplyEtaDependentCalib(bool apply) { ApplyEtaDependentCalib = apply; }
+  void set_ApplyResidualCalib(bool apply) { m_ApplyResidualCalib = apply; }
+  void set_CalibFile(const std::string &path) { m_calibFileOverride = path; }  // local file override (default: CDB)
 
  private:
   // Functions.
   static std::string fetchCalibDir(const char *calibType);
-  float doCalibration(const std::vector<std::vector<TF1 *>> &JetCalibFunc, float jetPt, float zvrtx, float eta) const;
+  // z-corrected eta acceptance window (intersection of EMCal/IHCal/OHCal reach,
+  // padded inward by the jet radius); must match the derivation exactly.
+  static void getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit);
+  // Bilinear interpolation with both coordinates clamped to the bin-center range.
+  static float interpolateClamped(TH2 *h2, double x, double y);
+  float getFirstPassPt(float jetPt, float emFrac) const;
+  float getResidualScale(float zvrtx, bool hasVertex, float eta) const;
 
   // Input.
   std::string m_inputNode{"AntiKt_Tower_r04"};
   std::string m_outputNode{"AntiKt_Tower_r04_Calib"};
-  std::string m_zvrtxNode{"GlobalVertexMap"};
+  std::string m_calibFileOverride;      // if set, read this file instead of the CDB payload
   float jet_radius{0.4};                // Jet radius.
-  bool ApplyZvrtxDependentCalib{true};  // Apply Z-vertex dependent calibration.
-  bool ApplyEtaDependentCalib{true};    // Apply eta dependent calibration.
+  bool m_ApplyResidualCalib{true};      // Apply the residual (z-vertex, eta) correction.
 
-  // Variables.
-  CDBTF *m_JetCalibFile{nullptr};
-  std::vector<std::vector<TF1 *>> m_JetCalibFunc{};
+  // Calibration objects (for the configured radius).
+  TFile *m_JetCalibFile{nullptr};
+  TH2 *m_JesCalibMap{nullptr};   // h2d_jes_calib_r0R: truth-equivalent pT vs (reco pT, EMCal fraction)
+  TH2 *m_ZetaCorrMap{nullptr};   // h2_zeta_corr_r0R: scale factor vs (signed z-vertex, f)
+  TF1 *m_NozCorrFunc{nullptr};   // f_zeta_noz_corr_r0R: scale factor vs f (f at z = 0), no-vertex events
+  bool m_warnedNoEmFrac{false};
 };
 
 #endif  // JETBASE_JETCALIB_H

--- a/offline/packages/jetbase/JetCalib.h
+++ b/offline/packages/jetbase/JetCalib.h
@@ -8,30 +8,24 @@
 #include <string>
 #include <vector>
 
+class CDBTF;
 class PHCompositeNode;
 class TF1;
 class TFile;
 class TH2;
 
-<<<<<<< Updated upstream
-// Jet energy scale calibration:
-=======
 // Jet energy scale calibration. Two methods are available:
 //
 // EMfrac method (DEFAULT; CDB payload "JES_Calib_EMfrac"):
->>>>>>> Stashed changes
 //   1) first pass: calibrated (truth-equivalent) pT read from a 2D map versus
 //      (reco pT, EMCal energy fraction), by clamped bilinear interpolation;
 //   2) residual correction: multiplicative scale factor versus (signed z-vertex,
 //      fractional eta position f within the z-corrected acceptance window);
 //      events without a reconstructed z-vertex instead use a 1D correction
 //      function versus f, with f computed at z = 0.
-<<<<<<< Updated upstream
-=======
 //
 // Legacy method (select with set_UseEMfracCalib(false); CDB payload
 // "JES_Calib_Default"): per-(z-vertex bin, eta bin) TF1 corrections versus pT.
->>>>>>> Stashed changes
 
 class JetCalib : public SubsysReco
 {
@@ -43,14 +37,6 @@ class JetCalib : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int CreateNodeTree(PHCompositeNode *topNode);
 
-<<<<<<< Updated upstream
-  // Setters.
-  void set_InputNode(const std::string &inputNode) { m_inputNode = inputNode; }
-  void set_OutputNode(const std::string &outputNode) { m_outputNode = outputNode; }
-  void set_JetRadius(float radius) { jet_radius = radius; }
-  void set_ApplyResidualCalib(bool apply) { m_ApplyResidualCalib = apply; }
-  void set_CalibFile(const std::string &path) { m_calibFileOverride = path; }  // local file override (default: CDB)
-=======
   // Setters (both methods).
   void set_InputNode(const std::string &inputNode) { m_inputNode = inputNode; }
   void set_OutputNode(const std::string &outputNode) { m_outputNode = outputNode; }
@@ -65,17 +51,13 @@ class JetCalib : public SubsysReco
   // Setters (legacy method).
   void set_ApplyZvrtxDependentCalib(bool apply) { ApplyZvrtxDependentCalib = apply; }
   void set_ApplyEtaDependentCalib(bool apply) { ApplyEtaDependentCalib = apply; }
->>>>>>> Stashed changes
 
  private:
   // Functions (common).
   static std::string fetchCalibDir(const char *calibType);
-<<<<<<< Updated upstream
-=======
 
   // Functions (EMfrac method).
   int initEMfracCalib();
->>>>>>> Stashed changes
   // z-corrected eta acceptance window (intersection of EMCal/IHCal/OHCal reach,
   // padded inward by the jet radius); must match the derivation exactly.
   static void getEtaAcceptance(float zvrtx, float radius, float &minlimit, float &maxlimit);
@@ -83,24 +65,14 @@ class JetCalib : public SubsysReco
   static float interpolateClamped(TH2 *h2, double x, double y);
   float getFirstPassPt(float jetPt, float emFrac) const;
   float getResidualScale(float zvrtx, bool hasVertex, float eta) const;
-<<<<<<< Updated upstream
-=======
 
   // Functions (legacy method).
   int initLegacyCalib();
   float doCalibration(const std::vector<std::vector<TF1 *>> &JetCalibFunc, float jetPt, float zvrtx, float eta) const;
->>>>>>> Stashed changes
 
   // Input.
   std::string m_inputNode{"AntiKt_Tower_r04"};
   std::string m_outputNode{"AntiKt_Tower_r04_Calib"};
-<<<<<<< Updated upstream
-  std::string m_calibFileOverride;      // if set, read this file instead of the CDB payload
-  float jet_radius{0.4};                // Jet radius.
-  bool m_ApplyResidualCalib{true};      // Apply the residual (z-vertex, eta) correction.
-
-  // Calibration objects (for the configured radius).
-=======
   std::string m_calibFileOverride;              // EMfrac method: if set, read this file instead of the CDB payload
   float jet_radius{0.4};                        // Jet radius.
   bool m_useEMfracCalib{true};                  // true = EMfrac method (default), false = legacy method
@@ -109,19 +81,15 @@ class JetCalib : public SubsysReco
   bool ApplyEtaDependentCalib{true};            // Legacy method: apply eta dependent calibration.
 
   // Calibration objects (EMfrac method, for the configured radius).
->>>>>>> Stashed changes
   TFile *m_JetCalibFile{nullptr};
   TH2 *m_JesCalibMap{nullptr};   // h2d_jes_calib_r0R: truth-equivalent pT vs (reco pT, EMCal fraction)
   TH2 *m_ZetaCorrMap{nullptr};   // h2_zeta_corr_r0R: scale factor vs (signed z-vertex, f)
   TF1 *m_NozCorrFunc{nullptr};   // f_zeta_noz_corr_r0R: scale factor vs f (f at z = 0), no-vertex events
   bool m_warnedNoEmFrac{false};
-<<<<<<< Updated upstream
-=======
 
   // Calibration objects (legacy method).
   CDBTF *m_LegacyCalibFile{nullptr};
   std::vector<std::vector<TF1 *>> m_JetCalibFunc{};
->>>>>>> Stashed changes
 };
 
 #endif  // JETBASE_JETCALIB_H


### PR DESCRIPTION
…endent calibration

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

Jet calibration must account for jet transverse momentum, EMCal fraction, z-vertex, and jet pseudorapidity. This update adds a selectable ROOT-map calibration method while preserving the legacy CDBTF method.

## Key Changes

- Added selectable EM-fraction calibration using ROOT calibration maps.
- Added pT-, EMCal fraction-, z-vertex-, and jet eta-dependent corrections.
- Added payload validation, clamped interpolation, acceptance limits, residual corrections, and legacy binning helpers.
- Added handling for missing EMCal fractions.
- Preserved the legacy CDBTF calibration path.
- Added cleanup for ROOT calibration files and legacy calibration objects.
- Added `set_UseEMfracCalib(bool use)`.
- Removed `set_ZvrtxNode(...)` and the stored vertex-node member.

## Potential Risk Areas

- ROOT payloads must contain the expected objects and format.
- The new calibration path can change reconstructed jet results.
- Boundary clamping and residual corrections require physics validation.
- Additional ROOT access and correction steps may affect performance.
- Calibration object access requires review for thread safety.
- Removing `set_ZvrtxNode(...)` can affect existing callers.

## Possible Future Improvements

- Add tests for method selection, interpolation, boundaries, missing EMCal fractions, and residual corrections.
- Document the ROOT payload schema and configuration.
- Compare the new method with the legacy method using reference datasets.
- Benchmark performance and validate full reconstruction workflows.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation, payloads, API usage, and physics validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->