### PR TITLE
Modify TpcClusterMover to better handle survey geometry

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -135,7 +135,7 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     return global_in;
   }
 
-  std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec,  tpc_cluskey_vec, 0);
+  std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec,  tpc_cluskey_vec, false);
   if(fitpars.size() < 5)
     {
       if(_verbosity > 1)

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -136,7 +136,14 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   }
 
   std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec,  tpc_cluskey_vec, 0);
-  
+  if(fitpars.size() == 0)
+    {
+      if(_verbosity > 1)
+	{
+	  std::cout << PHWHERE << "Warning: fit failed, return input positions. " << std::endl;
+	}
+      return global_in;
+    }  
   // Now we need to move each TPC cluster associated with this track to the readout surface radius
   for (unsigned int i = 0; i < tpc_global_vec.size(); ++i)
   {
@@ -157,11 +164,12 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     bool ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
     if(!ret)
     {
-      global_moved.emplace_back(cluskey, global_new); 
+      global_moved.emplace_back(cluskey, global); 
       if(_verbosity > 1)
 	{
-	  std::cout << PHWHERE << "Warning: get_moved_position failed, it did nothing. " << std::endl;
+	  std::cout << PHWHERE << "Warning: get_moved_position failed, use input position. " << std::endl;
 	}
+      continue;
     }
     
     int iter = 0;

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -7,10 +7,10 @@
 #include "TpcClusterMover.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <trackbase/TrackFitUtils.h>
 #include <trackbase/TpcDefs.h>
-#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
 
 #include <g4detectors/PHG4TpcGeom.h>
 #include <g4detectors/PHG4TpcGeomContainer.h>
@@ -57,23 +57,23 @@ TpcClusterMover::TpcClusterMover()
   }
 }
 
-void TpcClusterMover::initialize_geometry(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tGeometry, PHCompositeNode* topNode)
+void TpcClusterMover::initialize_geometry(PHG4TpcGeomContainer* cellgeo, ActsGeometry* tGeometry, PHCompositeNode* topNode)
 {
   _topNode = topNode;
-  
+
   if (_verbosity > 0)
   {
     std::cout << "TpcClusterMover: Getting ActsGeometry, and getting layer radii for Tpc from cell geometry object" << std::endl;
   }
 
-  if(!tGeometry || !cellgeo)
-    {
-      std::cout << PHWHERE << " Failed to get ActsGeometry or TPC cell geometry, cannot continue - quit!" << std::endl;
-	exit(1);
-    }
-  
+  if (!tGeometry || !cellgeo)
+  {
+    std::cout << PHWHERE << " Failed to get ActsGeometry or TPC cell geometry, cannot continue - quit!" << std::endl;
+    exit(1);
+  }
+
   _tGeometry = tGeometry;
-  
+
   int layer = 0;
   PHG4TpcGeomContainer::ConstRange layerrange = cellgeo->get_begin_end();
   for (PHG4TpcGeomContainer::ConstIterator layeriter = layerrange.first;
@@ -92,19 +92,19 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   // The input object contains all clusters for the track in world coordinates
   // The surface radii are in global coordinates. Needed because we are dealing with aligned surfaces
 
-  auto *cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER_SEED");
-  if(!cluster_map)
+  auto* cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER_SEED");
+  if (!cluster_map)
+  {
+    cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
+    if (!cluster_map)
     {
-      cluster_map = findNode::getClass<TrkrClusterContainer>(_topNode, "TRKR_CLUSTER");
-      if(!cluster_map)
-	{
-	  std::cout << PHWHERE << " Did not find TRKR_CLUSTER_SEED or TRKR_CLUSTER nodes, quit." << std::endl;
-	  exit(1);
-	}
+      std::cout << PHWHERE << " Did not find TRKR_CLUSTER_SEED or TRKR_CLUSTER nodes, quit." << std::endl;
+      exit(1);
     }
+  }
 
   auto surfMaps = _tGeometry->maps();
-    
+
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_moved;
 
   std::vector<Acts::Vector3> tpc_global_vec;
@@ -135,15 +135,15 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     return global_in;
   }
 
-  std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec,  tpc_cluskey_vec, false);
-  if(fitpars.size() < 5)
+  std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec, tpc_cluskey_vec, false);
+  if (fitpars.size() < 5)
+  {
+    if (_verbosity > 1)
     {
-      if(_verbosity > 1)
-	{
-	  std::cout << PHWHERE << "Warning: fit failed, return input positions. " << std::endl;
-	}
-      return global_in;
-    }  
+      std::cout << PHWHERE << "Warning: fit failed, return input positions. " << std::endl;
+    }
+    return global_in;
+  }
   // Now we need to move each TPC cluster associated with this track to the readout surface radius
   for (unsigned int i = 0; i < tpc_global_vec.size(); ++i)
   {
@@ -151,82 +151,91 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     Acts::Vector3 global = tpc_global_vec[i];
 
     // get target surface radius in global coordinates
-    auto *cluster = cluster_map->findCluster(cluskey);
-    if(!cluster) { continue; }
+    auto* cluster = cluster_map->findCluster(cluskey);
+    if (!cluster)
+    {
+      continue;
+    }
     auto surface = surfMaps.getSurface(cluskey, cluster);
-    if(!surface) { continue; }
-    
+    if (!surface)
+    {
+      continue;
+    }
+
     // Find the intersection of the helix fitted to the global cluster positions with
     // the surface associated with this cluster key
     TrkrDefs::subsurfkey sskey = cluster->getSubSurfKey();
-    Acts::Vector3 global_new= global;
+    Acts::Vector3 global_new = global;
     TrkrDefs::subsurfkey new_subsurfkey = sskey;
     bool ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
-    if(!ret)
+    if (!ret)
     {
-      global_moved.emplace_back(cluskey, global); 
-      if(_verbosity > 1)
-	{
-	  std::cout << PHWHERE << "Warning: get_moved_position failed, use input position. " << std::endl;
-	}
+      global_moved.emplace_back(cluskey, global);
+      if (_verbosity > 1)
+      {
+        std::cout << PHWHERE << "Warning: get_moved_position failed, use input position. " << std::endl;
+      }
       continue;
     }
 
     auto global_new_keep = global_new;
     int iter = 0;
-    while(new_subsurfkey != sskey)
+    while (new_subsurfkey != sskey)
+    {
+      iter++;
+      if (iter > 2)
       {
-	iter++;
-	if(iter > 2)
-	  {
-	    // cluster has been updated with subsurfkey from last iteration, global_new is still from last iteration - move on
-	    break;
-	  }
-
-	// surface changed, cluster subsurface has been updated, redo with new surface
-	sskey = new_subsurfkey;
-	ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
-	if(!ret)
-	  {
-	    global_new = global_new_keep;
-	    break;
-	  }
-	if(_verbosity > 2)
-	  {
-	    if(new_subsurfkey != sskey)
-	      {
-		std::cout << PHWHERE << "Warning: subsurfkey changed on iteration " << iter << " from "
-			  << sskey << " to " << new_subsurfkey << std::endl;
-	      }
-	    else
-	      {
-		std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
-	      }
-	  }
+        // cluster has been updated with subsurfkey from last iteration, global_new is still from last iteration - move on
+        break;
       }
 
-    if(_verbosity > 2)
+      // surface changed, cluster subsurface has been updated, redo with new surface
+      sskey = new_subsurfkey;
+      ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
+      if (!ret)
       {
-	std::cout << "    iterations " << iter << " clusterkey " << cluskey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
-	std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2]  << std::endl;
-	std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2]  << std::endl;
+        global_new = global_new_keep;
+        break;
       }
+      if (_verbosity > 2)
+      {
+        if (new_subsurfkey != sskey)
+        {
+          std::cout << PHWHERE << "Warning: subsurfkey changed on iteration " << iter << " from "
+                    << sskey << " to " << new_subsurfkey << std::endl;
+        }
+        else
+        {
+          std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
+        }
+      }
+    }
+
+    if (_verbosity > 2)
+    {
+      std::cout << "    iterations " << iter << " clusterkey " << cluskey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
+      std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2] << std::endl;
+      std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2] << std::endl;
+    }
 
     // add the new position and surface to the return object
-    global_moved.emplace_back(cluskey, global_new); 
+    global_moved.emplace_back(cluskey, global_new);
   }
-  
+
   return global_moved;
 }
 
-bool TpcClusterMover::get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster *cluster, std::vector<float> &fitpars, Acts::Vector3 &global, Acts::Vector3 &global_new, TrkrDefs::subsurfkey &new_subsurfkey) const
+bool TpcClusterMover::get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster* cluster, std::vector<float>& fitpars, Acts::Vector3& global, Acts::Vector3& global_new, TrkrDefs::subsurfkey& new_subsurfkey) const
 {
   auto surfMaps = _tGeometry->maps();
   auto surface = surfMaps.getSurface(cluskey, cluster);
-  if(!surface) { return false; }
+  if (!surface)
+  {
+    return false;
+  }
 
-  Acts::Vector3 surf_intercept = TrackFitUtils::get_helix_surface_intersection(surface,  fitpars, global, _tGeometry);
-  
+  Acts::Vector3 surf_intercept = TrackFitUtils::get_helix_surface_intersection(surface, fitpars, global, _tGeometry);
+
   // get circle position at cluster radius
   double cluster_radius = sqrt(global[0] * global[0] + global[1] * global[1]);
   double R = fitpars[0];
@@ -236,38 +245,38 @@ bool TpcClusterMover::get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster 
   double y_start = 0.0;
   int ret = get_circle_circle_intersection(cluster_radius, R, X0, Y0, global[0], global[1], x_start, y_start);
   if (ret == Fun4AllReturnCodes::ABORTEVENT)
-    {
-      return false;  // skip to next cluster
-    }
+  {
+    return false;  // skip to next cluster
+  }
   // z projection is unique
   double A = fitpars[3];
   double B = fitpars[4];
   double z_start = B + A * cluster_radius;
-  
-  Acts::Vector3 start_point(x_start, y_start, z_start); 
-  
+
+  Acts::Vector3 start_point(x_start, y_start, z_start);
+
   // calculate dx, dy, dz along circle trajectory from cluster radius to surface radius
   double xnew = global[0] - (start_point.x() - surf_intercept.x());
   double ynew = global[1] - (start_point.y() - surf_intercept.y());
   double znew = global[2] - (start_point.z() - surf_intercept.z());
-  
+
   global_new(0) = xnew;
   global_new(1) = ynew;
   global_new(2) = znew;
-  
+
   bool update_sskey = true;
-  if(update_sskey)
+  if (update_sskey)
+  {
+    unsigned int sskey = cluster->getSubSurfKey();
+
+    TrkrDefs::hitsetkey hkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+    auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
+    if (new_surf && (new_subsurfkey != sskey))
     {
-      unsigned int sskey = cluster->getSubSurfKey();
-      
-      TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
-      auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
-      if( new_surf && (new_subsurfkey != sskey) )
-	{
-	  cluster->setSubSurfKey(new_subsurfkey);
-	}
+      cluster->setSubSurfKey(new_subsurfkey);
     }
-  
+  }
+
   return true;
 }
 

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -136,7 +136,7 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   }
 
   std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec,  tpc_cluskey_vec, 0);
-  if(fitpars.size() == 0)
+  if(fitpars.size() < 5)
     {
       if(_verbosity > 1)
 	{
@@ -171,16 +171,26 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
 	}
       continue;
     }
-    
+
+    auto global_new_keep = global_new;
     int iter = 0;
     while(new_subsurfkey != sskey)
       {
 	iter++;
-	if(iter > 2) { break; }
+	if(iter > 2)
+	  {
+	    // cluster has been updated with subsurfkey from last iteration, global_new is still from last iteration - move on
+	    break;
+	  }
 
 	// surface changed, cluster subsurface has been updated, redo with new surface
 	sskey = new_subsurfkey;
-	ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);	  
+	ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
+	if(!ret)
+	  {
+	    global_new = global_new_keep;
+	    break;
+	  }
 	if(_verbosity > 2)
 	  {
 	    if(new_subsurfkey != sskey)
@@ -193,7 +203,6 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
 		std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
 	      }
 	  }
-	
       }
 
     if(_verbosity > 2)
@@ -214,9 +223,9 @@ bool TpcClusterMover::get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster 
 {
   auto surfMaps = _tGeometry->maps();
   auto surface = surfMaps.getSurface(cluskey, cluster);
-      
+  if(!surface) { return false; }
+
   Acts::Vector3 surf_intercept = TrackFitUtils::get_helix_surface_intersection(surface,  fitpars, global, _tGeometry);
-  if(fitpars.size() == 0) { return false; }
   
   // get circle position at cluster radius
   double cluster_radius = sqrt(global[0] * global[0] + global[1] * global[1]);

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -135,13 +135,9 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     return global_in;
   }
 
-  // fit a circle to the TPC clusters
-  const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin(tpc_global_vec);
-
-  // get the straight line representing the z trajectory in the form of z vs radius
-  const auto [A, B] = TrackFitUtils::line_fit(tpc_global_vec);
-
-  // Now we need to move each TPC cluster associated with this track to the readout layer radius
+  std::vector<float> fitpars = TrackFitUtils::fitClusters(tpc_global_vec,  tpc_cluskey_vec, 0);
+  
+  // Now we need to move each TPC cluster associated with this track to the readout surface radius
   for (unsigned int i = 0; i < tpc_global_vec.size(); ++i)
   {
     TrkrDefs::cluskey cluskey = tpc_cluskey_vec[i];
@@ -152,78 +148,110 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     if(!cluster) { continue; }
     auto surface = surfMaps.getSurface(cluskey, cluster);
     if(!surface) { continue; }
-    auto surfcent = surface->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // the aligned geometry
     
-    double target_radius = sqrt(surfcent[0]*surfcent[0]+surfcent[1]*surfcent[1]);	    
-    // get circle position at target surface radius
-    int ret = get_circle_circle_intersection(target_radius, R, X0, Y0, global[0], global[1], _x_proj, _y_proj);
-    if (ret == Fun4AllReturnCodes::ABORTEVENT)
-      {
-	continue;  // skip to next cluster
-      }
-    // z projection is unique
-    _z_proj = B + A * target_radius;
-
-    // get circle position at cluster radius
-    double cluster_radius = sqrt(global[0] * global[0] + global[1] * global[1]);
-    ret = get_circle_circle_intersection(cluster_radius, R, X0, Y0, global[0], global[1], _x_start, _y_start);
-    if (ret == Fun4AllReturnCodes::ABORTEVENT)
+    // Find the intersection of the helix fitted to the global cluster positions with
+    // the surface associated with this cluster key
+    TrkrDefs::subsurfkey sskey = cluster->getSubSurfKey();
+    Acts::Vector3 global_new= global;
+    TrkrDefs::subsurfkey new_subsurfkey = sskey;
+    bool ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
+    if(!ret)
     {
-      continue;  // skip to next cluster
+      global_moved.emplace_back(cluskey, global_new); 
+      if(_verbosity > 1)
+	{
+	  std::cout << PHWHERE << "Warning: get_moved_position failed, it did nothing. " << std::endl;
+	}
     }
-    // z projection is unique
-    _z_start = B + A * cluster_radius;
-
-    // calculate dx, dy, dz along circle trajectory from cluster radius to surface radius
-    double xnew = global[0] - (_x_start - _x_proj);
-    double ynew = global[1] - (_y_start - _y_proj);
-    double znew = global[2] - (_z_start - _z_proj);
-
-    // now move the cluster to the surface radius
-    // we keep the cluster key fixed, change the surface later if necessary
-
-    Acts::Vector3 global_new(xnew, ynew, znew);
-
-    bool update_sskey = true;
-    if(update_sskey)
-      {
-	unsigned int sskey = cluster->getSubSurfKey();
-
-	TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
-	TrkrDefs::subsurfkey new_subsurfkey = 0;
-	auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
-	if( new_surf && (new_subsurfkey != sskey) )
-	  {
-	    // std::cout << "    updating cluster subsurfkey from " << sskey << " to " << new_subsurfkey << std::endl;
-	    cluster->setSubSurfKey(new_subsurfkey);
-	  }
-      }
     
+    int iter = 0;
+    while(new_subsurfkey != sskey)
+      {
+	iter++;
+	if(iter > 2) { break; }
+
+	// surface changed, cluster subsurface has been updated, redo with new surface
+	sskey = new_subsurfkey;
+	ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);	  
+	if(_verbosity > 2)
+	  {
+	    if(new_subsurfkey != sskey)
+	      {
+		std::cout << PHWHERE << "Warning: subsurfkey changed on iteration " << iter << " from "
+			  << sskey << " to " << new_subsurfkey << std::endl;
+	      }
+	    else
+	      {
+		std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
+	      }
+	  }
+	
+      }
+
     if(_verbosity > 2)
       {
-	unsigned int layer = TrkrDefs::getLayer(cluskey);
-	if(layer == 28)
-	  {
-	    unsigned int sskey = cluster->getSubSurfKey();
-	      double new_radius = sqrt(xnew*xnew+ynew*ynew);
-	    // Check if the subsurface changed
-	    TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
-	    TrkrDefs::subsurfkey new_subsurfkey = 0;
-	    auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
-	    
-	    std::cout << "   layer " << layer << " clusterkey " << cluskey << " hitsetkey " << hkey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
-	    std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2]  << " clus_radius " << cluster_radius <<  " target radius " << target_radius << std::endl;
-	    std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2]  << " global_new radius " << new_radius << std::endl;
-	    std::cout << "        xstart " << _x_start << " xproj " << _x_proj << " ystart " << _y_start << " yproj " << _y_proj << " zstart " << _z_start << " zproj " << _z_proj << std::endl;
-	    std::cout << "        phi_in      " << atan2(global[1], global[0]) << " phi_moved " << atan2(global_new[1], global_new[0]) << std::endl;
-	  }
+	std::cout << "    iterations " << iter << " clusterkey " << cluskey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
+	std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2]  << std::endl;
+	std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2]  << std::endl;
       }
-    
-    // now we add the new position and surface to the return object
+
+    // add the new position and surface to the return object
     global_moved.emplace_back(cluskey, global_new); 
   }
-
+  
   return global_moved;
+}
+
+bool TpcClusterMover::get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster *cluster, std::vector<float> &fitpars, Acts::Vector3 &global, Acts::Vector3 &global_new, TrkrDefs::subsurfkey &new_subsurfkey) const
+{
+  auto surfMaps = _tGeometry->maps();
+  auto surface = surfMaps.getSurface(cluskey, cluster);
+      
+  Acts::Vector3 surf_intercept = TrackFitUtils::get_helix_surface_intersection(surface,  fitpars, global, _tGeometry);
+  if(fitpars.size() == 0) { return false; }
+  
+  // get circle position at cluster radius
+  double cluster_radius = sqrt(global[0] * global[0] + global[1] * global[1]);
+  double R = fitpars[0];
+  double X0 = fitpars[1];
+  double Y0 = fitpars[2];
+  double x_start = 0.0;
+  double y_start = 0.0;
+  int ret = get_circle_circle_intersection(cluster_radius, R, X0, Y0, global[0], global[1], x_start, y_start);
+  if (ret == Fun4AllReturnCodes::ABORTEVENT)
+    {
+      return false;  // skip to next cluster
+    }
+  // z projection is unique
+  double A = fitpars[3];
+  double B = fitpars[4];
+  double z_start = B + A * cluster_radius;
+  
+  Acts::Vector3 start_point(x_start, y_start, z_start); 
+  
+  // calculate dx, dy, dz along circle trajectory from cluster radius to surface radius
+  double xnew = global[0] - (start_point.x() - surf_intercept.x());
+  double ynew = global[1] - (start_point.y() - surf_intercept.y());
+  double znew = global[2] - (start_point.z() - surf_intercept.z());
+  
+  global_new(0) = xnew;
+  global_new(1) = ynew;
+  global_new(2) = znew;
+  
+  bool update_sskey = true;
+  if(update_sskey)
+    {
+      unsigned int sskey = cluster->getSubSurfKey();
+      
+      TrkrDefs::hitsetkey hkey= TrkrDefs:: getHitSetKeyFromClusKey(cluskey);
+      auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
+      if( new_surf && (new_subsurfkey != sskey) )
+	{
+	  cluster->setSubSurfKey(new_subsurfkey);
+	}
+    }
+  
+  return true;
 }
 
 int TpcClusterMover::get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double& x, double& y) const

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -29,14 +29,8 @@ class TpcClusterMover
  private:
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y) const;
 
-  double _z_start = 0.0;
-  double _y_start = 0.0;
-  double _x_start = 0.0;
-
-  double _z_proj = 0.0;
-  double _y_proj = 0.0;
-  double _x_proj = 0.0;
-
+  bool get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster *cluster, std::vector<float> &fitpars, Acts::Vector3 &global, Acts::Vector3 &global_new, TrkrDefs::subsurfkey &new_subsurfkey) const;
+    
   double layer_radius[48] = {0};
   double inner_tpc_min_radius = 30.0;
   double mid_tpc_min_radius = 40.0;

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -20,7 +20,7 @@ class TpcClusterMover
 
   void set_verbosity(int verb) { _verbosity = verb; }
 
-  std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_in);
+  std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> &global_in);
 
   //! Updates the assumed default geometry below to that contained in the
   //! cell geo
@@ -30,7 +30,7 @@ class TpcClusterMover
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y) const;
 
   bool get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster *cluster, std::vector<float> &fitpars, Acts::Vector3 &global, Acts::Vector3 &global_new, TrkrDefs::subsurfkey &new_subsurfkey) const;
-    
+
   double layer_radius[48] = {0};
   double inner_tpc_min_radius = 30.0;
   double mid_tpc_min_radius = 40.0;
@@ -43,9 +43,8 @@ class TpcClusterMover
 
   int _verbosity = 0;
 
-  ActsGeometry *_tGeometry  = nullptr;
-  PHCompositeNode* _topNode = nullptr;
-  
+  ActsGeometry *_tGeometry = nullptr;
+  PHCompositeNode *_topNode = nullptr;
 };
 
 #endif

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -456,6 +456,7 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
 
     // clustermover updates the subsurface key after moving the clusters to the surface, so this is safe
     auto* cluster = clusterContainer->findCluster(cluskey);
+    if(!cluster) { continue; }
     Surface surf = tGeometry->maps().getSurface(cluskey, cluster);
 
     auto trkrid = TrkrDefs::getTrkrId(cluskey);

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -56,6 +56,7 @@ void MakeSourceLinks::initialize(PHG4TpcGeomContainer* cellgeo, ActsGeometry *tG
   if (cellgeo && tGeometry && topNode)
   {
     _clusterMover.initialize_geometry(cellgeo, tGeometry, topNode);
+    _clusterMover.set_verbosity(m_verbosity);
   }
 }
 
@@ -440,18 +441,22 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
       continue;
     }
 
+    if (std::isnan(global.x()) || std::isnan(global.y()))
+    {
+      if (m_verbosity > 1)
+	{
+	  std::cout << "MakeSourceLinks::getSourceLinksClusterMover - invalid position"
+		    << " key: " << cluskey
+		    << " layer: " << (int) TrkrDefs::getLayer(cluskey)
+		    << " position: " << global
+		    << std::endl;
+	}
+      continue;
+    }
+
     // clustermover updates the subsurface key after moving the clusters to the surface, so this is safe
     auto* cluster = clusterContainer->findCluster(cluskey);
     Surface surf = tGeometry->maps().getSurface(cluskey, cluster);
-
-    if (std::isnan(global.x()) || std::isnan(global.y()))
-    {
-      std::cout << "MakeSourceLinks::getSourceLinksClusterMover - invalid position"
-                << " key: " << cluskey
-                << " layer: " << (int) TrkrDefs::getLayer(cluskey)
-                << " position: " << global
-                << std::endl;
-    }
 
     auto trkrid = TrkrDefs::getTrkrId(cluskey);
     if (trkrid == TrkrDefs::tpcId)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Change to using the helix-surface intersection for projecting the global cluster positions to the readout surfaces, and iterate (if needed) to find the correct surface. This properly handles the fact that the surface radius depends on z when the TPC is tilted and displaced.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Project global cluster positions onto the correct TPC readout surfaces. This accounts for the z-dependent surface radius in tilted and displaced TPC geometries.

## Key changes

- Use `TrackFitUtils::fitClusters` for cluster fitting.
- Intersect the fitted helix with each cluster surface.
- Recompute the movement when the subsurface key changes, up to two iterations.
- Preserve the last valid position when a retry fails.
- Fall back to the original position when fitting fails.
- Propagate verbosity to `TpcClusterMover`.
- Skip invalid moved positions and missing clusters before source-link construction.

## Potential risk areas

- Reconstruction behavior can change for tilted or displaced TPC geometries.
- Iterative surface selection can change cluster positions and subsurface keys.
- Fit failures and invalid moved positions now use explicit fallback or skip paths.
- The two-iteration limit can affect clusters that require further iteration.
- No I/O format or public interface changes are reported.
- Performance and thread-safety should be checked during concurrent reconstruction.

## Possible future improvements

- Add targeted tests for helix-surface intersections and subsurface changes.
- Quantify reconstruction and performance impacts.
- Confirm whether two iterations are sufficient for all supported geometries.
- Add diagnostic metrics for fit, movement, and skipped-source-link failures.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation and the physics requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->