### PR TITLE
Zero Field in PHGarfield

### DIFF
--- a/offline/packages/PHGarfield/PHGarfield.cc
+++ b/offline/packages/PHGarfield/PHGarfield.cc
@@ -332,7 +332,10 @@ void PHGarfield::GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, do
 
   // Get the magnetic field via the PHField3DCartesian object constructed using
   // the CDB url reference.
-  m_field->GetFieldValue(point, bfield_map);
+  if (!m_zerofield)
+  {
+    m_field->GetFieldValue(point, bfield_map);
+  }
 
   const TVector3 b_tpc = MagnetFieldMapVectorToTpcVector(
       bfield_map[0], bfield_map[1], bfield_map[2]);

--- a/offline/packages/PHGarfield/PHGarfield.h
+++ b/offline/packages/PHGarfield/PHGarfield.h
@@ -76,6 +76,8 @@ class PHGarfield : public SubsysReco
   double GetSpaceChargeScaleSide0() const { return m_spaceChargeScale_side0; }
   double GetSpaceChargeScaleSide1() const { return m_spaceChargeScale_side1; }
 
+  void setZeroField(bool zerofield) { m_zerofield = zerofield; }
+
  private:
   void GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double &bx_t, double &by_t, double &bz_t) const;      // Feeds magnetic field to Garfield
   void GetElectricFieldVcm(double x_cm, double y_cm, double z_cm, double &ex_vcm, double &ey_vcm, double &ez_vcm) const;  // Feeds electric field to Garfield
@@ -111,6 +113,7 @@ class PHGarfield : public SubsysReco
   double m_spaceChargeScale_side0{1.0};  // south, z < 0
   double m_spaceChargeScale_side1{1.0};  // north, z > 0
   double m_CMVoltageDefault{432.8};      // V/cm, nominal TPC field
+  bool m_zerofield{false};
   TH2 *m_erCorrection{nullptr};          // radial correction, input bins in V/m
   TH2 *m_ezCorrection{nullptr};          // local longitudinal correction, input bins in V/m
 

--- a/offline/packages/PHGarfield/PHGarfield.h
+++ b/offline/packages/PHGarfield/PHGarfield.h
@@ -76,7 +76,7 @@ class PHGarfield : public SubsysReco
   double GetSpaceChargeScaleSide0() const { return m_spaceChargeScale_side0; }
   double GetSpaceChargeScaleSide1() const { return m_spaceChargeScale_side1; }
 
-  void setZeroField(bool zerofield) { m_zerofield = zerofield; }
+  void SetZeroField(bool zerofield) { m_zerofield = zerofield; }
 
  private:
   void GetMagneticFieldTesla(double x_cm, double y_cm, double z_cm, double &bx_t, double &by_t, double &bz_t) const;      // Feeds magnetic field to Garfield


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Allows users to set zero B field. By default, field is on.


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

PHGarfield can now run with a zero magnetic field when required. The default magnetic-field behavior remains unchanged.

## Key changes

- Added `PHGarfield::SetZeroField(bool)`.
- Added `m_zerofield`, initialized to `false`.
- Skipped magnetic-field map lookup when zero-field mode is enabled.
- Preserved the zero-initialized field vector before coordinate conversion.
- Adjusted syntax as required.

## Potential risk areas

- No I/O format changes are expected.
- Reconstruction behavior changes only when zero-field mode is enabled.
- The change adds no apparent thread-safety or performance risk.
- Users must configure zero-field mode explicitly.

## Possible future improvements

- Add unit tests for zero-field and default-field modes.
- Add documentation and configuration examples.
- Validate behavior against representative reconstruction samples.

AI-generated summaries can contain errors. Contributors should verify these points against the implementation and physics requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->