### PR TITLE
delete feeadc_map histograms in dtor

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -49,10 +49,17 @@ TpcCombinedRawDataUnpacker::TpcCombinedRawDataUnpacker(std::string const& name, 
 {
   // Do nothing
 }
+
 TpcCombinedRawDataUnpacker::~TpcCombinedRawDataUnpacker()
 {
   delete m_cdbttree;
+  for (auto& hiter2 : feeadc_map)
+  {
+    delete  hiter2.second;
+  }
+  feeadc_map.clear();
 }
+
 void TpcCombinedRawDataUnpacker::ReadZeroSuppressedData()
 {
   m_do_zs_emulation = true;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
this PR deletes histograms which were left dangling at exit.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This non-breaking bug fix prevents `feeadc_map` histograms from remaining dangling at program exit.

## Key Changes

- Delete all histogram pointers stored in `feeadc_map` in the `TpcCombinedRawDataUnpacker` destructor.
- Clear `feeadc_map` after deleting its contents.
- Preserve existing cleanup of `m_cdbttree`.

## Potential Risk Areas

- No I/O format changes.
- No reconstruction behavior changes.
- No thread-safety or performance impact is expected.
- The cleanup assumes that the pointers in `feeadc_map` are valid and uniquely owned.

## Possible Future Improvements

- Add a regression test that verifies histogram cleanup during object destruction.
- Use automatic ownership for histogram objects where the framework permits it.

AI-generated summaries can contain mistakes. Review the implementation and test results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->