### PR TITLE
feat: add all TPOT clusters to cluster-on-seed map

### DIFF
--- a/offline/packages/trackreco/DSTClusterPruning.cc
+++ b/offline/packages/trackreco/DSTClusterPruning.cc
@@ -151,51 +151,58 @@ void DSTClusterPruning::prune_clusters()
   // use this to create object that looks through both tracks and clusters and saves into new object
   // make sure clusters exist
   // make sure tracks exist
-  if (Verbosity() > 1){
+  if (Verbosity() > 1)
+  {
     std::cout << "In Prune clusters" << std::endl;
-    if(!m_cluster_map){
+    if (!m_cluster_map)
+    {
       std::cout << "No cluster map" << std::endl;
     }
-    if(!m_reduced_cluster_map){
+    if (!m_reduced_cluster_map)
+    {
       std::cout << "No reduced cluster map" << std::endl;
     }
-    if(!m_track_seed_container){
+    if (!m_track_seed_container)
+    {
       std::cout << "No track seed container" << std::endl;
     }
-    if(!m_silicon_track_seed_container){
+    if (!m_silicon_track_seed_container)
+    {
       std::cout << "No silicon track seed container" << std::endl;
     }
-    if(!m_tpc_track_seed_container){
+    if (!m_tpc_track_seed_container)
+    {
       std::cout << "No tpc track seed container" << std::endl;
     }
   }
-  
+
   if (!(m_cluster_map && m_reduced_cluster_map && m_track_seed_container && m_silicon_track_seed_container && m_tpc_track_seed_container))
   {
-    if (Verbosity() > 1){
+    if (Verbosity() > 1)
+    {
       std::cout << "Missing container" << std::endl;
     }
     return;
   }
-  if(m_pruneAllSeeds)
+  if (m_pruneAllSeeds)
   {
-    for(const auto& container : {m_tpc_track_seed_container, m_silicon_track_seed_container})
+    for (const auto& container : {m_tpc_track_seed_container, m_silicon_track_seed_container})
     {
       for (const auto& trackseed : *container)
       {
         if (!trackseed)
         {
-	  if(Verbosity() > 1)
-	    {
-	      std::cout << "No TrackSeed" << std::endl;
-	    }
-	  continue;
+          if (Verbosity() > 1)
+          {
+            std::cout << "No TrackSeed" << std::endl;
+          }
+          continue;
         }
 
         for (auto key_iter = trackseed->begin_cluster_keys(); key_iter != trackseed->end_cluster_keys(); ++key_iter)
         {
           const auto& cluster_key = *key_iter;
-          auto *cluster = m_cluster_map->findCluster(cluster_key);
+          auto* cluster = m_cluster_map->findCluster(cluster_key);
           if (!cluster)
           {
             std::cout << "DSTClusterPruning::evaluate_tracks - unable to find cluster for key " << cluster_key << std::endl;

--- a/offline/packages/trackreco/DSTClusterPruning.cc
+++ b/offline/packages/trackreco/DSTClusterPruning.cc
@@ -186,6 +186,35 @@ void DSTClusterPruning::prune_clusters()
   }
   if (m_pruneAllSeeds)
   {
+    /**
+     * We want to dump out all clusters on track seeds
+     * Since the tpc-tpot matching requires drift velocity, we dump out all the tpot clusters
+     * so that the matching can be run in job c
+     * The additional data volume
+     * is minimal comparitvely and a worthwhile price to punt the calibration application to later
+     */
+    for (const auto& hitsetkey : m_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::micromegasId))
+    {
+      const auto& cluster_range = m_cluster_map->getClusters(hitsetkey);
+      for (auto cluster_iter = cluster_range.first; cluster_iter != cluster_range.second; ++cluster_iter)
+      {
+        const auto& cluster_key = cluster_iter->first;
+        const auto& cluster = cluster_iter->second;
+
+        if (!cluster)
+        {
+          continue;
+        }
+
+        if (!m_reduced_cluster_map->findCluster(cluster_key))
+        {
+          m_cluster = new TrkrClusterv5();
+          m_cluster->CopyFrom(cluster);
+          m_reduced_cluster_map->addClusterSpecifyKey(cluster_key, m_cluster);
+        }
+      }
+    }
+
     for (const auto& container : {m_tpc_track_seed_container, m_silicon_track_seed_container})
     {
       for (const auto& trackseed : *container)

--- a/offline/packages/trackreco/DSTClusterPruning.h
+++ b/offline/packages/trackreco/DSTClusterPruning.h
@@ -43,14 +43,14 @@ class DSTClusterPruning : public SubsysReco
   DSTClusterPruning(const std::string& = "DSTClusterPruning");
 
   //! run initialization
-  //int Init(PHCompositeNode*) override;
+  // int Init(PHCompositeNode*) override;
   int InitRun(PHCompositeNode*) override;
 
   //! event processing
   int process_event(PHCompositeNode*) override;
 
   //! end of processing
-  //int End(PHCompositeNode*) override;
+  // int End(PHCompositeNode*) override;
 
   //! dump all clusters on all seeds out
   void pruneAllSeeds()
@@ -74,8 +74,8 @@ class DSTClusterPruning : public SubsysReco
   TrackSeedContainer* m_tpc_track_seed_container = nullptr;
   TrackSeedContainer* m_silicon_track_seed_container = nullptr;
 
-//! set to true if you want to dump out all clusters on all silicon
-//! and all tpc seeds individually
+  //! set to true if you want to dump out all clusters on all silicon
+  //! and all tpc seeds individually
   bool m_pruneAllSeeds = false;
   //@}
 


### PR DESCRIPTION
This PR takes all the TPOT clusters and adds them to the reduced `TRKR_CLUSTER_SEED` cluster map for writing out to the seed DST. This will allow us to punt all silicon-TPC and TPC-TPOT matching into job C, since the TPC-TPOT matching requires a matched silicon-TPC seed (and thus, requires the drift velocity to be correct). The price of slightly increased cluster map size is a worthwhile price to pay to have seed DSTs not dependent on drift velocity calibrations.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and context

`TRKR_CLUSTER_SEED` currently stores only clusters used by TPC and silicon track seeds. This prevents later silicon–TPC and TPC–TPOT matching without drift-velocity calibration data. The change stores all TPOT clusters in the reduced cluster map. Job C can then perform matching independently of drift-velocity calibrations.

## Key changes

- When `m_pruneAllSeeds` is enabled, `DSTClusterPruning` copies missing Micromegas clusters into the reduced cluster container.
- The code continues to copy clusters referenced by TPC and silicon track seeds.
- Container validation and diagnostics for missing containers are retained or expanded.
- Null track-seed diagnostics are reformatted without changing behavior.
- Comments in `DSTClusterPruning.h` are clarified.
- No public or exported declarations change.

## Potential risk areas

- The seed DST cluster map becomes larger. This increases output size and may increase I/O and memory use.
- The pruning behavior changes when `m_pruneAllSeeds` is enabled. Downstream reconstruction must handle the additional clusters correctly.
- The change affects DST contents but does not describe a schema or API change.
- No thread-safety changes are indicated.
- The implementation should be checked for performance impact in high-occupancy events.

## Possible future improvements

- Measure DST size, memory use, and processing time before and after the change.
- Add tests that verify all required Micromegas clusters are present in `TRKR_CLUSTER_SEED`.
- Add validation for silicon–TPC and TPC–TPOT matching without drift-velocity calibrations.
- Document the expected cluster-map contents for each pruning configuration.

AI-generated summaries can contain errors. Contributors should verify these points against the implementation and reconstruction workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->