### PR TITLE
feat: cluster counting utility functions

### DIFF
--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -275,7 +275,7 @@ namespace TrackAnalysisUtils
     rot(2, 2) = 1;
     return rot;
   }
-  std::vector<TrkrDefs::cluskey> get_cluster_keys(TrackSeed* seed)
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(const TrackSeed* seed)
   {
     std::vector<TrkrDefs::cluskey> out;
 
@@ -286,8 +286,48 @@ namespace TrackAnalysisUtils
 
     return out;
   }
-
-  std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track)
+  std::tuple<int, int, int, int> get_cluster_counts(const SvtxTrack* track)
+  {
+    std::tuple<int, int, int, int> counts(0, 0, 0, 0);
+    for (const auto& key : get_cluster_keys(track))
+    {
+      auto trkrid = TrkrDefs::getTrkrId(key);
+      switch (trkrid)
+      {
+        case TrkrDefs::mvtxId:
+          std::get<0>(counts)++;
+          break;
+        case TrkrDefs::inttId:
+          std::get<1>(counts)++;
+          break;
+        case TrkrDefs::tpcId:
+          std::get<2>(counts)++;
+          break;
+        case TrkrDefs::micromegasId:
+          std::get<3>(counts)++;
+          break;
+        default:
+          break;
+      }
+    }
+    return counts;
+  }
+  int get_cluster_count(const TrackSeed* seed, const TrkrDefs::TrkrId& trkrid)
+  {
+    int count = 0;
+    if (seed)
+    {
+      for (const auto& key : get_cluster_keys(seed))
+      {
+        if (TrkrDefs::getTrkrId(key) == trkrid)
+        {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(const SvtxTrack* track)
   {
     std::vector<TrkrDefs::cluskey> out;
     for (const auto& seed : {track->get_silicon_seed(), track->get_tpc_seed()})

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.h
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.h
@@ -30,8 +30,11 @@ namespace TrackAnalysisUtils
   DCAPair get_dca(SvtxTrack* track, Acts::Vector3& vertex);
   DCAPair get_dca(SvtxTrack* track, GlobalVertex* vertex);
   Acts::RotationMatrix3 rotationMatrixToLocal(const Acts::Vector3& mom);
-  std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track);
-  std::vector<TrkrDefs::cluskey> get_cluster_keys(TrackSeed* seed);
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(const SvtxTrack* track);
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(const TrackSeed* seed);
+  // returns cluster counts for a track, in order mvtx, intt, tpc, tpot
+  std::tuple<int, int, int, int> get_cluster_counts(const SvtxTrack* track);
+  int get_cluster_count(const TrackSeed* seed, const TrkrDefs::TrkrId& trkrid);
   float calc_dedx_calib(SvtxTrack* track, TrkrClusterContainer* cluster_map,
                         ActsGeometry* tgeometry,
                         // this is the thickness from R1[0],R1[1],R2[2], and R4[3]. You need


### PR DESCRIPTION
This PR adds some utility functions for analyzers to easily count clusters from tracks or track seeds

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Provide reusable utilities for analyzers to count detector clusters from `SvtxTrack` objects and `TrackSeed` objects. This adds functionality without changing reconstruction behavior or data formats.

## Key changes

- Added `get_cluster_counts(const SvtxTrack*)` for per-detector cluster totals.
- Added `get_cluster_count(const TrackSeed*, const TrkrDefs::TrkrId&)` for detector-specific seed counts.
- Updated `get_cluster_keys` to accept `const` track and seed pointers.
- Preserved existing behavior through const-correct API extensions.

## Potential risk areas

- No IO format changes are introduced.
- No reconstruction behavior changes are expected.
- The utilities perform simple counting and should have low performance impact.
- Thread safety depends on callers providing objects that are not modified concurrently.

## Possible future improvements

- Add unit tests for empty tracks, empty seeds, and each detector type.
- Document the detector ordering returned by `get_cluster_counts`.
- Consider shared counting logic to reduce duplication.

AI-generated summaries can contain mistakes. Review the implementation and tests before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->