### PR TITLE
use emcal pixel occupancy and photoelectron count smearing to be on a…

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -233,8 +233,8 @@ class CaloWaveformSim : public SubsysReco
 
   LightCollectionModel light_collection_model;
 
-  bool m_use_photon_statistics{false};
-  bool m_use_sipm_occupancy{false};
+  bool m_use_photon_statistics{true};
+  bool m_use_sipm_occupancy{true};
   double kSamplingFraction = 2e-2;
   double kPhotoelectronsPerGeV = 500.;
   double kSiPMEffectivePixel = 40000 * 4.;


### PR DESCRIPTION
…s default

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Enable EMCal pixel occupancy and photoelectron count smearing by default. This provides a more realistic simulation of detector response.

## Key changes

- Set `m_use_photon_statistics` to `true` by default.
- Set `m_use_sipm_occupancy` to `true` by default.

## Potential risk areas

- The changes may alter reconstructed EMCal observables and simulation outputs.
- They may increase simulation CPU time.
- No I/O format or thread-safety changes are expected.

## Possible future improvements

- Validate the impact against reference simulations and data.
- Document the expected performance and reconstruction changes.
- Add regression tests for both smearing options.

This summary is based on the provided change description. AI-generated summaries can contain mistakes, so contributors should verify the implementation and its physics impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->