### PR TITLE
Modify seed matching to use the best crossing estimate

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -2133,9 +2133,9 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
     m_nmms = 0;
     m_nmmsstate = 0;
     m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
-    m_silseed_crossing = std::numeric_limits<short int>::quiet_NaN();
+    m_silseed_crossing = SHRT_MAX;
     m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
-    m_tpcseed_crossing = std::numeric_limits<short int>::quiet_NaN();
+    m_tpcseed_crossing = SHRT_MAX;
     m_silseedx = std::numeric_limits<float>::quiet_NaN();
     m_silseedy = std::numeric_limits<float>::quiet_NaN();
     m_silseedz = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1414,7 +1414,7 @@ void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey,  // SvtxTr
 					      const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_moved,
                                               PHCompositeNode* topNode)
 {
-  // The input map global contains the corrected cluster positions - NOT moved back to the surface.
+
   // When filling the residualtree:
   //    clusgx etc are the corrected - but not moved back to the surface - cluster positions
   //    clugxideal etc are the completely uncorrected cluster positions - they do not even have crossing corrections
@@ -1885,8 +1885,9 @@ void TrackResiduals::createBranches()
   m_tree->Branch("silid", &m_silid, "m_silid/I");
   m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
-  m_tree->Branch("crossing_estimate", &m_crossing_estimate, "m_crossing_estimate/I");
+  m_tree->Branch("geometric_crossing", &m_geometric_crossing, "m_geometric_crossing/I");
   m_tree->Branch("silseedit",&m_silseedit, "m_silseedit/I");
+  m_tree->Branch("silseed_crossing",&m_silseed_crossing, "m_silseed_crossing/I");
   m_tree->Branch("silseedx", &m_silseedx, "m_silseedx/F");
   m_tree->Branch("silseedy", &m_silseedy, "m_silseedy/F");
   m_tree->Branch("silseedz", &m_silseedz, "m_silseedz/F");
@@ -1896,6 +1897,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("silseedphi", &m_silseedphi, "m_silseedphi/F");
   m_tree->Branch("silseedeta", &m_silseedeta, "m_silseedeta/F");
   m_tree->Branch("silseedcharge", &m_silseedcharge, "m_silseedcharge/I");
+  m_tree->Branch("tpcseed_crossing",&m_tpcseed_crossing, "m_tpcseed_crossing/I");
   m_tree->Branch("tpcseedx", &m_tpcseedx, "m_tpcseedx/F");
   m_tree->Branch("tpcseedy", &m_tpcseedy, "m_tpcseedy/F");
   m_tree->Branch("tpcseedz", &m_tpcseedz, "m_tpcseedz/F");
@@ -2072,6 +2074,7 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
 {
   auto *silseedmap = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
   auto *tpcseedmap = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+  auto *svtxseedmap = findNode::getClass<TrackSeedContainer>(topNode, "SvtxTrackSeedContainer");
   auto *tpcGeom =
       findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
   auto *trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trackMapName);
@@ -2079,6 +2082,21 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
   auto *vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   auto *alignmentmap = findNode::getClass<SvtxAlignmentStateMap>(topNode, m_alignmentMapName);
   auto *geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+
+  std::map<std::pair<unsigned int, unsigned int>, short int> geom_crossing_map;
+ for (const auto& seed : *svtxseedmap)
+  {
+    if (!seed)
+    {
+      continue;
+    }
+    m_trackid = svtxseedmap->find(seed);
+    auto tpcseedindex = seed->get_tpc_seed_index();
+    auto silseedindex = seed->get_silicon_seed_index();
+    auto geometric_crossing = seed->get_crossing_estimate();    
+    geom_crossing_map.insert(std::make_pair(std::make_pair(silseedindex, tpcseedindex), geometric_crossing));
+  }
+
   std::set<unsigned int> tpc_seed_ids;
   for (const auto& [key, track] : *trackmap)
   {
@@ -2089,7 +2107,6 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
     m_trackid = track->get_id();
 
     m_crossing = track->get_crossing();
-    m_crossing_estimate = SHRT_MAX;
     m_px = track->get_px();
     m_py = track->get_py();
     m_pz = track->get_pz();
@@ -2116,7 +2133,9 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
     m_nmms = 0;
     m_nmmsstate = 0;
     m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
+    m_silseed_crossing = std::numeric_limits<short int>::quiet_NaN();
     m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
+    m_tpcseed_crossing = std::numeric_limits<short int>::quiet_NaN();
     m_silseedx = std::numeric_limits<float>::quiet_NaN();
     m_silseedy = std::numeric_limits<float>::quiet_NaN();
     m_silseedz = std::numeric_limits<float>::quiet_NaN();
@@ -2163,13 +2182,14 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
     if (tpcseed)
     {
       m_tpcid = tpcseedmap->find(tpcseed);
+      m_tpcseed_crossing = tpcseed->get_crossing();
       tpc_seed_ids.insert(tpcseedmap->find(tpcseed));
     }
     auto *silseed = track->get_silicon_seed();
     if (silseed)
     {
       m_silid = silseedmap->find(silseed);
-
+      m_silseed_crossing = silseed->get_crossing();
       const auto si_pos = TrackSeedHelper::get_xyz(silseed);
       m_silseedx = si_pos.x();
       m_silseedy = si_pos.y();
@@ -2181,6 +2201,18 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
       m_silseedeta = silseed->get_eta();
       m_silseedcharge = silseed->get_qOverR() > 0 ? 1 : -1;
     }
+
+    m_geometric_crossing = SHRT_MAX;
+    if(silseed && tpcseed)
+      {
+	auto pairid = std::make_pair(m_silid, m_tpcid);
+	auto it = geom_crossing_map.find(pairid);
+	if(it != geom_crossing_map.end())
+	  {
+	    m_geometric_crossing = it->second;
+	  }
+      }
+    
     if (tpcseed)
     {
       const auto tpc_pos = TrackSeedHelper::get_xyz(tpcseed);
@@ -2437,7 +2469,8 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
     m_trackid = track->get_id();
    
     m_crossing = track->get_crossing();
-    m_crossing_estimate = SHRT_MAX;
+    //   m_geometric_crossing =track->get_crossing_estimate();
+    m_geometric_crossing = SHRT_MAX;
     m_px = track->get_px();
     m_py = track->get_py();
     m_pz = track->get_pz();
@@ -2457,7 +2490,7 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
 
     if (Verbosity() > 1)
     {
-      std::cout << "fillResidualTreeSeeds:  track " << m_trackid << " m_crossing " << m_crossing << " m_crossing_estimate " << m_crossing_estimate << " m_pt " << m_pt << std::endl;
+      std::cout << "fillResidualTreeSeeds:  track " << m_trackid << " m_crossing " << m_crossing << " m_geometric_crossing " << m_geometric_crossing << " m_pt " << m_pt << std::endl;
     }
 
     m_nmaps = 0;
@@ -2465,7 +2498,9 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
     m_ntpc = 0;
     m_nmms = 0;
     m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
+    m_silseed_crossing = SHRT_MAX;
     m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
+    m_tpcseed_crossing = SHRT_MAX;
     m_silseedx = std::numeric_limits<float>::quiet_NaN();
     m_silseedy = std::numeric_limits<float>::quiet_NaN();
     m_silseedz = std::numeric_limits<float>::quiet_NaN();
@@ -2518,6 +2553,7 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
     if (silseed)
     {
       m_silid = silseedmap->find(silseed);
+      m_silseed_crossing = silseed->get_crossing();
       const auto si_pos = TrackSeedHelper::get_xyz(silseed);
       m_silseedx = si_pos.x();
       m_silseedy = si_pos.y();
@@ -2536,6 +2572,7 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
     }
     if (tpcseed)
     {
+      m_tpcseed_crossing = tpcseed->get_crossing();
       const auto tpc_pos = TrackSeedHelper::get_xyz(tpcseed);
       m_tpcseedx = tpc_pos.x();
       m_tpcseedy = tpc_pos.y();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -156,7 +156,7 @@ class TrackResiduals : public SubsysReco
   uint64_t m_bcotr = std::numeric_limits<uint64_t>::quiet_NaN();
   unsigned int m_trackid = std::numeric_limits<unsigned int>::quiet_NaN();
   int m_crossing = std::numeric_limits<int>::quiet_NaN();
-  int m_crossing_estimate = std::numeric_limits<int>::quiet_NaN();
+  int m_geometric_crossing = std::numeric_limits<int>::quiet_NaN();
   unsigned int m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
   unsigned int m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
   float m_px = std::numeric_limits<float>::quiet_NaN();
@@ -202,6 +202,7 @@ class TrackResiduals : public SubsysReco
   float m_tracklength = std::numeric_limits<float>::quiet_NaN();
   
   int m_silseedit = std::numeric_limits<int>::quiet_NaN();
+  int m_silseed_crossing = std::numeric_limits<int>::quiet_NaN();
   float m_silseedx = std::numeric_limits<float>::quiet_NaN();
   float m_silseedy = std::numeric_limits<float>::quiet_NaN();
   float m_silseedz = std::numeric_limits<float>::quiet_NaN();
@@ -221,7 +222,7 @@ class TrackResiduals : public SubsysReco
   float m_tpcseedphi = std::numeric_limits<float>::quiet_NaN();
   float m_tpcseedeta = std::numeric_limits<float>::quiet_NaN();
   int m_tpcseedit = std::numeric_limits<int>::quiet_NaN();
-  
+  int m_tpcseed_crossing = std::numeric_limits<int>::quiet_NaN();  
   float m_dedx = std::numeric_limits<float>::quiet_NaN();
 
   //! hit tree info

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -179,37 +179,40 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     }
 
     auto global_new_keep = global_new;
+    auto sskey_keep = sskey;
     int iter = 0;
     while (new_subsurfkey != sskey)
     {
-      iter++;
-      if (iter > 2)
-      {
-        // cluster has been updated with subsurfkey from last iteration, global_new is still from last iteration - move on
-        break;
-      }
+	iter++;
+	if(iter > 2)
+	  {
+	    // cluster has been updated with subsurfkey from last iteration, global_new is still from last iteration - move on
+	    break;
+	  }
 
-      // surface changed, cluster subsurface has been updated, redo with new surface
-      sskey = new_subsurfkey;
-      ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
-      if (!ret)
-      {
-        global_new = global_new_keep;
-        break;
-      }
-      if (_verbosity > 2)
-      {
-        if (new_subsurfkey != sskey)
-        {
-          std::cout << PHWHERE << "Warning: subsurfkey changed on iteration " << iter << " from "
-                    << sskey << " to " << new_subsurfkey << std::endl;
-        }
-        else
-        {
-          std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
-        }
-      }
+	// surface changed, cluster subsurface has been updated, redo with new surface
+	sskey = new_subsurfkey;
+	ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
+	if(!ret)
+	  {
+	    global_new = global_new_keep;
+	    cluster->setSubSurfKey(sskey_keep);
+	    break;
+	  }
+	if(_verbosity > 2)
+	  {
+	    if(new_subsurfkey != sskey)
+	      {
+		std::cout << PHWHERE << "Warning: subsurfkey changed on iteration " << iter << " from "
+			  << sskey << " to " << new_subsurfkey << std::endl;
+	      }
+	    else
+	      {
+		std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
+	      }
+	  }	
     }
+
 
     if (_verbosity > 2)
     {

--- a/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
+++ b/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
@@ -248,12 +248,12 @@ bool TpcPolyClusterTrkrClusterConverter::localFromMovedGlobal(const Tpc_PolyClus
   const double half_drift = 0.5 * m_geometry->get_max_driftlength();
   const double z_bunch_separation = m_crossingPeriodNs * drift_velocity;
   const double zloc_uncorrected = (side == 0) ?
-      local.y() + static_cast<double>(crossing) * z_bunch_separation :
-      local.y() - static_cast<double>(crossing) * z_bunch_separation;
+    local.y() + static_cast<double>(crossing) * z_bunch_separation :
+    local.y() - static_cast<double>(crossing) * z_bunch_separation;
   const double tuncorrected = (side == 0) ? (zloc_uncorrected + half_drift) / drift_velocity : (half_drift - zloc_uncorrected) / drift_velocity;
   const double stored_t_uncorrected = tuncorrected - m_geometry->get_tpc_tzero() - m_geometry->get_sampa_tzero_bias();
   if (!std::isfinite(stored_t_uncorrected)) { return false;
-}
+  }
 
   local_x = static_cast<float>(local.x());
   local_y = static_cast<float>(stored_t_uncorrected);

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -375,15 +375,15 @@ Acts::Vector2 ActsGeometry::getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* c
 Acts::Vector2 ActsGeometry::getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* cluster, short int crossing) const
 {
   Acts::Vector2 local;
-
+  
   const auto trkrid = TrkrDefs::getTrkrId(key);
   if (trkrid == TrkrDefs::tpcId)
   {
+    unsigned int side = TpcDefs::getSide(key);
     double crossing_tzero_correction = crossing * sphenix_constants::time_between_crossings;
     double tcorrected = cluster->getLocalY() +  _tpc_tzero + _sampa_tzero_bias - crossing_tzero_correction;
     double zdriftlength = tcorrected * _drift_velocity; 
     double zloc = _max_driftlength/2.0 - zdriftlength;         // local z relative to surface center (for north side):
-    unsigned int side = TpcDefs::getSide(key);
     if (side == 0)
     {
       zloc = -zloc;

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -27,6 +27,7 @@ pkginclude_HEADERS = \
   TrackSeed_v2.h \
   SvtxTrackSeed_v1.h \
   SvtxTrackSeed_v2.h \
+  SvtxTrackSeed_v3.h \
   TrackSeed_FastSim_v1.h \
   TrackSeed_FastSim_v2.h \
   TrackSeedContainer.h \
@@ -80,6 +81,7 @@ ROOTDICTS = \
   TrackSeed_v2_Dict.cc \
   SvtxTrackSeed_v1_Dict.cc \
   SvtxTrackSeed_v2_Dict.cc \
+  SvtxTrackSeed_v3_Dict.cc \
   TrackSeed_FastSim_v1_Dict.cc \
   TrackSeed_FastSim_v2_Dict.cc \
   TrackSeedContainer_Dict.cc \
@@ -142,6 +144,7 @@ libtrackbase_historic_io_la_SOURCES = \
   TrackSeed_v2.cc \
   SvtxTrackSeed_v1.cc \
   SvtxTrackSeed_v2.cc \
+  SvtxTrackSeed_v3.cc \
   TrackSeed_FastSim_v1.cc \
   TrackSeed_FastSim_v2.cc \
   TrackSeedContainer.cc \

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v3.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v3.cc
@@ -1,0 +1,47 @@
+#include "SvtxTrackSeed_v3.h"
+
+SvtxTrackSeed_v3::SvtxTrackSeed_v3() = default;
+
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
+SvtxTrackSeed_v3::SvtxTrackSeed_v3(const SvtxTrackSeed_v3& seed)
+  : TrackSeed(seed)
+{
+  SvtxTrackSeed_v3::CopyFrom(seed);
+}
+
+SvtxTrackSeed_v3& SvtxTrackSeed_v3::operator=(const SvtxTrackSeed_v3& seed)
+{
+  if (this != &seed)
+  {
+    CopyFrom(seed);
+  }
+  return *this;
+}
+
+SvtxTrackSeed_v3::~SvtxTrackSeed_v3() = default;
+
+void SvtxTrackSeed_v3::CopyFrom(const TrackSeed& seed)
+{
+  if (this == &seed)
+  {
+    return;
+  }
+  TrackSeed::CopyFrom(seed);
+
+  m_silicon_seed = seed.get_silicon_seed_index();
+  m_tpc_seed = seed.get_tpc_seed_index();
+  m_crossing_estimate = seed.get_crossing_estimate();
+  m_crossing = seed.get_crossing();
+}
+
+void SvtxTrackSeed_v3::identify(std::ostream& os) const
+{
+  os << "SvtxTrackSeed_v3 object ";
+  os << " Silicon seed index: " << m_silicon_seed;
+  os << " tpc seed index: " << m_tpc_seed;
+  os << " crossing estimate: " << m_crossing_estimate;
+  os << " crossing: " << m_crossing;
+  os << std::endl;
+}

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v3.h
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v3.h
@@ -1,0 +1,46 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKSEED_V3_H
+#define TRACKBASEHISTORIC_SVTXTRACKSEED_V3_H
+
+#include "TrackSeed.h"
+
+#include <phool/PHObject.h>
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+class SvtxTrackSeed_v3 : public TrackSeed
+{
+ public:
+  SvtxTrackSeed_v3();
+  ~SvtxTrackSeed_v3() override;
+
+  SvtxTrackSeed_v3(const SvtxTrackSeed_v3&);
+  SvtxTrackSeed_v3& operator=(const SvtxTrackSeed_v3& seed);
+
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override { *this = SvtxTrackSeed_v3(); }
+  int isValid() const override { return 1; }
+  void CopyFrom(const TrackSeed&) override;
+  void CopyFrom(TrackSeed* seed) override { CopyFrom(*seed); }
+  PHObject* CloneMe() const override { return new SvtxTrackSeed_v3(*this); }
+
+  unsigned int get_silicon_seed_index() const override { return m_silicon_seed; }
+  unsigned int get_tpc_seed_index() const override { return m_tpc_seed; }
+  short int get_crossing_estimate() const override { return m_crossing_estimate; }
+  short int get_crossing() const override { return m_crossing; }
+  void set_silicon_seed_index(const unsigned int index) override { m_silicon_seed = index; }
+  void set_tpc_seed_index(const unsigned int index) override { m_tpc_seed = index; }
+  void set_crossing_estimate(const short int cross) override { m_crossing_estimate = cross; }
+  void set_crossing(const short int cross) override { m_crossing = cross; }
+
+ private:
+  unsigned int m_silicon_seed {std::numeric_limits<unsigned int>::max()};
+  unsigned int m_tpc_seed {std::numeric_limits<unsigned int>::max()};
+  short int m_crossing_estimate {std::numeric_limits<short>::max()};
+  short int m_crossing {std::numeric_limits<short>::max()};
+
+  ClassDefOverride(SvtxTrackSeed_v3, 1);
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v3LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrackSeed_v3 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -471,7 +471,6 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     auto *tpcseed = m_tpcSeeds->get(tpcid);
 
     short int best_crossing = track->get_crossing();  // best crossing between INTT clusters and TPC seed
-    if(best_crossing == SHRT_MAX) { continue; }
 
     if(Verbosity() > 2 && siseed && tpcseed)
 	  {
@@ -507,13 +506,16 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       crossing = 0;
     }
 
+    // no path forward in this case, move on
+    if(crossing == SHRT_MAX && crossing_estimate == SHRT_MAX) { continue; }
+	
     /// Need to also check that the tpc seed wasn't removed by the ghost finder
     if (!tpcseed)
     {
       std::cout << "no tpc seed" << std::endl;
       continue;
     }
-    
+	
     if (Verbosity() > 0)
       {
 	if (siseed)
@@ -570,7 +572,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       }
       crossing_estimate = crossing;
     }
-
+	
     // Fit this track assuming either:
     //    crossing = best crossing value, if it exists (uses nvary = 0)
     //    crossing = crossing_estimate +/- max_bunch_search, if no INTT value exists and m_enable_crossing_estimate flag is set.

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -28,6 +28,7 @@
 #include <trackbase_historic/SvtxTrackState_v3.h>
 #include <trackbase_historic/SvtxTrack_v4.h>
 #include <trackbase_historic/TrackSeed.h>
+//#include <trackbase_historic/SvtxTrackSeed_v3.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/TrackSeedHelper.h>
 
@@ -463,19 +464,26 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       continue;
     }
-
+    
     unsigned int tpcid = track->get_tpc_seed_index();
     unsigned int siid = track->get_silicon_seed_index();
+    auto *siseed = m_siliconSeeds->get(siid);
+    auto *tpcseed = m_tpcSeeds->get(tpcid);
 
+    short int best_crossing = track->get_crossing();  // best crossing between INTT clusters and TPC seed
+    if(best_crossing == SHRT_MAX) { continue; }
+
+    if(Verbosity() > 2 && siseed && tpcseed)
+	  {
+	    std::cout << "tpc and si id " << tpcid << ", " << siid << " silicon_crossing " << siseed->get_crossing()
+		      << " tpc crossing " << tpcseed->get_crossing()
+		      << " best crossing " << best_crossing << " crossing estimate " << track->get_crossing_estimate() << std::endl;
+	  }
+    
     // capture the input crossing value, and set crossing parameters
     //==============================
-    short silicon_crossing = SHRT_MAX;
-    auto *siseed = m_siliconSeeds->get(siid);
-    if (siseed)
-    {
-      silicon_crossing = siseed->get_crossing();
-    }
-    short crossing = silicon_crossing;
+
+    short int crossing = best_crossing;
     short int crossing_estimate = crossing;
 
     if (m_enable_crossing_estimate)
@@ -487,7 +495,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     // must have silicon seed with valid crossing if we are doing a SC calibration fit
     if (m_fitSiliconMMs)
     {
-      if ((siid == std::numeric_limits<unsigned int>::max()) || (silicon_crossing == SHRT_MAX))
+      if ((siid == std::numeric_limits<unsigned int>::max()) || (crossing == SHRT_MAX))
       {
         continue;
       }
@@ -499,27 +507,16 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       crossing = 0;
     }
 
-    if (Verbosity() > 1)
-    {
-      if (siseed)
-      {
-        std::cout << "tpc and si id " << tpcid << ", " << siid << " silicon_crossing " << silicon_crossing
-                  << " crossing " << crossing << " crossing estimate " << crossing_estimate << std::endl;
-      }
-    }
-
-    auto *tpcseed = m_tpcSeeds->get(tpcid);
-
     /// Need to also check that the tpc seed wasn't removed by the ghost finder
     if (!tpcseed)
     {
       std::cout << "no tpc seed" << std::endl;
       continue;
     }
-
+    
     if (Verbosity() > 0)
-    {
-      if (siseed)
+      {
+	if (siseed)
       {
         const auto si_position = TrackSeedHelper::get_xyz(siseed);
         const auto tpc_position = TrackSeedHelper::get_xyz(tpcseed);
@@ -535,7 +532,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     if (Verbosity() > 1 && siseed)
     {
       std::cout << " m_pp_mode " << m_pp_mode << " m_enable_crossing_estimate " << m_enable_crossing_estimate
-                << " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
+                << " best crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
     }
 
     short int this_crossing = crossing;
@@ -559,14 +556,14 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       }
       else
       {
-        // use INTT crossing
+        // use best crossing
         crossing_estimate = crossing;
       }
     }
     else
     {
       // non pp mode, we want only crossing zero, veto others
-      if (siseed && silicon_crossing != 0)
+      if (siseed && best_crossing != 0)
       {
         crossing = 0;
         // continue;
@@ -575,7 +572,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
 
     // Fit this track assuming either:
-    //    crossing = INTT value, if it exists (uses nvary = 0)
+    //    crossing = best crossing value, if it exists (uses nvary = 0)
     //    crossing = crossing_estimate +/- max_bunch_search, if no INTT value exists and m_enable_crossing_estimate flag is set.
 
     for (short int ivary = -nvary; ivary <= nvary; ++ivary)
@@ -975,7 +972,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
           m_trackMap->insertWithKey(&svtx_vec[best_ivary], trid);
         }
-        else  // case where INTT crossing is known
+        else  // case where crossing is known
         {
           SvtxTrack_v4 newTrack;
           newTrack.set_tpc_seed(tpcseed);
@@ -1004,7 +1001,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
               m_trackMap->insertWithKey(&newTrack, trid);
             }
           }  // end insert track for normal fit
-        }  // end case where INTT crossing is known
+        }  // end case where crossing is known
       }
       else if (!m_fitSiliconMMs)
       {

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -9,7 +9,7 @@
 #include <trackbase/TrkrClusterv3.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey, getTrkrId, tpcId
 
-#include <trackbase_historic/SvtxTrackSeed_v2.h>
+#include <trackbase_historic/SvtxTrackSeed_v3.h>
 #include <trackbase_historic/TrackSeedContainer_v1.h>
 #include <trackbase_historic/TrackSeed_v2.h>
 #include <trackbase_historic/TrackSeedHelper.h>
@@ -198,29 +198,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
   {
     return Fun4AllReturnCodes::EVENT_OK;
   }
-
-  // loop over the silicon seeds and add the crossing to them
-  for (unsigned int trackid = 0; trackid != _track_map_silicon->size(); ++trackid)
-  {
-    _tracklet_si = _track_map_silicon->get(trackid);
-    if (!_tracklet_si)
-    {
-      continue;
-    }
-    auto crossing = _tracklet_si->get_crossing();
-    if (Verbosity() > 8)
-    {
-      std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta()
-        << " pt " << _tracklet_si->get_pt() << " si z " << TrackSeedHelper::get_z(_tracklet_si)
-        << " crossing " << crossing << std::endl;
-    }
-
-    if (Verbosity() > 1)
-    {
-      cout << " Si track " << trackid << " crossing " << crossing << endl;
-    }
-  }
-
+  
   // Find all matches of tpc and si tracklets in eta and phi, x and y
   std::multimap<unsigned int, unsigned int> tpc_matches;
   std::set<unsigned int> tpc_matched_set;
@@ -229,7 +207,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
 
   // check z matching for all matches of tpc and si
   // for _pp_mode=false, assume zero crossings for all tracks
-  // for _pp_mode=true, correct tpc seed z according to crossing number, do nothing if crossing number is not set
+  // for _pp_mode=true, correct tpc seed z according to crossing number, do nothing if no crossing set
   // remove matches from tpc_matches if z matching is not satisfied
   std::multimap<unsigned int, unsigned int> bad_map;
   checkZMatches(tpc_matches, bad_map);
@@ -253,30 +231,33 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
   // make the combined track seeds from tpc_matches
   for (auto [tpcid, si_id] : tpc_matches)
   {
-    auto svtxseed = std::make_unique<SvtxTrackSeed_v2>();
+    auto svtxseed = std::make_unique<SvtxTrackSeed_v3>();
     svtxseed->set_silicon_seed_index(si_id);
     svtxseed->set_tpc_seed_index(tpcid);
-    // In pp mode, if a matched track does not have INTT clusters we have to find the crossing geometrically
-    // Record the geometrically estimated crossing in the track seeds for later use if needed
-    short int crossing_estimate = findCrossingGeometrically(tpcid, si_id);
-    TrackSeed *tpc_track = _track_map->get(tpcid);
-    const short int tpc_crossing = tpc_track->get_crossing();
-    if (_use_tpc_crossing){
-        crossing_estimate = tpc_crossing;
-    }
-    svtxseed->set_crossing_estimate(crossing_estimate);
+
+    // the intt and tpc crossings are in the seeds already, add the geometric crossing to the full seed
+    std::vector<short int> crossing_list = getBestCrossing(tpcid, si_id);
+    short int best_crossing = crossing_list[3];        // the fourth entry is the best crossing choice
+    short int geometric_crossing_estimate = crossing_list[2];
+    svtxseed->set_crossing_estimate(geometric_crossing_estimate);
+    svtxseed->set_crossing(best_crossing);
     _svtx_seed_map->insert(svtxseed.get());
 
     if (Verbosity() > 1)
     {
-      std::cout << "  combined seed id " << _svtx_seed_map->size() - 1 << " si id " << si_id << " tpc id " << tpcid << " TPC crossing  " << tpc_crossing << " crossing estimate " << crossing_estimate << std::endl;
+      std::cout << "  combined seed id " << _svtx_seed_map->size() - 1 << " si id " << si_id << " tpc id " << tpcid
+		<< " sil crossing " << crossing_list[0]
+		<< " tpc crossing " << crossing_list[1]
+		<< " estimate " << geometric_crossing_estimate
+		<< " best crossing " << best_crossing
+		<< std::endl;
     }
   }
 
   // Also make the unmatched TPC seeds into SvtxTrackSeeds
   for (auto tpcid : tpc_unmatched_set)
   {
-    auto svtxseed = std::make_unique<SvtxTrackSeed_v2>();
+    auto svtxseed = std::make_unique<SvtxTrackSeed_v3>();
     svtxseed->set_tpc_seed_index(tpcid);
     _svtx_seed_map->insert(svtxseed.get());
 
@@ -706,7 +687,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
   // for _pp_mode=true, do crossing correction on track position z according to side and vdrift
   // z matching criteria follows window_z
   // there is a dz threshold cut to avoid window_z blow up at low pT
-
+  
   float vdrift = _tGeometry->get_drift_velocity();
 
   for (auto [tpcid, si_id] : tpc_matches)
@@ -714,8 +695,6 @@ void PHSiliconTpcTrackMatching::checkZMatches(
     TrackSeed *tpc_track = _track_map->get(tpcid);
     TrackSeed *si_track = _track_map_silicon->get(si_id);
 
-    short int crossing = si_track->get_crossing();
-    short int tpccrossing = tpc_track->get_crossing();
     float tpc_pt;
     float tpc_z;
     float si_z;
@@ -743,68 +722,64 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
     bool is_posQ = (tpc_q>0.);
 
+    bool z_match = false;
+
+    std::vector<short int> crossing_list = getBestCrossing(tpcid, si_id);
+    short int crossing = crossing_list[3];        // the fourth entry is the best crossing choice
+    if(crossing == SHRT_MAX) { continue; }
+    
     float z_mismatch = tpc_z - si_z;
-    if (_use_tpc_crossing){
-        crossing = tpccrossing;
-    }
     float tpc_z_corrected = TpcClusterZCrossingCorrection::correctZ(tpc_z, this_side, crossing);
     float z_mismatch_corrected = tpc_z_corrected - si_z;
-
-    bool z_match = false;
-    if (_pp_mode)
-    {
-      if (crossing == SHRT_MAX)
+    
+    if(_pp_mode)
       {
-        if (Verbosity() > 2)
-        {
-          std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << TrackSeedHelper::get_z(si_track) << " because crossing is undefined " << std::endl;
-        }
-        continue;
+	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (fabs(z_mismatch_corrected) < _crossing_deltaz_max))
+	  {
+	    z_match = true;
+	  }
+	else if (fabs(z_mismatch_corrected) < _crossing_deltaz_min)
+	  {
+	    z_match = true;
+	  }
       }
-
-      if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (fabs(z_mismatch_corrected) < _crossing_deltaz_max))
-      {
-        z_match = true;
-      }
-      else if (fabs(z_mismatch_corrected) < _crossing_deltaz_min)
-      {
-	z_match = true;
-      }
-    }
     else
-    {
-      if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (fabs(z_mismatch) < _crossing_deltaz_max))
       {
-        z_match = true;
+	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (fabs(z_mismatch) < _crossing_deltaz_max))
+	  {
+	    z_match = true;
+	  }
+	else if (fabs(z_mismatch) < _crossing_deltaz_min)
+	  {
+	    z_match = true;
+	  }
       }
-      else if (fabs(z_mismatch) < _crossing_deltaz_min)
-      {
-	z_match = true;
-      }
-    }
-
+      
     if (z_match)
-    {
-      if (Verbosity() > 1)
       {
-        std::cout << "  Success:  crossing " << crossing << " TPC crossing " << tpccrossing << " tpcid " << tpcid << " si id " << si_id
-                  << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc z corrected " << tpc_z_corrected
-                  << " z_mismatch_corrected " << z_mismatch_corrected << " drift velocity " << vdrift << std::endl;
+	if (Verbosity() > 1)
+	  {
+	    std::cout << "  Success:  crossing " << crossing << " INTT crossing " << si_track->get_crossing()
+		      << " TPC crossing " << tpc_track->get_crossing()
+		      << " tpcid " << tpcid << " si id " << si_id
+		      << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc z corrected " << tpc_z_corrected
+		      << " z_mismatch_corrected " << z_mismatch_corrected << " drift velocity " << vdrift << std::endl;
+	  }
       }
-    }
     else
-    {
-      if (Verbosity() > 1)
       {
-        std::cout << "  FAILURE:  crossing " << crossing << " TPC crossing " << tpccrossing << " tpcid " << tpcid << " si id " << si_id
-                  << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc_z_corrected " << tpc_z_corrected
-                  << " z_mismatch_corrected " << z_mismatch_corrected << std::endl;
+	if (Verbosity() > 1)
+	  {
+	    std::cout << "  FAILURE:  crossing " << crossing << " INTT crossing " << si_track->get_crossing()
+		      << " TPC crossing " <<  tpc_track->get_crossing() << " tpcid " << tpcid << " si id " << si_id
+		      << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc_z_corrected " << tpc_z_corrected
+		      << " z_mismatch_corrected " << z_mismatch_corrected << std::endl;
+	  }
+	
+	bad_map.insert(std::make_pair(tpcid, si_id));
       }
-
-      bad_map.insert(std::make_pair(tpcid, si_id));
-    }
   }
-
+  
   // remove bad entries from tpc_matches
   for (auto [tpcid, si_id] : bad_map)
   {
@@ -827,6 +802,52 @@ void PHSiliconTpcTrackMatching::checkZMatches(
   }
 
   return;
+}
+
+std::vector<short int>  PHSiliconTpcTrackMatching::getBestCrossing(unsigned int tpcid, unsigned int si_id)
+{
+  // returns vector containing (intt,tpc,geometric,best) crossing list 
+  short int maxcrossdiff = 5;
+  
+  TrackSeed *tpc_track = _track_map->get(tpcid);
+  TrackSeed *si_track = _track_map_silicon->get(si_id);
+
+  std::vector<short int> crossing_list;
+  
+  short int intt_crossing = si_track->get_crossing();
+  short int tpc_crossing = tpc_track->get_crossing();
+  short int geom_crossing = findCrossingGeometrically(tpcid, si_id);
+
+  crossing_list.emplace_back(intt_crossing);
+  crossing_list.emplace_back(tpc_crossing);
+  crossing_list.emplace_back(geom_crossing);
+
+  short int crossing = SHRT_MAX;
+
+  // get the best crossing reference for this track
+  if (intt_crossing == SHRT_MAX && tpc_crossing == SHRT_MAX)
+    {
+      crossing_list.emplace_back(crossing);
+      return crossing_list;
+    }
+  
+  if(intt_crossing == tpc_crossing)
+    {
+      crossing = intt_crossing;
+    }
+  else 
+    {
+      short int inttdiff = intt_crossing - geom_crossing;
+      short int tpcdiff = tpc_crossing - geom_crossing;
+      if( abs(inttdiff) < maxcrossdiff || abs(tpcdiff) < maxcrossdiff )
+	{
+	  crossing = ( abs(inttdiff) < abs(tpcdiff) ) ? (intt_crossing) : (tpc_crossing);
+	}
+    }
+  
+  crossing_list.emplace_back(crossing);
+
+  return crossing_list;
 }
 
 std::vector<TrkrDefs::cluskey> PHSiliconTpcTrackMatching::getTrackletClusterList(TrackSeed* tracklet)

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -726,7 +726,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
     std::vector<short int> crossing_list = getBestCrossing(tpcid, si_id);
     short int crossing = crossing_list[3];        // the fourth entry is the best crossing choice
-    if(crossing == SHRT_MAX) { continue; }
+    if(crossing == SHRT_MAX) { continue; }  // no valid crossing
     
     float z_mismatch = tpc_z - si_z;
     float tpc_z_corrected = TpcClusterZCrossingCorrection::correctZ(tpc_z, this_side, crossing);
@@ -807,30 +807,30 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 std::vector<short int>  PHSiliconTpcTrackMatching::getBestCrossing(unsigned int tpcid, unsigned int si_id)
 {
   // returns vector containing (intt,tpc,geometric,best) crossing list 
-  short int maxcrossdiff = 5;
   
   TrackSeed *tpc_track = _track_map->get(tpcid);
   TrackSeed *si_track = _track_map_silicon->get(si_id);
 
-  std::vector<short int> crossing_list;
-  
+  std::vector<short int> crossing_list;  
   short int intt_crossing = si_track->get_crossing();
   short int tpc_crossing = tpc_track->get_crossing();
   short int geom_crossing = findCrossingGeometrically(tpcid, si_id);
-
   crossing_list.emplace_back(intt_crossing);
   crossing_list.emplace_back(tpc_crossing);
   crossing_list.emplace_back(geom_crossing);
 
+  // get the best crossing reference for this track
+  
   short int crossing = SHRT_MAX;
 
-  // get the best crossing reference for this track
-  if (intt_crossing == SHRT_MAX && tpc_crossing == SHRT_MAX)
+  // discard the track if there is no input crossing, or no geometric reference
+  if ((intt_crossing == SHRT_MAX && tpc_crossing == SHRT_MAX) || geom_crossing == SHRT_MAX)
     {
       crossing_list.emplace_back(crossing);
       return crossing_list;
     }
-  
+
+  // decision tree
   if(intt_crossing == tpc_crossing)
     {
       crossing = intt_crossing;
@@ -839,7 +839,7 @@ std::vector<short int>  PHSiliconTpcTrackMatching::getBestCrossing(unsigned int 
     {
       short int inttdiff = intt_crossing - geom_crossing;
       short int tpcdiff = tpc_crossing - geom_crossing;
-      if( abs(inttdiff) < maxcrossdiff || abs(tpcdiff) < maxcrossdiff )
+      if( abs(inttdiff) < _max_crossing_diff || abs(tpcdiff) < _max_crossing_diff )
 	{
 	  crossing = ( abs(inttdiff) < abs(tpcdiff) ) ? (intt_crossing) : (tpc_crossing);
 	}

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -852,7 +852,7 @@ std::vector<short int>  PHSiliconTpcTrackMatching::getBestCrossing(unsigned int 
     {
       crossing = intt_crossing;
     }
-  else   if(_use_tpc_crossing_only)
+  else if(_use_tpc_crossing_only)
     {
       crossing = tpc_crossing;
     }

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -64,7 +64,9 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
   }
   // put these in the output file
   cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta "
-       << _eta_search_win << " _pp_mode " << _pp_mode << " _use_intt_crossing " << _use_intt_crossing << endl;
+       << _eta_search_win << " _pp_mode " << _pp_mode 
+       << " _use_silicon_crossing_only " << _use_silicon_crossing_only
+       << " _use_tpc_crossing_only " << _use_tpc_crossing_only << endl;
 
   int ret = GetNodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK)
@@ -726,7 +728,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
     std::vector<short int> crossing_list = getBestCrossing(tpcid, si_id);
     short int crossing = crossing_list[3];        // the fourth entry is the best crossing choice
-    if(crossing == SHRT_MAX) { continue; }  // no valid crossing
+    if(crossing == SHRT_MAX) { continue; }  // no INTT or TPC crossing, maybe can recover in the fitter using geometric crossing - don't delete
     
     float z_mismatch = tpc_z - si_z;
     float tpc_z_corrected = TpcClusterZCrossingCorrection::correctZ(tpc_z, this_side, crossing);
@@ -843,6 +845,16 @@ std::vector<short int>  PHSiliconTpcTrackMatching::getBestCrossing(unsigned int 
 	{
 	  crossing = ( abs(inttdiff) < abs(tpcdiff) ) ? (intt_crossing) : (tpc_crossing);
 	}
+    }
+
+  // special cases, default to false, set from macro
+  if(_use_silicon_crossing_only)
+    {
+      crossing = intt_crossing;
+    }
+  else   if(_use_tpc_crossing_only)
+    {
+      crossing = tpc_crossing;
     }
   
   crossing_list.emplace_back(crossing);

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -144,6 +144,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   {
     _cluster_map_name = name;
   }
+  void set_max_crossing_diff(const short int diff) { _max_crossing_diff = diff; }
+
   int InitRun(PHCompositeNode *topNode) override;
 
   int process_event(PHCompositeNode *) override;
@@ -198,6 +200,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   int m_event = 0;
   std::map<unsigned int, double> _z_mismatch_map;
 
+  short int _max_crossing_diff = 5;
+  
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
   float _crossing_deltaz_max = 10.0;
   float _crossing_deltaz_min = 1.5;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -204,7 +204,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   int m_event = 0;
   std::map<unsigned int, double> _z_mismatch_map;
 
-  short int _max_crossing_diff = 6;  // good for Polyseeding, use 50 for CA seeding
+  short int _max_crossing_diff = 20;  // good for CA seeds, use 10 for polyseeding
   
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
   float _crossing_deltaz_max = 10.0;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -138,8 +138,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_test_windows_printout(const bool test) { _test_windows = test; }
   void set_file_name(const std::string &name) { _file_name = name; }
   void set_pp_mode(const bool flag) { _pp_mode = flag; }
-  void set_use_intt_crossing(const bool flag) { _use_intt_crossing = flag; }
-  void set_use_tpc_crossing(const bool flag) { _use_tpc_crossing = flag; }
+  void set_use_silicon_crossing_only(const bool flag) { _use_silicon_crossing_only = flag; }
+  void set_use_tpc_crossing_only(const bool flag) { _use_tpc_crossing_only = flag; }
   void set_cluster_map_name(const std::string &name)
   {
     _cluster_map_name = name;
@@ -200,7 +200,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   int m_event = 0;
   std::map<unsigned int, double> _z_mismatch_map;
 
-  short int _max_crossing_diff = 6;
+  short int _max_crossing_diff = 6;  // good for Polyseeding, use 50 for CA seeding
   
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
   float _crossing_deltaz_max = 10.0;
@@ -214,8 +214,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   bool _test_windows = false;
   bool _pp_mode = false;
-  bool _use_intt_crossing = true;  // should always be true except for testing
-  bool _use_tpc_crossing = false;
+  bool _use_tpc_crossing_only = false;
+  bool _use_silicon_crossing_only = false;
 
   int _n_iteration = 0;
   std::string _track_map_name = "TpcTrackSeedContainer";

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -140,8 +140,10 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_pp_mode(const bool flag) { _pp_mode = flag; }
   void set_use_silicon_crossing_only(const bool flag) { _use_silicon_crossing_only = flag; }
   void set_use_tpc_crossing_only(const bool flag) { _use_tpc_crossing_only = flag; }
-  void set_use_intt_crossing(const bool flag) { _use_intt_crossing_only = flag; }  // deprecated, left for backward compatibility
+  
+  void set_use_intt_crossing(const bool flag) { _use_silicon_crossing_only = flag; }  // deprecated, left for backward compatibility
   void set_use_tpc_crossing(const bool flag) { _use_tpc_crossing_only = flag; }   // deprecated, left for backward compatibility
+
   void set_cluster_map_name(const std::string &name)
   {
     _cluster_map_name = name;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -200,7 +200,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   int m_event = 0;
   std::map<unsigned int, double> _z_mismatch_map;
 
-  short int _max_crossing_diff = 5;
+  short int _max_crossing_diff = 6;
   
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
   float _crossing_deltaz_max = 10.0;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -169,7 +169,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   // void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
   short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
   double getBunchCrossing(unsigned int trid, double z_mismatch);
-
+  std::vector<short int>  getBestCrossing(unsigned int tpcid, unsigned int si_id);
+  
   TFile *_file = nullptr;
   TNtuple *_tree = nullptr;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -140,6 +140,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_pp_mode(const bool flag) { _pp_mode = flag; }
   void set_use_silicon_crossing_only(const bool flag) { _use_silicon_crossing_only = flag; }
   void set_use_tpc_crossing_only(const bool flag) { _use_tpc_crossing_only = flag; }
+  void set_use_intt_crossing(const bool flag) { _use_intt_crossing_only = flag; }  // deprecated, left for backward compatibility
+  void set_use_tpc_crossing(const bool flag) { _use_tpc_crossing_only = flag; }   // deprecated, left for backward compatibility
   void set_cluster_map_name(const std::string &name)
   {
     _cluster_map_name = name;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
To make use of the TPC seed crossing, 
1) the seed matcher is modified to find the best crossing by comparing both the silicon seed and TPC seed crossing with the geometric crossing value.
2) The combined track seed is updated to SvtxTrackSeed_v3, which has the best crossing added explicitly.
3) The Acts fitter uses the best crossing for the fit.
3) TrackResiduals now contains the silicon seed crossing, the TPC seed crossing, the geometric crossing estimate, and the best crossing found by the seed matcher (which is used by Acts for the fit). 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Improve consistency between silicon-seed crossings, TPC-seed crossings, geometric crossing estimates, and Acts track fitting.

## Key changes

- Added `SvtxTrackSeed_v3` with seed IDs, crossing values, selected crossing, ROOT dictionary support, and IO integration.
- Updated `PHSiliconTpcTrackMatching` to select the best compatible crossing.
- Added silicon-only and TPC-only crossing options, a configurable crossing-difference limit, and deprecated setter aliases.
- Updated `PHActsTrkFitter` to use the selected crossing.
- Expanded `TrackResiduals` to record silicon-seed, TPC-seed, geometric, and selected crossings.
- Preserved TPC cluster state when a surface-movement retry fails.
- Applied minor formatting and geometry-code updates.

## Potential risk areas

- `SvtxTrackSeed_v3` changes the track-seed IO schema. Validate ROOT dictionary generation and compatibility.
- Crossing selection can change reconstruction results for ambiguous or inconsistent crossings.
- Invalid crossings can prevent track fitting.
- TPC cluster retry changes can affect reconstructed cluster positions.
- High-occupancy matching can affect performance. No specific thread-safety issue is indicated.

## Possible future improvements

- Add tests for crossing selection, invalid values, and seed serialization.
- Compare tracking efficiency and residual distributions before and after the change.
- Document crossing-selection rules and sentinel values.
- Measure performance with representative high-occupancy samples.

AI-generated descriptions can contain errors. Contributors should verify the implementation and validate the physics impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->