### PR TITLE
feat: add svtxtrackv5

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -41,6 +41,7 @@ pkginclude_HEADERS = \
   SvtxTrack_v2.h \
   SvtxTrack_v3.h \
   SvtxTrack_v4.h \
+  SvtxTrack_v5.h \
   SvtxTrack_FastSim.h \
   SvtxTrack_FastSim_v1.h \
   SvtxTrack_FastSim_v2.h \
@@ -98,6 +99,7 @@ ROOTDICTS = \
   SvtxTrack_v2_Dict.cc \
   SvtxTrack_v3_Dict.cc \
   SvtxTrack_v4_Dict.cc \
+  SvtxTrack_v5_Dict.cc \
   SvtxTrack_FastSim_Dict.cc \
   SvtxTrack_FastSim_v1_Dict.cc \
   SvtxTrack_FastSim_v2_Dict.cc \
@@ -158,6 +160,7 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrack_v2.cc \
   SvtxTrack_v3.cc \
   SvtxTrack_v4.cc \
+  SvtxTrack_v5.cc \
   SvtxTrack_FastSim.cc \
   SvtxTrack_FastSim_v1.cc \
   SvtxTrack_FastSim_v2.cc \

--- a/offline/packages/trackbase_historic/SvtxTrack_v5.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v5.cc
@@ -1,0 +1,350 @@
+#include "SvtxTrack_v5.h"
+#include "SvtxTrackState.h"
+#include "SvtxTrackState_v1.h"
+#include "TrackSeed.h"
+
+#include <trackbase/TrkrDefs.h>
+
+#include <phool/PHObject.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <utility>
+
+namespace
+{
+  void count_cluster_key(TrkrDefs::cluskey key,
+                         unsigned int& nmvtx,
+                         unsigned int& nintt,
+                         unsigned int& ntpc,
+                         unsigned int& ntpot)
+  {
+    switch (TrkrDefs::getTrkrId(key))
+    {
+    case TrkrDefs::mvtxId:
+      ++nmvtx;
+      break;
+    case TrkrDefs::inttId:
+      ++nintt;
+      break;
+    case TrkrDefs::tpcId:
+      ++ntpc;
+      break;
+    case TrkrDefs::micromegasId:
+      ++ntpot;
+      break;
+    default:
+      break;
+    }
+  }
+
+  void count_seed_clusters(const TrackSeed* seed,
+                           unsigned int& nmvtx,
+                           unsigned int& nintt,
+                           unsigned int& ntpc,
+                           unsigned int& ntpot)
+  {
+    if (!seed)
+    {
+      return;
+    }
+
+    for (auto iter = seed->begin_cluster_keys(); iter != seed->end_cluster_keys(); ++iter)
+    {
+      count_cluster_key(*iter, nmvtx, nintt, ntpc, ntpot);
+    }
+  }
+}
+
+SvtxTrack_v5::SvtxTrack_v5()
+{
+  // always include the pca point
+  _states.insert(std::make_pair(0, new SvtxTrackState_v1(0)));
+}
+
+SvtxTrack_v5::SvtxTrack_v5(const SvtxTrack& source)
+{
+  SvtxTrack_v5::CopyFrom(source);
+}
+
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
+SvtxTrack_v5::SvtxTrack_v5(const SvtxTrack_v5& source)
+  : SvtxTrack(source)
+{
+  SvtxTrack_v5::CopyFrom(source);
+}
+
+SvtxTrack_v5& SvtxTrack_v5::operator=(const SvtxTrack_v5& source)
+{
+  if (this != &source)
+  {
+    CopyFrom(source);
+  }
+  return *this;
+}
+
+SvtxTrack_v5::~SvtxTrack_v5()
+{
+  clear_states();
+}
+
+void SvtxTrack_v5::CopyFrom(const SvtxTrack& source)
+{
+  // do nothing if copying onto oneself
+  if (this == &source)
+  {
+    return;
+  }
+
+  // parent class method
+  SvtxTrack::CopyFrom(source);
+
+  _track_id = source.get_id();
+  _vertex_id = source.get_vertex_id();
+  m_charge = static_cast<signed char>((source.get_charge() > 0) ? 1 : -1);
+  _chisq = source.get_chisq();
+  set_ndf(source.get_ndf());
+  _track_crossing = source.get_crossing();
+
+  clear_states();
+  for (auto iter = source.begin_states(); iter != source.end_states(); ++iter)
+  {
+    _states.insert(std::make_pair(iter->first, static_cast<SvtxTrackState*>(iter->second->CloneMe())));
+  }
+
+  const auto* source_v5 = dynamic_cast<const SvtxTrack_v5*>(&source);
+  if (source_v5)
+  {
+    set_nmvtx_clusters(source_v5->get_nmvtx_clusters());
+    set_nintt_clusters(source_v5->get_nintt_clusters());
+    set_ntpc_clusters(source_v5->get_ntpc_clusters());
+    set_ntpot_clusters(source_v5->get_ntpot_clusters());
+    return;
+  }
+
+  unsigned int nmvtx = 0;
+  unsigned int nintt = 0;
+  unsigned int ntpc = 0;
+  unsigned int ntpot = 0;
+
+  const auto begin_cluster_keys = source.begin_cluster_keys();
+  const auto end_cluster_keys = source.end_cluster_keys();
+  if (begin_cluster_keys != end_cluster_keys)
+  {
+    for (auto iter = begin_cluster_keys; iter != end_cluster_keys; ++iter)
+    {
+      count_cluster_key(*iter, nmvtx, nintt, ntpc, ntpot);
+    }
+  }
+  else
+  {
+    count_seed_clusters(source.get_silicon_seed(), nmvtx, nintt, ntpc, ntpot);
+    count_seed_clusters(source.get_tpc_seed(), nmvtx, nintt, ntpc, ntpot);
+  }
+
+  set_nmvtx_clusters(nmvtx);
+  set_nintt_clusters(nintt);
+  set_ntpc_clusters(ntpc);
+  set_ntpot_clusters(ntpot);
+}
+
+void SvtxTrack_v5::identify(std::ostream& os) const
+{
+  os << "SvtxTrack_v5 Object ";
+  os << "id: " << get_id() << " ";
+  os << "vertex id: " << get_vertex_id() << " ";
+  os << "charge: " << get_charge() << " ";
+  os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
+  os << "crossing: " << get_crossing() << " ";
+  os << "clusters: MVTX " << get_nmvtx_clusters()
+     << " INTT " << get_nintt_clusters()
+     << " TPC " << get_ntpc_clusters()
+     << " TPOT " << get_ntpot_clusters() << " ";
+  os << "nstates: " << _states.size() << " ";
+  os << std::endl;
+
+  os << "(px,py,pz) = ("
+     << get_px() << ","
+     << get_py() << ","
+     << get_pz() << ")" << std::endl;
+
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
+}
+
+int SvtxTrack_v5::isValid() const
+{
+  return 1;
+}
+
+void SvtxTrack_v5::set_ndf(int ndf)
+{
+  _ndf = static_cast<unsigned char>(std::max(0, std::min(ndf, static_cast<int>(std::numeric_limits<unsigned char>::max()))));
+}
+
+float SvtxTrack_v5::get_x() const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_x() : NAN;
+}
+
+void SvtxTrack_v5::set_x(float x)
+{
+  get_pca_state()->set_x(x);
+}
+
+float SvtxTrack_v5::get_y() const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_y() : NAN;
+}
+
+void SvtxTrack_v5::set_y(float y)
+{
+  get_pca_state()->set_y(y);
+}
+
+float SvtxTrack_v5::get_z() const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_z() : NAN;
+}
+
+void SvtxTrack_v5::set_z(float z)
+{
+  get_pca_state()->set_z(z);
+}
+
+float SvtxTrack_v5::get_pos(unsigned int i) const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_pos(i) : NAN;
+}
+
+float SvtxTrack_v5::get_px() const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_px() : NAN;
+}
+
+void SvtxTrack_v5::set_px(float px)
+{
+  get_pca_state()->set_px(px);
+}
+
+float SvtxTrack_v5::get_py() const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_py() : NAN;
+}
+
+void SvtxTrack_v5::set_py(float py)
+{
+  get_pca_state()->set_py(py);
+}
+
+float SvtxTrack_v5::get_pz() const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_pz() : NAN;
+}
+
+void SvtxTrack_v5::set_pz(float pz)
+{
+  get_pca_state()->set_pz(pz);
+}
+
+float SvtxTrack_v5::get_mom(unsigned int i) const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_mom(i) : NAN;
+}
+
+float SvtxTrack_v5::get_error(int i, int j) const
+{
+  const auto* state = get_pca_state();
+  return state ? state->get_error(i, j) : NAN;
+}
+
+void SvtxTrack_v5::set_error(int i, int j, float value)
+{
+  get_pca_state()->set_error(i, j, value);
+}
+
+void SvtxTrack_v5::clear_states()
+{
+  for (const auto& pair : _states)
+  {
+    delete pair.second;
+  }
+
+  _states.clear();
+}
+
+const SvtxTrackState* SvtxTrack_v5::get_state(float pathlength) const
+{
+  const auto iter = _states.find(pathlength);
+  return (iter == _states.end()) ? nullptr : iter->second;
+}
+
+SvtxTrackState* SvtxTrack_v5::get_state(float pathlength)
+{
+  const auto iter = _states.find(pathlength);
+  return (iter == _states.end()) ? nullptr : iter->second;
+}
+
+SvtxTrackState* SvtxTrack_v5::insert_state(const SvtxTrackState* state)
+{
+  if (!state)
+  {
+    return nullptr;
+  }
+
+  const auto pathlength = state->get_pathlength();
+  auto iterator = _states.lower_bound(pathlength);
+  if (iterator == _states.end() || pathlength < iterator->first)
+  {
+    auto* const copy = static_cast<SvtxTrackState*>(state->CloneMe());
+    iterator = _states.insert(iterator, std::make_pair(pathlength, copy));
+  }
+
+  return iterator->second;
+}
+
+size_t SvtxTrack_v5::erase_state(float pathlength)
+{
+  StateIter iter = _states.find(pathlength);
+  if (iter == _states.end())
+  {
+    return _states.size();
+  }
+
+  delete iter->second;
+  _states.erase(iter);
+  return _states.size();
+}
+
+unsigned char SvtxTrack_v5::compress_cluster_count(unsigned int nclusters)
+{
+  return static_cast<unsigned char>(std::min(nclusters, static_cast<unsigned int>(std::numeric_limits<unsigned char>::max())));
+}
+
+const SvtxTrackState* SvtxTrack_v5::get_pca_state() const
+{
+  const auto iter = _states.find(0.0);
+  return (iter == _states.end()) ? nullptr : iter->second;
+}
+
+SvtxTrackState* SvtxTrack_v5::get_pca_state()
+{
+  auto iter = _states.find(0.0);
+  if (iter == _states.end())
+  {
+    iter = _states.insert(std::make_pair(0.0, new SvtxTrackState_v1(0.0))).first;
+  }
+
+  return iter->second;
+}

--- a/offline/packages/trackbase_historic/SvtxTrack_v5.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v5.h
@@ -139,6 +139,8 @@ class SvtxTrack_v5 : public SvtxTrack
   StateIter end_states() override { return _states.end(); }
 
  private:
+  static unsigned char compress_cluster_count(unsigned int nclusters);
+
   const SvtxTrackState* get_pca_state() const;
   SvtxTrackState* get_pca_state();
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v5.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v5.h
@@ -1,0 +1,163 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKV5_H
+#define TRACKBASEHISTORIC_SVTXTRACKV5_H
+
+#include "SvtxTrack.h"
+#include "SvtxTrackState.h"
+
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <map>
+
+class PHObject;
+
+class SvtxTrack_v5 : public SvtxTrack
+{
+ public:
+  SvtxTrack_v5();
+
+  //* base class copy constructor
+  SvtxTrack_v5(const SvtxTrack&);
+
+  //* copy constructor
+  SvtxTrack_v5(const SvtxTrack_v5&);
+
+  //* assignment operator
+  SvtxTrack_v5& operator=(const SvtxTrack_v5& source);
+
+  //* destructor
+  ~SvtxTrack_v5() override;
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override { *this = SvtxTrack_v5(); }
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new SvtxTrack_v5(*this); }
+
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  // copy content from base class
+  void CopyFrom(const SvtxTrack&) override;
+  void CopyFrom(SvtxTrack* source) override
+  {
+    CopyFrom(*source);
+  }
+
+  //
+  // basic track information ---------------------------------------------------
+  //
+
+  unsigned int get_id() const override { return _track_id; }
+  void set_id(unsigned int id) override { _track_id = id; }
+
+  short int get_crossing() const override { return _track_crossing; }
+  void set_crossing(short int crossing) override { _track_crossing = crossing; }
+
+  unsigned int get_vertex_id() const override { return _vertex_id; }
+  void set_vertex_id(unsigned int id) override { _vertex_id = id; }
+
+  bool get_positive_charge() const override { return m_charge > 0; }
+  void set_positive_charge(bool ispos) override { m_charge = ispos ? 1 : -1; }
+
+  int get_charge() const override { return m_charge; }
+  void set_charge(int charge) override { m_charge = (charge > 0) ? 1 : -1; }
+
+  float get_chisq() const override { return _chisq; }
+  void set_chisq(float chisq) override { _chisq = chisq; }
+
+  unsigned int get_ndf() const override { return _ndf; }
+  void set_ndf(int ndf) override;
+
+  float get_quality() const override { return (_ndf != 0) ? _chisq / _ndf : NAN; }
+
+  float get_x() const override;
+  void set_x(float x) override;
+
+  float get_y() const override;
+  void set_y(float y) override;
+
+  float get_z() const override;
+  void set_z(float z) override;
+
+  float get_pos(unsigned int i) const override;
+
+  float get_px() const override;
+  void set_px(float px) override;
+
+  float get_py() const override;
+  void set_py(float py) override;
+
+  float get_pz() const override;
+  void set_pz(float pz) override;
+
+  float get_mom(unsigned int i) const override;
+
+  float get_p() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2) + pow(get_pz(), 2)); }
+  float get_pt() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2)); }
+  float get_eta() const override { return asinh(get_pz() / get_pt()); }
+  float get_phi() const override { return atan2(get_py(), get_px()); }
+
+  float get_error(int i, int j) const override;
+  void set_error(int i, int j, float value) override;
+
+  //
+  // cluster count information -------------------------------------------------
+  //
+
+  unsigned int get_nmvtx_clusters() const { return _nmvtx_clusters; }
+  void set_nmvtx_clusters(unsigned int nclusters) { _nmvtx_clusters = compress_cluster_count(nclusters); }
+
+  unsigned int get_nintt_clusters() const { return _nintt_clusters; }
+  void set_nintt_clusters(unsigned int nclusters) { _nintt_clusters = compress_cluster_count(nclusters); }
+
+  unsigned int get_ntpc_clusters() const { return _ntpc_clusters; }
+  void set_ntpc_clusters(unsigned int nclusters) { _ntpc_clusters = compress_cluster_count(nclusters); }
+
+  unsigned int get_ntpot_clusters() const { return _ntpot_clusters; }
+  void set_ntpot_clusters(unsigned int nclusters) { _ntpot_clusters = compress_cluster_count(nclusters); }
+
+  //
+  // state methods -------------------------------------------------------------
+  //
+  bool empty_states() const override { return _states.empty(); }
+  size_t size_states() const override { return _states.size(); }
+  size_t count_states(float pathlength) const override { return _states.count(pathlength); }
+  void clear_states() override;
+
+  const SvtxTrackState* get_state(float pathlength) const override;
+  SvtxTrackState* get_state(float pathlength) override;
+  SvtxTrackState* insert_state(const SvtxTrackState* state) override;
+  size_t erase_state(float pathlength) override;
+
+  ConstStateIter begin_states() const override { return _states.begin(); }
+  ConstStateIter find_state(float pathlength) const override { return _states.find(pathlength); }
+  ConstStateIter end_states() const override { return _states.end(); }
+
+  StateIter begin_states() override { return _states.begin(); }
+  StateIter find_state(float pathlength) override { return _states.find(pathlength); }
+  StateIter end_states() override { return _states.end(); }
+
+ private:
+  const SvtxTrackState* get_pca_state() const;
+  SvtxTrackState* get_pca_state();
+
+  // track state information
+  StateMap _states;  //< path length => state object. each state has 30 floats, a string, and a cluskey
+
+  // track information
+  float _chisq = std::numeric_limits<float>::quiet_NaN(); //4byte
+  unsigned int _track_id = std::numeric_limits<unsigned int>::max(); //4byte
+  unsigned int _vertex_id = std::numeric_limits<unsigned int>::max(); //4byte
+  short int _track_crossing = std::numeric_limits<short int>::max(); //2byte
+  signed char m_charge = 0; //1byte
+  unsigned char _ndf = 0; //1byte
+  unsigned char _nmvtx_clusters = 0; //1byte
+  unsigned char _nintt_clusters = 0; //1byte
+  unsigned char _ntpc_clusters = 0; //1byte
+  unsigned char _ntpot_clusters = 0; //1byte
+
+  ClassDefOverride(SvtxTrack_v5, 1)
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxTrack_v5LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v5LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrack_v5 + ;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
This PR adds a v5 track object that does not depend on the seed pointers at all. It is intended to be an analysis level DST object that is minimal, and should be something like 50x smaller than the current object once you strip out all of the track states. This was made in conjunction with discussion from Virginia who expressed it would be valuable to have something not dependent on the lower level tracking objects at all

Created with codex and my own review of the generated code.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Add a smaller analysis-level DST track object that does not depend on seed pointers or lower-level tracking objects. Removing track states should reduce storage size.

## Key changes

- Add `SvtxTrack_v5`, derived from `SvtxTrack`.
- Provide track identity, fit, charge, position, momentum, covariance, cluster-count, and track-state APIs.
- Store kinematic and error values through the PCA state.
- Support copying from older track versions, including detector-cluster counting.
- Register the class in installed headers, ROOT dictionaries, and the I/O library.

## Potential risk areas

- The new class introduces a new DST I/O representation.
- Compatibility copying may affect detector-cluster counts.
- Reduced track-state content may affect consumers that expect lower-level tracking information.
- Compact storage and state handling require validation against existing track implementations.
- No thread-safety changes are reported.
- Storage and runtime improvements require measurement.

## Possible future improvements

- Add tests for copying, validation, state handling, cluster counting, and ROOT I/O.
- Compare file size and runtime with existing track versions.
- Document omitted track states, seed information, and compatibility behavior.
- Review the implementation and test results carefully because AI-generated summaries can contain mistakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->