### PR TITLE
Poly svtx tracks

### DIFF
--- a/offline/packages/tpctrackreco/Makefile.am
+++ b/offline/packages/tpctrackreco/Makefile.am
@@ -25,6 +25,11 @@ pkginclude_HEADERS = \
   Tpc_AssembledTrackContainer.h \
   Tpc_AssembledTrackContainerv1.h \
   Tpc_AssembledTrackReco.h \
+  TpcCrossingDecision.h \
+  TpcCrossingDecisionv1.h \
+  TpcCrossingDecisionContainer.h \
+  TpcCrossingDecisionContainerv1.h \
+  TpcCrossingFinder.h \
   Tpc_PolyTrack.h \
   Tpc_PolyTrackv1.h \
   Tpc_PolyTrackContainer.h \
@@ -43,6 +48,8 @@ pkginclude_HEADERS = \
   TpcTrackFit.h \
   TpcTrackHelixFitter.h \
   TpcTrackKalmanFitter.h \
+  TpcPolyTrackSeedConverter.h \
+  TpcPolyClusterTrkrClusterConverter.h \
   Tpc_FittingTools.h \
   IdealPadMap.h
 
@@ -52,6 +59,10 @@ ROOTDICTS = \
   Tpc_AssembledTrackContainer_Dict.cc \
   Tpc_AssembledTrackContainerv1_Dict.cc \
   Tpc_AssembledTrackv1_Dict.cc \
+  TpcCrossingDecision_Dict.cc \
+  TpcCrossingDecisionv1_Dict.cc \
+  TpcCrossingDecisionContainer_Dict.cc \
+  TpcCrossingDecisionContainerv1_Dict.cc \
   Tpc_ModuleTrack_Dict.cc \
   Tpc_ModuleTrackContainer_Dict.cc \
   Tpc_ModuleTrackContainerv1_Dict.cc \
@@ -80,6 +91,9 @@ libtpctrackreco_la_SOURCES = \
   Tpc_AssembledTrackv1.cc \
   Tpc_AssembledTrackContainerv1.cc \
   Tpc_AssembledTrackReco.cc \
+  TpcCrossingDecisionv1.cc \
+  TpcCrossingDecisionContainerv1.cc \
+  TpcCrossingFinder.cc \
   Tpc_PolyTrackv1.cc \
   Tpc_PolyTrackContainerv1.cc \
   Tpc_PolyTrackVertexv1.cc \
@@ -89,6 +103,8 @@ libtpctrackreco_la_SOURCES = \
   Tpc_PolyClusterContainerv1.cc \
   Tpc_PolyClusterizer.cc \
   Tpc_PolyTrackReco.cc \
+  TpcPolyTrackSeedConverter.cc \
+  TpcPolyClusterTrkrClusterConverter.cc \
   TpcTrackHelixFitter.cc \
   TpcTrackKalmanFitter.cc \
   Tpc_FittingTools.cc \

--- a/offline/packages/tpctrackreco/TpcCrossingDecision.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecision.h
@@ -1,0 +1,246 @@
+#ifndef TPCTRACKRECO_TPCCROSSINGDECISION_H
+#define TPCTRACKRECO_TPCCROSSINGDECISION_H
+
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+enum class TpcCrossingStatus : unsigned char
+{
+  Unknown = 0,
+  NoInttCrossings = 1,
+  NoAllowedCrossing = 2,
+  GarfieldInvalid = 3,
+  OutsideTpcVolume = 4,
+  WrongTpcSide = 5,
+  FitFailed = 6,
+  SelectedByContainment = 7,
+  SelectedByVertex = 8,
+  AmbiguousWithoutVertex = 9,
+  AmbiguousWithVertex = 10,
+  VertexIncompatible = 11,
+  NoValidCrossing = 12,
+  SelectedByVertexAmbiguous = 13,
+  SelectedByVertexLoose = 14,
+  SelectedByContainmentAmbiguous = 15
+};
+
+enum class TpcCrossingCandidateStage : unsigned char
+{
+  AvailableFromIntt = 0,
+  PassedTimeWindow = 1,
+  GarfieldValid = 2,
+  InsideTpc = 3,
+  CorrectSide = 4,
+  FitValid = 5,
+  HasVertex = 6,
+  VertexCompatible = 7,
+  FinalRanking = 8,
+  Selected = 9
+};
+
+enum TpcCrossingCandidateQABits : unsigned int
+{
+  FromInttCrossing = 1U << 0,
+  PassedTimeWindow = 1U << 1,
+  MinEndpointGarfieldOK = 1U << 2,
+  MaxEndpointGarfieldOK = 1U << 3,
+  EndpointsInsideTPC = 1U << 4,
+  EndpointsCorrectSide = 1U << 5,
+  FitSuccessful = 1U << 6,
+  HasSiliconVertex = 1U << 7,
+  PassesVertexDz = 1U << 8,
+  IsBestVertexCandidate = 1U << 9,
+  IsSelected = 1U << 10
+};
+
+class TpcCrossingCandidate
+{
+ public:
+  static float nan() { return std::numeric_limits<float>::quiet_NaN(); }
+
+  short crossing {0};
+  bool is_available_from_intt {false};
+  bool passes_time_window {false};
+  bool was_tested {false};
+  bool min_endpoint_garfield_valid {false};
+  bool max_endpoint_garfield_valid {false};
+  bool endpoints_inside_tpc {false};
+  bool endpoints_on_correct_side {false};
+  bool fit_valid {false};
+  bool tpc_valid {false};
+  bool has_silicon_vertex {false};
+  bool vertex_compatible {false};
+  bool is_selected {false};
+  unsigned char confidence_tier {std::numeric_limits<unsigned char>::max()};
+  float confidence_score {nan()};
+  unsigned char rejection_status {static_cast<unsigned char>(TpcCrossingStatus::Unknown)};
+
+  float min_tbin_time_crossing0_ns {nan()};
+  float max_tbin_time_crossing0_ns {nan()};
+  float candidate_min_time_ns {nan()};
+  float candidate_max_time_ns {nan()};
+  float max_lookup_time_ns {nan()};
+  float min_time_margin_ns {nan()};
+  float max_time_margin_ns {nan()};
+
+  unsigned int min_time_layer {0};
+  unsigned int min_time_side {0};
+  unsigned int min_time_pad {0};
+  unsigned int min_time_tbin {0};
+  float min_time_x {nan()};
+  float min_time_y {nan()};
+  float min_time_z {nan()};
+  float min_time_r {nan()};
+  float min_time_phi {nan()};
+
+  unsigned int max_time_layer {0};
+  unsigned int max_time_side {0};
+  unsigned int max_time_pad {0};
+  unsigned int max_time_tbin {0};
+  float max_time_x {nan()};
+  float max_time_y {nan()};
+  float max_time_z {nan()};
+  float max_time_r {nan()};
+  float max_time_phi {nan()};
+
+  unsigned int inner_layer {0};
+  unsigned int inner_tbin {0};
+  float inner_x {nan()};
+  float inner_y {nan()};
+  float inner_z {nan()};
+
+  unsigned int outer_layer {0};
+  unsigned int outer_tbin {0};
+  float outer_x {nan()};
+  float outer_y {nan()};
+  float outer_z {nan()};
+
+  float min_time_distance_to_central_membrane {nan()};
+  float max_time_distance_to_central_membrane {nan()};
+  float min_time_distance_to_padplane {nan()};
+  float max_time_distance_to_padplane {nan()};
+  bool min_time_inside_tpc {false};
+  bool max_time_inside_tpc {false};
+  bool min_time_correct_side {false};
+  bool max_time_correct_side {false};
+
+  std::vector<unsigned int> fit_point_layer;
+  std::vector<unsigned int> fit_point_pad;
+  std::vector<unsigned int> fit_point_tbin;
+  std::vector<float> fit_point_x;
+  std::vector<float> fit_point_y;
+  std::vector<float> fit_point_z;
+  std::vector<float> fit_point_r;
+  std::vector<float> fit_point_s;
+
+  unsigned int n_fit_points {0};
+  float z_vs_s_slope {nan()};
+  float z_vs_s_intercept {nan()};
+  float z_fit_chi2 {nan()};
+  int z_fit_ndf {-1};
+  float s_at_transverse_pca {nan()};
+  float minimum_transverse_radius {nan()};
+  float tpc_z_at_transverse_pca {nan()};
+  float tpc_z_at_r0 {nan()};
+
+  unsigned int n_vertices_at_crossing {0};
+  std::vector<unsigned int> candidate_vertex_ids;
+  std::vector<float> candidate_vertex_z;
+  std::vector<float> candidate_vertex_sigma_z;
+  std::vector<unsigned int> candidate_vertex_ntracks;
+  std::vector<float> candidate_vertex_delta_z;
+  std::vector<float> candidate_vertex_pull_z;
+
+  unsigned int closest_vertex_id {std::numeric_limits<unsigned int>::max()};
+  float closest_vertex_z {nan()};
+  float closest_vertex_sigma_z {nan()};
+  float closest_vertex_delta_z {nan()};
+  float closest_vertex_abs_delta_z {nan()};
+  float closest_vertex_pull_z {nan()};
+
+  int candidate_rank_by_abs_delta_z {-1};
+  int candidate_rank_by_abs_collision_z {-1};
+  unsigned int candidate_qa_bits {0};
+  unsigned char first_failed_stage {static_cast<unsigned char>(TpcCrossingCandidateStage::AvailableFromIntt)};
+
+ private:
+  ClassDefNV(TpcCrossingCandidate, 3)
+};
+
+class TpcCrossingDecision : public PHObject
+{
+ public:
+  TpcCrossingDecision() = default;
+  ~TpcCrossingDecision() override = default;
+
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "TpcCrossingDecision base class" << std::endl;
+  }
+  void Reset() override {}
+  int isValid() const override { return 0; }
+
+  virtual unsigned int get_assembled_track_id() const { return 0; }
+  virtual void set_assembled_track_id(unsigned int) {}
+
+  virtual short get_selected_crossing() const { return 0; }
+  virtual void set_selected_crossing(short) {}
+
+  virtual unsigned int get_silicon_vertex_id() const { return 0; }
+  virtual void set_silicon_vertex_id(unsigned int) {}
+
+  virtual float get_tpc_z0() const { return 0.0F; }
+  virtual void set_tpc_z0(float) {}
+
+  virtual float get_silicon_vertex_z() const { return 0.0F; }
+  virtual void set_silicon_vertex_z(float) {}
+
+  virtual float get_delta_z() const { return 0.0F; }
+  virtual void set_delta_z(float) {}
+
+  virtual float get_best_abs_delta_z() const { return 0.0F; }
+  virtual void set_best_abs_delta_z(float) {}
+
+  virtual float get_second_best_abs_delta_z() const { return 0.0F; }
+  virtual void set_second_best_abs_delta_z(float) {}
+
+  virtual unsigned char get_selected_tier() const { return std::numeric_limits<unsigned char>::max(); }
+  virtual void set_selected_tier(unsigned char) {}
+
+  virtual float get_selected_score() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_selected_score(float) {}
+
+  virtual unsigned short get_number_of_available_crossings() const { return 0; }
+  virtual void set_number_of_available_crossings(unsigned short) {}
+
+  virtual unsigned short get_number_of_allowed_crossings() const { return 0; }
+  virtual void set_number_of_allowed_crossings(unsigned short) {}
+
+  virtual unsigned short get_number_of_tested_crossings() const { return 0; }
+  virtual void set_number_of_tested_crossings(unsigned short) {}
+
+  virtual unsigned short get_number_of_tpc_valid_crossings() const { return 0; }
+  virtual void set_number_of_tpc_valid_crossings(unsigned short) {}
+
+  virtual unsigned short get_number_of_vertex_compatible_crossings() const { return 0; }
+  virtual void set_number_of_vertex_compatible_crossings(unsigned short) {}
+
+  virtual unsigned int get_number_of_candidates() const { return 0; }
+  virtual const TpcCrossingCandidate* get_candidate(unsigned int) const { return nullptr; }
+  virtual void add_candidate(const TpcCrossingCandidate&) {}
+  virtual void clear_candidates() {}
+
+  virtual unsigned char get_status() const { return static_cast<unsigned char>(TpcCrossingStatus::Unknown); }
+  virtual void set_status(unsigned char) {}
+  virtual void set_status(TpcCrossingStatus status) { set_status(static_cast<unsigned char>(status)); }
+
+ private:
+  ClassDefOverride(TpcCrossingDecision, 0)
+};
+
+#endif  // TPCTRACKRECO_TPCCROSSINGDECISION_H

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionContainer.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionContainer.h
@@ -1,0 +1,33 @@
+#ifndef TPCTRACKRECO_TPCCROSSINGDECISIONCONTAINER_H
+#define TPCTRACKRECO_TPCCROSSINGDECISIONCONTAINER_H
+
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+
+class TpcCrossingDecision;
+
+class TpcCrossingDecisionContainer : public PHObject
+{
+ public:
+  TpcCrossingDecisionContainer() = default;
+  ~TpcCrossingDecisionContainer() override = default;
+
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "TpcCrossingDecisionContainer base class" << std::endl;
+  }
+  void Reset() override {}
+  int isValid() const override { return 0; }
+
+  virtual unsigned int size() const { return 0; }
+  virtual void add_decision(TpcCrossingDecision*) {}
+  virtual TpcCrossingDecision* get_decision(unsigned int) { return nullptr; }
+  virtual const TpcCrossingDecision* get_decision(unsigned int) const { return nullptr; }
+
+ private:
+  ClassDefOverride(TpcCrossingDecisionContainer, 0)
+};
+
+#endif  // TPCTRACKRECO_TPCCROSSINGDECISIONCONTAINER_H

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionContainerLinkDef.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionContainerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TpcCrossingDecisionContainer + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionContainerv1.cc
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionContainerv1.cc
@@ -1,0 +1,74 @@
+#include "TpcCrossingDecisionContainerv1.h"
+
+#include "TpcCrossingDecision.h"
+
+ClassImp(TpcCrossingDecisionContainerv1)
+
+TpcCrossingDecisionContainerv1::TpcCrossingDecisionContainerv1()
+{
+  Reset();
+}
+
+TpcCrossingDecisionContainerv1::~TpcCrossingDecisionContainerv1()
+{
+  Reset();
+}
+
+void TpcCrossingDecisionContainerv1::identify(std::ostream& os) const
+{
+  os << "TpcCrossingDecisionContainerv1 with "
+     << m_decisions.size()
+     << " decisions"
+     << std::endl;
+}
+
+void TpcCrossingDecisionContainerv1::Reset()
+{
+  for (auto& decision : m_decisions) { delete decision.second;
+}
+  m_decisions.clear();
+}
+
+int TpcCrossingDecisionContainerv1::isValid() const
+{
+  return m_decisions.empty() ? 0 : 1;
+}
+
+PHObject* TpcCrossingDecisionContainerv1::CloneMe() const
+{
+  TpcCrossingDecisionContainerv1* copy = new TpcCrossingDecisionContainerv1();
+  for (const auto& decision : m_decisions)
+  {
+    if (decision.second) { copy->m_decisions[decision.first] = static_cast<TpcCrossingDecision*>(decision.second->CloneMe());
+}
+  }
+  return copy;
+}
+
+void TpcCrossingDecisionContainerv1::add_decision(TpcCrossingDecision* decision)
+{
+  if (!decision) { return;
+}
+
+  const unsigned int assembled_track_id = decision->get_assembled_track_id();
+  auto iter = m_decisions.find(assembled_track_id);
+  if (iter != m_decisions.end())
+  {
+    delete iter->second;
+    iter->second = decision;
+    return;
+  }
+  m_decisions[assembled_track_id] = decision;
+}
+
+TpcCrossingDecision* TpcCrossingDecisionContainerv1::get_decision(unsigned int assembled_track_id)
+{
+  auto iter = m_decisions.find(assembled_track_id);
+  return iter == m_decisions.end() ? nullptr : iter->second;
+}
+
+const TpcCrossingDecision* TpcCrossingDecisionContainerv1::get_decision(unsigned int assembled_track_id) const
+{
+  auto iter = m_decisions.find(assembled_track_id);
+  return iter == m_decisions.end() ? nullptr : iter->second;
+}

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionContainerv1.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionContainerv1.h
@@ -1,0 +1,34 @@
+#ifndef TPCTRACKRECO_TPCCROSSINGDECISIONCONTAINERV1_H
+#define TPCTRACKRECO_TPCCROSSINGDECISIONCONTAINERV1_H
+
+
+#include "TpcCrossingDecisionContainer.h"
+
+#include <iostream>
+#include <map>
+
+class TpcCrossingDecision;
+
+class TpcCrossingDecisionContainerv1 : public TpcCrossingDecisionContainer
+{
+ public:
+  TpcCrossingDecisionContainerv1();
+  ~TpcCrossingDecisionContainerv1() override;
+
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override;
+  PHObject* CloneMe() const override;
+
+  unsigned int size() const override { return static_cast<unsigned int>(m_decisions.size()); }
+  void add_decision(TpcCrossingDecision* decision) override;
+  TpcCrossingDecision* get_decision(unsigned int assembled_track_id) override;
+  const TpcCrossingDecision* get_decision(unsigned int assembled_track_id) const override;
+
+ private:
+  std::map<unsigned int, TpcCrossingDecision*> m_decisions;
+
+  ClassDefOverride(TpcCrossingDecisionContainerv1, 1)
+};
+
+#endif  // TPCTRACKRECO_TPCCROSSINGDECISIONCONTAINERV1_H

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionContainerv1LinkDef.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionContainerv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TpcCrossingDecisionContainerv1 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionLinkDef.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionLinkDef.h
@@ -1,0 +1,10 @@
+#ifdef __CINT__
+
+#pragma link C++ enum TpcCrossingStatus + ;
+#pragma link C++ enum TpcCrossingCandidateStage + ;
+#pragma link C++ enum TpcCrossingCandidateQABits + ;
+#pragma link C++ class TpcCrossingCandidate + ;
+#pragma link C++ class std::vector<TpcCrossingCandidate> + ;
+#pragma link C++ class TpcCrossingDecision + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionv1.cc
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionv1.cc
@@ -1,0 +1,55 @@
+#include "TpcCrossingDecisionv1.h"
+
+ClassImp(TpcCrossingCandidate)
+ClassImp(TpcCrossingDecisionv1)
+
+TpcCrossingDecisionv1::TpcCrossingDecisionv1()
+{
+  Reset();
+}
+
+void TpcCrossingDecisionv1::identify(std::ostream& os) const
+{
+  os << "TpcCrossingDecisionv1:"
+     << " assembled_track_id=" << m_assembled_track_id
+     << " selected_crossing=" << m_selected_crossing
+     << " status=" << static_cast<unsigned int>(m_status)
+     << " selected_tier=" << static_cast<unsigned int>(m_selected_tier)
+     << " selected_score=" << m_selected_score
+     << " tpc_z0=" << m_tpc_z0
+     << " silicon_vertex_id=" << m_silicon_vertex_id
+     << " delta_z=" << m_delta_z
+     << " available=" << m_number_of_available_crossings
+     << " allowed=" << m_number_of_allowed_crossings
+     << " tested=" << m_number_of_tested_crossings
+     << " tpc_valid=" << m_number_of_tpc_valid_crossings
+     << " vertex_compatible=" << m_number_of_vertex_compatible_crossings
+     << " candidates=" << m_candidates.size()
+     << std::endl;
+}
+
+void TpcCrossingDecisionv1::Reset()
+{
+  m_assembled_track_id = 0;
+  m_selected_crossing = std::numeric_limits<short>::max();
+  m_silicon_vertex_id = std::numeric_limits<unsigned int>::max();
+  m_tpc_z0 = nan();
+  m_silicon_vertex_z = nan();
+  m_delta_z = nan();
+  m_best_abs_delta_z = nan();
+  m_second_best_abs_delta_z = nan();
+  m_selected_tier = std::numeric_limits<unsigned char>::max();
+  m_selected_score = nan();
+  m_number_of_available_crossings = 0;
+  m_number_of_allowed_crossings = 0;
+  m_number_of_tested_crossings = 0;
+  m_number_of_tpc_valid_crossings = 0;
+  m_number_of_vertex_compatible_crossings = 0;
+  m_candidates.clear();
+  m_status = static_cast<unsigned char>(TpcCrossingStatus::Unknown);
+}
+
+int TpcCrossingDecisionv1::isValid() const
+{
+  return m_status != static_cast<unsigned char>(TpcCrossingStatus::Unknown) ? 1 : 0;
+}

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionv1.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionv1.h
@@ -1,0 +1,99 @@
+#ifndef TPCTRACKRECO_TPCCROSSINGDECISIONV1_H
+#define TPCTRACKRECO_TPCCROSSINGDECISIONV1_H
+
+
+#include "TpcCrossingDecision.h"
+
+#include <iostream>
+#include <limits>
+
+class TpcCrossingDecisionv1 : public TpcCrossingDecision
+{
+ public:
+  TpcCrossingDecisionv1();
+  ~TpcCrossingDecisionv1() override = default;
+
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new TpcCrossingDecisionv1(*this); }
+
+  unsigned int get_assembled_track_id() const override { return m_assembled_track_id; }
+  void set_assembled_track_id(unsigned int v) override { m_assembled_track_id = v; }
+
+  short get_selected_crossing() const override { return m_selected_crossing; }
+  void set_selected_crossing(short v) override { m_selected_crossing = v; }
+
+  unsigned int get_silicon_vertex_id() const override { return m_silicon_vertex_id; }
+  void set_silicon_vertex_id(unsigned int v) override { m_silicon_vertex_id = v; }
+
+  float get_tpc_z0() const override { return m_tpc_z0; }
+  void set_tpc_z0(float v) override { m_tpc_z0 = v; }
+
+  float get_silicon_vertex_z() const override { return m_silicon_vertex_z; }
+  void set_silicon_vertex_z(float v) override { m_silicon_vertex_z = v; }
+
+  float get_delta_z() const override { return m_delta_z; }
+  void set_delta_z(float v) override { m_delta_z = v; }
+
+  float get_best_abs_delta_z() const override { return m_best_abs_delta_z; }
+  void set_best_abs_delta_z(float v) override { m_best_abs_delta_z = v; }
+
+  float get_second_best_abs_delta_z() const override { return m_second_best_abs_delta_z; }
+  void set_second_best_abs_delta_z(float v) override { m_second_best_abs_delta_z = v; }
+
+  unsigned char get_selected_tier() const override { return m_selected_tier; }
+  void set_selected_tier(unsigned char v) override { m_selected_tier = v; }
+
+  float get_selected_score() const override { return m_selected_score; }
+  void set_selected_score(float v) override { m_selected_score = v; }
+
+  unsigned short get_number_of_available_crossings() const override { return m_number_of_available_crossings; }
+  void set_number_of_available_crossings(unsigned short v) override { m_number_of_available_crossings = v; }
+
+  unsigned short get_number_of_allowed_crossings() const override { return m_number_of_allowed_crossings; }
+  void set_number_of_allowed_crossings(unsigned short v) override { m_number_of_allowed_crossings = v; }
+
+  unsigned short get_number_of_tested_crossings() const override { return m_number_of_tested_crossings; }
+  void set_number_of_tested_crossings(unsigned short v) override { m_number_of_tested_crossings = v; }
+
+  unsigned short get_number_of_tpc_valid_crossings() const override { return m_number_of_tpc_valid_crossings; }
+  void set_number_of_tpc_valid_crossings(unsigned short v) override { m_number_of_tpc_valid_crossings = v; }
+
+  unsigned short get_number_of_vertex_compatible_crossings() const override { return m_number_of_vertex_compatible_crossings; }
+  void set_number_of_vertex_compatible_crossings(unsigned short v) override { m_number_of_vertex_compatible_crossings = v; }
+
+  unsigned int get_number_of_candidates() const override { return m_candidates.size(); }
+  const TpcCrossingCandidate* get_candidate(unsigned int index) const override { return index < m_candidates.size() ? &m_candidates[index] : nullptr; }
+  void add_candidate(const TpcCrossingCandidate& candidate) override { m_candidates.push_back(candidate); }
+  void clear_candidates() override { m_candidates.clear(); }
+
+  unsigned char get_status() const override { return m_status; }
+  void set_status(unsigned char v) override { m_status = v; }
+  void set_status(TpcCrossingStatus status) override { set_status(static_cast<unsigned char>(status)); }
+
+ private:
+  static float nan() { return std::numeric_limits<float>::quiet_NaN(); }
+
+  unsigned int m_assembled_track_id {0};
+  short m_selected_crossing {std::numeric_limits<short>::max()};
+  unsigned int m_silicon_vertex_id {std::numeric_limits<unsigned int>::max()};
+  float m_tpc_z0 {nan()};
+  float m_silicon_vertex_z {nan()};
+  float m_delta_z {nan()};
+  float m_best_abs_delta_z {nan()};
+  float m_second_best_abs_delta_z {nan()};
+  unsigned char m_selected_tier {std::numeric_limits<unsigned char>::max()};
+  float m_selected_score {nan()};
+  unsigned short m_number_of_available_crossings {0};
+  unsigned short m_number_of_allowed_crossings {0};
+  unsigned short m_number_of_tested_crossings {0};
+  unsigned short m_number_of_tpc_valid_crossings {0};
+  unsigned short m_number_of_vertex_compatible_crossings {0};
+  std::vector<TpcCrossingCandidate> m_candidates;
+  unsigned char m_status {static_cast<unsigned char>(TpcCrossingStatus::Unknown)};
+
+  ClassDefOverride(TpcCrossingDecisionv1, 3)
+};
+
+#endif  // TPCTRACKRECO_TPCCROSSINGDECISIONV1_H

--- a/offline/packages/tpctrackreco/TpcCrossingDecisionv1LinkDef.h
+++ b/offline/packages/tpctrackreco/TpcCrossingDecisionv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TpcCrossingDecisionv1 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/tpctrackreco/TpcCrossingFinder.cc
+++ b/offline/packages/tpctrackreco/TpcCrossingFinder.cc
@@ -1,0 +1,1319 @@
+#include "TpcCrossingFinder.h"
+
+#include "IdealPadMap.h"
+#include "Tpc_AssembledTrack.h"
+#include "Tpc_AssembledTrackContainer.h"
+#include "TpcCrossingDecisionContainerv1.h"
+#include "TpcCrossingDecisionv1.h"
+#include "Tpc_FittingTools.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+
+#include <trackbase/InttDefs.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <globalvertex/SvtxVertex.h>
+#include <globalvertex/SvtxVertexMap.h>
+
+#include <phgarfield/PHGarfield.h>
+#include <TPolyLine3D.h>
+
+#include <g4detectors/PHG4TpcGeom.h>
+#include <g4detectors/PHG4TpcGeomContainer.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace
+{
+  constexpr unsigned int FirstLayer = 7;
+  constexpr unsigned int LastLayer = 54;
+  constexpr unsigned int NLayers = LastLayer - FirstLayer + 1;
+  constexpr unsigned int NSides = 2;
+  constexpr unsigned int NSectors = 12;
+  constexpr double PhiConsistencyTolerance = 1.0e-10;
+  constexpr unsigned char InvalidConfidenceTier = std::numeric_limits<unsigned char>::max();
+
+  double wrap_phi(double phi)
+  {
+    while (phi > M_PI) { phi -= 2.0 * M_PI;
+}
+    while (phi <= -M_PI) { phi += 2.0 * M_PI;
+}
+    return phi;
+  }
+
+  double unwrap_phi_near(double phi, const double reference)
+  {
+    while (phi - reference > M_PI) { phi -= 2.0 * M_PI;
+}
+    while (phi - reference <= -M_PI) { phi += 2.0 * M_PI;
+}
+    return phi;
+  }
+
+  double clamp_unit(const double value)
+  {
+    return std::max(0.0, std::min(1.0, value));
+  }
+
+  double phi_sample_fraction(const unsigned int sample)
+  {
+    if (TpcCrossingFinder::NPhiSamples <= 1U) { return 0.0;
+}
+    return static_cast<double>(sample) / static_cast<double>(TpcCrossingFinder::NPhiSamples - 1U);
+  }
+
+  float finite_float_or_nan(const double value)
+  {
+    return std::isfinite(value) ? static_cast<float>(value) : std::numeric_limits<float>::quiet_NaN();
+  }
+}
+
+TpcCrossingFinder::TpcCrossingFinder(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+TpcCrossingFinder::~TpcCrossingFinder()
+{
+  delete m_idealPadMap;
+  m_idealPadMap = nullptr;
+  delete m_garfield;
+  m_garfield = nullptr;
+}
+
+int TpcCrossingFinder::InitRun(PHCompositeNode* topNode)
+{
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTRUN;
+}
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTRUN;
+}
+
+  delete m_idealPadMap;
+  m_idealPadMap = new IdealPadMap();
+  if (m_idealPadMap->load_from_cdb(Verbosity()) != 0 || !m_idealPadMap->is_loaded())
+  {
+    std::cerr << Name() << "::InitRun - failed to load IdealPadMap" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  PHG4TpcGeom* layergeom = m_geomContainerTpc->GetLayerCellGeom(20);
+  if (layergeom)
+  {
+    const double rot_x = layergeom->get_rot_x();
+    const double rot_y = layergeom->get_rot_y();
+    const double rot_z = layergeom->get_rot_z();
+    const double place_x = layergeom->get_place_x();
+    const double place_y = layergeom->get_place_y();
+    const double place_z = layergeom->get_place_z();
+    if (use_survey_geometry)
+    {
+      m_tpcMove = {{place_x, place_y, place_z}};
+      m_tpcRotations = {{{{rot_x, rot_y, rot_z}}, {{0.0, 0.0, 0.0}}}};
+    }
+  }
+
+  delete m_garfield;
+  const std::string electricFieldMap = "/sphenix/user/mitrankov/garf/include/sphenix_rossegger_garfield_field.root";
+  m_garfield = new PHGarfield(Name() + "_PHGarfield", electricFieldMap, m_kEffSide0, m_kEffSide1);
+  configure_garfield(m_garfield);
+  if (m_garfield->InitRun(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  {
+    std::cerr << Name() << "::InitRun - PHGarfield InitRun failed" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  if (!build_drift_lookup()) { return Fun4AllReturnCodes::ABORTRUN;
+}
+
+  m_event = 0;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcCrossingFinder::getNodes(PHCompositeNode* topNode)
+{
+  m_assembledTracks = findNode::getClass<Tpc_AssembledTrackContainer>(topNode, m_inputNodeName);
+  if (!m_assembledTracks)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_inputNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_hits = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  if (!m_hits)
+  {
+    std::cerr << Name() << "::getNodes - missing TRKR_HITSET" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!m_clusterMap && Verbosity() > 0)
+  {
+    std::cout << Name() << "::getNodes - optional TRKR_CLUSTER node not found" << std::endl;
+  }
+
+  m_geomContainerTpc = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  if (!m_geomContainerTpc)
+  {
+    std::cerr << Name() << "::getNodes - missing TPCGEOMCONTAINER" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, m_vertexMapNodeName);
+  if (!m_vertexMap && Verbosity() > 0)
+  {
+    std::cout << Name() << "::getNodes - optional " << m_vertexMapNodeName << " node not found" << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcCrossingFinder::createNodes(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    dstNode = new PHCompositeNode("DST");
+    topNode->addNode(dstNode);
+  }
+
+  m_decisions = findNode::getClass<TpcCrossingDecisionContainerv1>(topNode, m_outputNodeName);
+  if (!m_decisions)
+  {
+    m_decisions = new TpcCrossingDecisionContainerv1();
+    PHIODataNode<PHObject>* node = new PHIODataNode<PHObject>(m_decisions, m_outputNodeName, "PHObject");
+    dstNode->addNode(node);
+    std::cout << Name() << "::createNodes - created " << m_outputNodeName << " node" << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void TpcCrossingFinder::configure_garfield(PHGarfield* garfield) const
+{
+  if (!garfield) { return;
+}
+
+  garfield->MoveTpc(m_tpcMove[0], m_tpcMove[1], m_tpcMove[2]);
+  for (const auto& rotation : m_tpcRotations)
+  {
+    garfield->RotateTpc(rotation[0], rotation[1], rotation[2]);
+  }
+  garfield->SetCMVoltageDefault(m_cmVoltageDefault);
+}
+
+unsigned int TpcCrossingFinder::drift_lookup_index(const unsigned int layer_index,
+                                                   const unsigned int side,
+                                                   const unsigned int sector,
+                                                   const unsigned int sample)
+{
+  return (((layer_index * NSides + side) * NSectors + sector) * NPhiSamples + sample);
+}
+
+bool TpcCrossingFinder::build_drift_lookup()
+{
+  if (!m_idealPadMap || !m_garfield) { return false;
+}
+  if (m_reverseDriftStepNs <= 0.0 || !std::isfinite(m_reverseDriftStepNs)) { return false;
+}
+
+  m_maxLookupTimeNs = std::numeric_limits<double>::max();
+  for (DriftPolyline& polyline : m_driftLookup)
+  {
+    polyline.phi = 0.0;
+    polyline.points.clear();
+  }
+
+  unsigned int nbuilt = 0;
+  for (unsigned int layer = FirstLayer; layer <= LastLayer; ++layer)
+  {
+    const unsigned int layer_index = layer - FirstLayer;
+    const double radius = m_idealPadMap->get_radius(layer);
+    const unsigned int pads_per_sector = m_idealPadMap->get_pads_per_sector_for_layer(layer);
+    if (!std::isfinite(radius) || pads_per_sector == 0U) { return false;
+}
+
+    for (unsigned int side = 0; side < NSides; ++side)
+    {
+      const double z0 = (side == 0U) ? m_startZSouth : m_startZNorth;
+      for (unsigned int sector = 0; sector < NSectors; ++sector)
+      {
+        for (unsigned int sample = 0; sample < NPhiSamples; ++sample)
+        {
+          const unsigned int local_phibin = static_cast<unsigned int>(std::llround(
+              phi_sample_fraction(sample) * static_cast<double>(pads_per_sector - 1U)));
+          const unsigned int global_pad = sector * pads_per_sector + local_phibin;
+          const double phi_local = m_idealPadMap->get_phi(side, sector, layer, local_phibin);
+          const double phi_global = m_idealPadMap->get_phi(side, layer, global_pad);
+          if (!std::isfinite(phi_local) || !std::isfinite(phi_global)) { return false;
+}
+          if (std::abs(wrap_phi(phi_global - phi_local)) > PhiConsistencyTolerance) { return false;
+}
+
+          const double x0 = radius * std::cos(phi_local);
+          const double y0 = radius * std::sin(phi_local);
+          TPolyLine3D* drift = m_garfield->ReverseDrift(x0, y0, z0, m_reverseDriftStepNs);
+          if (!drift || drift->GetN() <= 0)
+          {
+            delete drift;
+            return false;
+          }
+
+          const int npoints = drift->GetN();
+          const Float_t* xyz = drift->GetP();
+          if (!xyz || npoints <= 0)
+          {
+            delete drift;
+            return false;
+          }
+
+          DriftPolyline& polyline = m_driftLookup[drift_lookup_index(layer_index, side, sector, sample)];
+          polyline.phi = phi_local;
+          polyline.points.resize(static_cast<std::size_t>(npoints));
+          for (int ipoint = 0; ipoint < npoints; ++ipoint)
+          {
+            const int idx = 3 * ipoint;
+            DriftPoint& point = polyline.points[static_cast<std::size_t>(ipoint)];
+            const double output_r = std::hypot(static_cast<double>(xyz[idx]), static_cast<double>(xyz[idx + 1]));
+            const double output_phi = unwrap_phi_near(std::atan2(static_cast<double>(xyz[idx + 1]), static_cast<double>(xyz[idx])), phi_local);
+            point.delta_r = static_cast<float>(output_r - radius);
+            point.delta_phi = static_cast<float>(output_phi - phi_local);
+            point.z = xyz[idx + 2];
+          }
+          m_maxLookupTimeNs = std::min(m_maxLookupTimeNs, static_cast<double>(npoints - 1) * m_reverseDriftStepNs);
+          delete drift;
+          ++nbuilt;
+        }
+      }
+    }
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << "::build_drift_lookup - built " << nbuilt
+              << " drift polylines max_lookup_time_ns=" << m_maxLookupTimeNs << std::endl;
+  }
+  return nbuilt == NLayers * NSides * NSectors * NPhiSamples && std::isfinite(m_maxLookupTimeNs) && m_maxLookupTimeNs > 0.0;
+}
+
+bool TpcCrossingFinder::sample_drift_lookup(const unsigned int layer,
+                                            const unsigned int side,
+                                            const unsigned int pad,
+                                            const unsigned int tbin,
+                                            const short crossing,
+                                            double& x,
+                                            double& y,
+                                            double& z) const
+{
+  if (!m_idealPadMap) { return false;
+}
+  if (layer < FirstLayer || layer > LastLayer) { return false;
+}
+  if (side >= NSides) { return false;
+}
+  if (m_reverseDriftStepNs <= 0.0 || !std::isfinite(m_reverseDriftStepNs)) { return false;
+}
+
+  const unsigned int pads_per_sector = m_idealPadMap->get_pads_per_sector_for_layer(layer);
+  if (pads_per_sector == 0U) { return false;
+}
+  const unsigned int sector = pad / pads_per_sector;
+  if (sector >= NSectors) { return false;
+}
+
+  const double hit_radius = m_idealPadMap->get_radius(layer);
+  const double hit_phi = m_idealPadMap->get_phi(side, layer, pad);
+  if (!std::isfinite(hit_radius) || !std::isfinite(hit_phi)) { return false;
+}
+
+  const double target_time_ns = (static_cast<double>(tbin) - m_t0) * m_tpcAdcClock
+    - static_cast<double>(crossing) * m_crossingPeriodNs;
+  if (target_time_ns <= 0.0 || !std::isfinite(target_time_ns)) { return false;
+}
+
+  const unsigned int layer_index = layer - FirstLayer;
+  std::array<const DriftPolyline*, NPhiSamples> samples{};
+  std::array<double, NPhiSamples> sample_phi{};
+  for (unsigned int sample = 0; sample < NPhiSamples; ++sample)
+  {
+    samples[sample] = &m_driftLookup[drift_lookup_index(layer_index, side, sector, sample)];
+    if (samples[sample]->points.empty()) { return false;
+}
+    sample_phi[sample] = samples[sample]->phi;
+    if (sample > 0U) { sample_phi[sample] = unwrap_phi_near(sample_phi[sample], sample_phi[sample - 1U]);
+}
+  }
+
+  const double unwrapped_hit_phi = unwrap_phi_near(hit_phi, sample_phi[NPhiSamples / 2U]);
+  const bool increasing = sample_phi[NPhiSamples - 1U] >= sample_phi[0];
+
+  bool bracket_found = false;
+  unsigned int sample0 = 0;
+  unsigned int sample1 = 0;
+  double phi_fraction = 0.0;
+  if ((increasing && unwrapped_hit_phi <= sample_phi[0]) || (!increasing && unwrapped_hit_phi >= sample_phi[0]))
+  {
+    bracket_found = true;
+  }
+  else if ((increasing && unwrapped_hit_phi >= sample_phi[NPhiSamples - 1U]) ||
+           (!increasing && unwrapped_hit_phi <= sample_phi[NPhiSamples - 1U]))
+  {
+    sample0 = NPhiSamples - 1U;
+    sample1 = NPhiSamples - 1U;
+    bracket_found = true;
+  }
+  else
+  {
+    for (unsigned int sample = 0; sample + 1U < NPhiSamples; ++sample)
+    {
+      const bool in_interval = increasing ?
+        (unwrapped_hit_phi >= sample_phi[sample] && unwrapped_hit_phi <= sample_phi[sample + 1U]) :
+        (unwrapped_hit_phi <= sample_phi[sample] && unwrapped_hit_phi >= sample_phi[sample + 1U]);
+      if (!in_interval) { continue;
+}
+
+      sample0 = sample;
+      sample1 = sample + 1U;
+      const double denom = sample_phi[sample1] - sample_phi[sample0];
+      phi_fraction = (denom != 0.0) ? clamp_unit((unwrapped_hit_phi - sample_phi[sample0]) / denom) : 0.0;
+      bracket_found = true;
+      break;
+    }
+  }
+  if (!bracket_found) { return false;
+}
+
+  auto sample_time = [this, target_time_ns](const DriftPolyline& polyline,
+                                            double& delta_r,
+                                            double& delta_phi,
+                                            double& point_z) -> bool
+  {
+    const int npoints = static_cast<int>(polyline.points.size());
+    if (npoints <= 0) { return false;
+}
+    const double max_time_ns = static_cast<double>(npoints - 1) * m_reverseDriftStepNs;
+    if (target_time_ns > max_time_ns) { return false;
+}
+
+    const double fbin = target_time_ns / m_reverseDriftStepNs;
+    const int i0 = std::min(static_cast<int>(std::floor(fbin)), npoints - 1);
+    const int i1 = std::min(i0 + 1, npoints - 1);
+    const double frac = fbin - static_cast<double>(i0);
+
+    const DriftPoint& p0 = polyline.points[static_cast<std::size_t>(i0)];
+    const DriftPoint& p1 = polyline.points[static_cast<std::size_t>(i1)];
+    const double dphi0 = static_cast<double>(p0.delta_phi);
+    const double dphi1 = unwrap_phi_near(static_cast<double>(p1.delta_phi), dphi0);
+    delta_r = static_cast<double>(p0.delta_r) + frac * static_cast<double>(p1.delta_r - p0.delta_r);
+    delta_phi = dphi0 + frac * (dphi1 - dphi0);
+    point_z = static_cast<double>(p0.z) + frac * static_cast<double>(p1.z - p0.z);
+    return std::isfinite(delta_r) && std::isfinite(delta_phi) && std::isfinite(point_z);
+  };
+
+  double delta_r0 = 0.0;
+  double delta_phi0 = 0.0;
+  double z0 = 0.0;
+  const bool valid0 = sample_time(*samples[sample0], delta_r0, delta_phi0, z0);
+  double delta_r1 = 0.0;
+  double delta_phi1 = 0.0;
+  double z1 = 0.0;
+  const bool same_sample = sample0 == sample1;
+  const bool valid1 = same_sample ? valid0 : sample_time(*samples[sample1], delta_r1, delta_phi1, z1);
+  if (same_sample)
+  {
+    delta_r1 = delta_r0;
+    delta_phi1 = delta_phi0;
+    z1 = z0;
+  }
+  if (!valid0 && !valid1) { return false;
+}
+
+  double delta_r = 0.0;
+  double delta_phi = 0.0;
+  if (valid0 && valid1 && !same_sample)
+  {
+    delta_r = delta_r0 + phi_fraction * (delta_r1 - delta_r0);
+    const double unwrapped_delta_phi1 = unwrap_phi_near(delta_phi1, delta_phi0);
+    delta_phi = delta_phi0 + phi_fraction * (unwrapped_delta_phi1 - delta_phi0);
+    z = z0 + phi_fraction * (z1 - z0);
+  }
+  else if (valid0)
+  {
+    delta_r = delta_r0;
+    delta_phi = delta_phi0;
+    z = z0;
+  }
+  else
+  {
+    delta_r = delta_r1;
+    delta_phi = delta_phi1;
+    z = z1;
+  }
+
+  const double radius = hit_radius + delta_r;
+  const double output_phi = unwrapped_hit_phi + delta_phi;
+  x = radius * std::cos(output_phi);
+  y = radius * std::sin(output_phi);
+  return std::isfinite(x) && std::isfinite(y) && std::isfinite(z);
+}
+
+bool TpcCrossingFinder::make_xyz_point(TrkrDefs::hitsetkey hsk,
+                                       TrkrDefs::hitkey hk,
+                                       short crossing,
+                                       Point& p) const
+{
+  const unsigned int layer = TrkrDefs::getLayer(hsk);
+  const unsigned int hit_side = TpcDefs::getSide(hsk);
+  const unsigned int pad = TpcDefs::getPad(hk);
+  const unsigned int tbin = TpcDefs::getTBin(hk);
+
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
+  if (!sample_drift_lookup(layer, hit_side, pad, tbin, crossing, x, y, z)) { return false;
+}
+
+  p.hitsetkey = hsk;
+  p.hitkey = hk;
+  p.layer = layer;
+  p.side = hit_side;
+  p.pad = pad;
+  p.tbin = tbin;
+  p.x = x;
+  p.y = y;
+  p.z = z;
+  return true;
+}
+
+bool TpcCrossingFinder::find_time_extrema(const Tpc_AssembledTrack* track,
+                                          TrkrDefs::hitsetkey& min_hsk,
+                                          TrkrDefs::hitkey& min_hk,
+                                          TrkrDefs::hitsetkey& max_hsk,
+                                          TrkrDefs::hitkey& max_hk) const
+{
+  if (!track || track->size_hit_indices() == 0) { return false;
+}
+
+  unsigned int min_tbin = std::numeric_limits<unsigned int>::max();
+  unsigned int max_tbin = 0;
+  bool found = false;
+  for (unsigned int ih = 0; ih < track->size_hit_indices(); ++ih)
+  {
+    const Tpc_AssembledTrack::HitIndex hi = track->get_hit_index(ih);
+    const unsigned int tbin = TpcDefs::getTBin(hi.second);
+    if (!found || tbin < min_tbin)
+    {
+      min_tbin = tbin;
+      min_hsk = hi.first;
+      min_hk = hi.second;
+    }
+    if (!found || tbin > max_tbin)
+    {
+      max_tbin = tbin;
+      max_hsk = hi.first;
+      max_hk = hi.second;
+    }
+    found = true;
+  }
+  return found;
+}
+
+std::set<short> TpcCrossingFinder::get_available_crossings() const
+{
+  std::set<short> available_crossings;
+  if (!m_vertexMap) { return available_crossings;
+}
+
+  for (auto & iter : *m_vertexMap)
+  {
+    const SvtxVertex* vertex = iter.second;
+    if (!vertex) { continue;
+}
+    available_crossings.insert(vertex->get_beam_crossing());
+  }
+  return available_crossings;
+}
+
+std::set<short> TpcCrossingFinder::get_intt_crossings() const
+{
+  std::set<short> intt_crossings;
+  if (!m_clusterMap) { return intt_crossings;
+}
+
+  for (const auto& hitsetkey : m_clusterMap->getHitSetKeys())
+  {
+    if (static_cast<TrkrDefs::TrkrId>(TrkrDefs::getTrkrId(hitsetkey)) != TrkrDefs::TrkrId::inttId) { continue;
+}
+    intt_crossings.insert(static_cast<short>(InttDefs::getTimeBucketId(hitsetkey)));
+  }
+  return intt_crossings;
+}
+
+std::map<short, std::vector<TpcCrossingFinder::SiliconVertexHypothesis>>
+TpcCrossingFinder::get_vertices_by_crossing() const
+{
+  std::map<short, std::vector<SiliconVertexHypothesis>> vertices_by_crossing;
+  if (!m_vertexMap) { return vertices_by_crossing;
+}
+
+  for (auto & iter : *m_vertexMap)
+  {
+    const SvtxVertex* vertex = iter.second;
+    if (!vertex) { continue;
+}
+
+    SiliconVertexHypothesis hyp;
+    hyp.crossing = vertex->get_beam_crossing();
+    hyp.vertex_id = iter.first;
+    hyp.x = vertex->get_x();
+    hyp.y = vertex->get_y();
+    hyp.z = vertex->get_z();
+    const double errzz = vertex->get_error(2, 2);
+    hyp.sigma_z = errzz >= 0.0 ? std::sqrt(errzz) : std::numeric_limits<double>::quiet_NaN();
+    hyp.ntracks = vertex->size_tracks();
+    vertices_by_crossing[hyp.crossing].push_back(hyp);
+  }
+  return vertices_by_crossing;
+}
+
+std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>>
+TpcCrossingFinder::select_representatives(const Tpc_AssembledTrack* track,
+                                          TrkrDefs::hitsetkey min_hsk,
+                                          TrkrDefs::hitkey min_hk,
+                                          TrkrDefs::hitsetkey max_hsk,
+                                          TrkrDefs::hitkey max_hk) const
+{
+  std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> representatives;
+  auto add_unique = [&representatives](const Tpc_AssembledTrack::HitIndex& hi)
+  {
+    if (std::find(representatives.begin(), representatives.end(), hi) == representatives.end())
+    {
+      representatives.push_back(hi);
+    }
+  };
+
+  add_unique({min_hsk, min_hk});
+  add_unique({max_hsk, max_hk});
+  if (!track) { return representatives;
+}
+
+  std::map<unsigned int, Tpc_AssembledTrack::HitIndex> hit_by_layer;
+  for (unsigned int ih = 0; ih < track->size_hit_indices(); ++ih)
+  {
+    const Tpc_AssembledTrack::HitIndex hi = track->get_hit_index(ih);
+    hit_by_layer.emplace(TrkrDefs::getLayer(hi.first), hi);
+  }
+  if (hit_by_layer.empty()) { return representatives;
+}
+
+  add_unique(hit_by_layer.begin()->second);
+  add_unique(hit_by_layer.rbegin()->second);
+
+  std::vector<unsigned int> layers;
+  layers.reserve(hit_by_layer.size());
+  for (const auto& item : hit_by_layer) { layers.push_back(item.first);
+}
+  const unsigned int fractions[] = {1U, 2U};
+  for (const unsigned int fraction : fractions)
+  {
+    if (layers.size() < 3U) { continue;
+}
+    const std::size_t index = (fraction * (layers.size() - 1U)) / 3U;
+    add_unique(hit_by_layer[layers[index]]);
+  }
+
+  return representatives;
+}
+
+TpcCrossingFinder::ZFitResult TpcCrossingFinder::estimate_tpc_z0_diagnostics(std::vector<Point> points) const
+{
+  ZFitResult result;
+  if (points.size() < 2U) { return result;
+}
+  std::sort(points.begin(), points.end(), [](const Point& a, const Point& b) {
+    return a.layer < b.layer;
+  });
+
+  std::vector<double> s(points.size(), 0.0);
+  for (std::size_t i = 1; i < points.size(); ++i)
+  {
+    s[i] = s[i - 1] + std::hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
+  }
+
+  std::vector<Tpc_FittingTools::FitPoint> fit_points;
+  fit_points.reserve(points.size());
+  std::vector<Tpc_FittingTools::FitPoint> radial_fit_points;
+  radial_fit_points.reserve(points.size());
+  for (std::size_t i = 0; i < points.size(); ++i)
+  {
+    fit_points.emplace_back(s[i], points[i].z, 1.0);
+    radial_fit_points.emplace_back(std::hypot(points[i].x, points[i].y), points[i].z, 1.0);
+  }
+  const Tpc_FittingTools::LineFit zfit = Tpc_FittingTools::fitLine(fit_points);
+  const Tpc_FittingTools::LineFit radial_zfit = Tpc_FittingTools::fitLine(radial_fit_points);
+  if (!zfit.ok || !radial_zfit.ok) { return result;
+}
+
+  double best_s = s.front();
+  double best_d2 = std::numeric_limits<double>::max();
+  for (std::size_t i = 0; i + 1U < points.size(); ++i)
+  {
+    const double vx = points[i + 1U].x - points[i].x;
+    const double vy = points[i + 1U].y - points[i].y;
+    const double len2 = vx * vx + vy * vy;
+    double frac = 0.0;
+    if (len2 > 0.0)
+    {
+      frac = clamp_unit(-(points[i].x * vx + points[i].y * vy) / len2);
+    }
+    const double x = points[i].x + frac * vx;
+    const double y = points[i].y + frac * vy;
+    const double d2 = x * x + y * y;
+    if (d2 < best_d2)
+    {
+      best_d2 = d2;
+      best_s = s[i] + frac * (s[i + 1U] - s[i]);
+    }
+  }
+
+  result.valid = std::isfinite(best_s) && std::isfinite(best_d2);
+  result.slope = zfit.slope;
+  result.intercept = zfit.intercept;
+  result.chi2 = zfit.chi2;
+  result.ndf = zfit.ndof;
+  result.s_at_pca = best_s;
+  result.minimum_radius = std::sqrt(best_d2);
+  result.z_at_pca = zfit.slope * best_s + zfit.intercept;
+  result.z_at_r0 = radial_zfit.intercept;
+  result.points = std::move(points);
+  result.path_length.reserve(s.size());
+  for (const double value : s) { result.path_length.push_back(finite_float_or_nan(value));
+}
+  result.valid = result.valid && std::isfinite(result.z_at_pca) && std::isfinite(result.z_at_r0);
+  return result;
+}
+
+bool TpcCrossingFinder::estimate_tpc_z0(std::vector<Point>& points, double& z0) const
+{
+  const ZFitResult result = estimate_tpc_z0_diagnostics(points);
+  if (!result.valid) { return false;
+}
+  z0 = result.z_at_r0;
+  return true;
+}
+
+bool TpcCrossingFinder::point_in_tpc(const Point& p) const
+{
+  const double r = std::hypot(p.x, p.y);
+  const double inner = m_idealPadMap ? m_idealPadMap->get_radius(FirstLayer) : 0.0;
+  const double outer = m_idealPadMap ? m_idealPadMap->get_radius(LastLayer) : 0.0;
+  return std::isfinite(r) && std::isfinite(p.z) &&
+    r >= inner - m_radialTolerance &&
+    r <= outer + m_radialTolerance &&
+    p.z >= -m_tpcHalfLength - m_zTolerance &&
+    p.z <= m_tpcHalfLength + m_zTolerance;
+}
+
+bool TpcCrossingFinder::point_in_correct_side(const Point& p) const
+{
+  if (p.side == 0U) { return p.z >= -m_tpcHalfLength - m_zTolerance && p.z <= m_centralMembraneTolerance;
+}
+  if (p.side == 1U) { return p.z >= -m_centralMembraneTolerance && p.z <= m_tpcHalfLength + m_zTolerance;
+}
+  return false;
+}
+
+TpcCrossingFinder::Candidate
+TpcCrossingFinder::test_candidate(const Tpc_AssembledTrack* track,
+                                  short crossing,
+                                  TrkrDefs::hitsetkey min_hsk,
+                                  TrkrDefs::hitkey min_hk,
+                                  TrkrDefs::hitsetkey max_hsk,
+                                  TrkrDefs::hitkey max_hk,
+                                  const std::map<short, std::vector<SiliconVertexHypothesis>>& vertices_by_crossing) const
+{
+  Candidate candidate;
+  candidate.crossing = crossing;
+  candidate.silicon_vertex_id = std::numeric_limits<unsigned int>::max();
+  candidate.tpc_z0 = std::numeric_limits<double>::quiet_NaN();
+  candidate.silicon_vertex_z = std::numeric_limits<double>::quiet_NaN();
+  candidate.delta_z = std::numeric_limits<double>::quiet_NaN();
+
+  TpcCrossingCandidate& qa = candidate.qa;
+  qa.crossing = crossing;
+  qa.is_available_from_intt = true;
+  qa.passes_time_window = true;
+  qa.was_tested = true;
+  qa.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::Unknown);
+  qa.max_lookup_time_ns = finite_float_or_nan(m_maxLookupTimeNs);
+  qa.min_tbin_time_crossing0_ns = finite_float_or_nan((static_cast<double>(TpcDefs::getTBin(min_hk)) - m_t0) * m_tpcAdcClock);
+  qa.max_tbin_time_crossing0_ns = finite_float_or_nan((static_cast<double>(TpcDefs::getTBin(max_hk)) - m_t0) * m_tpcAdcClock);
+  qa.candidate_min_time_ns = finite_float_or_nan(static_cast<double>(qa.min_tbin_time_crossing0_ns) - static_cast<double>(crossing) * m_crossingPeriodNs);
+  qa.candidate_max_time_ns = finite_float_or_nan(static_cast<double>(qa.max_tbin_time_crossing0_ns) - static_cast<double>(crossing) * m_crossingPeriodNs);
+  qa.min_time_margin_ns = qa.candidate_min_time_ns;
+  qa.max_time_margin_ns = finite_float_or_nan(m_maxLookupTimeNs - static_cast<double>(qa.candidate_max_time_ns));
+  qa.candidate_qa_bits |= FromInttCrossing | PassedTimeWindow;
+
+  auto fill_point_summary = [](const Point& point,
+                               unsigned int& layer,
+                               unsigned int& side,
+                               unsigned int& pad,
+                               unsigned int& tbin,
+                               float& x,
+                               float& y,
+                               float& z,
+                               float& r,
+                               float& phi)
+  {
+    layer = point.layer;
+    side = point.side;
+    pad = point.pad;
+    tbin = point.tbin;
+    x = finite_float_or_nan(point.x);
+    y = finite_float_or_nan(point.y);
+    z = finite_float_or_nan(point.z);
+    r = finite_float_or_nan(std::hypot(point.x, point.y));
+    phi = finite_float_or_nan(std::atan2(point.y, point.x));
+  };
+
+  auto distance_to_padplane = [this](const Point& point) -> float
+  {
+    const double padplane_z = point.side == 0U ? -m_tpcHalfLength : m_tpcHalfLength;
+    return finite_float_or_nan(std::abs(point.z - padplane_z));
+  };
+
+  Point min_point;
+  Point max_point;
+  qa.min_endpoint_garfield_valid = make_xyz_point(min_hsk, min_hk, crossing, min_point);
+  qa.max_endpoint_garfield_valid = make_xyz_point(max_hsk, max_hk, crossing, max_point);
+  if (qa.min_endpoint_garfield_valid)
+  {
+    fill_point_summary(min_point, qa.min_time_layer, qa.min_time_side, qa.min_time_pad, qa.min_time_tbin,
+                       qa.min_time_x, qa.min_time_y, qa.min_time_z, qa.min_time_r, qa.min_time_phi);
+    qa.min_time_distance_to_central_membrane = finite_float_or_nan(std::abs(min_point.z));
+    qa.min_time_distance_to_padplane = distance_to_padplane(min_point);
+    qa.min_time_inside_tpc = point_in_tpc(min_point);
+    qa.min_time_correct_side = point_in_correct_side(min_point);
+    qa.candidate_qa_bits |= MinEndpointGarfieldOK;
+  }
+  if (qa.max_endpoint_garfield_valid)
+  {
+    fill_point_summary(max_point, qa.max_time_layer, qa.max_time_side, qa.max_time_pad, qa.max_time_tbin,
+                       qa.max_time_x, qa.max_time_y, qa.max_time_z, qa.max_time_r, qa.max_time_phi);
+    qa.max_time_distance_to_central_membrane = finite_float_or_nan(std::abs(max_point.z));
+    qa.max_time_distance_to_padplane = distance_to_padplane(max_point);
+    qa.max_time_inside_tpc = point_in_tpc(max_point);
+    qa.max_time_correct_side = point_in_correct_side(max_point);
+    qa.candidate_qa_bits |= MaxEndpointGarfieldOK;
+  }
+
+  if (!qa.min_endpoint_garfield_valid || !qa.max_endpoint_garfield_valid)
+  {
+    qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::GarfieldValid);
+    candidate.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::GarfieldInvalid);
+    qa.rejection_status = candidate.rejection_status;
+    return candidate;
+  }
+
+  qa.endpoints_inside_tpc = qa.min_time_inside_tpc && qa.max_time_inside_tpc;
+  if (qa.endpoints_inside_tpc) { qa.candidate_qa_bits |= EndpointsInsideTPC;
+}
+  if (!qa.endpoints_inside_tpc)
+  {
+    qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::InsideTpc);
+    candidate.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::OutsideTpcVolume);
+    qa.rejection_status = candidate.rejection_status;
+    return candidate;
+  }
+
+  qa.endpoints_on_correct_side = qa.min_time_correct_side && qa.max_time_correct_side;
+  if (qa.endpoints_on_correct_side) { qa.candidate_qa_bits |= EndpointsCorrectSide;
+}
+  if (!qa.endpoints_on_correct_side)
+  {
+    qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::CorrectSide);
+    candidate.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::WrongTpcSide);
+    qa.rejection_status = candidate.rejection_status;
+    return candidate;
+  }
+
+  std::vector<Point> points;
+  for (const auto& hi : select_representatives(track, min_hsk, min_hk, max_hsk, max_hk))
+  {
+    Point p;
+    if (!make_xyz_point(hi.first, hi.second, crossing, p)) { continue;
+}
+    if (!point_in_tpc(p) || !point_in_correct_side(p)) { continue;
+}
+    points.push_back(p);
+  }
+
+  const ZFitResult fit = estimate_tpc_z0_diagnostics(points);
+  qa.fit_valid = fit.valid;
+  if (!fit.valid)
+  {
+    qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::FitValid);
+    candidate.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::FitFailed);
+    qa.rejection_status = candidate.rejection_status;
+    return candidate;
+  }
+
+  qa.candidate_qa_bits |= FitSuccessful;
+  qa.n_fit_points = fit.points.size();
+  qa.z_vs_s_slope = finite_float_or_nan(fit.slope);
+  qa.z_vs_s_intercept = finite_float_or_nan(fit.intercept);
+  qa.z_fit_chi2 = finite_float_or_nan(fit.chi2);
+  qa.z_fit_ndf = fit.ndf;
+  qa.s_at_transverse_pca = finite_float_or_nan(fit.s_at_pca);
+  qa.minimum_transverse_radius = finite_float_or_nan(fit.minimum_radius);
+  qa.tpc_z_at_transverse_pca = finite_float_or_nan(fit.z_at_pca);
+  qa.tpc_z_at_r0 = finite_float_or_nan(fit.z_at_r0);
+  for (std::size_t i = 0; i < fit.points.size(); ++i)
+  {
+    const Point& point = fit.points[i];
+    qa.fit_point_layer.push_back(point.layer);
+    qa.fit_point_pad.push_back(point.pad);
+    qa.fit_point_tbin.push_back(point.tbin);
+    qa.fit_point_x.push_back(finite_float_or_nan(point.x));
+    qa.fit_point_y.push_back(finite_float_or_nan(point.y));
+    qa.fit_point_z.push_back(finite_float_or_nan(point.z));
+    qa.fit_point_r.push_back(finite_float_or_nan(std::hypot(point.x, point.y)));
+    qa.fit_point_s.push_back(i < fit.path_length.size() ? fit.path_length[i] : TpcCrossingCandidate::nan());
+  }
+
+  std::map<unsigned int, Tpc_AssembledTrack::HitIndex> hit_by_layer;
+  if (track)
+  {
+    for (unsigned int ih = 0; ih < track->size_hit_indices(); ++ih)
+    {
+      const Tpc_AssembledTrack::HitIndex hi = track->get_hit_index(ih);
+      hit_by_layer.emplace(TrkrDefs::getLayer(hi.first), hi);
+    }
+  }
+  if (!hit_by_layer.empty())
+  {
+    Point inner;
+    if (make_xyz_point(hit_by_layer.begin()->second.first, hit_by_layer.begin()->second.second, crossing, inner))
+    {
+      qa.inner_layer = inner.layer;
+      qa.inner_tbin = inner.tbin;
+      qa.inner_x = finite_float_or_nan(inner.x);
+      qa.inner_y = finite_float_or_nan(inner.y);
+      qa.inner_z = finite_float_or_nan(inner.z);
+    }
+    Point outer;
+    if (make_xyz_point(hit_by_layer.rbegin()->second.first, hit_by_layer.rbegin()->second.second, crossing, outer))
+    {
+      qa.outer_layer = outer.layer;
+      qa.outer_tbin = outer.tbin;
+      qa.outer_x = finite_float_or_nan(outer.x);
+      qa.outer_y = finite_float_or_nan(outer.y);
+      qa.outer_z = finite_float_or_nan(outer.z);
+    }
+  }
+
+  candidate.tpc_z0 = fit.z_at_r0;
+  if (!std::isfinite(candidate.tpc_z0) || std::abs(candidate.tpc_z0 - m_collisionZ) > m_maxCandidateVertexZ)
+  {
+    qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::VertexCompatible);
+    candidate.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::VertexIncompatible);
+    qa.rejection_status = candidate.rejection_status;
+    return candidate;
+  }
+
+  const auto vertex_iter = vertices_by_crossing.find(crossing);
+  if (vertex_iter != vertices_by_crossing.end())
+  {
+    qa.n_vertices_at_crossing = vertex_iter->second.size();
+    double best_abs_delta = std::numeric_limits<double>::max();
+    for (const SiliconVertexHypothesis& vertex : vertex_iter->second)
+    {
+      const double delta_z = fit.z_at_r0 - vertex.z;
+      const double abs_delta = std::abs(delta_z);
+      const double pull_z = std::isfinite(vertex.sigma_z) && vertex.sigma_z > 0.0 ? delta_z / vertex.sigma_z : std::numeric_limits<double>::quiet_NaN();
+      qa.candidate_vertex_ids.push_back(vertex.vertex_id);
+      qa.candidate_vertex_z.push_back(finite_float_or_nan(vertex.z));
+      qa.candidate_vertex_sigma_z.push_back(finite_float_or_nan(vertex.sigma_z));
+      qa.candidate_vertex_ntracks.push_back(vertex.ntracks);
+      qa.candidate_vertex_delta_z.push_back(finite_float_or_nan(delta_z));
+      qa.candidate_vertex_pull_z.push_back(finite_float_or_nan(pull_z));
+      if (!std::isfinite(abs_delta) || abs_delta >= best_abs_delta) { continue;
+}
+
+      best_abs_delta = abs_delta;
+      candidate.has_silicon_vertex = true;
+      candidate.silicon_vertex_id = vertex.vertex_id;
+      candidate.silicon_vertex_z = vertex.z;
+      candidate.delta_z = delta_z;
+      qa.closest_vertex_id = vertex.vertex_id;
+      qa.closest_vertex_z = finite_float_or_nan(vertex.z);
+      qa.closest_vertex_sigma_z = finite_float_or_nan(vertex.sigma_z);
+      qa.closest_vertex_delta_z = finite_float_or_nan(delta_z);
+      qa.closest_vertex_abs_delta_z = finite_float_or_nan(abs_delta);
+      qa.closest_vertex_pull_z = finite_float_or_nan(pull_z);
+    }
+  }
+
+  qa.has_silicon_vertex = candidate.has_silicon_vertex;
+  if (qa.has_silicon_vertex) { qa.candidate_qa_bits |= HasSiliconVertex;
+}
+  candidate.vertex_compatible = candidate.has_silicon_vertex && std::abs(candidate.delta_z) <= m_maxVertexDz;
+  qa.vertex_compatible = candidate.vertex_compatible;
+  if (qa.vertex_compatible) { qa.candidate_qa_bits |= PassesVertexDz;
+}
+
+  candidate.tpc_valid = true;
+  qa.tpc_valid = candidate.tpc_valid;
+  qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::FinalRanking);
+  qa.rejection_status = candidate.rejection_status;
+  return candidate;
+}
+
+int TpcCrossingFinder::process_event(PHCompositeNode* topNode)
+{
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTEVENT;
+}
+  if (!m_assembledTracks || !m_decisions) { return Fun4AllReturnCodes::EVENT_OK;
+}
+  m_decisions->Reset();
+
+  std::set<short> available_crossings = get_available_crossings();
+  const std::set<short> intt_crossings = get_intt_crossings();
+  available_crossings.insert(intt_crossings.begin(), intt_crossings.end());
+  const auto vertices_by_crossing = get_vertices_by_crossing();
+  const bool has_vertex_map = m_vertexMap != nullptr;
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << "::process_event - event " << m_event << " available candidate crossings:";
+    for (const short crossing : available_crossings) { std::cout << " " << crossing;
+}
+    std::cout << " | intt crossings:";
+    for (const short crossing : intt_crossings) { std::cout << " " << crossing;
+}
+    std::cout << " | vertices by crossing:";
+    for (const auto& item : vertices_by_crossing)
+    {
+      std::cout << " " << item.first << "(" << item.second.size() << ":";
+      for (std::size_t ivtx = 0; ivtx < item.second.size(); ++ivtx)
+      {
+        const SiliconVertexHypothesis& vertex = item.second[ivtx];
+        if (ivtx != 0U) { std::cout << ",";
+}
+        std::cout << " id=" << vertex.vertex_id
+                  << " x=" << vertex.x
+                  << " y=" << vertex.y
+                  << " z=" << vertex.z;
+      }
+      std::cout << ")";
+    }
+    std::cout << std::endl;
+  }
+
+  const unsigned int nassembled = m_assembledTracks->size();
+  for (unsigned int iassembled = 0; iassembled < nassembled; ++iassembled)
+  {
+    const Tpc_AssembledTrack* assembled = m_assembledTracks->get_track(iassembled);
+    if (!assembled) { continue;
+}
+
+    TpcCrossingDecisionv1* decision = new TpcCrossingDecisionv1();
+    std::vector<TpcCrossingCandidate> candidate_qa_records;
+    auto add_decision_with_candidates = [&candidate_qa_records, decision, this]()
+    {
+      for (const TpcCrossingCandidate& candidate : candidate_qa_records) { decision->add_candidate(candidate);
+}
+      m_decisions->add_decision(decision);
+    };
+    decision->set_assembled_track_id(assembled->get_track_id());
+    decision->set_number_of_available_crossings(static_cast<unsigned short>(std::min<std::size_t>(available_crossings.size(), std::numeric_limits<unsigned short>::max())));
+
+    if (available_crossings.empty())
+    {
+      decision->set_status(TpcCrossingStatus::NoInttCrossings);
+      add_decision_with_candidates();
+      continue;
+    }
+
+    TrkrDefs::hitsetkey min_hsk = 0;
+    TrkrDefs::hitkey min_hk = 0;
+    TrkrDefs::hitsetkey max_hsk = 0;
+    TrkrDefs::hitkey max_hk = 0;
+    if (!find_time_extrema(assembled, min_hsk, min_hk, max_hsk, max_hk))
+    {
+      for (const short crossing : available_crossings)
+      {
+        TpcCrossingCandidate qa;
+        qa.crossing = crossing;
+        qa.is_available_from_intt = intt_crossings.contains(crossing);
+        qa.candidate_qa_bits = qa.is_available_from_intt ? FromInttCrossing : 0U;
+        qa.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::NoValidCrossing);
+        qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::PassedTimeWindow);
+        candidate_qa_records.push_back(qa);
+      }
+      decision->set_status(TpcCrossingStatus::NoValidCrossing);
+      add_decision_with_candidates();
+      continue;
+    }
+
+    const unsigned int min_tbin = TpcDefs::getTBin(min_hk);
+    const unsigned int max_tbin = TpcDefs::getTBin(max_hk);
+    std::vector<short> allowed_crossings;
+    for (const short crossing : available_crossings)
+    {
+      const double min_time0_ns = (static_cast<double>(min_tbin) - m_t0) * m_tpcAdcClock;
+      const double max_time0_ns = (static_cast<double>(max_tbin) - m_t0) * m_tpcAdcClock;
+      const double min_time_ns = min_time0_ns - static_cast<double>(crossing) * m_crossingPeriodNs;
+      const double max_time_ns = max_time0_ns - static_cast<double>(crossing) * m_crossingPeriodNs;
+      const bool passes_time_window = std::isfinite(min_time_ns) && std::isfinite(max_time_ns) &&
+        min_time_ns > 0.0 && max_time_ns <= m_maxLookupTimeNs;
+      if (passes_time_window)
+      {
+        allowed_crossings.push_back(crossing);
+      }
+      else
+      {
+        TpcCrossingCandidate qa;
+        qa.crossing = crossing;
+        qa.is_available_from_intt = intt_crossings.contains(crossing);
+        qa.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::NoAllowedCrossing);
+        qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::PassedTimeWindow);
+        qa.min_tbin_time_crossing0_ns = finite_float_or_nan(min_time0_ns);
+        qa.max_tbin_time_crossing0_ns = finite_float_or_nan(max_time0_ns);
+        qa.candidate_min_time_ns = finite_float_or_nan(min_time_ns);
+        qa.candidate_max_time_ns = finite_float_or_nan(max_time_ns);
+        qa.max_lookup_time_ns = finite_float_or_nan(m_maxLookupTimeNs);
+        qa.min_time_margin_ns = finite_float_or_nan(min_time_ns);
+        qa.max_time_margin_ns = finite_float_or_nan(m_maxLookupTimeNs - max_time_ns);
+        qa.min_time_layer = TrkrDefs::getLayer(min_hsk);
+        qa.min_time_side = TpcDefs::getSide(min_hsk);
+        qa.min_time_pad = TpcDefs::getPad(min_hk);
+        qa.min_time_tbin = min_tbin;
+        qa.max_time_layer = TrkrDefs::getLayer(max_hsk);
+        qa.max_time_side = TpcDefs::getSide(max_hsk);
+        qa.max_time_pad = TpcDefs::getPad(max_hk);
+        qa.max_time_tbin = max_tbin;
+        qa.candidate_qa_bits = qa.is_available_from_intt ? FromInttCrossing : 0U;
+        candidate_qa_records.push_back(qa);
+      }
+    }
+    decision->set_number_of_allowed_crossings(static_cast<unsigned short>(std::min<std::size_t>(allowed_crossings.size(), std::numeric_limits<unsigned short>::max())));
+
+    if (allowed_crossings.empty())
+    {
+      decision->set_status(TpcCrossingStatus::NoAllowedCrossing);
+      add_decision_with_candidates();
+      continue;
+    }
+
+    std::vector<Candidate> valid_candidates;
+    unsigned char last_rejection = static_cast<unsigned char>(TpcCrossingStatus::NoValidCrossing);
+    for (const short crossing : allowed_crossings)
+    {
+      Candidate candidate = test_candidate(assembled, crossing, min_hsk, min_hk, max_hsk, max_hk, vertices_by_crossing);
+      decision->set_number_of_tested_crossings(decision->get_number_of_tested_crossings() + 1U);
+      candidate.qa.is_available_from_intt = intt_crossings.contains(crossing);
+      if (!candidate.qa.is_available_from_intt) { candidate.qa.candidate_qa_bits &= ~FromInttCrossing;
+}
+      candidate_qa_records.push_back(candidate.qa);
+      if (candidate.tpc_valid)
+      {
+        valid_candidates.push_back(candidate);
+      }
+      else if (candidate.rejection_status != 0U)
+      {
+        last_rejection = candidate.rejection_status;
+      }
+    }
+    for (Candidate& candidate : valid_candidates)
+    {
+      if (candidate.has_silicon_vertex)
+      {
+        const double abs_delta = std::isfinite(candidate.delta_z) ? std::abs(candidate.delta_z) : std::numeric_limits<double>::max();
+        candidate.confidence_tier = abs_delta <= m_maxVertexDz ? 0U : 1U;
+        candidate.confidence_score = abs_delta;
+      }
+      else
+      {
+        const double abs_z0 = std::isfinite(candidate.tpc_z0) ? std::abs(candidate.tpc_z0 - m_collisionZ) : std::numeric_limits<double>::max();
+        candidate.confidence_tier = 2U;
+        candidate.confidence_score = abs_z0;
+        if (abs_z0 > m_maxTier2BeamlineZ)
+        {
+          candidate.tpc_valid = false;
+          candidate.rejection_status = static_cast<unsigned char>(TpcCrossingStatus::VertexIncompatible);
+          last_rejection = candidate.rejection_status;
+        }
+      }
+    }
+
+    std::vector<Candidate> ranked_candidates;
+    for (const Candidate& candidate : valid_candidates)
+    {
+      if (!candidate.tpc_valid) { continue;
+}
+      if (candidate.confidence_tier == InvalidConfidenceTier) { continue;
+}
+      if (!std::isfinite(candidate.confidence_score)) { continue;
+}
+      ranked_candidates.push_back(candidate);
+    }
+
+    for (TpcCrossingCandidate& qa : candidate_qa_records)
+    {
+      const auto iq = std::find_if(valid_candidates.begin(), valid_candidates.end(), [&qa](const Candidate& candidate) { return candidate.crossing == qa.crossing; });
+      if (iq == valid_candidates.end()) { continue;
+}
+      qa.confidence_tier = iq->confidence_tier;
+      qa.confidence_score = finite_float_or_nan(iq->confidence_score);
+      qa.tpc_valid = iq->tpc_valid;
+      if (!iq->tpc_valid && iq->rejection_status != 0U) { qa.rejection_status = iq->rejection_status;
+}
+    }
+
+    decision->set_number_of_tpc_valid_crossings(static_cast<unsigned short>(std::min<std::size_t>(ranked_candidates.size(), std::numeric_limits<unsigned short>::max())));
+    const auto n_vertex_compatible = std::count_if(ranked_candidates.begin(), ranked_candidates.end(), [](const Candidate& candidate) { return candidate.confidence_tier == 0U; });
+    decision->set_number_of_vertex_compatible_crossings(static_cast<unsigned short>(std::min<std::size_t>(n_vertex_compatible, std::numeric_limits<unsigned short>::max())));
+
+    if (ranked_candidates.empty())
+    {
+      decision->set_status(last_rejection != 0U ? last_rejection : static_cast<unsigned char>(TpcCrossingStatus::NoValidCrossing));
+      add_decision_with_candidates();
+      continue;
+    }
+
+    std::sort(ranked_candidates.begin(), ranked_candidates.end(), [](const Candidate& a, const Candidate& b) {
+      if (a.confidence_tier != b.confidence_tier) { return a.confidence_tier < b.confidence_tier;
+}
+      if (a.confidence_score != b.confidence_score) { return a.confidence_score < b.confidence_score;
+}
+      return a.crossing < b.crossing;
+    });
+
+    const Candidate& best_candidate = ranked_candidates.front();
+    const double best_score = best_candidate.confidence_score;
+    double second_score = std::numeric_limits<double>::infinity();
+    for (std::size_t icandidate = 1; icandidate < ranked_candidates.size(); ++icandidate)
+    {
+      if (ranked_candidates[icandidate].confidence_tier != best_candidate.confidence_tier) { break;
+}
+      second_score = ranked_candidates[icandidate].confidence_score;
+      break;
+    }
+    const bool close_rival = std::isfinite(second_score) && second_score - best_score <= m_minBestSecondSeparation;
+
+    auto selected_status = TpcCrossingStatus::SelectedByContainment;
+    if (best_candidate.confidence_tier == 0U)
+    {
+      selected_status = close_rival ? TpcCrossingStatus::SelectedByVertexAmbiguous : TpcCrossingStatus::SelectedByVertex;
+    }
+    else if (best_candidate.confidence_tier == 1U)
+    {
+      selected_status = TpcCrossingStatus::SelectedByVertexLoose;
+    }
+    else if (best_candidate.confidence_tier == 2U)
+    {
+      selected_status = close_rival ? TpcCrossingStatus::SelectedByContainmentAmbiguous : TpcCrossingStatus::SelectedByContainment;
+    }
+
+    decision->set_best_abs_delta_z(finite_float_or_nan(best_score));
+    decision->set_second_best_abs_delta_z(finite_float_or_nan(second_score));
+    decision->set_selected_crossing(best_candidate.crossing);
+    decision->set_tpc_z0(finite_float_or_nan(best_candidate.tpc_z0));
+    decision->set_silicon_vertex_id(best_candidate.silicon_vertex_id);
+    decision->set_silicon_vertex_z(finite_float_or_nan(best_candidate.silicon_vertex_z));
+    decision->set_delta_z(finite_float_or_nan(best_candidate.delta_z));
+    decision->set_selected_tier(best_candidate.confidence_tier);
+    decision->set_selected_score(finite_float_or_nan(best_candidate.confidence_score));
+    decision->set_status(selected_status);
+
+    std::vector<short> by_vertex;
+    by_vertex.reserve(valid_candidates.size());
+    std::vector<short> by_collision;
+    by_collision.reserve(valid_candidates.size());
+    for (const Candidate& candidate : valid_candidates)
+    {
+      by_vertex.push_back(candidate.crossing);
+      by_collision.push_back(candidate.crossing);
+    }
+    std::sort(by_vertex.begin(), by_vertex.end(), [&valid_candidates](short a, short b) {
+      const auto ia = std::find_if(valid_candidates.begin(), valid_candidates.end(), [a](const Candidate& c) { return c.crossing == a; });
+      const auto ib = std::find_if(valid_candidates.begin(), valid_candidates.end(), [b](const Candidate& c) { return c.crossing == b; });
+      const double da = std::isfinite(ia->delta_z) ? std::abs(ia->delta_z) : std::numeric_limits<double>::max();
+      const double db = std::isfinite(ib->delta_z) ? std::abs(ib->delta_z) : std::numeric_limits<double>::max();
+      if (da != db) { return da < db;
+}
+      return a < b;
+    });
+    std::sort(by_collision.begin(), by_collision.end(), [this, &valid_candidates](short a, short b) {
+      const auto ia = std::find_if(valid_candidates.begin(), valid_candidates.end(), [a](const Candidate& c) { return c.crossing == a; });
+      const auto ib = std::find_if(valid_candidates.begin(), valid_candidates.end(), [b](const Candidate& c) { return c.crossing == b; });
+      const double da = std::isfinite(ia->tpc_z0) ? std::abs(ia->tpc_z0 - m_collisionZ) : std::numeric_limits<double>::max();
+      const double db = std::isfinite(ib->tpc_z0) ? std::abs(ib->tpc_z0 - m_collisionZ) : std::numeric_limits<double>::max();
+      if (da != db) { return da < db;
+}
+      return a < b;
+    });
+
+    for (TpcCrossingCandidate& qa : candidate_qa_records)
+    {
+      const auto iv = std::find(by_vertex.begin(), by_vertex.end(), qa.crossing);
+      if (iv != by_vertex.end()) { qa.candidate_rank_by_abs_delta_z = std::distance(by_vertex.begin(), iv);
+}
+      const auto ic = std::find(by_collision.begin(), by_collision.end(), qa.crossing);
+      if (ic != by_collision.end()) { qa.candidate_rank_by_abs_collision_z = std::distance(by_collision.begin(), ic);
+}
+      const auto iq = std::find_if(valid_candidates.begin(), valid_candidates.end(), [&qa](const Candidate& candidate) { return candidate.crossing == qa.crossing; });
+      if (iq != valid_candidates.end())
+      {
+        qa.confidence_tier = iq->confidence_tier;
+        qa.confidence_score = finite_float_or_nan(iq->confidence_score);
+        qa.tpc_valid = iq->tpc_valid;
+        if (!iq->tpc_valid && iq->rejection_status != 0U) { qa.rejection_status = iq->rejection_status;
+}
+      }
+      qa.is_selected = qa.crossing == decision->get_selected_crossing();
+      if (qa.is_selected)
+      {
+        qa.candidate_qa_bits |= IsSelected;
+        qa.first_failed_stage = static_cast<unsigned char>(TpcCrossingCandidateStage::Selected);
+      }
+      if (qa.candidate_rank_by_abs_delta_z == 0) { qa.candidate_qa_bits |= IsBestVertexCandidate;
+}
+    }
+
+    add_decision_with_candidates();
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << "::process_event - event " << m_event
+              << " assembled_tracks=" << nassembled
+              << " decisions=" << m_decisions->size()
+              << " available_crossings=" << available_crossings.size()
+              << " vertex_map=" << has_vertex_map
+              << std::endl;
+  }
+
+  ++m_event;
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/tpctrackreco/TpcCrossingFinder.h
+++ b/offline/packages/tpctrackreco/TpcCrossingFinder.h
@@ -1,0 +1,230 @@
+#ifndef TPCTRACKRECO_TPCCROSSINGFINDER_H
+#define TPCTRACKRECO_TPCCROSSINGFINDER_H
+
+
+#include <fun4all/SubsysReco.h>
+
+#include "TpcCrossingDecision.h"
+#include <trackbase/TrkrDefs.h>
+
+#include <array>
+#include <limits>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+class IdealPadMap;
+class PHCompositeNode;
+class PHGarfield;
+class PHG4TpcGeomContainer;
+class SvtxVertexMap;
+class Tpc_AssembledTrack;
+class Tpc_AssembledTrackContainer;
+class TpcCrossingDecisionContainerv1;
+class TrkrClusterContainer;
+class TrkrHitSetContainer;
+
+class TpcCrossingFinder : public SubsysReco
+{
+ public:
+  explicit TpcCrossingFinder(const std::string& name = "TpcCrossingFinder");
+  ~TpcCrossingFinder() override;
+
+  int InitRun(PHCompositeNode*) override;
+  int process_event(PHCompositeNode*) override;
+
+  static constexpr unsigned int NPhiSamples = 3;
+
+  void setInputNodeName(const std::string& n) { m_inputNodeName = n; }
+  void setOutputNodeName(const std::string& n) { m_outputNodeName = n; }
+  void setVertexMapNodeName(const std::string& n) { m_vertexMapNodeName = n; }
+  void setT0(double v) { m_t0 = v; }
+  void setTpcAdcClock(double v) { m_tpcAdcClock = v; }
+  void setCrossingPeriodNs(double v) { m_crossingPeriodNs = v; }
+  void setReverseDriftStepNs(double v) { m_reverseDriftStepNs = v; }
+  void setKEffSide0(double v) { m_kEffSide0 = v; }
+  void setKEffSide1(double v) { m_kEffSide1 = v; }
+  void setCMVoltageDefault(double v) { m_cmVoltageDefault = v; }
+  void setRequireSiliconVertex(bool v) { m_requireSiliconVertex = v; }
+  void setResolveAmbiguousWithoutVertex(bool v) { m_resolveAmbiguousWithoutVertex = v; }
+  void setPreferTriggeredCrossing(bool v) { m_preferTriggeredCrossing = v; }
+  void setTriggeredCrossing(short v) { m_triggeredCrossing = v; }
+  void setCollisionZ(double v) { m_collisionZ = v; }
+  void setMaxVertexDz(double v) { m_maxVertexDz = v; }
+  void setMaxTier2BeamlineZ(double v) { m_maxTier2BeamlineZ = v; }
+  void setMaxCandidateVertexZ(double v) { m_maxCandidateVertexZ = v; }
+  void setMinBestSecondSeparation(double v) { m_minBestSecondSeparation = v; }
+  void setTpcGeometryTolerance(double radial_cm, double z_cm, double central_membrane_cm)
+  {
+    m_radialTolerance = radial_cm;
+    m_zTolerance = z_cm;
+    m_centralMembraneTolerance = central_membrane_cm;
+  }
+  void setTpcHalfLength(double v) { m_tpcHalfLength = v; }
+  void setUseSurveyGeometry(bool v) { use_survey_geometry = v; }
+  void setMoveTpc(double x, double y, double z) { m_tpcMove = {{x, y, z}}; }
+  void setRotateTpc(unsigned int index, double x, double y, double z)
+  {
+    if (index < m_tpcRotations.size()) m_tpcRotations[index] = {{x, y, z}};
+  }
+  void setStartZ(double south_z, double north_z)
+  {
+    m_startZSouth = south_z;
+    m_startZNorth = north_z;
+  }
+
+ private:
+  struct DriftPoint
+  {
+    float delta_r {0.0F};
+    float delta_phi {0.0F};
+    float z {0.0F};
+  };
+
+  struct DriftPolyline
+  {
+    double phi {0.0};
+    std::vector<DriftPoint> points;
+  };
+
+  struct Point
+  {
+    TrkrDefs::hitsetkey hitsetkey {0};
+    TrkrDefs::hitkey hitkey {0};
+    unsigned int layer {0};
+    unsigned int side {0};
+    unsigned int pad {0};
+    unsigned int tbin {0};
+    double x {0.0};
+    double y {0.0};
+    double z {0.0};
+  };
+
+  struct SiliconVertexHypothesis
+  {
+    short crossing {0};
+    unsigned int vertex_id {0};
+    double x {0.0};
+    double y {0.0};
+    double z {0.0};
+    double sigma_z {0.0};
+    unsigned int ntracks {0};
+  };
+
+  struct ZFitResult
+  {
+    bool valid {false};
+    double slope {0.0};
+    double intercept {0.0};
+    double chi2 {0.0};
+    int ndf {-1};
+    double s_at_pca {0.0};
+    double minimum_radius {0.0};
+    double z_at_pca {0.0};
+    double z_at_r0 {0.0};
+    std::vector<Point> points;
+    std::vector<float> path_length;
+  };
+
+  struct Candidate
+  {
+    short crossing {0};
+    bool tpc_valid {false};
+    bool has_silicon_vertex {false};
+    bool vertex_compatible {false};
+    unsigned int silicon_vertex_id {0};
+    double tpc_z0 {0.0};
+    double silicon_vertex_z {0.0};
+    double delta_z {0.0};
+    unsigned char rejection_status {0};
+    unsigned char confidence_tier {std::numeric_limits<unsigned char>::max()};
+    double confidence_score {std::numeric_limits<double>::quiet_NaN()};
+    TpcCrossingCandidate qa;
+  };
+
+  int getNodes(PHCompositeNode*);
+  int createNodes(PHCompositeNode*);
+  void configure_garfield(PHGarfield* garfield) const;
+  bool build_drift_lookup();
+  bool sample_drift_lookup(unsigned int layer,
+                           unsigned int side,
+                           unsigned int pad,
+                           unsigned int tbin,
+                           short crossing,
+                           double& x,
+                           double& y,
+                           double& z) const;
+  bool make_xyz_point(TrkrDefs::hitsetkey hsk, TrkrDefs::hitkey hk, short crossing, Point& p) const;
+  bool find_time_extrema(const Tpc_AssembledTrack* track,
+                         TrkrDefs::hitsetkey& min_hsk,
+                         TrkrDefs::hitkey& min_hk,
+                         TrkrDefs::hitsetkey& max_hsk,
+                         TrkrDefs::hitkey& max_hk) const;
+  std::set<short> get_available_crossings() const;
+  std::set<short> get_intt_crossings() const;
+  std::map<short, std::vector<SiliconVertexHypothesis>> get_vertices_by_crossing() const;
+  std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> select_representatives(const Tpc_AssembledTrack* track,
+                                                                   TrkrDefs::hitsetkey min_hsk,
+                                                                   TrkrDefs::hitkey min_hk,
+                                                                   TrkrDefs::hitsetkey max_hsk,
+                                                                   TrkrDefs::hitkey max_hk) const;
+  bool estimate_tpc_z0(std::vector<Point>& points, double& z0) const;
+  ZFitResult estimate_tpc_z0_diagnostics(std::vector<Point> points) const;
+  bool point_in_tpc(const Point& p) const;
+  bool point_in_correct_side(const Point& p) const;
+  Candidate test_candidate(const Tpc_AssembledTrack* track,
+                           short crossing,
+                           TrkrDefs::hitsetkey min_hsk,
+                           TrkrDefs::hitkey min_hk,
+                           TrkrDefs::hitsetkey max_hsk,
+                           TrkrDefs::hitkey max_hk,
+                           const std::map<short, std::vector<SiliconVertexHypothesis>>& vertices_by_crossing) const;
+  static unsigned int drift_lookup_index(unsigned int layer_index, unsigned int side, unsigned int sector, unsigned int sample);
+
+  std::string m_inputNodeName {"TPC_ASSEMBLEDTRACKS"};
+  std::string m_outputNodeName {"TPC_CROSSING_DECISIONS"};
+  std::string m_vertexMapNodeName {"SvtxVertexMap"};
+
+  Tpc_AssembledTrackContainer* m_assembledTracks {nullptr};
+  TpcCrossingDecisionContainerv1* m_decisions {nullptr};
+  TrkrHitSetContainer* m_hits {nullptr};
+  TrkrClusterContainer* m_clusterMap {nullptr};
+  PHG4TpcGeomContainer* m_geomContainerTpc {nullptr};
+  SvtxVertexMap* m_vertexMap {nullptr};
+  IdealPadMap* m_idealPadMap {nullptr};
+  PHGarfield* m_garfield {nullptr};
+
+  std::array<DriftPolyline, 48 * 2 * 12 * NPhiSamples> m_driftLookup;
+  unsigned int m_event {0};
+  double m_maxLookupTimeNs {0.0};
+
+  double m_t0 {8};
+  double m_tpcAdcClock {56.881262};
+  double m_crossingPeriodNs {106.56};
+  double m_reverseDriftStepNs {56.881262};
+  double m_startZSouth {-102.325};
+  double m_startZNorth {102.325};
+  double m_tpcHalfLength {105.5};
+  double m_radialTolerance {2.0};
+  double m_zTolerance {1.0};
+  double m_centralMembraneTolerance {1.0};
+  double m_cmVoltageDefault {380.0};
+  double m_kEffSide0 {0.0};
+  double m_kEffSide1 {-1.5};
+  double m_maxVertexDz {2.0};
+  double m_minBestSecondSeparation {0.4};
+  double m_collisionZ {0.0};
+  double m_maxTier2BeamlineZ {40.0};
+  double m_maxCandidateVertexZ {20.0};
+  bool m_requireSiliconVertex {false};
+  bool m_resolveAmbiguousWithoutVertex {true};
+  bool m_preferTriggeredCrossing {false};
+  short m_triggeredCrossing {0};
+  bool use_survey_geometry {false};
+  std::array<double, 3> m_tpcMove {{0.0, 0.0, 0.0}};
+  std::array<std::array<double, 3>, 2> m_tpcRotations {{{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}}};
+};
+
+#endif  // TPCTRACKRECO_TPCCROSSINGFINDER_H

--- a/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
+++ b/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
@@ -1,0 +1,488 @@
+#include "TpcPolyClusterTrkrClusterConverter.h"
+
+#include "Tpc_PolyCluster.h"
+#include "Tpc_PolyClusterContainer.h"
+#include "Tpc_PolyTrack.h"
+#include "Tpc_PolyTrackContainer.h"
+#include "TpcCrossingDecision.h"
+#include "TpcCrossingDecisionContainer.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterContainerv4.h>
+#include <trackbase/TrkrClusterv5.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <tpc/TpcClusterMover.h>
+
+#include <g4detectors/PHG4TpcGeomContainer.h>
+
+#include <Acts/Definitions/Units.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace
+{
+  unsigned int adc_to_uint16(const double value)
+  {
+    if (!std::isfinite(value) || value <= 0.0) { return 0;
+}
+    return static_cast<unsigned int>(std::min(value, static_cast<double>(std::numeric_limits<unsigned short>::max())));
+  }
+
+  char size_to_char(const unsigned int value)
+  {
+    return static_cast<char>(std::min(value, 127U));
+  }
+
+  float finite_nonnegative_or_zero(const double value)
+  {
+    return std::isfinite(value) && value > 0.0 ? static_cast<float>(value) : 0.0F;
+  }
+}
+
+TpcPolyClusterTrkrClusterConverter::TpcPolyClusterTrkrClusterConverter(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+TpcPolyClusterTrkrClusterConverter::~TpcPolyClusterTrkrClusterConverter() = default;
+
+int TpcPolyClusterTrkrClusterConverter::InitRun(PHCompositeNode* topNode)
+{
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTRUN;
+}
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTRUN;
+}
+  if (!initializeClusterMover(topNode)) { return Fun4AllReturnCodes::ABORTRUN;
+}
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcPolyClusterTrkrClusterConverter::getNodes(PHCompositeNode* topNode)
+{
+  m_polyClusters = findNode::getClass<Tpc_PolyClusterContainer>(topNode, m_polyClusterNodeName);
+  if (!m_polyClusters)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_polyClusterNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_polyTracks = findNode::getClass<Tpc_PolyTrackContainer>(topNode, m_polyTrackNodeName);
+  if (!m_polyTracks)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_polyTrackNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_crossingDecisions = findNode::getClass<TpcCrossingDecisionContainer>(topNode, m_crossingDecisionNodeName);
+  if (!m_crossingDecisions)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_crossingDecisionNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!m_geometry)
+  {
+    std::cerr << Name() << "::getNodes - missing ActsGeometry" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_tpcGeomContainer = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  if (!m_tpcGeomContainer)
+  {
+    std::cerr << Name() << "::getNodes - missing TPCGEOMCONTAINER" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcPolyClusterTrkrClusterConverter::createNodes(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    dstNode = new PHCompositeNode("DST");
+    topNode->addNode(dstNode);
+  }
+
+  m_outputClusters = findNode::getClass<TrkrClusterContainer>(topNode, m_outputNodeName);
+  if (!m_outputClusters)
+  {
+    m_outputClusters = new TrkrClusterContainerv4();
+    PHIODataNode<PHObject>* node = new PHIODataNode<PHObject>(m_outputClusters, m_outputNodeName, "PHObject");
+    dstNode->addNode(node);
+    std::cout << Name() << "::createNodes - created " << m_outputNodeName << " node" << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void TpcPolyClusterTrkrClusterConverter::clearOutputTpcClusters()
+{
+  if (!m_outputClusters) { return;
+}
+
+  const auto hitsetkeys = m_outputClusters->getHitSetKeys(TrkrDefs::TrkrId::tpcId);
+  for (const auto hitsetkey : hitsetkeys)
+  {
+    m_outputClusters->removeClusters(hitsetkey);
+  }
+}
+
+void TpcPolyClusterTrkrClusterConverter::buildTrackMap()
+{
+  m_tracksBySourceId.clear();
+  if (!m_polyTracks) { return;
+}
+
+  for (unsigned int itrack = 0; itrack < m_polyTracks->size(); ++itrack)
+  {
+    const Tpc_PolyTrack* track = m_polyTracks->get_track(itrack);
+    if (!isAcceptedTrack(track)) { continue;
+}
+    m_tracksBySourceId[track->get_source_assembled_track_id()] = track;
+  }
+}
+
+bool TpcPolyClusterTrkrClusterConverter::isAcceptedTrack(const Tpc_PolyTrack* track) const
+{
+  if (!track || !track->isValid() || track->get_fit_status() == 0) { return false;
+}
+  if (track->get_nclusters() <= 20) { return false;
+}
+
+  const double pt = std::hypot(track->get_px(), track->get_py());
+  return std::isfinite(pt) && pt > 0.1;
+}
+
+bool TpcPolyClusterTrkrClusterConverter::initializeClusterMover(PHCompositeNode* topNode)
+{
+  if (!m_geometry || !m_tpcGeomContainer || !topNode) { return false;
+}
+
+  m_clusterMover = std::make_unique<TpcClusterMover>();
+  m_clusterMover->set_verbosity(Verbosity());
+  m_clusterMover->initialize_geometry(m_tpcGeomContainer, m_geometry, topNode);
+  return true;
+}
+
+TrkrDefs::cluskey TpcPolyClusterTrkrClusterConverter::getClusterKey(const Tpc_PolyCluster* cluster) const
+{
+  if (!cluster || cluster->size_hits() == 0) { return TrkrDefs::CLUSKEYMAX;
+}
+
+  const TrkrDefs::hitsetkey hitsetkey = cluster->get_hit_index(0).first;
+  TrkrDefs::cluskey cluskey = cluster->get_trkr_cluster_key();
+  const bool stored_key_is_tpc = cluskey != TrkrDefs::CLUSKEYMAX &&
+                                 static_cast<TrkrDefs::TrkrId>(TrkrDefs::getTrkrId(cluskey)) == TrkrDefs::TrkrId::tpcId &&
+                                 TrkrDefs::getHitSetKeyFromClusKey(cluskey) == hitsetkey;
+  if (!stored_key_is_tpc)
+  {
+    cluskey = TrkrDefs::genClusKey(hitsetkey, cluster->get_cluster_id());
+  }
+
+  return cluskey;
+}
+
+bool TpcPolyClusterTrkrClusterConverter::localFromMovedGlobal(const Tpc_PolyCluster* cluster,
+                                                              const TrkrDefs::cluskey cluskey,
+                                                              const std::array<double, 3>& moved_global,
+                                                              short crossing,
+                                                              float& local_x,
+                                                              float& local_y,
+                                                              unsigned short& subsurfkey,
+                                                              unsigned long long& surface_id) const
+{
+  if (!cluster || !m_geometry || cluster->size_hits() == 0) { return false;
+}
+
+  const TrkrDefs::hitsetkey hitsetkey = cluster->get_hit_index(0).first;
+  const Acts::Vector3 global(moved_global[0], moved_global[1], moved_global[2]);
+  if (!std::isfinite(global.x()) || !std::isfinite(global.y()) || !std::isfinite(global.z())) { return false;
+}
+
+  TrkrDefs::subsurfkey new_subsurfkey = 0;
+  Surface surface = m_geometry->get_tpc_surface_from_coords(hitsetkey, global, new_subsurfkey);
+  if (!surface)
+  {
+    const auto seed_iter = m_seedSubSurfKeys.find(cluskey);
+    if (seed_iter == m_seedSubSurfKeys.end()) { return false;
+}
+    new_subsurfkey = seed_iter->second;
+    surface = m_geometry->maps().getTpcSurface(hitsetkey, new_subsurfkey);
+  }
+  if (!surface) { return false;
+}
+  surface_id = surface->geometryId().value();
+
+  const auto& geo_context = m_geometry->geometry().getGeoContext();
+  Acts::Vector3 local = surface->localToGlobalTransform(geo_context).inverse() * (global * Acts::UnitConstants::cm);
+  local /= Acts::UnitConstants::cm;
+  const unsigned int side = TpcDefs::getSide(hitsetkey);
+  const double drift_velocity = m_geometry->get_drift_velocity();
+  if (drift_velocity <= 0.0 || !std::isfinite(drift_velocity)) { return false;
+}
+
+  const double half_drift = 0.5 * m_geometry->get_max_driftlength();
+  const double z_bunch_separation = m_crossingPeriodNs * drift_velocity;
+  const double zloc_uncorrected = (side == 0) ?
+      local.y() + static_cast<double>(crossing) * z_bunch_separation :
+      local.y() - static_cast<double>(crossing) * z_bunch_separation;
+  const double tuncorrected = (side == 0) ? (zloc_uncorrected + half_drift) / drift_velocity : (half_drift - zloc_uncorrected) / drift_velocity;
+  const double stored_t_uncorrected = tuncorrected - m_geometry->get_tpc_tzero() - m_geometry->get_sampa_tzero_bias();
+  if (!std::isfinite(stored_t_uncorrected)) { return false;
+}
+
+  local_x = static_cast<float>(local.x());
+  local_y = static_cast<float>(stored_t_uncorrected);
+  subsurfkey = new_subsurfkey;
+  return std::isfinite(local_x) && std::isfinite(local_y);
+}
+
+bool TpcPolyClusterTrkrClusterConverter::seedOutputCluster(const Tpc_PolyCluster* cluster, TrkrDefs::cluskey& cluskey)
+{
+  if (!cluster || !cluster->isValid() || !m_outputClusters) { return false;
+}
+  if (cluster->size_hits() == 0) { return false;
+}
+
+  const TrkrDefs::hitsetkey hitsetkey = cluster->get_hit_index(0).first;
+  if (static_cast<TrkrDefs::TrkrId>(TrkrDefs::getTrkrId(hitsetkey)) != TrkrDefs::TrkrId::tpcId) { return false;
+}
+
+  cluskey = getClusterKey(cluster);
+  if (static_cast<TrkrDefs::TrkrId>(TrkrDefs::getTrkrId(cluskey)) != TrkrDefs::TrkrId::tpcId) { return false;
+}
+
+  const Acts::Vector3 centroid(cluster->get_centroid_x(), cluster->get_centroid_y(), cluster->get_centroid_z());
+  if (!std::isfinite(centroid.x()) || !std::isfinite(centroid.y()) || !std::isfinite(centroid.z())) { return false;
+}
+
+  TrkrDefs::subsurfkey subsurfkey = 0;
+  Surface surface = m_geometry->get_tpc_surface_from_coords(hitsetkey, centroid, subsurfkey);
+  if (!surface)
+  {
+    subsurfkey = 0;
+  }
+  m_seedSubSurfKeys[cluskey] = subsurfkey;
+
+  auto out = std::make_unique<TrkrClusterv5>();
+  out->setSubSurfKey(subsurfkey);
+  out->setLocalX(0.0F);
+  out->setLocalY(0.0F);
+  m_outputClusters->addClusterSpecifyKey(cluskey, out.release());
+  return true;
+}
+
+void TpcPolyClusterTrkrClusterConverter::buildMovedClusterMap()
+{
+  m_movedGlobals.clear();
+  m_seedSubSurfKeys.clear();
+  if (!m_polyClusters || !m_clusterMover) { return;
+}
+
+  std::map<unsigned int, std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>> clusters_by_track;
+  for (unsigned int icluster = 0; icluster < m_polyClusters->size(); ++icluster)
+  {
+    const Tpc_PolyCluster* cluster = m_polyClusters->get_cluster(icluster);
+    if (!cluster || !cluster->isValid()) { continue;
+}
+
+    const auto track_iter = m_tracksBySourceId.find(cluster->get_source_assembled_track_id());
+    if (track_iter == m_tracksBySourceId.end()) { continue;
+}
+
+    TrkrDefs::cluskey cluskey = TrkrDefs::CLUSKEYMAX;
+    if (!seedOutputCluster(cluster, cluskey)) { continue;
+}
+
+    const Acts::Vector3 centroid(cluster->get_centroid_x(),
+                                 cluster->get_centroid_y(),
+                                 cluster->get_centroid_z());
+    m_movedGlobals[cluskey] = {{centroid.x(), centroid.y(), centroid.z()}};
+    clusters_by_track[track_iter->first].emplace_back(cluskey, centroid);
+  }
+
+  for (const auto& track_clusters : clusters_by_track)
+  {
+    const auto moved_globals = m_clusterMover->processTrack(track_clusters.second);
+    for (const auto& [cluskey, moved_global] : moved_globals)
+    {
+      m_movedGlobals[cluskey] = {{moved_global.x(), moved_global.y(), moved_global.z()}};
+    }
+  }
+
+  clearOutputTpcClusters();
+}
+
+bool TpcPolyClusterTrkrClusterConverter::publishCluster(const Tpc_PolyCluster* cluster,
+                                                        const Tpc_PolyTrack* track) const
+{
+  if (!cluster || !cluster->isValid() || !track || !m_outputClusters) { return false;
+}
+  if (cluster->size_hits() == 0) { return false;
+}
+
+  const TrkrDefs::hitsetkey hitsetkey = cluster->get_hit_index(0).first;
+  if (static_cast<TrkrDefs::TrkrId>(TrkrDefs::getTrkrId(hitsetkey)) != TrkrDefs::TrkrId::tpcId) { return false;
+}
+
+  const TrkrDefs::cluskey cluskey = getClusterKey(cluster);
+  if (static_cast<TrkrDefs::TrkrId>(TrkrDefs::getTrkrId(cluskey)) != TrkrDefs::TrkrId::tpcId) { return false;
+}
+
+  const auto moved_iter = m_movedGlobals.find(cluskey);
+  if (moved_iter == m_movedGlobals.end()) { return false;
+}
+
+  if (!m_crossingDecisions) { return false;
+}
+  const TpcCrossingDecision* crossing_decision =
+      m_crossingDecisions->get_decision(track->get_source_assembled_track_id());
+  if (!crossing_decision) { return false;
+}
+  const short crossing = crossing_decision->get_selected_crossing();
+
+  float local_x = std::numeric_limits<float>::quiet_NaN();
+  float local_y = std::numeric_limits<float>::quiet_NaN();
+  unsigned short subsurfkey = 0;
+  unsigned long long surface_id = 0;
+  if (!localFromMovedGlobal(cluster, cluskey, moved_iter->second, crossing, local_x, local_y, subsurfkey, surface_id))
+  {
+    return false;
+  }
+
+  auto out = std::make_unique<TrkrClusterv5>();
+  const unsigned int adc = adc_to_uint16(cluster->get_adc());
+  out->setAdc(adc);
+  out->setMaxAdc(static_cast<uint16_t>(adc));
+  out->setEdge(0);
+  out->setPhiSize(size_to_char(cluster->get_phi_width()));
+  out->setZSize(size_to_char(cluster->get_time_width()));
+  out->setSubSurfKey(subsurfkey);
+  out->setOverlap(0);
+  out->setLocalX(local_x);
+  out->setLocalY(local_y);
+  //out->setPhiError(0.002);
+  //out->setPhiError(0.002);
+  out->setPhiError(finite_nonnegative_or_zero(std::hypot(cluster->get_rms_x(), cluster->get_rms_y())));
+  out->setZError(finite_nonnegative_or_zero(std::fabs(cluster->get_rms_z())));
+
+  if (Verbosity() > 1)
+  {
+    const uint8_t sector = TpcDefs::getSectorId(hitsetkey);
+    const uint8_t side = TpcDefs::getSide(hitsetkey);
+    const uint8_t layer = TrkrDefs::getLayer(hitsetkey);
+    const Acts::Vector3 trkr_global = m_geometry ? m_geometry->getGlobalPosition(cluskey, out.get()) : Acts::Vector3(
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN());
+
+    std::cout << Name() << "::publishCluster"
+              << " track_id=" << track->get_track_id()
+              << " source_track=" << track->get_source_assembled_track_id()
+              << " crossing=" << crossing
+              << " poly_cluster=" << cluster->get_cluster_id()
+              << " hitsetkey=0x" << std::hex << hitsetkey
+              << " cluskey=0x" << cluskey
+              << " surface_id=0x" << surface_id << std::dec
+              << " sector=" << static_cast<unsigned int>(sector)
+              << " side=" << static_cast<unsigned int>(side)
+              << " layer=" << static_cast<unsigned int>(layer)
+              << " poly_pos=(" << cluster->get_centroid_x()
+              << ", " << cluster->get_centroid_y()
+              << ", " << cluster->get_centroid_z() << ")"
+              << " moved_global=(" << moved_iter->second[0]
+              << ", " << moved_iter->second[1]
+              << ", " << moved_iter->second[2] << ")"
+              << " trkr_local=(rphi,stored_t)=(" << out->getLocalX()
+              << ", " << out->getLocalY() << ")"
+              << " subsurfkey=" << static_cast<unsigned int>(out->getSubSurfKey())
+              << " adc=" << out->getAdc()
+              << " max_adc=" << out->getMaxAdc()
+              << " phisize=" << out->getPhiSize()
+              << " zsize=" << out->getZSize()
+              << " edge=" << static_cast<unsigned int>(out->getEdge())
+              << " overlap=" << static_cast<unsigned int>(out->getOverlap())
+              << " phi_error=" << out->getRPhiError()
+              << " z_error=" << out->getZError()
+              << " trkr_global=(" << trkr_global.x()
+              << ", " << trkr_global.y()
+              << ", " << trkr_global.z() << ")"
+              << " dz_check=" << trkr_global.z() - moved_iter->second[2]
+              << std::endl;
+  }
+
+  m_outputClusters->addClusterSpecifyKey(cluskey, out.release());
+  return true;
+}
+
+int TpcPolyClusterTrkrClusterConverter::process_event(PHCompositeNode* topNode)
+{
+  if (!m_polyClusters || !m_polyTracks || !m_outputClusters || !m_crossingDecisions || !m_geometry || !m_tpcGeomContainer || !m_clusterMover)
+  {
+    if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK ||
+        createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK ||
+        !initializeClusterMover(topNode))
+    {
+      return Fun4AllReturnCodes::EVENT_OK;
+    }
+  }
+
+  clearOutputTpcClusters();
+  buildTrackMap();
+  buildMovedClusterMap();
+
+  unsigned int nconverted = 0;
+  unsigned int nmissingTrack = 0;
+  unsigned int nfailed = 0;
+  for (unsigned int icluster = 0; icluster < m_polyClusters->size(); ++icluster)
+  {
+    const Tpc_PolyCluster* cluster = m_polyClusters->get_cluster(icluster);
+    if (!cluster || !cluster->isValid()) { continue;
+}
+
+    const auto track_iter = m_tracksBySourceId.find(cluster->get_source_assembled_track_id());
+    if (track_iter == m_tracksBySourceId.end())
+    {
+      ++nmissingTrack;
+      continue;
+    }
+
+    if (publishCluster(cluster, track_iter->second)) { ++nconverted;
+    } else { ++nfailed;
+}
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << "::process_event - poly_clusters=" << m_polyClusters->size()
+              << " converted=" << nconverted
+              << " missing_track=" << nmissingTrack
+              << " failed=" << nfailed << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.h
+++ b/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <fun4all/SubsysReco.h>
+
+#include <trackbase/TrkrDefs.h>
+
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+
+class ActsGeometry;
+class PHG4TpcGeomContainer;
+class PHCompositeNode;
+class TpcClusterMover;
+class TpcCrossingDecisionContainer;
+class Tpc_PolyCluster;
+class Tpc_PolyClusterContainer;
+class Tpc_PolyTrack;
+class Tpc_PolyTrackContainer;
+class TrkrClusterContainer;
+
+class TpcPolyClusterTrkrClusterConverter : public SubsysReco
+{
+ public:
+  explicit TpcPolyClusterTrkrClusterConverter(const std::string& name = "TpcPolyClusterTrkrClusterConverter");
+  ~TpcPolyClusterTrkrClusterConverter() override;
+
+  int InitRun(PHCompositeNode*) override;
+  int process_event(PHCompositeNode*) override;
+
+  void setPolyClusterNodeName(const std::string& name) { m_polyClusterNodeName = name; }
+  void setPolyTrackNodeName(const std::string& name) { m_polyTrackNodeName = name; }
+  void setOutputNodeName(const std::string& name) { m_outputNodeName = name; }
+  void setCrossingDecisionNodeName(const std::string& name) { m_crossingDecisionNodeName = name; }
+  void setCrossingPeriodNs(double value) { m_crossingPeriodNs = value; }
+  void setMagneticFieldTesla(double value) { m_magneticFieldTesla = value; }
+
+ private:
+  int getNodes(PHCompositeNode*);
+  int createNodes(PHCompositeNode*);
+  void clearOutputTpcClusters();
+  void buildTrackMap();
+  bool isAcceptedTrack(const Tpc_PolyTrack* track) const;
+  bool initializeClusterMover(PHCompositeNode* topNode);
+  TrkrDefs::cluskey getClusterKey(const Tpc_PolyCluster* cluster) const;
+  bool seedOutputCluster(const Tpc_PolyCluster* cluster, TrkrDefs::cluskey& cluskey);
+  void buildMovedClusterMap();
+  bool localFromMovedGlobal(const Tpc_PolyCluster* cluster, TrkrDefs::cluskey cluskey, const std::array<double, 3>& moved_global,
+                            short crossing, float& local_x, float& local_y, unsigned short& subsurfkey,
+                            unsigned long long& surface_id) const;
+  bool publishCluster(const Tpc_PolyCluster* cluster, const Tpc_PolyTrack* track) const;
+
+  std::string m_polyClusterNodeName {"TPC_POLYCLUSTERS"};
+  std::string m_polyTrackNodeName {"TPC_POLYTRACKS"};
+  std::string m_outputNodeName {"TRKR_CLUSTER"};
+  std::string m_crossingDecisionNodeName {"TPC_CROSSING_DECISIONS"};
+
+  Tpc_PolyClusterContainer* m_polyClusters {nullptr};
+  Tpc_PolyTrackContainer* m_polyTracks {nullptr};
+  TrkrClusterContainer* m_outputClusters {nullptr};
+  TpcCrossingDecisionContainer* m_crossingDecisions {nullptr};
+  ActsGeometry* m_geometry {nullptr};
+  PHG4TpcGeomContainer* m_tpcGeomContainer {nullptr};
+  std::unique_ptr<TpcClusterMover> m_clusterMover;
+  std::map<unsigned int, const Tpc_PolyTrack*> m_tracksBySourceId;
+  std::map<TrkrDefs::cluskey, std::array<double, 3>> m_movedGlobals;
+  std::map<TrkrDefs::cluskey, unsigned short> m_seedSubSurfKeys;
+  double m_crossingPeriodNs {106.56};
+  double m_magneticFieldTesla {1.4};
+};

--- a/offline/packages/tpctrackreco/TpcPolyTrackSeedConverter.cc
+++ b/offline/packages/tpctrackreco/TpcPolyTrackSeedConverter.cc
@@ -1,0 +1,245 @@
+#include "TpcPolyTrackSeedConverter.h"
+
+#include "Tpc_PolyTrack.h"
+#include "Tpc_PolyTrackContainer.h"
+#include "TpcCrossingDecision.h"
+#include "TpcCrossingDecisionContainer.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/SvtxTrackSeed_v2.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/TrackSeedHelper.h>
+#include <trackbase_historic/TrackSeed_v2.h>
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+TpcPolyTrackSeedConverter::TpcPolyTrackSeedConverter(const std::string& name)
+  : SubsysReco(name)
+  , m_inputNodeName("TPC_POLYTRACKS")
+  , m_outputNodeName("TpcTrackSeedContainer")
+{
+}
+
+int TpcPolyTrackSeedConverter::InitRun(PHCompositeNode* topNode)
+{
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTRUN;
+}
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK) { return Fun4AllReturnCodes::ABORTRUN;
+}
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcPolyTrackSeedConverter::getNodes(PHCompositeNode* topNode)
+{
+  m_polyTracks = findNode::getClass<Tpc_PolyTrackContainer>(topNode, m_inputNodeName);
+  if (!m_polyTracks)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_inputNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_crossingDecisions = findNode::getClass<TpcCrossingDecisionContainer>(topNode, m_crossingDecisionNodeName);
+  if (!m_crossingDecisions)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_crossingDecisionNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!m_geometry)
+  {
+    std::cerr << Name() << "::getNodes - missing ActsGeometry" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TpcPolyTrackSeedConverter::createNodes(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    dstNode = new PHCompositeNode("DST");
+    topNode->addNode(dstNode);
+  }
+
+  PHNodeIterator dstIter(dstNode);
+  PHCompositeNode* svtxNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode", "SVTX"));
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+  m_trackSeeds = findNode::getClass<TrackSeedContainer>(topNode, m_outputNodeName);
+  if (!m_trackSeeds)
+  {
+    m_trackSeeds = new TrackSeedContainer_v1();
+    PHIODataNode<PHObject>* node = new PHIODataNode<PHObject>(m_trackSeeds, m_outputNodeName, "PHObject");
+    svtxNode->addNode(node);
+    std::cout << Name() << "::createNodes - created " << m_outputNodeName << " node" << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+bool TpcPolyTrackSeedConverter::isValidTrack(const Tpc_PolyTrack* track) const
+{
+  if (!track || track->get_fit_status() == 0) { return false;
+}
+  if (track->size_cluster_keys() == 0) { return false;
+}
+  if (track->get_nclusters() != track->size_cluster_keys()) { return false;
+}
+  if (track->get_nclusters() <= 20) { return false;
+}
+
+  const double pt = std::hypot(track->get_px(), track->get_py());
+  if (!std::isfinite(pt) || pt <= 0.1) { return false;
+}
+
+  for (unsigned int i = 0; i < track->size_cluster_keys(); ++i)
+  {
+    if (track->get_cluster_key(i) == TrkrDefs::CLUSKEYMAX) { return false;
+}
+  }
+
+  return std::isfinite(track->get_seed_x0()) &&
+         std::isfinite(track->get_seed_y0()) &&
+         std::isfinite(track->get_seed_z0()) &&
+         std::isfinite(track->get_seed_phi()) &&
+         std::isfinite(track->get_seed_slope()) &&
+         std::isfinite(track->get_seed_q_over_r()) &&
+         std::fabs(track->get_seed_q_over_r()) > 0.0;
+}
+
+bool TpcPolyTrackSeedConverter::publishSeed(const Tpc_PolyTrack* track) const
+{
+  if (!track || !m_crossingDecisions || !m_geometry || !m_trackSeeds) { return false;
+}
+
+  const TpcCrossingDecision* crossing_decision =
+      m_crossingDecisions->get_decision(track->get_source_assembled_track_id());
+  if (!crossing_decision) { return false;
+}
+
+  const short crossing = crossing_decision->get_selected_crossing();
+  const double drift_velocity = m_geometry->get_drift_velocity();
+  if (drift_velocity <= 0.0 || !std::isfinite(drift_velocity)) { return false;
+}
+
+  unsigned int side = 2;
+  for (unsigned int i = 0; i < track->size_cluster_keys(); ++i)
+  {
+    const TrkrDefs::cluskey cluster_key = track->get_cluster_key(i);
+    if (TrkrDefs::getTrkrId(cluster_key) != TrkrDefs::tpcId) { continue;
+}
+    side = TpcDefs::getSide(cluster_key);
+    break;
+  }
+  if (side > 1) { return false;
+}
+
+  const double z_bunch_separation = m_crossingPeriodNs * drift_velocity;
+  const double z0_uncorrected = (side == 0) ?
+      track->get_seed_z0() + static_cast<double>(crossing) * z_bunch_separation :
+      track->get_seed_z0() - static_cast<double>(crossing) * z_bunch_separation;
+  if (!std::isfinite(z0_uncorrected)) { return false;
+}
+
+  const double q_over_r = track->get_seed_q_over_r();
+  const double helix_radius = std::fabs(1.0 / q_over_r);
+  const double helix_sign = q_over_r > 0.0 ? 1.0 : -1.0;
+  const double helix_center_x = track->get_seed_x0() - helix_sign * helix_radius * std::sin(track->get_seed_phi());
+  const double helix_center_y = track->get_seed_y0() + helix_sign * helix_radius * std::cos(track->get_seed_phi());
+  if (!std::isfinite(helix_center_x) || !std::isfinite(helix_center_y)) { return false;
+}
+
+  auto seed = std::make_unique<TrackSeed_v2>();
+  seed->set_X0(static_cast<float>(helix_center_x));
+  seed->set_Y0(static_cast<float>(helix_center_y));
+  seed->set_Z0(static_cast<float>(z0_uncorrected));
+  seed->set_phi(static_cast<float>(track->get_seed_phi()));
+  seed->set_slope(static_cast<float>(track->get_seed_slope()));
+  seed->set_qOverR(static_cast<float>(q_over_r));
+  seed->set_crossing(crossing);
+
+  for (unsigned int i = 0; i < track->size_cluster_keys(); ++i)
+  {
+    seed->insert_cluster_key(track->get_cluster_key(i));
+  }
+
+  const auto* converted_seed = m_trackSeeds->insert(seed.get());
+
+  if (Verbosity() > 1 && converted_seed)
+  {
+    std::cout << Name() << "::publishSeed"
+              << " track_id=" << track->get_track_id()
+              << " source_track=" << track->get_source_assembled_track_id()
+              << " crossing=" << crossing
+              << " side=" << side
+              << " drift_velocity=" << drift_velocity
+              << " helix_radius=" << helix_radius
+              << " poly_seed=(x0=" << track->get_seed_x0()
+              << ", y0=" << track->get_seed_y0()
+              << ", z0=" << track->get_seed_z0()
+              << ", phi=" << track->get_seed_phi()
+              << ", slope=" << track->get_seed_slope()
+              << ", qOverR=" << track->get_seed_q_over_r() << ")"
+              << " converted_seed=(x0=" << converted_seed->get_X0()
+              << ", y0=" << converted_seed->get_Y0()
+              << ", z0=" << converted_seed->get_Z0()
+              << ", phi=" << converted_seed->get_phi()
+              << ", slope=" << converted_seed->get_slope()
+              << ", qOverR=" << converted_seed->get_qOverR() << ")"
+              << " ncluster_keys=" << track->size_cluster_keys()
+              << std::endl;
+  }
+
+  return converted_seed != nullptr;
+}
+
+int TpcPolyTrackSeedConverter::process_event(PHCompositeNode* topNode)
+{
+  if (!m_polyTracks || !m_trackSeeds || !m_crossingDecisions || !m_geometry)
+  {
+    if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK ||
+        createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    {
+      return Fun4AllReturnCodes::EVENT_OK;
+    }
+  }
+
+  m_trackSeeds->Reset();
+
+  unsigned int naccepted = 0;
+  for (unsigned int itrack = 0; itrack < m_polyTracks->size(); ++itrack)
+  {
+    const Tpc_PolyTrack* track = m_polyTracks->get_track(itrack);
+    if (!isValidTrack(track)) { continue;
+}
+    if (publishSeed(track)) { ++naccepted;
+}
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << "::process_event - poly_tracks=" << m_polyTracks->size()
+              << " tpc_seeds=" << naccepted << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/tpctrackreco/TpcPolyTrackSeedConverter.h
+++ b/offline/packages/tpctrackreco/TpcPolyTrackSeedConverter.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+class Tpc_PolyTrack;
+class Tpc_PolyTrackContainer;
+class TpcCrossingDecisionContainer;
+class ActsGeometry;
+class TrackSeedContainer;
+
+class TpcPolyTrackSeedConverter : public SubsysReco
+{
+ public:
+  explicit TpcPolyTrackSeedConverter(const std::string& name = "TpcPolyTrackSeedConverter");
+  ~TpcPolyTrackSeedConverter() override = default;
+
+  int InitRun(PHCompositeNode*) override;
+  int process_event(PHCompositeNode*) override;
+
+  void setInputNodeName(const std::string& name) { m_inputNodeName = name; }
+  void setOutputNodeName(const std::string& name) { m_outputNodeName = name; }
+  void setCrossingDecisionNodeName(const std::string& name) { m_crossingDecisionNodeName = name; }
+  void setCrossingPeriodNs(double value) { m_crossingPeriodNs = value; }
+
+ private:
+  int getNodes(PHCompositeNode*);
+  int createNodes(PHCompositeNode*);
+  bool isValidTrack(const Tpc_PolyTrack*) const;
+  bool publishSeed(const Tpc_PolyTrack*) const;
+
+  std::string m_inputNodeName;
+  std::string m_outputNodeName;
+  std::string m_crossingDecisionNodeName {"TPC_CROSSING_DECISIONS"};
+  Tpc_PolyTrackContainer* m_polyTracks {nullptr};
+  TpcCrossingDecisionContainer* m_crossingDecisions {nullptr};
+  ActsGeometry* m_geometry {nullptr};
+  TrackSeedContainer* m_trackSeeds {nullptr};
+  double m_crossingPeriodNs {106.56};
+};

--- a/offline/packages/tpctrackreco/Tpc_FittingTools.cc
+++ b/offline/packages/tpctrackreco/Tpc_FittingTools.cc
@@ -649,6 +649,8 @@ bool Tpc_FittingTools::fit(const std::vector<Point>& points, FitResult& fit)
   const double ry = py - yc;
   const double tx = -sign * ry / R;
   const double ty = sign * rx / R;
+  fit.cx = xc;
+  fit.cy = yc;
   fit.phi0 = wrap_pi(std::atan2(ty, tx));
 
   const double phi_perigee = std::atan2(ry, rx);

--- a/offline/packages/tpctrackreco/Tpc_FittingTools.h
+++ b/offline/packages/tpctrackreco/Tpc_FittingTools.h
@@ -60,6 +60,8 @@ class Tpc_FittingTools
   {
     bool ok{false};
     bool is_line{false};
+    double cx{0.0};
+    double cy{0.0};
     double d0{0.0};
     double z0{0.0};
     double phi0{0.0};

--- a/offline/packages/tpctrackreco/Tpc_PolyCluster.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyCluster.h
@@ -69,6 +69,9 @@ class Tpc_PolyCluster : public PHObject
     return empty_indices;
   }
 
+  virtual TrkrDefs::cluskey get_trkr_cluster_key() const { return TrkrDefs::CLUSKEYMAX; }
+  virtual void set_trkr_cluster_key(TrkrDefs::cluskey) {}
+
  private:
   ClassDefOverride(Tpc_PolyCluster, 0)
 };

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
@@ -5,6 +5,8 @@
 #include "Tpc_AssembledTrackContainer.h"
 #include "Tpc_PolyClusterContainerv1.h"
 #include "Tpc_PolyClusterv1.h"
+#include "TpcCrossingDecision.h"
+#include "TpcCrossingDecisionContainer.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -19,6 +21,13 @@
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
+
+#include <trackbase/ActsGeometry.h>
+#include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <g4detectors/PHG4TpcGeom.h>
+#include <g4detectors/PHG4TpcGeomContainer.h>
+
 
 #include <TPolyLine3D.h>
 #include <phgarfield/PHGarfield.h>
@@ -72,6 +81,11 @@ namespace
     return std::max(0.0, std::min(1.0, value));
   }
 
+  double square(const double value)
+  {
+    return value * value;
+  }
+
   double phi_sample_fraction(const unsigned int sample)
   {
     if (Tpc_PolyClusterizer::NPhiSamples <= 1U)
@@ -114,6 +128,19 @@ int Tpc_PolyClusterizer::InitRun(PHCompositeNode* topNode)
   {
     std::cerr << Name() << "::InitRun - failed to load IdealPadMap" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  PHG4TpcGeom *layergeom = m_geomContainerTpc->GetLayerCellGeom(20); 
+  double rot_x = layergeom->get_rot_x();
+  double rot_y = layergeom->get_rot_y();
+  double rot_z = layergeom->get_rot_z();
+  double place_x = layergeom->get_place_x();
+  double place_y = layergeom->get_place_y();
+  double place_z = layergeom->get_place_z();
+  if (use_survey_geometry) 
+  {
+    m_tpcMove = {place_x, place_y, place_z};
+    m_tpcRotations = {{{rot_x, rot_y, rot_z}, {0.0, 0.0, 0.0}}};
   }
 
   delete m_garfield;
@@ -167,6 +194,20 @@ int Tpc_PolyClusterizer::getNodes(PHCompositeNode* topNode)
   if (!m_hits)
   {
     std::cerr << Name() << "::getNodes - missing TRKR_HITSET" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_crossingDecisions = findNode::getClass<TpcCrossingDecisionContainer>(topNode, m_crossingDecisionNodeName);
+  if (!m_crossingDecisions)
+  {
+    std::cerr << Name() << "::getNodes - missing " << m_crossingDecisionNodeName << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_geomContainerTpc = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  if (!m_geomContainerTpc)
+  {
+    std::cerr << Name() << "::getNodes - missing TPCGEOMCONTAINER" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -379,6 +420,7 @@ bool Tpc_PolyClusterizer::sample_drift_lookup(const unsigned int layer,
                                               const unsigned int side,
                                               const unsigned int pad,
                                               const unsigned int tbin,
+                                              const short crossing,
                                               double& x,
                                               double& y,
                                               double& z) const
@@ -419,8 +461,7 @@ bool Tpc_PolyClusterizer::sample_drift_lookup(const unsigned int layer,
     return false;
   }
 
-  const double corrected_tbin = static_cast<double>(tbin) - m_t0;
-  const double target_time_ns = corrected_tbin * m_tpcAdcClock;
+  const double target_time_ns = (static_cast<double>(tbin) - m_t0) * m_tpcAdcClock - static_cast<double>(crossing) * m_crossingPeriodNs;
   if (target_time_ns <= 0.0 || !std::isfinite(target_time_ns))
   {
     return false;
@@ -585,6 +626,7 @@ bool Tpc_PolyClusterizer::sample_drift_lookup(const unsigned int layer,
 
 bool Tpc_PolyClusterizer::make_xyz_point(TrkrDefs::hitsetkey hsk,
                                          TrkrDefs::hitkey hk,
+                                         const short crossing,
                                          Point& p) const
 {
   if (!m_hits || !m_idealPadMap)
@@ -612,7 +654,7 @@ bool Tpc_PolyClusterizer::make_xyz_point(TrkrDefs::hitsetkey hsk,
   double x = 0.0;
   double y = 0.0;
   double z = 0.0;
-  if (!sample_drift_lookup(layer, hit_side, pad, tbin, x, y, z))
+  if (!sample_drift_lookup(layer, hit_side, pad, tbin, crossing, x, y, z))
   {
     return false;
   }
@@ -723,16 +765,21 @@ Tpc_PolyClusterizer::make_centroid(const std::vector<Point>& points)
   return c;
 }
 
-int Tpc_PolyClusterizer::process_event(PHCompositeNode* /*unused*/)
+int Tpc_PolyClusterizer::process_event(PHCompositeNode* topNode)
 {
-  if (!m_assembledTracks || !m_clusters || !m_garfield)
+  if (!m_assembledTracks || !m_clusters || !m_crossingDecisions || !m_garfield) { return Fun4AllReturnCodes::EVENT_OK;
+}
+
+  ActsGeometry* tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!tGeometry)
   {
-    return Fun4AllReturnCodes::EVENT_OK;
+    std::cerr << Name() << "::process_event - missing ActsGeometry, using RMS fallback for errors" << std::endl;
   }
   m_clusters->Reset();
 
   const unsigned int nassembled = m_assembledTracks->size();
   unsigned int nclusters = 0;
+  std::map<TrkrDefs::hitsetkey, unsigned int> next_cluster_index_by_hitset;
 
   for (int side = 0; side < 2; ++side)
   {
@@ -741,69 +788,127 @@ int Tpc_PolyClusterizer::process_event(PHCompositeNode* /*unused*/)
       for (unsigned int iassembled = 0; iassembled < nassembled; ++iassembled)
       {
         const Tpc_AssembledTrack* assembled = m_assembledTracks->get_track(iassembled);
-        if (!assembled)
-        {
-          continue;
-        }
-        if (assembled->get_side() != side)
-        {
-          continue;
-        }
-        if (assembled->get_first_sector() % 12U != sector)
-        {
-          continue;
-        }
+        if (!assembled) { continue;
+}
+        if (assembled->get_side() != side) { continue;
+}
+        if (assembled->get_first_sector() % 12U != sector) { continue;
+}
+        const TpcCrossingDecision* crossing_decision = m_crossingDecisions->get_decision(assembled->get_track_id());
+        if (!crossing_decision) { continue;
+}
+        const unsigned char selected_tier = crossing_decision->get_selected_tier();
+        if (selected_tier > m_maxAcceptedTier) { continue;
+}
+        const short selected_crossing = crossing_decision->get_selected_crossing();
 
-        std::map<unsigned int, std::vector<Point>> points_by_layer;
+
+        std::map<TrkrDefs::hitsetkey, std::vector<Point>> points_by_hitset;
         for (unsigned int ih = 0; ih < assembled->size_hit_indices(); ++ih)
         {
           const Tpc_AssembledTrack::HitIndex hi = assembled->get_hit_index(ih);
-          if (TpcDefs::getSide(hi.first) != static_cast<unsigned int>(side))
-          {
-            continue;
-          }
+          if (TpcDefs::getSide(hi.first) != static_cast<unsigned int>(side)) { continue;
+}
 
           Point p;
-          if (make_xyz_point(hi.first, hi.second, p))
-          {
-            points_by_layer[p.layer].push_back(p);
-          }
+          if (make_xyz_point(hi.first, hi.second, selected_crossing, p)) { points_by_hitset[p.hitsetkey].push_back(p);
+}
         }
-        if (points_by_layer.empty())
-        {
-          continue;
-        }
+        if (points_by_hitset.empty()) { continue;
+}
 
-        for (const auto& layer_points : points_by_layer)
+        for (const auto& hitset_points : points_by_hitset)
         {
-          const std::vector<Point>& points = layer_points.second;
+          const TrkrDefs::hitsetkey cluster_hitsetkey = hitset_points.first;
+          const std::vector<Point>& points = hitset_points.second;
           const Centroid centroid = make_centroid(points);
-          if (!centroid.ok)
-          {
-            continue;
-          }
+          if (!centroid.ok) { continue;
+}
+
+          const unsigned int cluster_index = next_cluster_index_by_hitset[cluster_hitsetkey]++;
+          const TrkrDefs::cluskey trkr_cluster_key = TrkrDefs::genClusKey(cluster_hitsetkey, cluster_index);
 
           Tpc_PolyClusterv1* out = new Tpc_PolyClusterv1();
           out->set_event(m_event);
           out->set_cluster_id(m_clusters->size());
           out->set_source_assembled_track_id(assembled->get_track_id());
+          out->set_trkr_cluster_key(trkr_cluster_key);
           out->set_side(side);
           out->set_centroid_x(centroid.x);
           out->set_centroid_y(centroid.y);
           out->set_centroid_z(centroid.z);
-          out->set_rms_x(centroid.rms_x);
-          out->set_rms_y(centroid.rms_y);
-          out->set_rms_z(centroid.rms_z);
+
+          double phi_error = std::hypot(centroid.rms_x, centroid.rms_y);
+          double z_error = std::fabs(centroid.rms_z);
+          PHG4TpcGeom* layergeom = m_geomContainerTpc ? m_geomContainerTpc->GetLayerCellGeom(centroid.layer) : nullptr;
+          if (layergeom && tGeometry)
+          {
+            double adc_sum = 0.0;
+            double iphi_sum = 0.0;
+            double iphi2_sum = 0.0;
+            double t_sum = 0.0;
+            double t2_sum = 0.0;
+            int phibinhi = -1;
+            int phibinlo = std::numeric_limits<int>::max();
+            int tbinhi = -1;
+            int tbinlo = std::numeric_limits<int>::max();
+
+            for (const Point& p : points)
+            {
+              if (p.adc <= 0.0) { continue;
+}
+
+              const int iphi = static_cast<int>(p.pad);
+              const int it = static_cast<int>(p.tbin);
+              const double adc = p.adc;
+              phibinhi = std::max(iphi, phibinhi);
+              phibinlo = std::min(iphi, phibinlo);
+              tbinhi = std::max(it, tbinhi);
+              tbinlo = std::min(it, tbinlo);
+
+              iphi_sum += static_cast<double>(iphi) * adc;
+              iphi2_sum += square(static_cast<double>(iphi)) * adc;
+
+              const double t = layergeom->get_zcenter(it);
+              t_sum += t * adc;
+              t2_sum += square(t) * adc;
+              adc_sum += adc;
+            }
+
+            const double drift_velocity = tGeometry->get_drift_velocity();
+            if (adc_sum > 0.0 && std::isfinite(drift_velocity))
+            {
+              const double radius = layergeom->get_radius();
+              const double clusiphi = iphi_sum / adc_sum;
+              const double clust = t_sum / adc_sum;
+              const double phi_cov = std::max(0.0, (iphi2_sum / adc_sum - square(clusiphi)) * square(layergeom->get_phistep()));
+              const double t_cov = std::max(0.0, t2_sum / adc_sum - square(clust));
+              const double phi_err_square = (phibinhi == phibinlo) ?
+                  9.0 * (square(radius * layergeom->get_phistep()) / 12.0) :
+                  square(radius) * phi_cov / (adc_sum * 0.14);
+              const double t_err_square = (tbinhi == tbinlo) ?
+                  9.0 * (square(layergeom->get_zstep()) / 12.0) :
+                  t_cov / (adc_sum * 0.14);
+
+              if (phi_err_square >= 0.0 && std::isfinite(phi_err_square)) { phi_error = std::sqrt(phi_err_square);
+}
+              const double z_err_square = t_err_square * square(drift_velocity);
+              if (z_err_square >= 0.0 && std::isfinite(z_err_square)) { z_error = std::sqrt(z_err_square);
+}
+            }
+          }
+
+          out->set_rms_x(phi_error);
+          out->set_rms_y(0.0);
+          out->set_rms_z(z_error);
 
           const ClusterParameters params = make_cluster_parameters(points, centroid, static_cast<int>(points.front().side));
           out->set_adc(params.adc);
           out->set_phi_width(params.phi_width);
           out->set_time_width(params.time_width);
           out->set_phase(params.phase);
-          for (const Point& p : points)
-          {
-            out->add_hit(p.hitsetkey, p.hitkey, p.x, p.y, p.z);
-          }
+          for (const Point& p : points) { out->add_hit(p.hitsetkey, p.hitkey, p.x, p.y, p.z);
+}
           if (out->size_hits() == 0)
           {
             delete out;

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
@@ -15,7 +15,10 @@ class IdealPadMap;
 class PHCompositeNode;
 class PHGarfield;
 class Tpc_PolyClusterContainer;
+class TpcCrossingDecisionContainer;
 class TrkrHitSetContainer;
+class PHG4CylinderGeomContainer;
+class PHG4TpcGeomContainer;
 
 class Tpc_PolyClusterizer : public SubsysReco
 {
@@ -30,12 +33,16 @@ class Tpc_PolyClusterizer : public SubsysReco
 
   void setInputNodeName(const std::string& n) { m_inputNodeName = n; }
   void setOutputNodeName(const std::string& n) { m_outputNodeName = n; }
+  void setCrossingDecisionNodeName(const std::string& n) { m_crossingDecisionNodeName = n; }
+  void setMaxAcceptedTier(unsigned char v) { m_maxAcceptedTier = v; }
   void setT0(double v) { m_t0 = v; }
   void setTpcAdcClock(double v) { m_tpcAdcClock = v; }
+  void setCrossingPeriodNs(double v) { m_crossingPeriodNs = v; }
   void setReverseDriftStepNs(double v) { m_reverseDriftStepNs = v; }
   void setKEffSide0(double v) { m_kEffSide0 = v; }
   void setKEffSide1(double v) { m_kEffSide1 = v; }
   void setCMVoltageDefault(double v) { m_cmVoltageDefault = v; }
+  void setUseSurveyGeometry(bool v) { use_survey_geometry = v; }
   void setMoveTpc(double x, double y, double z) { m_tpcMove = {{x, y, z}}; }
   void setRotateTpc(unsigned int index, double x, double y, double z)
   {
@@ -97,12 +104,13 @@ class Tpc_PolyClusterizer : public SubsysReco
 
   int getNodes(PHCompositeNode*);
   int createNodes(PHCompositeNode*);
-  bool make_xyz_point(TrkrDefs::hitsetkey hsk, TrkrDefs::hitkey hk, Point& p) const;
+  bool make_xyz_point(TrkrDefs::hitsetkey hsk, TrkrDefs::hitkey hk, short crossing, Point& p) const;
   bool build_drift_lookup();
   bool sample_drift_lookup(unsigned int layer,
                            unsigned int side,
                            unsigned int pad,
                            unsigned int tbin,
+                           short crossing,
                            double& x,
                            double& y,
                            double& z) const;
@@ -112,21 +120,27 @@ class Tpc_PolyClusterizer : public SubsysReco
   static unsigned int drift_lookup_index(unsigned int layer_index, unsigned int side, unsigned int sector, unsigned int sample);
   std::string m_inputNodeName;
   std::string m_outputNodeName;
+  std::string m_crossingDecisionNodeName{"TPC_CROSSING_DECISIONS"};
+  unsigned char m_maxAcceptedTier{1};
   Tpc_AssembledTrackContainer* m_assembledTracks{nullptr};
   Tpc_PolyClusterContainer* m_clusters{nullptr};
+  TpcCrossingDecisionContainer* m_crossingDecisions {nullptr};
   TrkrHitSetContainer* m_hits{nullptr};
   IdealPadMap* m_idealPadMap{nullptr};
   PHGarfield* m_garfield{nullptr};
+  PHG4TpcGeomContainer* m_geomContainerTpc{nullptr};
   std::array<DriftPolyline, 48 * 2 * 12 * NPhiSamples> m_driftLookup;
   unsigned int m_event{0};
   double m_t0{8};
   double m_tpcAdcClock{56.881262};
+  double m_crossingPeriodNs {106.56};
   double m_reverseDriftStepNs{56.881262};
   double m_startZSouth{-102.325};
   double m_startZNorth{102.325};
   double m_kEffSide0{0.0};
   double m_kEffSide1{-1.5};
   double m_cmVoltageDefault{380.0};
+  bool use_survey_geometry = false;
   std::array<double, 3> m_tpcMove{{0.0, 0.0, 0.0}};                                             //{{-0.16775, -0.0337, -0.71365}};
   std::array<std::array<double, 3>, 2> m_tpcRotations{{{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}}};  //{{{{0.0, 0.01485 / 10.0, 0.0}}, {{0.0298 / 8.0, 0.0, 0.0}}}};
 };

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterv1.cc
@@ -13,6 +13,7 @@ void Tpc_PolyClusterv1::identify(std::ostream& os) const
      << " event=" << m_event
      << " cluster_id=" << m_cluster_id
      << " source_assembled_track_id=" << m_source_assembled_track_id
+     << " trkr_cluster_key=" << m_trkr_cluster_key
      << " side=" << m_side
      << " nhits=" << m_hit_indices.size()
      << " centroid_x=" << m_centroid_x
@@ -33,6 +34,7 @@ void Tpc_PolyClusterv1::Reset()
   m_event = 0;
   m_cluster_id = 0;
   m_source_assembled_track_id = 0;
+  m_trkr_cluster_key = TrkrDefs::CLUSKEYMAX;
   m_side = 0;
   m_centroid_x = 0.0;
   m_centroid_y = 0.0;

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterv1.h
@@ -22,6 +22,7 @@ class Tpc_PolyClusterv1 : public Tpc_PolyCluster
   unsigned int get_event() const override { return m_event; }
   unsigned int get_cluster_id() const override { return m_cluster_id; }
   unsigned int get_source_assembled_track_id() const override { return m_source_assembled_track_id; }
+  TrkrDefs::cluskey get_trkr_cluster_key() const override { return m_trkr_cluster_key; }
   int get_side() const override { return m_side; }
   unsigned int get_nhits() const override { return static_cast<unsigned int>(m_hit_indices.size()); }
 
@@ -39,6 +40,7 @@ class Tpc_PolyClusterv1 : public Tpc_PolyCluster
   void set_event(unsigned int v) override { m_event = v; }
   void set_cluster_id(unsigned int v) override { m_cluster_id = v; }
   void set_source_assembled_track_id(unsigned int v) override { m_source_assembled_track_id = v; }
+  void set_trkr_cluster_key(TrkrDefs::cluskey v) override { m_trkr_cluster_key = v; }
   void set_side(int v) override { m_side = v; }
   void set_centroid_x(double v) override { m_centroid_x = v; }
   void set_centroid_y(double v) override { m_centroid_y = v; }
@@ -75,6 +77,7 @@ class Tpc_PolyClusterv1 : public Tpc_PolyCluster
   unsigned int m_event{0};
   unsigned int m_cluster_id{0};
   unsigned int m_source_assembled_track_id{0};
+  TrkrDefs::cluskey m_trkr_cluster_key {TrkrDefs::CLUSKEYMAX};
   int m_side{0};
 
   double m_centroid_x{0.0};

--- a/offline/packages/tpctrackreco/Tpc_PolyTrack.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrack.h
@@ -4,8 +4,10 @@
 #define TPCTRACKRECO_TPCPOLYTRACK_H
 
 #include <phool/PHObject.h>
+#include <trackbase/TrkrDefs.h>
 
 #include <iostream>
+#include <vector>
 
 class Tpc_PolyTrack : public PHObject
 {
@@ -52,6 +54,32 @@ class Tpc_PolyTrack : public PHObject
   virtual void set_ndf(double) {}
   virtual void set_dedx(double) {}
   virtual void set_cov(unsigned int, unsigned int, double) {}
+
+  virtual double get_seed_x0() const { return 0.0; }
+  virtual double get_seed_y0() const { return 0.0; }
+  virtual double get_helix_x0() const { return 0.0; }
+  virtual double get_helix_y0() const { return 0.0; }
+  virtual double get_seed_z0() const { return 0.0; }
+  virtual double get_seed_phi() const { return 0.0; }
+  virtual double get_seed_slope() const { return 0.0; }
+  virtual double get_seed_q_over_r() const { return 0.0; }
+  virtual void set_seed_x0(double) {}
+  virtual void set_seed_y0(double) {}
+  virtual void set_helix_x0(double) {}
+  virtual void set_helix_y0(double) {}
+  virtual void set_seed_z0(double) {}
+  virtual void set_seed_phi(double) {}
+  virtual void set_seed_slope(double) {}
+  virtual void set_seed_q_over_r(double) {}
+  virtual unsigned int size_cluster_keys() const { return 0; }
+  virtual TrkrDefs::cluskey get_cluster_key(unsigned int) const { return TrkrDefs::CLUSKEYMAX; }
+  virtual const std::vector<TrkrDefs::cluskey>& get_cluster_keys() const
+  {
+    static const std::vector<TrkrDefs::cluskey> empty_keys;
+    return empty_keys;
+  }
+  virtual void add_cluster_key(TrkrDefs::cluskey) {}
+  virtual void clear_cluster_keys() {}
 
  private:
   ClassDefOverride(Tpc_PolyTrack, 0)

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackReco.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackReco.cc
@@ -189,7 +189,14 @@ void Tpc_PolyTrackReco::fillTpc_PolyTrack(unsigned int source_assembled_track_id
   out->set_track_id(m_polyTracks->size());
   out->set_source_assembled_track_id(source_assembled_track_id);
   out->set_fit_status(fit_ok ? 1 : 0);
-  out->set_nclusters(static_cast<unsigned int>(clusters.size()));
+  out->clear_cluster_keys();
+  for (const Tpc_PolyCluster* cluster : clusters)
+  {
+    if (!cluster) { continue;
+}
+    out->add_cluster_key(cluster->get_trkr_cluster_key());
+  }
+  out->set_nclusters(out->size_cluster_keys());
   out->set_dedx(calc_dedx(clusters, fit, fit_ok));
 
   if (fit_ok)
@@ -203,6 +210,12 @@ void Tpc_PolyTrackReco::fillTpc_PolyTrack(unsigned int source_assembled_track_id
       out->set_py(fit.line_dy);
       out->set_pz(fit.line_dz);
       out->set_charge(0.0);
+      out->set_seed_x0(fit.line_x);
+      out->set_seed_y0(fit.line_y);
+      out->set_seed_z0(fit.line_z);
+      out->set_seed_phi(fit.phi0);
+      out->set_seed_slope(std::fabs(std::tan(fit.theta)) > 1.0e-12 ? 1.0 / std::tan(fit.theta) : 0.0);
+      out->set_seed_q_over_r(0.0);
     }
     else
     {
@@ -221,12 +234,21 @@ void Tpc_PolyTrackReco::fillTpc_PolyTrack(unsigned int source_assembled_track_id
       out->set_pz(pz);
       double charge = fit.curvature >= 0.0 ? -1.0 : 1.0;
       out->set_charge(charge);
+      out->set_seed_x0(out->get_x());
+      out->set_seed_y0(out->get_y());
+      out->set_helix_x0(fit.cx);
+      out->set_helix_y0(fit.cy);
+      out->set_seed_z0(fit.z0);
+      out->set_seed_phi(fit.phi0);
+      out->set_seed_slope(std::fabs(std::tan(fit.theta)) > 1.0e-12 ? 1.0 / std::tan(fit.theta) : 0.0);
+      out->set_seed_q_over_r(charge * std::fabs(fit.curvature));
     }
     out->set_chi2(fit.chi2_xy + fit.chi2_z);
     out->set_ndf(static_cast<double>(fit.ndof_xy + fit.ndof_z));
   }
 
   m_polyTracks->add_track(out);
+  //out->identify();
 }
 
 int Tpc_PolyTrackReco::process_event(PHCompositeNode* topNode)

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackv1.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackv1.cc
@@ -22,6 +22,11 @@ void Tpc_PolyTrackv1::identify(std::ostream& os) const
      << " chi2=" << m_chi2
      << " ndf=" << m_ndf
      << " dedx=" << m_dedx
+     << " seed=(" << m_seed_x0 << "," << m_seed_y0 << "," << m_seed_z0
+     << " helix coords =(" << m_helix_x0 << "," << m_helix_y0 << ")"
+     << "; phi=" << m_seed_phi << " slope=" << m_seed_slope
+     << " qOverR=" << m_seed_q_over_r << ")"
+     << " ncluster_keys=" << m_cluster_keys.size()
      << std::endl;
 }
 
@@ -42,12 +47,21 @@ void Tpc_PolyTrackv1::Reset()
   m_chi2 = 0.0;
   m_ndf = 0.0;
   m_dedx = std::numeric_limits<double>::quiet_NaN();
+  m_seed_x0 = 0.0;
+  m_seed_y0 = 0.0;
+  m_helix_x0 = 0.0;
+  m_helix_y0 = 0.0;
+  m_seed_z0 = 0.0;
+  m_seed_phi = 0.0;
+  m_seed_slope = 0.0;
+  m_seed_q_over_r = 0.0;
+  m_cluster_keys.clear();
   m_cov.assign(36, 0.0);
 }
 
 int Tpc_PolyTrackv1::isValid() const
 {
-  return (m_fit_status != 0 && m_nclusters > 0 &&
+  return (m_fit_status != 0 && get_nclusters() > 0 &&
           std::isfinite(m_x) && std::isfinite(m_y) && std::isfinite(m_z) &&
           std::isfinite(m_px) && std::isfinite(m_py) && std::isfinite(m_pz))
              ? 1

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackv1.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackv1.h
@@ -34,6 +34,21 @@ class Tpc_PolyTrackv1 : public Tpc_PolyTrack
   double get_chi2() const override { return m_chi2; }
   double get_ndf() const override { return m_ndf; }
   double get_dedx() const override { return m_dedx; }
+  double get_seed_x0() const override { return m_seed_x0; }
+  double get_seed_y0() const override { return m_seed_y0; }
+  double get_helix_x0() const override { return m_helix_x0; }
+  double get_helix_y0() const override { return m_helix_y0; }
+  double get_seed_z0() const override { return m_seed_z0; }
+  double get_seed_phi() const override { return m_seed_phi; }
+  double get_seed_slope() const override { return m_seed_slope; }
+  double get_seed_q_over_r() const override { return m_seed_q_over_r; }
+  unsigned int size_cluster_keys() const override { return static_cast<unsigned int>(m_cluster_keys.size()); }
+  TrkrDefs::cluskey get_cluster_key(unsigned int i) const override
+  {
+    if (i >= m_cluster_keys.size()) return TrkrDefs::CLUSKEYMAX;
+    return m_cluster_keys[i];
+  }
+  const std::vector<TrkrDefs::cluskey>& get_cluster_keys() const override { return m_cluster_keys; }
   double get_cov(unsigned int i, unsigned int j) const override
   {
     const unsigned int idx = 6 * i + j;
@@ -56,6 +71,24 @@ class Tpc_PolyTrackv1 : public Tpc_PolyTrack
   void set_chi2(double v) override { m_chi2 = v; }
   void set_ndf(double v) override { m_ndf = v; }
   void set_dedx(double v) override { m_dedx = v; }
+  void set_seed_x0(double v) override { m_seed_x0 = v; }
+  void set_seed_y0(double v) override { m_seed_y0 = v; }
+  void set_helix_x0(double v) override { m_helix_x0 = v; }
+  void set_helix_y0(double v) override { m_helix_y0 = v; }
+  void set_seed_z0(double v) override { m_seed_z0 = v; }
+  void set_seed_phi(double v) override { m_seed_phi = v; }
+  void set_seed_slope(double v) override { m_seed_slope = v; }
+  void set_seed_q_over_r(double v) override { m_seed_q_over_r = v; }
+  void add_cluster_key(TrkrDefs::cluskey v) override
+  {
+    m_cluster_keys.push_back(v);
+    m_nclusters = static_cast<unsigned int>(m_cluster_keys.size());
+  }
+  void clear_cluster_keys() override
+  {
+    m_cluster_keys.clear();
+    m_nclusters = 0;
+  }
   void set_cov(unsigned int i, unsigned int j, double v) override
   {
     if (i >= 6 || j >= 6) return;
@@ -80,6 +113,15 @@ class Tpc_PolyTrackv1 : public Tpc_PolyTrack
   double m_chi2{0.0};
   double m_ndf{0.0};
   double m_dedx{0.0};
+  double m_seed_x0 {0.0};
+  double m_seed_y0 {0.0};
+  double m_helix_x0 {0.0};
+  double m_helix_y0 {0.0};
+  double m_seed_z0 {0.0};
+  double m_seed_phi {0.0};
+  double m_seed_slope {0.0};
+  double m_seed_q_over_r {0.0};
+  std::vector<TrkrDefs::cluskey> m_cluster_keys;
   std::vector<double> m_cov;
 
   ClassDefOverride(Tpc_PolyTrackv1, 1)

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -194,7 +194,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
     cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << endl;
   }
 
-  if (_track_map->size() == 0)
+  if (_track_map->empty())
   {
     return Fun4AllReturnCodes::EVENT_OK;
   }
@@ -243,7 +243,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
 
   for (const auto& [key, _] : bad_map)
   {
-    if (!tpc_matched_set.count(key))
+    if (!tpc_matched_set.contains(key))
     {
         tpc_unmatched_set.insert(key);
     }
@@ -259,12 +259,17 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
     // In pp mode, if a matched track does not have INTT clusters we have to find the crossing geometrically
     // Record the geometrically estimated crossing in the track seeds for later use if needed
     short int crossing_estimate = findCrossingGeometrically(tpcid, si_id);
+    TrackSeed *tpc_track = _track_map->get(tpcid);
+    const short int tpc_crossing = tpc_track->get_crossing();
+    if (_use_tpc_crossing){
+        crossing_estimate = tpc_crossing;
+    }
     svtxseed->set_crossing_estimate(crossing_estimate);
     _svtx_seed_map->insert(svtxseed.get());
 
     if (Verbosity() > 1)
     {
-      std::cout << "  combined seed id " << _svtx_seed_map->size() - 1 << " si id " << si_id << " tpc id " << tpcid << " crossing estimate " << crossing_estimate << std::endl;
+      std::cout << "  combined seed id " << _svtx_seed_map->size() - 1 << " si id " << si_id << " tpc id " << tpcid << " TPC crossing  " << tpc_crossing << " crossing estimate " << crossing_estimate << std::endl;
     }
   }
 
@@ -309,6 +314,7 @@ short int PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpci
 
   TrackSeed *tpc_track = _track_map->get(tpcid);
   const double tpc_z = TrackSeedHelper::get_z(tpc_track);
+  const short int tpc_crossing = tpc_track->get_crossing();
 
   // this is an initial estimate of the bunch crossing based on the z-mismatch of the seeds for this track
   short int crossing_estimate = (short int) getBunchCrossing(tpcid, tpc_z - si_z);
@@ -317,7 +323,7 @@ short int PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpci
   {
     std::cout << "findCrossing: "
               << " tpcid " << tpcid << " si_id " << si_id << " tpc_z " << tpc_z << " si_z " << si_z << " dz " << tpc_z - si_z
-              << " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
+              << " INTT crossing " << crossing << " TPC crossing " << tpc_crossing << " crossing_estimate " << crossing_estimate << std::endl;
   }
 
   return crossing_estimate;
@@ -490,9 +496,14 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
           << endl;
     }
 
-    double tpc_phi, tpc_eta, tpc_pt;
-    float tpc_px, tpc_py, tpc_pz;
+    double tpc_phi;
+    double tpc_eta;
+    double tpc_pt;
+    float tpc_px;
+    float tpc_py;
+    float tpc_pz;
     int tpc_q;
+    short int tpc_crossing = -999;
     Acts::Vector3 tpc_pos;
     if (_zero_field) {
       auto cluster_list = getTrackletClusterList(_tracklet_tpc);
@@ -512,6 +523,8 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       tpc_eta = _tracklet_tpc->get_eta();
       tpc_pt = fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
 
+      tpc_crossing = _tracklet_tpc->get_crossing();
+
       tpc_pos = TrackSeedHelper::get_xyz(_tracklet_tpc);
 
       tpc_px = _tracklet_tpc->get_px();
@@ -525,7 +538,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
     if (Verbosity() > 8)
     {
-      std::cout << " tpc stub: " << tpcid << " eta " << tpc_eta << " phi " << tpc_phi << " pt " << tpc_pt << " tpc z " << TrackSeedHelper::get_z(_tracklet_tpc) << std::endl;
+      std::cout << " tpc stub: " << tpcid << " tpc crossing " << tpc_crossing << " eta " << tpc_eta << " phi " << tpc_phi << " pt " << tpc_pt << " tpc z " << TrackSeedHelper::get_z(_tracklet_tpc) << std::endl;
     }
 
     if (Verbosity() > 3)
@@ -549,8 +562,12 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
         continue;
       }
 
-      double si_phi, si_eta, si_pt;
-      float si_px, si_py, si_pz;
+      double si_phi;
+      double si_eta;
+      double si_pt;
+      float si_px;
+      float si_py;
+      float si_pz;
       int si_q;
       Acts::Vector3 si_pos;
       if (_zero_field) {
@@ -583,8 +600,8 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       {
         float data[] = {
           (float) m_event, (float) si_crossing,
-          (float) si_q, (float) si_phi, (float) si_eta, (float) si_pos.x(), (float) si_pos.y(), (float) si_pos.z(), (float) si_px, (float) si_py, (float) si_pz,
-          (float) tpc_q, (float) tpc_phi, (float) tpc_eta, (float) tpc_pos.x(), (float) tpc_pos.y(), (float) tpc_pos.z(), (float) tpc_px, (float) tpc_py, (float) tpc_pz,
+          (float) si_q, (float) si_phi, (float) si_eta, (float) si_pos.x(), (float) si_pos.y(), (float) si_pos.z(), si_px, si_py, si_pz,
+          (float) tpc_q, (float) tpc_phi, (float) tpc_eta, (float) tpc_pos.x(), (float) tpc_pos.y(), (float) tpc_pos.z(), tpc_px, tpc_py, tpc_pz,
           (float) tpcid, (float) siid
 	};
         _tree->Fill(data);
@@ -698,7 +715,10 @@ void PHSiliconTpcTrackMatching::checkZMatches(
     TrackSeed *si_track = _track_map_silicon->get(si_id);
 
     short int crossing = si_track->get_crossing();
-    float tpc_pt, tpc_z, si_z;
+    short int tpccrossing = tpc_track->get_crossing();
+    float tpc_pt;
+    float tpc_z;
+    float si_z;
     int tpc_q;
     if (_zero_field) {
       auto cluster_list_tpc = getTrackletClusterList(tpc_track);
@@ -718,13 +738,16 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
     // get TPC side from one of the TPC clusters
     std::vector<TrkrDefs::cluskey> temp_clusters = getTrackletClusterList(tpc_track);
-    if(temp_clusters.size() == 0) { continue; }
+    if(temp_clusters.empty()) { continue; }
     unsigned int this_side = TpcDefs::getSide(temp_clusters[0]);
 
     bool is_posQ = (tpc_q>0.);
 
     float z_mismatch = tpc_z - si_z;
-    float tpc_z_corrected = _clusterCrossingCorrection.correctZ(tpc_z, this_side, crossing);
+    if (_use_tpc_crossing){
+        crossing = tpccrossing;
+    }
+    float tpc_z_corrected = TpcClusterZCrossingCorrection::correctZ(tpc_z, this_side, crossing);
     float z_mismatch_corrected = tpc_z_corrected - si_z;
 
     bool z_match = false;
@@ -764,7 +787,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
     {
       if (Verbosity() > 1)
       {
-        std::cout << "  Success:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id
+        std::cout << "  Success:  crossing " << crossing << " TPC crossing " << tpccrossing << " tpcid " << tpcid << " si id " << si_id
                   << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc z corrected " << tpc_z_corrected
                   << " z_mismatch_corrected " << z_mismatch_corrected << " drift velocity " << vdrift << std::endl;
       }
@@ -773,7 +796,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
     {
       if (Verbosity() > 1)
       {
-        std::cout << "  FAILURE:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id
+        std::cout << "  FAILURE:  crossing " << crossing << " TPC crossing " << tpccrossing << " tpcid " << tpcid << " si id " << si_id
                   << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc_z_corrected " << tpc_z_corrected
                   << " z_mismatch_corrected " << z_mismatch_corrected << std::endl;
       }
@@ -814,7 +837,7 @@ std::vector<TrkrDefs::cluskey> PHSiliconTpcTrackMatching::getTrackletClusterList
        ++clusIter)
   {
     auto key = *clusIter;
-    auto cluster = _cluster_map->findCluster(key);
+    auto *cluster = _cluster_map->findCluster(key);
     if (!cluster)
     {
       if(Verbosity() > 1)

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -139,6 +139,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_file_name(const std::string &name) { _file_name = name; }
   void set_pp_mode(const bool flag) { _pp_mode = flag; }
   void set_use_intt_crossing(const bool flag) { _use_intt_crossing = flag; }
+  void set_use_tpc_crossing(const bool flag) { _use_tpc_crossing = flag; }
   void set_cluster_map_name(const std::string &name)
   {
     _cluster_map_name = name;
@@ -209,6 +210,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   bool _test_windows = false;
   bool _pp_mode = false;
   bool _use_intt_crossing = true;  // should always be true except for testing
+  bool _use_tpc_crossing = false;
 
   int _n_iteration = 0;
   std::string _track_map_name = "TpcTrackSeedContainer";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Add new functionality to the TPC SA seeds:
    Find TPC SA seed crossing 
    Convert PolyCluster and PolyTrack containers to TRKR_CLUSTER and TpcTrackSeed 
    Add _use_tpc_crossing flag in SiliconTpcMatching

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

This PR adds TPC South Arm seed processing. It identifies TPC crossing candidates and converts polynomial TPC data into standard tracking containers. The crossing information supports improved timing, geometry, and vertex matching.

## Key changes

- Added TPC crossing decision objects and containers.
- Added `TpcCrossingFinder` with drift, geometry, silicon-vertex, candidate validation, ranking, and QA logic.
- Extended `Tpc_PolyTrack` and `Tpc_PolyCluster` with tracking parameters and cluster-key support.
- Added conversion from `PolyCluster` to `TRKR_CLUSTER`.
- Added conversion from `PolyTrack` to `TpcTrackSeed`.
- Updated `Tpc_PolyClusterizer` to use crossing-dependent drift corrections and geometry.
- Added helix-circle center parameters to `FitResult`.
- Added `_use_tpc_crossing` configuration to `PHSiliconTpcTrackMatching`.

## Potential risk areas

- Reconstruction behavior changes may affect cluster positions, track seeds, crossing selection, and silicon-TPC matching.
- New node types and ROOT dictionaries require consistent I/O configuration.
- Garfield and detector-geometry calculations may increase event-processing time.
- Crossing-dependent state and shared detector resources require review for thread safety.
- Invalid or missing crossing decisions can cause tracks or clusters to be rejected.

## Possible future improvements

- Add focused unit and integration tests for crossing selection and conversion boundaries.
- Benchmark the new drift and candidate-ranking calculations.
- Validate output against reference events from both TPC sides.
- Document node configuration, accepted crossing tiers, and failure conditions.
- Review AI-generated change descriptions against the implementation, since AI summaries can contain mistakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->