### PR TITLE
Laser cluster hit Fix

### DIFF
--- a/offline/QA/Tpc/TpcLaserQA.cc
+++ b/offline/QA/Tpc/TpcLaserQA.cc
@@ -55,6 +55,7 @@ int TpcLaserQA::InitRun(PHCompositeNode* topNode)
   }
 
   m_laserClusterHelper.set_useZ(m_useZ);
+  m_laserClusterHelper.set_useGlobal(m_useGlobal);
   m_laserClusterHelper.loadNodes(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -117,8 +118,8 @@ int TpcLaserQA::process_event(PHCompositeNode *topNode)
     {        
       LaserClusterHitInfo LCHI = cmclus->getHit(i);
 
-      Acts::Vector3 hitGlobal = m_laserClusterHelper.getHitGlobalPosition(LCHI.hitsetkey, LCHI.hitkey);
-      if(hitGlobal.hasNaN())
+      Acts::Vector3 hitCoords = m_laserClusterHelper.getHitPosition(LCHI.hitsetkey, LCHI.hitkey);
+      if(hitCoords.hasNaN())
       {
         continue;
       }    
@@ -131,7 +132,7 @@ int TpcLaserQA::process_event(PHCompositeNode *topNode)
       //float hitAdc = cmclus->getHitAdc(i);
       //float hitIT = cmclus->getHitIT(i);
 
-      double phi = std::atan2(hitGlobal(1), hitGlobal(0));
+      double phi = std::atan2(hitCoords(1), hitCoords(0));
       if (phi < -M_PI / 12.) { phi += 2 * M_PI;
 }
 

--- a/offline/QA/Tpc/TpcLaserQA.h
+++ b/offline/QA/Tpc/TpcLaserQA.h
@@ -22,6 +22,7 @@ class TpcLaserQA : public SubsysReco
   int process_event(PHCompositeNode* topNode) override;
 
   void set_useZ(bool use) { m_useZ = use; }
+  void set_useGlobal(bool use) { m_useGlobal = use; }
 
  private:
   void createHistos();
@@ -41,6 +42,7 @@ class TpcLaserQA : public SubsysReco
 
   LaserClusterHelper m_laserClusterHelper;
   bool m_useZ{false};
+  bool m_useGlobal{true};
 };
 
 #endif

--- a/offline/packages/tpc/LaserClusterHelper.cc
+++ b/offline/packages/tpc/LaserClusterHelper.cc
@@ -83,7 +83,10 @@ Acts::Vector3 LaserClusterHelper::getHitPosition(TrkrDefs::hitsetkey hitsetkey, 
     }
 
     Acts::Vector3 env_global(env_x, env_y, env_z);
-    if(!m_useGlobal) return env_global;
+    if(!m_useGlobal)
+    {
+        return env_global;
+    }
 
     return m_tGeometry->transformTpcEnvelopeToWorld(env_global);
 }

--- a/offline/packages/tpc/LaserClusterHelper.cc
+++ b/offline/packages/tpc/LaserClusterHelper.cc
@@ -38,7 +38,7 @@ void LaserClusterHelper::loadNodes(PHCompositeNode* topNode)
 }
 
 //____________________________________________________________________________
-Acts::Vector3 LaserClusterHelper::getHitGlobalPosition(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::hitkey hitkey) const
+Acts::Vector3 LaserClusterHelper::getHitPosition(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::hitkey hitkey) const
 {
     //const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
     //                            std::numeric_limits<double>::quiet_NaN(),
@@ -83,6 +83,8 @@ Acts::Vector3 LaserClusterHelper::getHitGlobalPosition(TrkrDefs::hitsetkey hitse
     }
 
     Acts::Vector3 env_global(env_x, env_y, env_z);
+    if(!m_useGlobal) return env_global;
+
     return m_tGeometry->transformTpcEnvelopeToWorld(env_global);
 }
 
@@ -105,13 +107,13 @@ Acts::Vector3 LaserClusterHelper::getClusterCentroid(LaserCluster* cluster) cons
     for(unsigned int i=0; i<nhits; ++i)
     {
         const LaserClusterHitInfo hit= cluster->getHit(i);
-        const Acts::Vector3 global = getHitGlobalPosition(hit.hitsetkey, hit.hitkey);
-        if(global.hasNaN())
+        const Acts::Vector3 hitCoords = getHitPosition(hit.hitsetkey, hit.hitkey);
+        if(hitCoords.hasNaN())
         {
             continue;
         }
 
-        weightedSum += hit.adc * global;
+        weightedSum += hit.adc * hitCoords;
         adcSum += hit.adc;
     }
 

--- a/offline/packages/tpc/LaserClusterHelper.cc
+++ b/offline/packages/tpc/LaserClusterHelper.cc
@@ -19,6 +19,10 @@ namespace
   Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
                         std::numeric_limits<double>::quiet_NaN(),
                         std::numeric_limits<double>::quiet_NaN());
+
+  std::array<double, 3> invalidArr = {std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN()};
 }
 
 //____________________________________________________________________________
@@ -126,4 +130,45 @@ Acts::Vector3 LaserClusterHelper::getClusterCentroid(LaserCluster* cluster) cons
     }
 
     return weightedSum / adcSum;
+}
+
+//____________________________________________________________________________
+std::array<double, 3> LaserClusterHelper::getClusterHardwareCentroid(LaserCluster* cluster) const
+{
+    //const Acts::Vector3 invalid(std::numeric_limits<double>::quiet_NaN(),
+    //                            std::numeric_limits<double>::quiet_NaN(),
+    //                            std::numeric_limits<double>::quiet_NaN());
+    
+    if(!cluster)
+    {
+        return invalidArr;
+    }
+
+    Acts::Vector3 weightedSum(0.0, 0.0, 0.0);
+    double adcSum = 0.0;
+    double layerSum = 0.0;
+    double iphiSum = 0.0;
+    double itSum = 0.0;
+
+    const unsigned int nhits = cluster->getNhits();
+    for(unsigned int i=0; i<nhits; ++i)
+    {
+        const LaserClusterHitInfo hit= cluster->getHit(i);
+
+        const int layer = TrkrDefs::getLayer(hit.hitsetkey);
+        const int iphi = TpcDefs::getPad(hit.hitkey);
+        const int it = TpcDefs::getTBin(hit.hitkey);
+
+        adcSum += hit.adc;
+        layerSum += layer * hit.adc;
+        iphiSum += iphi * hit.adc;
+        itSum += it * hit.adc;
+    }
+
+    if(adcSum <= 0.0)
+    {
+        return invalidArr;
+    }
+
+    return {layerSum / adcSum, iphiSum / adcSum, itSum / adcSum};
 }

--- a/offline/packages/tpc/LaserClusterHelper.h
+++ b/offline/packages/tpc/LaserClusterHelper.h
@@ -16,16 +16,18 @@ class LaserClusterHelper
 
     void loadNodes(PHCompositeNode *topNode);
   
-    Acts::Vector3 getHitGlobalPosition(TrkrDefs::hitsetkey, TrkrDefs::hitkey) const;
+    Acts::Vector3 getHitPosition(TrkrDefs::hitsetkey, TrkrDefs::hitkey) const;
     Acts::Vector3 getClusterCentroid(LaserCluster*) const;
 
     void set_useZ(bool use) { m_useZ = use; }
+    void set_useGlobal(bool use) { m_useGlobal = use; }
   private:
 
     ActsGeometry *m_tGeometry{nullptr};
     PHG4TpcGeomContainer *m_geom_container{nullptr};
 
     bool m_useZ{false};
+    bool m_useGlobal{true};
 
 };
 

--- a/offline/packages/tpc/LaserClusterHelper.h
+++ b/offline/packages/tpc/LaserClusterHelper.h
@@ -4,6 +4,8 @@
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrDefs.h>
 
+#include <array>
+
 class ActsGeometry;
 class LaserCluster;
 class PHCompositeNode;
@@ -18,6 +20,7 @@ class LaserClusterHelper
   
     Acts::Vector3 getHitPosition(TrkrDefs::hitsetkey, TrkrDefs::hitkey) const;
     Acts::Vector3 getClusterCentroid(LaserCluster*) const;
+    std::array<double, 3> getClusterHardwareCentroid(LaserCluster*) const;
 
     void set_useZ(bool use) { m_useZ = use; }
     void set_useGlobal(bool use) { m_useGlobal = use; }

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -449,7 +449,7 @@ namespace
     //double secondmaxAdc = 0.0;
     //TrkrDefs::hitsetkey secondmaxKey = 0;
 
-    auto *clus = new LaserClusterv4;
+    LaserCluster *clus = new LaserClusterv4;
 
     int meanSide = 0;
 
@@ -592,9 +592,6 @@ namespace
     clus->setNLayers(usedLayer.size());
     clus->setNIPhi(usedIPhi.size());
     clus->setNIT(usedIT.size());
-    clus->setLayer(layerSum / adcSum);
-    clus->setIPhi(iphiSum / adcSum);
-    clus->setIT(itSum / adcSum);
     clus->setSDLayer(sqrt(sigmaLayer / nHits));
     clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
     clus->setSDIT(sqrt(sigmaIT / nHits));

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -5,7 +5,7 @@
 #include <trackbase/LaserCluster.h>
 #include <trackbase/LaserClusterContainer.h>
 #include <trackbase/LaserClusterContainerv1.h>
-#include <trackbase/LaserClusterv3.h>
+#include <trackbase/LaserClusterv4.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHit.h>
@@ -449,7 +449,7 @@ namespace
     //double secondmaxAdc = 0.0;
     //TrkrDefs::hitsetkey secondmaxKey = 0;
 
-    auto *clus = new LaserClusterv3;
+    auto *clus = new LaserClusterv4;
 
     int meanSide = 0;
 

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -592,9 +592,9 @@ namespace
     clus->setNLayers(usedLayer.size());
     clus->setNIPhi(usedIPhi.size());
     clus->setNIT(usedIT.size());
-    clus->setLayer(layerSum / adcSum);
-    clus->setIPhi(iphiSum / adcSum);
-    clus->setIT(itSum / adcSum);
+    clus->setLayerInt((unsigned int) round(layerSum / adcSum));
+    clus->setIPhiInt((unsigned int) round(iphiSum / adcSum));
+    clus->setITInt((unsigned int) round(itSum / adcSum));
     clus->setSDLayer(sqrt(sigmaLayer / nHits));
     clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
     clus->setSDIT(sqrt(sigmaIT / nHits));

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -592,9 +592,9 @@ namespace
     clus->setNLayers(usedLayer.size());
     clus->setNIPhi(usedIPhi.size());
     clus->setNIT(usedIT.size());
-    clus->setLayerInt((unsigned int) round(layerSum / adcSum));
-    clus->setIPhiInt((unsigned int) round(iphiSum / adcSum));
-    clus->setITInt((unsigned int) round(itSum / adcSum));
+    clus->setLayer(layerSum / adcSum);
+    clus->setIPhi(iphiSum / adcSum);
+    clus->setIT(itSum / adcSum);
     clus->setSDLayer(sqrt(sigmaLayer / nHits));
     clus->setSDIPhi(sqrt(sigmaIPhi / nHits));
     clus->setSDIT(sqrt(sigmaIT / nHits));

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.cc
@@ -2793,6 +2793,7 @@ int TpcCentralMembraneMatching::GetNodes(PHCompositeNode* topNode)
   }
 
   m_laserClusterHelper.set_useZ(m_useZ);
+  m_laserClusterHelper.set_useGlobal(m_useGlobal);
   m_laserClusterHelper.loadNodes(topNode);
 
   // input tpc distortion correction module edge

--- a/offline/packages/tpccalib/TpcCentralMembraneMatching.h
+++ b/offline/packages/tpccalib/TpcCentralMembraneMatching.h
@@ -129,6 +129,8 @@ class TpcCentralMembraneMatching : public SubsysReco
 
   void set_useZ(bool use) { m_useZ = use; }
 
+  void set_useGlobal(bool use) { m_useGlobal = use; }
+
   // void set_laminationFile(const std::string& filename)
   //{
   // m_lamfilename = filename;
@@ -428,6 +430,7 @@ class TpcCentralMembraneMatching : public SubsysReco
 
   LaserClusterHelper m_laserClusterHelper;
   bool m_useZ{false};
+  bool m_useGlobal{true};
 };
 
 #endif  // PHTPCCENTRALMEMBRANEMATCHER_H

--- a/offline/packages/tpccalib/TpcLaminationFitting.cc
+++ b/offline/packages/tpccalib/TpcLaminationFitting.cc
@@ -173,6 +173,7 @@ int TpcLaminationFitting::GetNodes(PHCompositeNode *topNode)
   */
 
   m_laserClusterHelper.set_useZ(m_useZ);
+  m_laserClusterHelper.set_useGlobal(m_useGlobal);
   m_laserClusterHelper.loadNodes(topNode);
 
   m_dcc_in_module_edge = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerModuleEdge");

--- a/offline/packages/tpccalib/TpcLaminationFitting.h
+++ b/offline/packages/tpccalib/TpcLaminationFitting.h
@@ -73,6 +73,8 @@ class TpcLaminationFitting : public SubsysReco
   void set_lam_grid_dimensions(int phibins, int rbins);
 
   void set_useZ(bool use) { m_useZ = use; }
+  
+  void set_useGlobal(bool use) { m_useGlobal = use; }
 
   int InitRun(PHCompositeNode *topNode) override;
 
@@ -205,6 +207,7 @@ class TpcLaminationFitting : public SubsysReco
 
   LaserClusterHelper m_laserClusterHelper;
   bool m_useZ{false};
+  bool m_useGlobal{true};
 };
 
 #endif

--- a/offline/packages/trackbase/LaserClusterv3.h
+++ b/offline/packages/trackbase/LaserClusterv3.h
@@ -45,12 +45,12 @@ class LaserClusterv3 : public LaserCluster
   bool getFitMode() const override { return m_fitMode; }
   void setFitMode(bool fitMode) override { m_fitMode = fitMode; }
 
-  unsigned int getLayerInt() const override { return m_posHardware[0]; }
-  void setLayerInt(unsigned int layer) override { m_posHardware[0] = layer; }
-  unsigned int getIPhiInt() const override { return m_posHardware[1]; }
-  void setIPhiInt(unsigned int iphi) override { m_posHardware[1] = iphi; }
-  unsigned int getITInt() const override { return m_posHardware[2]; }
-  void setITInt(unsigned int it) override { m_posHardware[2] = it; }
+  float getLayer() const override { return m_posHardware[0]; }
+  void setLayer(float layer) override { m_posHardware[0] = layer; }
+  float getIPhi() const override { return m_posHardware[1]; }
+  void setIPhi(float iphi) override { m_posHardware[1] = iphi; }
+  float getIT() const override { return m_posHardware[2]; }
+  void setIT(float it) override { m_posHardware[2] = it; }
 
   unsigned int getNhits() const override {return (unsigned int)m_hits.size();}
 
@@ -95,7 +95,7 @@ class LaserClusterv3 : public LaserCluster
 
   std::vector<LaserClusterHitInfo> m_hits;
   
-  unsigned int m_posHardware[3] = {std::numeric_limits<unsigned int>::max(), std::numeric_limits<unsigned int>::max(), std::numeric_limits<unsigned int>::max()};
+  float m_posHardware[3] = {std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
   bool m_fitMode{false};
 
   /// number of TPC clusters used to create this central mebrane cluster

--- a/offline/packages/trackbase/LaserClusterv4.cc
+++ b/offline/packages/trackbase/LaserClusterv4.cc
@@ -56,6 +56,8 @@ void LaserClusterv4::CopyFrom( const LaserCluster& source )
  
   // parent class method
   LaserCluster::CopyFrom( source );
+  m_hits.clear();
+  setFitMode(source.getFitMode());
   setLayer( source.getLayer() );
   setIPhi( source.getIPhi() );
   setIT( source.getIT() );

--- a/offline/packages/trackbase/LaserClusterv4.cc
+++ b/offline/packages/trackbase/LaserClusterv4.cc
@@ -1,0 +1,78 @@
+/**
+ * @file trackbase/LaserClusterv4.cc
+ * @author Ben Kimelman
+ * @date July 2026
+ * @brief Implementation of LaserClusterv4
+ */
+#include "LaserClusterv4.h"
+
+#include <cmath>
+#include <utility>          // for swap
+
+void LaserClusterv4::identify(std::ostream& os) const
+{
+  os << "---LaserClusterv4--------------------" << std::endl;
+
+  os << " " << m_hits.size() << " hits";
+  os << " fit? " << m_fitMode;
+  os << " (layer, iphi, it) =  (" << m_posHardware[0];
+  os << ", " << m_posHardware[1] << ", ";
+  os << m_posHardware[2] << ")";
+  os << " adc = " << getAdc() << std::endl;
+
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
+
+  return;
+}
+
+int LaserClusterv4::isValid() const
+{
+  if(getNhits() == 0)
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+unsigned int LaserClusterv4::getAdc() const
+{
+  unsigned int adc = 0;
+  for(const auto &LCHI : m_hits)
+  {
+    adc += (unsigned int) LCHI.adc;
+  }
+  return adc;
+}
+
+void LaserClusterv4::CopyFrom( const LaserCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source )
+    {
+      return;
+    }
+ 
+  // parent class method
+  LaserCluster::CopyFrom( source );
+  setLayer( source.getLayer() );
+  setIPhi( source.getIPhi() );
+  setIT( source.getIT() );
+  setNLayers( source.getNLayers() );
+  setNIPhi( source.getNIPhi() );
+  setNIT( source.getNIT() );
+  setSDLayer( source.getSDLayer() );
+  setSDIPhi( source.getSDIPhi() );
+  setSDIT( source.getSDIT() );
+  setSDWeightedLayer( source.getSDWeightedLayer() );
+  setSDWeightedIPhi( source.getSDWeightedIPhi() );
+  setSDWeightedIT( source.getSDWeightedIT() );
+
+
+  for(int i=0; i<(int)source.getNhits(); i++){
+    LaserClusterHitInfo LCHI = source.getHit(i);
+    addHit(LCHI.hitsetkey, LCHI.hitkey, LCHI.adc);
+  }
+}
+

--- a/offline/packages/trackbase/LaserClusterv4.cc
+++ b/offline/packages/trackbase/LaserClusterv4.cc
@@ -15,9 +15,6 @@ void LaserClusterv4::identify(std::ostream& os) const
 
   os << " " << m_hits.size() << " hits";
   os << " fit? " << m_fitMode;
-  os << " (layer, iphi, it) =  (" << m_posHardware[0];
-  os << ", " << m_posHardware[1] << ", ";
-  os << m_posHardware[2] << ")";
   os << " adc = " << getAdc() << std::endl;
 
   os << std::endl;
@@ -58,9 +55,6 @@ void LaserClusterv4::CopyFrom( const LaserCluster& source )
   LaserCluster::CopyFrom( source );
   m_hits.clear();
   setFitMode(source.getFitMode());
-  setLayer( source.getLayer() );
-  setIPhi( source.getIPhi() );
-  setIT( source.getIT() );
   setNLayers( source.getNLayers() );
   setNIPhi( source.getNIPhi() );
   setNIT( source.getNIT() );

--- a/offline/packages/trackbase/LaserClusterv4.h
+++ b/offline/packages/trackbase/LaserClusterv4.h
@@ -1,11 +1,11 @@
 /**
- * @file trackbase/LaserClusterv3.h
+ * @file trackbase/LaserClusterv4.h
  * @author Ben Kimelman
  * @date July 2026
- * @brief Version 3 of CMFLashCluster
+ * @brief Version 4 of CMFLashCluster
  */
-#ifndef TRACKBASE_LASERCLUSTERV3_H
-#define TRACKBASE_LASERCLUSTERV3_H
+#ifndef TRACKBASE_LASERCLUSTERV4_H
+#define TRACKBASE_LASERCLUSTERV4_H
 
 #include "LaserCluster.h"
 
@@ -15,7 +15,7 @@
 class PHObject;
 
 /**
- * @brief Version 3 of LaserCluster
+ * @brief Version 4 of LaserCluster
  *
  * Note - D. McGlinchey June 2018:
  *   CINT does not like "override", so ignore where CINT
@@ -24,16 +24,16 @@ class PHObject;
  */
 
 
-class LaserClusterv3 : public LaserCluster
+class LaserClusterv4 : public LaserCluster
 {
  public:
   //! ctor
-  LaserClusterv3() = default;
+  LaserClusterv4() = default;
 
   // PHObject virtual overloads
   void Reset() override {}
   int isValid() const override;
-  PHObject* CloneMe() const override { return new LaserClusterv3(*this); }
+  PHObject* CloneMe() const override { return new LaserClusterv4(*this); }
  
   //! copy content from base class
   void CopyFrom( const LaserCluster& ) override;
@@ -45,12 +45,12 @@ class LaserClusterv3 : public LaserCluster
   bool getFitMode() const override { return m_fitMode; }
   void setFitMode(bool fitMode) override { m_fitMode = fitMode; }
 
-  unsigned int getLayerInt() const override { return m_posHardware[0]; }
-  void setLayerInt(unsigned int layer) override { m_posHardware[0] = layer; }
-  unsigned int getIPhiInt() const override { return m_posHardware[1]; }
-  void setIPhiInt(unsigned int iphi) override { m_posHardware[1] = iphi; }
-  unsigned int getITInt() const override { return m_posHardware[2]; }
-  void setITInt(unsigned int it) override { m_posHardware[2] = it; }
+  float getLayer() const override { return m_posHardware[0]; }
+  void setLayer(float layer) override { m_posHardware[0] = layer; }
+  float getIPhi() const override { return m_posHardware[1]; }
+  void setIPhi(float iphi) override { m_posHardware[1] = iphi; }
+  float getIT() const override { return m_posHardware[2]; }
+  void setIT(float it) override { m_posHardware[2] = it; }
 
   unsigned int getNhits() const override {return (unsigned int)m_hits.size();}
 
@@ -95,7 +95,7 @@ class LaserClusterv3 : public LaserCluster
 
   std::vector<LaserClusterHitInfo> m_hits;
   
-  unsigned int m_posHardware[3] = {std::numeric_limits<unsigned int>::max(), std::numeric_limits<unsigned int>::max(), std::numeric_limits<unsigned int>::max()};
+  float m_posHardware[3] = {std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
   bool m_fitMode{false};
 
   /// number of TPC clusters used to create this central mebrane cluster
@@ -110,7 +110,7 @@ class LaserClusterv3 : public LaserCluster
   float m_SDWeightedIPhi = std::numeric_limits<float>::quiet_NaN();
   float m_SDWeightedIT = std::numeric_limits<float>::quiet_NaN();
 
-  ClassDefOverride(LaserClusterv3, 1)
+  ClassDefOverride(LaserClusterv4, 1)
 };
 
-#endif //TRACKBASE_LASERCLUSTERV3_H
+#endif //TRACKBASE_4_H

--- a/offline/packages/trackbase/LaserClusterv4.h
+++ b/offline/packages/trackbase/LaserClusterv4.h
@@ -45,13 +45,6 @@ class LaserClusterv4 : public LaserCluster
   bool getFitMode() const override { return m_fitMode; }
   void setFitMode(bool fitMode) override { m_fitMode = fitMode; }
 
-  float getLayer() const override { return m_posHardware[0]; }
-  void setLayer(float layer) override { m_posHardware[0] = layer; }
-  float getIPhi() const override { return m_posHardware[1]; }
-  void setIPhi(float iphi) override { m_posHardware[1] = iphi; }
-  float getIT() const override { return m_posHardware[2]; }
-  void setIT(float it) override { m_posHardware[2] = it; }
-
   unsigned int getNhits() const override {return (unsigned int)m_hits.size();}
 
   //
@@ -95,7 +88,6 @@ class LaserClusterv4 : public LaserCluster
 
   std::vector<LaserClusterHitInfo> m_hits;
   
-  float m_posHardware[3] = {std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
   bool m_fitMode{false};
 
   /// number of TPC clusters used to create this central mebrane cluster

--- a/offline/packages/trackbase/LaserClusterv4LinkDef.h
+++ b/offline/packages/trackbase/LaserClusterv4LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class LaserClusterv4+;
+
+#endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -70,6 +70,7 @@ pkginclude_HEADERS = \
   LaserClusterv1.h \
   LaserClusterv2.h \
   LaserClusterv3.h \
+  LaserClusterv4.h \
   MaterialWiper.h \
   MagneticFieldOptions.h \
   MvtxDefs.h \
@@ -154,6 +155,7 @@ ROOTDICTS = \
   LaserClusterv1_Dict.cc \
   LaserClusterv2_Dict.cc \
   LaserClusterv3_Dict.cc \
+  LaserClusterv4_Dict.cc \
   MvtxEventInfo_Dict.cc \
   MvtxEventInfov1_Dict.cc \
   MvtxEventInfov2_Dict.cc \
@@ -244,6 +246,7 @@ libtrack_io_la_SOURCES = \
   LaserClusterv1.cc \
   LaserClusterv2.cc \
   LaserClusterv3.cc \
+  LaserClusterv4.cc \
   MvtxDefs.cc \
   MvtxEventInfo.cc \
   MvtxEventInfov1.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )
Fixed error where new laser clusters did not call correct functions to set hardware coordinate centroids by upgrading to laserClusterv4 which stores centroids as floats rather than the uncorrect unsigned int from v3

Added toggle for LaserClusterHelper to easily swap between global (default) and local coordinates. Added setters in codes that call this helper class to set it when initialized.

## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Fix laser cluster centroid handling. The previous implementation stored centroid values as unsigned integers and used incorrect coordinate-setting functions. This could affect hardware-coordinate reconstruction and laser-based calibration.

## Key changes

- Add `LaserClusterv4` with floating-point centroid storage and laser-cluster metadata support.
- Use `LaserClusterv4` for new clusters while preserving v3-compatible behavior for existing DSTs.
- Correct hardware-coordinate centroid handling.
- Add global/local coordinate selection through `LaserClusterHelper::set_useGlobal`.
- Configure coordinate selection in `TpcLaserQA`, `TpcCentralMembraneMatching`, and `TpcLaminationFitting`.
- Rename `getHitGlobalPosition` to `getHitPosition` to support both coordinate systems.

## Potential risks

- The new cluster version changes the laser-cluster I/O format for newly produced data.
- Reconstruction results may change because centroids now retain floating-point precision.
- Existing DST compatibility requires validation across v3 and v4 data.
- No thread-safety or significant performance risks are evident from the supplied changes.

## Possible future improvements

- Add regression tests for v3 DST reading and v4 DST writing.
- Compare global and local coordinate results in calibration workflows.
- Validate centroid precision against established laser calibration samples.
- Document the coordinate-selection behavior and migration requirements.

This summary is based on the supplied change descriptions. AI-generated summaries can contain errors, so contributors should verify the implementation and I/O behavior during review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->