### PR TITLE
CaloReco: add tower timing calibration

### DIFF
--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
@@ -22,9 +22,9 @@
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
-#include <TH1F.h>
-#include <TH2F.h>
 #include <TAxis.h>
+#include <TH1.h>
+#include <TH2.h>
 #include <TSystem.h>
 
 #include <cmath>
@@ -143,22 +143,22 @@ bool CaloTowerTimeCalibration::ResolveDetector()
 
 void CaloTowerTimeCalibration::ResolveNames()
 {
-  if (!m_useExactInputNodeName)
+  if (!m_inputNodePrefix.empty())
   {
     m_inputNodeName = m_inputNodePrefix + m_detector;
   }
 
-  if (!m_useExactOutputNodeName)
+  if (!m_outputNodePrefix.empty())
   {
     m_outputNodeName = m_outputNodePrefix + m_detector;
   }
 
-  if (!m_useCustomMeanTimeCalibName)
+  if (!m_meanTimeCalibName.empty())
   {
     m_meanTimeCalibName = m_detector + "_meanTime";
   }
 
-  if (!m_useCustomTimeCorrectionCalibName)
+  if (!m_timeCorrectionCalibName.empty())
   {
     // Central-CDB fallback used after an official domain is available.
     m_timeCorrectionCalibName = m_detector + "_timeCalib_MV_test";
@@ -167,8 +167,7 @@ void CaloTowerTimeCalibration::ResolveNames()
 
 std::string CaloTowerTimeCalibration::BuildLocalTimeCorrectionURL() const
 {
-  if (!m_useLocalTimeCorrectionFiles
-      || m_localTimeCorrectionDirectory.empty())
+  if (m_localTimeCorrectionDirectory.empty())
   {
     return {};
   }
@@ -214,14 +213,14 @@ int CaloTowerTimeCalibration::InitRun(PHCompositeNode *topNode)
   m_calibrationAvailable = false;
 
   const std::string meanTimeURL =
-      m_useDirectMeanTimeURL
+    !m_directMeanTimeURL.empty()
           ? m_directMeanTimeURL
           : CDBInterface::instance()->getUrl(m_meanTimeCalibName);
 
   std::string timeCorrectionURL;
   std::string attemptedLocalURL;
 
-  if (m_useDirectTimeCorrectionURL)
+  if (!m_directTimeCorrectionURL.empty())
   {
     timeCorrectionURL = m_directTimeCorrectionURL;
     std::cout << Name() << "::" << m_detector

--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
@@ -1,0 +1,782 @@
+#include "CaloTowerTimeCalibration.h"
+
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <globalvertex/GlobalVertex.h>
+#include <globalvertex/GlobalVertexMap.h>
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <qautils/QAHistManagerDef.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/recoConsts.h>
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TAxis.h>
+#include <TSystem.h>
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+// Towers with invalid timing calibration are assigned NaN.
+// Downstream analyses should require std::isfinite(tower->get_time())
+// before using tower timing.
+//
+// ZS tower timing is not recalibrated; the standard calibrated
+// tower time is copied unchanged.
+namespace
+{
+  constexpr float InvalidSentinelLimit = -998.5F;
+
+  bool IsUsableConstant(float value)
+  {
+    return std::isfinite(value) && value > InvalidSentinelLimit;
+  }
+
+  std::string FoundText(const std::string &url)
+  {
+    return url.empty() ? " [missing]" : " [found]";
+  }
+
+  template <class HistogramType>
+  void StyleHistogram(HistogramType *histogram)
+  {
+    if (!histogram)
+    {
+      return;
+    }
+
+    // Store HIST as the default ROOT draw option for every QA histogram.
+    // This keeps bin outlines/steps visible instead of point/error-bar drawing
+    // when the histogram is opened without an explicit Draw() option.
+    histogram->SetOption("HIST");
+
+    // ROOT font 62 is Helvetica bold. Use a slightly smaller stored axis
+    // style so long labels like "(sample)" fit cleanly when users open the
+    // histograms directly from the ROOT file.
+    constexpr int boldFont = 62;
+    constexpr float axisTitleSize = 0.045F;
+    constexpr float axisLabelSize = 0.036F;
+    constexpr float xTitleOffset = 0.95F;
+    constexpr float yTitleOffset = 0.90F;
+    constexpr float zTitleOffset = 0.95F;
+
+    TAxis *axes[] = {
+        histogram->GetXaxis(),
+        histogram->GetYaxis(),
+        histogram->GetZaxis()};
+
+    for (TAxis *axis : axes)
+    {
+      if (!axis)
+      {
+        continue;
+      }
+
+      axis->SetTitleFont(boldFont);
+      axis->SetLabelFont(boldFont);
+      axis->SetTitleSize(axisTitleSize);
+      axis->SetLabelSize(axisLabelSize);
+    }
+
+    if (histogram->GetXaxis())
+    {
+      histogram->GetXaxis()->SetTitleOffset(xTitleOffset);
+    }
+    if (histogram->GetYaxis())
+    {
+      histogram->GetYaxis()->SetTitleOffset(yTitleOffset);
+    }
+    if (histogram->GetZaxis())
+    {
+      histogram->GetZaxis()->SetTitleOffset(zTitleOffset);
+    }
+  }
+}  // namespace
+
+CaloTowerTimeCalibration::CaloTowerTimeCalibration(const std::string &name)
+  : SubsysReco(name)
+  , m_qaEnergyThreshold(0.3F)
+{
+}
+
+CaloTowerTimeCalibration::~CaloTowerTimeCalibration()
+{
+  delete m_meanTimeCDB;
+  delete m_timeCorrectionCDB;
+}
+
+bool CaloTowerTimeCalibration::ResolveDetector()
+{
+  if (m_detectorType == CaloTowerDefs::CEMC)
+  {
+    m_detector = "CEMC";
+    return true;
+  }
+  if (m_detectorType == CaloTowerDefs::HCALIN)
+  {
+    m_detector = "HCALIN";
+    return true;
+  }
+  if (m_detectorType == CaloTowerDefs::HCALOUT)
+  {
+    m_detector = "HCALOUT";
+    return true;
+  }
+
+  return false;
+}
+
+void CaloTowerTimeCalibration::ResolveNames()
+{
+  if (!m_useExactInputNodeName)
+  {
+    m_inputNodeName = m_inputNodePrefix + m_detector;
+  }
+
+  if (!m_useExactOutputNodeName)
+  {
+    m_outputNodeName = m_outputNodePrefix + m_detector;
+  }
+
+  if (!m_useCustomMeanTimeCalibName)
+  {
+    m_meanTimeCalibName = m_detector + "_meanTime";
+  }
+
+  if (!m_useCustomTimeCorrectionCalibName)
+  {
+    // Central-CDB fallback used after an official domain is available.
+    m_timeCorrectionCalibName = m_detector + "_timeCalib_MV_test";
+  }
+}
+
+std::string CaloTowerTimeCalibration::BuildLocalTimeCorrectionURL() const
+{
+  if (!m_useLocalTimeCorrectionFiles
+      || m_localTimeCorrectionDirectory.empty())
+  {
+    return {};
+  }
+
+  recoConsts *recoConst = recoConsts::instance();
+  const uint64_t runnumber =
+      recoConst->get_uint64Flag("TIMESTAMP");
+
+  if (runnumber == 0)
+  {
+    return {};
+  }
+
+  std::string directory = m_localTimeCorrectionDirectory;
+  while (!directory.empty() && directory.back() == '/')
+  {
+    directory.pop_back();
+  }
+
+  return directory
+         + "/"
+         + m_detector
+         + "_timeCalib_MV_test_run"
+         + std::to_string(runnumber)
+         + ".root";
+}
+
+int CaloTowerTimeCalibration::InitRun(PHCompositeNode *topNode)
+{
+  if (!ResolveDetector())
+  {
+    std::cerr << Name() << ": unsupported detector type" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  ResolveNames();
+
+  delete m_meanTimeCDB;
+  m_meanTimeCDB = nullptr;
+  delete m_timeCorrectionCDB;
+  m_timeCorrectionCDB = nullptr;
+  m_timingInfo.clear();
+  m_calibrationAvailable = false;
+
+  const std::string meanTimeURL =
+      m_useDirectMeanTimeURL
+          ? m_directMeanTimeURL
+          : CDBInterface::instance()->getUrl(m_meanTimeCalibName);
+
+  std::string timeCorrectionURL;
+  std::string attemptedLocalURL;
+
+  if (m_useDirectTimeCorrectionURL)
+  {
+    timeCorrectionURL = m_directTimeCorrectionURL;
+    std::cout << Name() << "::" << m_detector
+              << ": using direct custom timing payload "
+              << timeCorrectionURL << std::endl;
+  }
+  else
+  {
+    attemptedLocalURL = BuildLocalTimeCorrectionURL();
+
+    if (!attemptedLocalURL.empty()
+        && !gSystem->AccessPathName(attemptedLocalURL.c_str()))
+    {
+      timeCorrectionURL = attemptedLocalURL;
+      std::cout << Name() << "::" << m_detector
+                << ": using local custom timing payload "
+                << timeCorrectionURL << std::endl;
+    }
+    else
+    {
+      if (!attemptedLocalURL.empty())
+      {
+        std::cout << Name() << "::" << m_detector
+                  << ": local custom timing payload not found: "
+                  << attemptedLocalURL << std::endl;
+      }
+
+      // Future fallback after the payload has an official CDB domain.
+      timeCorrectionURL =
+          CDBInterface::instance()->getUrl(m_timeCorrectionCalibName);
+    }
+  }
+
+  if (meanTimeURL.empty() || timeCorrectionURL.empty())
+  {
+    std::cerr << Name() << "::" << m_detector
+              << ": missing required timing calibration" << std::endl
+              << "  mean-time CDB " << m_meanTimeCalibName
+              << FoundText(meanTimeURL) << std::endl;
+
+    if (!attemptedLocalURL.empty())
+    {
+      std::cerr << "  attempted local payload "
+                << attemptedLocalURL << " [missing]" << std::endl;
+    }
+
+    std::cerr << "  custom timing CDB " << m_timeCorrectionCalibName
+              << FoundText(timeCorrectionURL) << std::endl;
+
+    if (m_abortMissingCalibration)
+    {
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  m_meanTimeCDB = new CDBTTree(meanTimeURL);
+  m_timeCorrectionCDB = new CDBTTree(timeCorrectionURL);
+
+  try
+  {
+    CreateNodeTree(topNode);
+    CreateQAHistograms();
+    LoadCalibration(topNode);
+  }
+  catch (const std::exception &error)
+  {
+    std::cerr << Name() << "::" << m_detector
+              << ": " << error.what() << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_calibrationAvailable = true;
+
+  std::cout << Name() << "::" << m_detector
+            << " input=" << m_inputNodeName
+            << " output=" << m_outputNodeName
+            << " custom_payload=" << timeCorrectionURL
+            << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloTowerTimeCalibration::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator iterator(topNode);
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(
+      iterator.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    throw std::runtime_error("DST node is missing");
+  }
+
+  TowerInfoContainer *inputTowers =
+      findNode::getClass<TowerInfoContainer>(topNode, m_inputNodeName);
+  if (!inputTowers)
+  {
+    throw std::runtime_error(
+        "missing input node " + m_inputNodeName
+        + "; register this subsystem after standard CaloTowerCalib");
+  }
+
+  PHCompositeNode *detectorNode = dynamic_cast<PHCompositeNode *>(
+      iterator.findFirst("PHCompositeNode", m_detector));
+  if (!detectorNode)
+  {
+    detectorNode = new PHCompositeNode(m_detector);
+    dstNode->addNode(detectorNode);
+  }
+
+  TowerInfoContainer *outputTowers =
+      findNode::getClass<TowerInfoContainer>(topNode, m_outputNodeName);
+
+  if (!outputTowers)
+  {
+    outputTowers =
+        dynamic_cast<TowerInfoContainer *>(inputTowers->CloneMe());
+    if (!outputTowers)
+    {
+      throw std::runtime_error("failed to clone input tower container");
+    }
+
+    auto *outputNode = new PHIODataNode<PHObject>(
+        outputTowers,
+        m_outputNodeName,
+        "PHObject");
+
+    detectorNode->addNode(outputNode);
+  }
+}
+
+void CaloTowerTimeCalibration::LoadCalibration(PHCompositeNode *topNode)
+{
+  TowerInfoContainer *inputTowers =
+      findNode::getClass<TowerInfoContainer>(topNode, m_inputNodeName);
+  if (!inputTowers)
+  {
+    throw std::runtime_error("missing input node " + m_inputNodeName);
+  }
+
+  if (!m_meanTimeCDB || !m_timeCorrectionCDB)
+  {
+    throw std::runtime_error("timing CDB objects were not created");
+  }
+
+  const unsigned int numberOfTowers = inputTowers->size();
+  m_timingInfo.resize(numberOfTowers);
+
+  const int payloadTowerCount =
+      m_timeCorrectionCDB->GetSingleIntValue("ntowers");
+  const int formulaVersion =
+      m_timeCorrectionCDB->GetSingleIntValue("formula_version");
+  const int payloadRun =
+      m_timeCorrectionCDB->GetSingleIntValue("runnumber");
+
+  recoConsts *recoConst = recoConsts::instance();
+  const int requestedRun = static_cast<int>(
+      recoConst->get_uint64Flag("TIMESTAMP"));
+
+  if (payloadTowerCount > 0
+      && static_cast<unsigned int>(payloadTowerCount) != numberOfTowers)
+  {
+    throw std::runtime_error(
+        "payload ntowers does not match " + m_inputNodeName);
+  }
+
+  if (payloadRun > 0 && requestedRun > 0 && payloadRun != requestedRun)
+  {
+    throw std::runtime_error(
+        "payload run " + std::to_string(payloadRun)
+        + " does not match TIMESTAMP " + std::to_string(requestedRun));
+  }
+
+  unsigned int invalidTowers = 0;
+
+  for (unsigned int channel = 0;
+       channel < numberOfTowers;
+       ++channel)
+  {
+    const unsigned int encodedKey = inputTowers->encode_key(channel);
+    TimingInfo &timing = m_timingInfo[channel];
+
+    // Standard CaloTowerCalib used this value as:
+    // standard_time = raw_time - mean_time.
+    timing.meanTime =
+        m_meanTimeCDB->GetFloatValue(encodedKey, "time");
+
+    // MakeAllTimingCDB_MV_test writes these values by flat channel.
+    timing.phase1Shift =
+        m_timeCorrectionCDB->GetFloatValue(channel, "phase1_shift");
+    timing.sectorOffset =
+        m_timeCorrectionCDB->GetFloatValue(channel, "sector_offset");
+    timing.towerOffset =
+        m_timeCorrectionCDB->GetFloatValue(channel, "tower_offset");
+    timing.slewP0 =
+        m_timeCorrectionCDB->GetFloatValue(channel, "slew_p0");
+    timing.slewP1 =
+        m_timeCorrectionCDB->GetFloatValue(channel, "slew_p1");
+    timing.slewP2 =
+        m_timeCorrectionCDB->GetFloatValue(channel, "slew_p2");
+
+    bool valid =
+        IsUsableConstant(timing.meanTime)
+        && IsUsableConstant(timing.phase1Shift)
+        && IsUsableConstant(timing.sectorOffset)
+        && IsUsableConstant(timing.towerOffset)
+        && IsUsableConstant(timing.slewP0)
+        && IsUsableConstant(timing.slewP1)
+        && IsUsableConstant(timing.slewP2);
+
+    if (formulaVersion >= 3)
+    {
+      valid = valid
+              && m_timeCorrectionCDB->GetIntValue(
+                     channel,
+                     "timing_valid") != 0;
+    }
+
+    timing.valid = valid;
+
+    if (!valid)
+    {
+      ++invalidTowers;
+    }
+
+  }
+
+  std::cout << Name() << "::" << m_detector
+            << " loaded " << numberOfTowers
+            << " channels; invalid=" << invalidTowers
+            << ", formula_version=" << formulaVersion
+            << std::endl;
+}
+
+int CaloTowerTimeCalibration::process_event(PHCompositeNode *topNode)
+{
+  if (!m_calibrationAvailable)
+  {
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  TowerInfoContainer *standardTowers =
+      findNode::getClass<TowerInfoContainer>(topNode, m_inputNodeName);
+  TowerInfoContainer *timingTowers =
+      findNode::getClass<TowerInfoContainer>(topNode, m_outputNodeName);
+
+  if (!standardTowers || !timingTowers)
+  {
+    std::cerr << Name() << "::" << m_detector
+              << ": required tower node is missing" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  if (standardTowers->size() != timingTowers->size()
+      || standardTowers->size() != m_timingInfo.size())
+  {
+    std::cerr << Name() << "::" << m_detector
+              << ": tower-container size mismatch" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  const unsigned int numberOfTowers = standardTowers->size();
+
+  // QA is filled only for events with a finite reconstructed global z vertex.
+  // There is no |zvtx| magnitude cut and no zvtx-vs-time histogram.
+  bool haveValidZVertex = false;
+
+  if (m_doQA)
+  {
+    GlobalVertexMap *vertexMap =
+        findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+
+    if (vertexMap && !vertexMap->empty())
+    {
+      GlobalVertex *vertex = vertexMap->begin()->second;
+      if (vertex)
+      {
+        haveValidZVertex = std::isfinite(vertex->get_z());
+      }
+    }
+  }
+
+  for (unsigned int channel = 0;
+       channel < numberOfTowers;
+       ++channel)
+  {
+    TowerInfo *standardTower =
+        standardTowers->get_tower_at_channel(channel);
+    TowerInfo *timingTower =
+        timingTowers->get_tower_at_channel(channel);
+
+    if (!standardTower || !timingTower)
+    {
+      continue;
+    }
+
+    // Preserve calibrated energy and all metadata/status in the sidecar node.
+    timingTower->copy_tower(standardTower);
+
+    // ZS timing is not custom-corrected. Fill dedicated ZS QA directly from
+    // the standard calibrated tower, then leave the copied sidecar unchanged.
+    // ZS QA is restricted to towers that pass get_isGood(). Do not apply
+    // m_qaEnergyThreshold here: all energies of good ZS towers are retained.
+    if (standardTower->get_isZS())
+    {
+      if (m_doQA && haveValidZVertex && standardTower->get_isGood())
+      {
+        const float zsTime = standardTower->get_time();
+        const float zsEnergy = standardTower->get_energy();
+
+        if (std::isfinite(zsTime) && m_hZSTime)
+        {
+          m_hZSTime->Fill(zsTime);
+        }
+
+        if (std::isfinite(zsEnergy) && m_hZSEnergy)
+        {
+          m_hZSEnergy->Fill(zsEnergy);
+        }
+
+        if (std::isfinite(zsTime)
+            && std::isfinite(zsEnergy)
+            && m_hZSEnergyVsTime)
+        {
+          // Time is the x axis, matching the rest of the timing QA.
+          m_hZSEnergyVsTime->Fill(zsTime, zsEnergy);
+        }
+      }
+
+      continue;
+    }
+
+    const TimingInfo &timing = m_timingInfo[channel];
+    if (!timing.valid)
+    {
+      timingTower->set_time(std::numeric_limits<float>::quiet_NaN());
+      continue;
+    }
+
+    const float standardTime = standardTower->get_time();
+    const float calibratedEnergy = standardTower->get_energy();
+
+    if (!std::isfinite(standardTime)
+        || !std::isfinite(calibratedEnergy))
+    {
+      timingTower->set_time(std::numeric_limits<float>::quiet_NaN());
+      continue;
+    }
+
+    // Standard CaloTowerCalib stores raw_time - official_mean_time.
+    const float reconstructedRawTime =
+        standardTime + timing.meanTime;
+
+    const float slewCorrection =
+        timing.slewP0
+        + timing.slewP1
+              * std::exp(timing.slewP2 * calibratedEnergy);
+
+    const float correctedTime =
+        reconstructedRawTime
+        + timing.phase1Shift
+        - timing.sectorOffset
+        - timing.towerOffset
+        - slewCorrection;
+
+    if (!std::isfinite(reconstructedRawTime)
+        || !std::isfinite(slewCorrection)
+        || !std::isfinite(correctedTime))
+    {
+      timingTower->set_time(std::numeric_limits<float>::quiet_NaN());
+      continue;
+    }
+
+    // Calibration is written before any QA quality definition is applied.
+    timingTower->set_time(correctedTime);
+
+    if (!m_doQA
+        || !haveValidZVertex
+        || calibratedEnergy < m_qaEnergyThreshold)
+    {
+      continue;
+    }
+
+    const auto fillTowerQA =
+        [&](TowerQASet &qa)
+        {
+          qa.hStandardTime->Fill(standardTime);
+          qa.hCorrectedTime->Fill(correctedTime);
+
+          // Time is always the x axis.
+          qa.hStandardEnergyVsTime->Fill(
+              standardTime,
+              calibratedEnergy);
+          qa.hCorrectedEnergyVsTime->Fill(
+              correctedTime,
+              calibratedEnergy);
+
+        };
+
+    // No get_isGood() requirement.
+    fillTowerQA(m_qaAllTowers);
+
+    if (standardTower->get_isGood())
+    {
+      fillTowerQA(m_qaGoodTowers);
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloTowerTimeCalibration::CreateQAHistograms()
+{
+  if (!m_doQA || m_qaHistogramsInitialized)
+  {
+    return;
+  }
+
+  Fun4AllHistoManager *histogramManager =
+      QAHistManagerDef::getHistoManager();
+  if (!histogramManager)
+  {
+    throw std::runtime_error(
+        Name() + "::" + m_detector
+        + ": QAHistManagerDef returned a null histogram manager");
+  }
+
+  const std::string prefix =
+      "h_CaloTowerTimeCalibration_" + m_detector;
+  const std::string title =
+      "CaloTowerTimeCalibration " + m_detector;
+
+  constexpr int timeBins = 2000;
+  constexpr float timeMin = -10.0F;
+  constexpr float timeMax = 10.0F;
+  constexpr int energyBins = 250;
+  constexpr float energyMin = 0.0F;
+  constexpr float energyMax = 25.0F;
+
+  // ZS towers are concentrated at low energy. Use 10 MeV (0.01 GeV) bins
+  // over 0--1 GeV for the dedicated ZS energy QA.
+  constexpr int zsEnergyBins = 100;
+  constexpr float zsEnergyMin = 0.0F;
+  constexpr float zsEnergyMax = 1.0F;
+
+  // Dedicated good-ZS QA. The timing sidecar intentionally does not modify ZS
+  // tower times, so these are filled from standard towers passing get_isGood().
+  m_hZSTime = new TH1F(
+      (prefix + "_ZS_time").c_str(),
+      (title + ", good ZS towers;ZS tower time (sample);towers").c_str(),
+      timeBins,
+      timeMin,
+      timeMax);
+
+  m_hZSEnergy = new TH1F(
+      (prefix + "_ZS_energy").c_str(),
+      (title + ", good ZS towers;ZS tower calibrated energy (GeV);towers").c_str(),
+      zsEnergyBins,
+      zsEnergyMin,
+      zsEnergyMax);
+
+  m_hZSEnergyVsTime = new TH2F(
+      (prefix + "_ZS_energy_vs_time").c_str(),
+      (title
+       + ", good ZS towers;ZS tower time (sample);ZS tower calibrated energy (GeV)")
+          .c_str(),
+      timeBins,
+      timeMin,
+      timeMax,
+      zsEnergyBins,
+      zsEnergyMin,
+      zsEnergyMax);
+
+  StyleHistogram(m_hZSTime);
+  StyleHistogram(m_hZSEnergy);
+  StyleHistogram(m_hZSEnergyVsTime);
+
+  histogramManager->registerHisto(m_hZSTime);
+  histogramManager->registerHisto(m_hZSEnergy);
+  histogramManager->registerHisto(m_hZSEnergyVsTime);
+
+  const auto bookTowerQASet =
+      [&](TowerQASet &qa,
+          const std::string &nameSuffix,
+          const std::string &titleSuffix)
+      {
+        const std::string qaPrefix = prefix + nameSuffix;
+        const std::string qaTitle = title + titleSuffix;
+
+        qa.hStandardTime = new TH1F(
+            (qaPrefix + "_standard_time").c_str(),
+            (qaTitle + ";standard time (sample);towers").c_str(),
+            timeBins,
+            timeMin,
+            timeMax);
+
+        qa.hCorrectedTime = new TH1F(
+            (qaPrefix + "_corrected_time").c_str(),
+            (qaTitle + ";custom corrected time (sample);towers").c_str(),
+            timeBins,
+            timeMin,
+            timeMax);
+
+        qa.hStandardEnergyVsTime = new TH2F(
+            (qaPrefix + "_standard_energy_vs_time").c_str(),
+            (qaTitle + ";standard time (sample);calibrated energy (GeV)").c_str(),
+            timeBins,
+            timeMin,
+            timeMax,
+            energyBins,
+            energyMin,
+            energyMax);
+
+        qa.hCorrectedEnergyVsTime = new TH2F(
+            (qaPrefix + "_corrected_energy_vs_time").c_str(),
+            (qaTitle + ";custom corrected time (sample);calibrated energy (GeV)").c_str(),
+            timeBins,
+            timeMin,
+            timeMax,
+            energyBins,
+            energyMin,
+            energyMax);
+
+        StyleHistogram(qa.hStandardTime);
+        StyleHistogram(qa.hCorrectedTime);
+        StyleHistogram(qa.hStandardEnergyVsTime);
+        StyleHistogram(qa.hCorrectedEnergyVsTime);
+
+        histogramManager->registerHisto(qa.hStandardTime);
+        histogramManager->registerHisto(qa.hCorrectedTime);
+        histogramManager->registerHisto(qa.hStandardEnergyVsTime);
+        histogramManager->registerHisto(qa.hCorrectedEnergyVsTime);
+
+        // No |zvtx| magnitude-cut histograms are booked. These inclusive
+        // histograms are filled only when the event has a finite global z vertex.
+      };
+
+  bookTowerQASet(
+      m_qaAllTowers,
+      "",
+      ", all accepted towers (no get_isGood cut)");
+
+  bookTowerQASet(
+      m_qaGoodTowers,
+      "_isGood",
+      ", strict TowerInfo::get_isGood() towers");
+
+  // Intentionally no Sumw2 calls; all histograms are filled with unit weight.
+  m_qaHistogramsInitialized = true;
+
+  std::cout << Name() << "::" << m_detector
+            << " booked all-tower and strict-get_isGood energy/time QA sets"
+            << "; plus get_isGood ZS time, energy, and energy-vs-time QA"
+            << "; QA requires a finite global z vertex but applies no |zvtx| cut"
+            << std::endl;
+}

--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
@@ -25,7 +25,6 @@
 #include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TSystem.h>
 
 #include <cmath>
 #include <iostream>
@@ -59,6 +58,8 @@ namespace
     {
       return;
     }
+
+    histogram->SetDirectory(nullptr);
 
     // Store HIST as the default ROOT draw option for every QA histogram.
     // This keeps bin outlines/steps visible instead of point/error-bar drawing
@@ -143,57 +144,30 @@ bool CaloTowerTimeCalibration::ResolveDetector()
 
 void CaloTowerTimeCalibration::ResolveNames()
 {
-  if (!m_inputNodePrefix.empty())
-  {
-    m_inputNodeName = m_inputNodePrefix + m_detector;
-  }
+ if (m_inputNodeName.empty())
+ {
+   m_inputNodeName = m_inputNodePrefix + m_detector;
+ }
 
-  if (!m_outputNodePrefix.empty())
-  {
-    m_outputNodeName = m_outputNodePrefix + m_detector;
-  }
+ if (m_outputNodeName.empty())
+ {
+   m_outputNodeName = m_outputNodePrefix + m_detector;
+ }
 
-  if (!m_meanTimeCalibName.empty())
-  {
-    m_meanTimeCalibName = m_detector + "_meanTime";
-  }
+ if (m_meanTimeCalibName.empty())
+ {
+   m_meanTimeCalibName = m_detector + "_meanTime";
+ }
 
-  if (!m_timeCorrectionCalibName.empty())
-  {
-    // Central-CDB fallback used after an official domain is available.
-    m_timeCorrectionCalibName = m_detector + "_timeCalib_MV_test";
-  }
+ if (m_timeCorrectionCalibName.empty())
+ {
+   // Official custom tower timing calibration CDB domain.
+   m_timeCorrectionCalibName =
+       m_detector + "_towerTimeCalib";
+ }
+
 }
 
-std::string CaloTowerTimeCalibration::BuildLocalTimeCorrectionURL() const
-{
-  if (m_localTimeCorrectionDirectory.empty())
-  {
-    return {};
-  }
-
-  recoConsts *recoConst = recoConsts::instance();
-  const uint64_t runnumber =
-      recoConst->get_uint64Flag("TIMESTAMP");
-
-  if (runnumber == 0)
-  {
-    return {};
-  }
-
-  std::string directory = m_localTimeCorrectionDirectory;
-  while (!directory.empty() && directory.back() == '/')
-  {
-    directory.pop_back();
-  }
-
-  return directory
-         + "/"
-         + m_detector
-         + "_timeCalib_MV_test_run"
-         + std::to_string(runnumber)
-         + ".root";
-}
 
 int CaloTowerTimeCalibration::InitRun(PHCompositeNode *topNode)
 {
@@ -217,69 +191,50 @@ int CaloTowerTimeCalibration::InitRun(PHCompositeNode *topNode)
           ? m_directMeanTimeURL
           : CDBInterface::instance()->getUrl(m_meanTimeCalibName);
 
-  std::string timeCorrectionURL;
-  std::string attemptedLocalURL;
+  const std::string timeCorrectionURL =
+      !m_directTimeCorrectionURL.empty()
+          ? m_directTimeCorrectionURL
+          : CDBInterface::instance()->getUrl(
+                m_timeCorrectionCalibName);
+
+  if (!m_directMeanTimeURL.empty())
+  {
+    std::cout << Name() << "::" << m_detector
+              << ": using direct mean-time payload "
+              << meanTimeURL
+              << std::endl;
+  }
 
   if (!m_directTimeCorrectionURL.empty())
   {
-    timeCorrectionURL = m_directTimeCorrectionURL;
     std::cout << Name() << "::" << m_detector
               << ": using direct custom timing payload "
-              << timeCorrectionURL << std::endl;
-  }
-  else
-  {
-    attemptedLocalURL = BuildLocalTimeCorrectionURL();
-
-    if (!attemptedLocalURL.empty()
-        && !gSystem->AccessPathName(attemptedLocalURL.c_str()))
-    {
-      timeCorrectionURL = attemptedLocalURL;
-      std::cout << Name() << "::" << m_detector
-                << ": using local custom timing payload "
-                << timeCorrectionURL << std::endl;
-    }
-    else
-    {
-      if (!attemptedLocalURL.empty())
-      {
-        std::cout << Name() << "::" << m_detector
-                  << ": local custom timing payload not found: "
-                  << attemptedLocalURL << std::endl;
-      }
-
-      // Future fallback after the payload has an official CDB domain.
-      timeCorrectionURL =
-          CDBInterface::instance()->getUrl(m_timeCorrectionCalibName);
-    }
+              << timeCorrectionURL
+              << std::endl;
   }
 
   if (meanTimeURL.empty() || timeCorrectionURL.empty())
   {
     std::cerr << Name() << "::" << m_detector
-              << ": missing required timing calibration" << std::endl
-              << "  mean-time CDB " << m_meanTimeCalibName
-              << FoundText(meanTimeURL) << std::endl;
+              << ": missing required timing calibration"
+              << std::endl
+              << "  mean-time CDB "
+              << m_meanTimeCalibName
+              << FoundText(meanTimeURL)
+              << std::endl
+              << "  custom timing CDB "
+              << m_timeCorrectionCalibName
+              << FoundText(timeCorrectionURL)
+              << std::endl;
 
-    if (!attemptedLocalURL.empty())
-    {
-      std::cerr << "  attempted local payload "
-                << attemptedLocalURL << " [missing]" << std::endl;
-    }
-
-    std::cerr << "  custom timing CDB " << m_timeCorrectionCalibName
-              << FoundText(timeCorrectionURL) << std::endl;
-
-    if (m_abortMissingCalibration)
-    {
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
-
-    return Fun4AllReturnCodes::EVENT_OK;
+    return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_meanTimeCDB = new CDBTTree(meanTimeURL);
-  m_timeCorrectionCDB = new CDBTTree(timeCorrectionURL);
+  m_meanTimeCDB =
+      new CDBTTree(meanTimeURL);
+
+  m_timeCorrectionCDB =
+      new CDBTTree(timeCorrectionURL);
 
   try
   {
@@ -290,7 +245,9 @@ int CaloTowerTimeCalibration::InitRun(PHCompositeNode *topNode)
   catch (const std::exception &error)
   {
     std::cerr << Name() << "::" << m_detector
-              << ": " << error.what() << std::endl;
+              << ": " << error.what()
+              << std::endl;
+
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -299,6 +256,7 @@ int CaloTowerTimeCalibration::InitRun(PHCompositeNode *topNode)
   std::cout << Name() << "::" << m_detector
             << " input=" << m_inputNodeName
             << " output=" << m_outputNodeName
+            << " mean_time_payload=" << meanTimeURL
             << " custom_payload=" << timeCorrectionURL
             << std::endl;
 
@@ -325,8 +283,10 @@ void CaloTowerTimeCalibration::CreateNodeTree(PHCompositeNode *topNode)
         + "; register this subsystem after standard CaloTowerCalib");
   }
 
+  PHNodeIterator dstIterator(dstNode);
+
   PHCompositeNode *detectorNode = dynamic_cast<PHCompositeNode *>(
-      iterator.findFirst("PHCompositeNode", m_detector));
+      dstIterator.findFirst("PHCompositeNode", m_detector));
   if (!detectorNode)
   {
     detectorNode = new PHCompositeNode(m_detector);
@@ -380,7 +340,7 @@ void CaloTowerTimeCalibration::LoadCalibration(PHCompositeNode *topNode)
 
   recoConsts *recoConst = recoConsts::instance();
   const int requestedRun = static_cast<int>(
-      recoConst->get_uint64Flag("TIMESTAMP"));
+      recoConst->get_IntFlag("RUNNUMBER"));
 
   if (payloadTowerCount > 0
       && static_cast<unsigned int>(payloadTowerCount) != numberOfTowers)
@@ -393,7 +353,7 @@ void CaloTowerTimeCalibration::LoadCalibration(PHCompositeNode *topNode)
   {
     throw std::runtime_error(
         "payload run " + std::to_string(payloadRun)
-        + " does not match TIMESTAMP " + std::to_string(requestedRun));
+        + " does not match RUNNUMBER " + std::to_string(requestedRun));
   }
 
   unsigned int invalidTowers = 0;
@@ -609,16 +569,25 @@ int CaloTowerTimeCalibration::process_event(PHCompositeNode *topNode)
     const auto fillTowerQA =
         [&](TowerQASet &qa)
         {
-          qa.hStandardTime->Fill(standardTime);
-          qa.hCorrectedTime->Fill(correctedTime);
+	 if (qa.hStandardTime)
+	 {
+     qa.hStandardTime->Fill(standardTime);
+	 }
 
-          // Time is always the x axis.
-          qa.hStandardEnergyVsTime->Fill(
-              standardTime,
-              calibratedEnergy);
-          qa.hCorrectedEnergyVsTime->Fill(
-              correctedTime,
-              calibratedEnergy);
+	 if (qa.hCorrectedTime)
+	 {
+     qa.hCorrectedTime->Fill(correctedTime);
+	 }
+
+	 if (qa.hStandardEnergyVsTime)
+	 {
+     qa.hStandardEnergyVsTime->Fill(standardTime, calibratedEnergy);
+	 }
+
+	 if (qa.hCorrectedEnergyVsTime)
+	 {
+     qa.hCorrectedEnergyVsTime->Fill(correctedTime, calibratedEnergy);
+	 }
 
         };
 

--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.cc
@@ -339,8 +339,7 @@ void CaloTowerTimeCalibration::LoadCalibration(PHCompositeNode *topNode)
       m_timeCorrectionCDB->GetSingleIntValue("runnumber");
 
   recoConsts *recoConst = recoConsts::instance();
-  const int requestedRun = static_cast<int>(
-      recoConst->get_IntFlag("RUNNUMBER"));
+  const int requestedRun = recoConst->get_IntFlag("RUNNUMBER");
 
   if (payloadTowerCount > 0
       && static_cast<unsigned int>(payloadTowerCount) != numberOfTowers)

--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.h
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.h
@@ -1,0 +1,222 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-
+#ifndef CALOTOWERTIMECALIBRATION_H
+#define CALOTOWERTIMECALIBRATION_H
+
+#include <caloreco/CaloTowerDefs.h>
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+#include <vector>
+
+class CDBTTree;
+class PHCompositeNode;
+class TH1F;
+class TH2F;
+
+/**
+ * Timing-only sidecar calibration for calibrated TowerInfo nodes.
+ *
+ * Default input node:
+ *   TOWERINFO_CALIB_<detector>
+ *
+ * Default output node:
+ *   TOWERINFO_CALIB_TIMING_<detector>
+ *
+ * The input node is never modified. The output container is copied from the
+ * input container, preserving calibrated energy and tower metadata/status.
+ * Only the output tower time is replaced for valid, non-ZS towers:
+ *
+ *   raw_time = standard_time + official_mean_time
+ *
+ *   slew(E) = slew_p0 + slew_p1 * exp(slew_p2 * calibrated_energy)
+ *
+ *   corrected_time = raw_time
+ *                  + phase1_shift
+ *                  - sector_offset
+ *                  - tower_offset
+ *                  - slew(E)
+ *
+ * QA is intentionally reduced to:
+ *   - standard and corrected tower-time distributions;
+ *   - standard and corrected energy-vs-time distributions;
+ *   - ZS-tower time, energy, and energy-vs-time distributions.
+ *
+ * ZS towers are copied into the timing sidecar without a custom timing
+ * correction. Their QA therefore uses the time and calibrated energy from the
+ * standard input tower directly.
+ *
+ * There are two tower-quality populations:
+ *   (1) all accepted non-ZS towers, with no get_isGood() requirement;
+ *   (2) strict TowerInfo::get_isGood().
+ *
+ * QA histograms are filled only for events with a finite reconstructed global
+ * z vertex, but no |zvtx| magnitude cut is applied.
+ */
+class CaloTowerTimeCalibration : public SubsysReco
+{
+ public:
+  explicit CaloTowerTimeCalibration(
+      const std::string &name = "CaloTowerTimeCalibration");
+  ~CaloTowerTimeCalibration() override;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+
+  void set_detector_type(CaloTowerDefs::DetectorSystem detector)
+  {
+    m_detectorType = detector;
+  }
+
+  void set_inputNodePrefix(const std::string &prefix)
+  {
+    m_inputNodePrefix = prefix;
+    m_useExactInputNodeName = false;
+  }
+
+  void set_outputNodePrefix(const std::string &prefix)
+  {
+    m_outputNodePrefix = prefix;
+    m_useExactOutputNodeName = false;
+  }
+
+  void set_inputNodeName(const std::string &name)
+  {
+    m_inputNodeName = name;
+    m_useExactInputNodeName = true;
+  }
+
+  void set_outputNodeName(const std::string &name)
+  {
+    m_outputNodeName = name;
+    m_useExactOutputNodeName = true;
+  }
+
+  void set_meanTimeCalibName(const std::string &name)
+  {
+    m_meanTimeCalibName = name;
+    m_useCustomMeanTimeCalibName = true;
+  }
+
+  void set_timeCorrectionCalibName(const std::string &name)
+  {
+    m_timeCorrectionCalibName = name;
+    m_useCustomTimeCorrectionCalibName = true;
+  }
+
+  void set_directURL_timeCorrection(const std::string &url)
+  {
+    m_directTimeCorrectionURL = url;
+    m_useDirectTimeCorrectionURL = true;
+  }
+
+  void set_localTimeCorrectionDirectory(const std::string &directory)
+  {
+    m_localTimeCorrectionDirectory = directory;
+  }
+
+  void set_useLocalTimeCorrectionFiles(bool value = true)
+  {
+    m_useLocalTimeCorrectionFiles = value;
+  }
+
+  void set_directURL_meanTime(const std::string &url)
+  {
+    m_directMeanTimeURL = url;
+    m_useDirectMeanTimeURL = true;
+  }
+
+  void set_doAbortMissingCalibration(bool value = true)
+  {
+    m_abortMissingCalibration = value;
+  }
+
+  void set_doQA(bool value = true)
+  {
+    m_doQA = value;
+  }
+
+  // QA threshold only; calibration is still applied below this energy.
+  void set_qaEnergyThreshold(float value)
+  {
+    m_qaEnergyThreshold = value;
+  }
+
+ private:
+  struct TimingInfo
+  {
+    float meanTime{0.0F};
+    float phase1Shift{0.0F};
+    float sectorOffset{0.0F};
+    float towerOffset{0.0F};
+    float slewP0{0.0F};
+    float slewP1{0.0F};
+    float slewP2{0.0F};
+    bool valid{false};
+  };
+
+  struct TowerQASet
+  {
+    TH1F *hStandardTime{nullptr};
+    TH1F *hCorrectedTime{nullptr};
+    TH2F *hStandardEnergyVsTime{nullptr};
+    TH2F *hCorrectedEnergyVsTime{nullptr};
+  };
+
+  bool ResolveDetector();
+  void ResolveNames();
+  std::string BuildLocalTimeCorrectionURL() const;
+  void CreateNodeTree(PHCompositeNode *topNode);
+  void LoadCalibration(PHCompositeNode *topNode);
+  void CreateQAHistograms();
+
+  CaloTowerDefs::DetectorSystem m_detectorType{CaloTowerDefs::HCALOUT};
+  std::string m_detector{"HCALOUT"};
+
+  std::string m_inputNodePrefix{"TOWERINFO_CALIB_"};
+  std::string m_outputNodePrefix{"TOWERINFO_CALIB_TIMING_"};
+  std::string m_inputNodeName;
+  std::string m_outputNodeName;
+  bool m_useExactInputNodeName{false};
+  bool m_useExactOutputNodeName{false};
+
+  std::string m_meanTimeCalibName;
+  std::string m_timeCorrectionCalibName;
+  bool m_useCustomMeanTimeCalibName{false};
+  bool m_useCustomTimeCorrectionCalibName{false};
+
+  bool m_useDirectMeanTimeURL{false};
+  bool m_useDirectTimeCorrectionURL{false};
+  std::string m_directMeanTimeURL;
+  std::string m_directTimeCorrectionURL;
+
+  bool m_useLocalTimeCorrectionFiles{true};
+  std::string m_localTimeCorrectionDirectory{
+      "/gpfs/mnt/gpfs02/sphenix/user/dading/"
+      "my_tower_time_calibrations/macro/timing_cdb"};
+
+  bool m_abortMissingCalibration{true};
+  bool m_calibrationAvailable{false};
+
+  CDBTTree *m_meanTimeCDB{nullptr};
+  CDBTTree *m_timeCorrectionCDB{nullptr};
+  std::vector<TimingInfo> m_timingInfo;
+
+  bool m_doQA{false};
+  bool m_qaHistogramsInitialized{false};
+  float m_qaEnergyThreshold;
+
+  // ZS-tower QA. ZS timing is not custom-corrected.
+  TH1F *m_hZSTime{nullptr};
+  TH1F *m_hZSEnergy{nullptr};
+  TH2F *m_hZSEnergyVsTime{nullptr};
+
+  // Complete tower QA without a get_isGood() requirement.
+  TowerQASet m_qaAllTowers;
+
+  // Strict TowerInfo::get_isGood() QA.
+  TowerQASet m_qaGoodTowers;
+};
+
+#endif  // CALOTOWERTIMECALIBRATION_H

--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.h
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.h
@@ -33,7 +33,7 @@ class TH2;
  *   slew(E) = slew_p0 + slew_p1 * exp(slew_p2 * calibrated_energy)
  *
  *   corrected_time = raw_time
- *                  + phase1_shift
+ *                  + phase1_shift(sample alignment)
  *                  - sector_offset
  *                  - tower_offset
  *                  - slew(E)
@@ -60,6 +60,15 @@ class CaloTowerTimeCalibration : public SubsysReco
   explicit CaloTowerTimeCalibration(
       const std::string &name = "CaloTowerTimeCalibration");
   ~CaloTowerTimeCalibration() override;
+
+  CaloTowerTimeCalibration(const CaloTowerTimeCalibration &) = delete;
+
+  CaloTowerTimeCalibration &operator=(const CaloTowerTimeCalibration &) = delete;
+
+  CaloTowerTimeCalibration(CaloTowerTimeCalibration &&) = delete;
+
+  CaloTowerTimeCalibration &operator=(CaloTowerTimeCalibration &&) = delete;
+
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -104,19 +113,9 @@ class CaloTowerTimeCalibration : public SubsysReco
     m_directTimeCorrectionURL = url;
   }
 
-  void set_localTimeCorrectionDirectory(const std::string &directory)
-  {
-    m_localTimeCorrectionDirectory = directory;
-  }
-
   void set_directURL_meanTime(const std::string &url)
   {
     m_directMeanTimeURL = url;
-  }
-
-  void set_doAbortMissingCalibration(bool value = true)
-  {
-    m_abortMissingCalibration = value;
   }
 
   void set_doQA(bool value = true)
@@ -153,7 +152,6 @@ class CaloTowerTimeCalibration : public SubsysReco
 
   bool ResolveDetector();
   void ResolveNames();
-  std::string BuildLocalTimeCorrectionURL() const;
   void CreateNodeTree(PHCompositeNode *topNode);
   void LoadCalibration(PHCompositeNode *topNode);
   void CreateQAHistograms();
@@ -172,9 +170,6 @@ class CaloTowerTimeCalibration : public SubsysReco
   std::string m_directMeanTimeURL;
   std::string m_directTimeCorrectionURL;
 
-  std::string m_localTimeCorrectionDirectory;
-
-  bool m_abortMissingCalibration{true};
   bool m_calibrationAvailable{false};
 
   CDBTTree *m_meanTimeCDB{nullptr};

--- a/offline/packages/CaloReco/CaloTowerTimeCalibration.h
+++ b/offline/packages/CaloReco/CaloTowerTimeCalibration.h
@@ -12,8 +12,8 @@
 
 class CDBTTree;
 class PHCompositeNode;
-class TH1F;
-class TH2F;
+class TH1;
+class TH2;
 
 /**
  * Timing-only sidecar calibration for calibrated TowerInfo nodes.
@@ -72,43 +72,36 @@ class CaloTowerTimeCalibration : public SubsysReco
   void set_inputNodePrefix(const std::string &prefix)
   {
     m_inputNodePrefix = prefix;
-    m_useExactInputNodeName = false;
   }
 
   void set_outputNodePrefix(const std::string &prefix)
   {
     m_outputNodePrefix = prefix;
-    m_useExactOutputNodeName = false;
   }
 
   void set_inputNodeName(const std::string &name)
   {
     m_inputNodeName = name;
-    m_useExactInputNodeName = true;
   }
 
   void set_outputNodeName(const std::string &name)
   {
     m_outputNodeName = name;
-    m_useExactOutputNodeName = true;
   }
 
   void set_meanTimeCalibName(const std::string &name)
   {
     m_meanTimeCalibName = name;
-    m_useCustomMeanTimeCalibName = true;
   }
 
   void set_timeCorrectionCalibName(const std::string &name)
   {
     m_timeCorrectionCalibName = name;
-    m_useCustomTimeCorrectionCalibName = true;
   }
 
   void set_directURL_timeCorrection(const std::string &url)
   {
     m_directTimeCorrectionURL = url;
-    m_useDirectTimeCorrectionURL = true;
   }
 
   void set_localTimeCorrectionDirectory(const std::string &directory)
@@ -116,15 +109,9 @@ class CaloTowerTimeCalibration : public SubsysReco
     m_localTimeCorrectionDirectory = directory;
   }
 
-  void set_useLocalTimeCorrectionFiles(bool value = true)
-  {
-    m_useLocalTimeCorrectionFiles = value;
-  }
-
   void set_directURL_meanTime(const std::string &url)
   {
     m_directMeanTimeURL = url;
-    m_useDirectMeanTimeURL = true;
   }
 
   void set_doAbortMissingCalibration(bool value = true)
@@ -158,10 +145,10 @@ class CaloTowerTimeCalibration : public SubsysReco
 
   struct TowerQASet
   {
-    TH1F *hStandardTime{nullptr};
-    TH1F *hCorrectedTime{nullptr};
-    TH2F *hStandardEnergyVsTime{nullptr};
-    TH2F *hCorrectedEnergyVsTime{nullptr};
+    TH1 *hStandardTime{nullptr};
+    TH1 *hCorrectedTime{nullptr};
+    TH2 *hStandardEnergyVsTime{nullptr};
+    TH2 *hCorrectedEnergyVsTime{nullptr};
   };
 
   bool ResolveDetector();
@@ -178,23 +165,14 @@ class CaloTowerTimeCalibration : public SubsysReco
   std::string m_outputNodePrefix{"TOWERINFO_CALIB_TIMING_"};
   std::string m_inputNodeName;
   std::string m_outputNodeName;
-  bool m_useExactInputNodeName{false};
-  bool m_useExactOutputNodeName{false};
 
   std::string m_meanTimeCalibName;
   std::string m_timeCorrectionCalibName;
-  bool m_useCustomMeanTimeCalibName{false};
-  bool m_useCustomTimeCorrectionCalibName{false};
 
-  bool m_useDirectMeanTimeURL{false};
-  bool m_useDirectTimeCorrectionURL{false};
   std::string m_directMeanTimeURL;
   std::string m_directTimeCorrectionURL;
 
-  bool m_useLocalTimeCorrectionFiles{true};
-  std::string m_localTimeCorrectionDirectory{
-      "/gpfs/mnt/gpfs02/sphenix/user/dading/"
-      "my_tower_time_calibrations/macro/timing_cdb"};
+  std::string m_localTimeCorrectionDirectory;
 
   bool m_abortMissingCalibration{true};
   bool m_calibrationAvailable{false};
@@ -208,9 +186,9 @@ class CaloTowerTimeCalibration : public SubsysReco
   float m_qaEnergyThreshold;
 
   // ZS-tower QA. ZS timing is not custom-corrected.
-  TH1F *m_hZSTime{nullptr};
-  TH1F *m_hZSEnergy{nullptr};
-  TH2F *m_hZSEnergyVsTime{nullptr};
+  TH1 *m_hZSTime{nullptr};
+  TH1 *m_hZSEnergy{nullptr};
+  TH2 *m_hZSEnergyVsTime{nullptr};
 
   // Complete tower QA without a get_isGood() requirement.
   TowerQASet m_qaAllTowers;

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -31,6 +31,7 @@ libcalo_reco_la_LIBADD = \
   -lphg4hit \
   -lphparameter_io \
   -lphool \
+  -lqautils \
   -lSubsysReco \
   -lTMVA \
   -lTMVAUtils
@@ -54,6 +55,7 @@ pkginclude_HEADERS = \
   CaloTowerBuilder.h \
   CaloTowerCalib.h \
   CaloTowerStatus.h \
+  CaloTowerTimeCalibration.h \
   CaloTowerDefs.h \
   PhotonClusterBuilder.h \
   RawClusterBuilderGraph.h \
@@ -88,6 +90,7 @@ libcalo_reco_la_SOURCES = \
   CaloTowerBuilder.cc \
   CaloTowerCalib.cc \
   CaloTowerStatus.cc \
+  CaloTowerTimeCalibration.cc \
   PhotonClusterBuilder.cc \
   RawClusterBuilderGraph.cc \
   RawClusterBuilderTopo.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds `CaloTowerTimeCalibration` to `CaloReco` for additional tower timing calibration of CEMC, HCALIN, and HCALOUT.

The subsystem runs after the standard `CaloTowerCalib` and uses the standard calibrated tower nodes as input:

- `TOWERINFO_CALIB_CEMC`
- `TOWERINFO_CALIB_HCALIN`
- `TOWERINFO_CALIB_HCALOUT`

It produces separate timing-calibrated tower nodes:

- `TOWERINFO_CALIB_TIMING_CEMC`
- `TOWERINFO_CALIB_TIMING_HCALIN`
- `TOWERINFO_CALIB_TIMING_HCALOUT`

The standard `TOWERINFO_CALIB_*` nodes are left unchanged.

For timing, the subsystem reads the standard calibrated tower time and reconstructs the time before the standard mean-time correction using the corresponding official mean-time CDB payload. The additional timing calibration is then applied using the sample alignment, sector offset, tower offset, and energy-dependent slew correction.

The calibrated tower energy from `TOWERINFO_CALIB_*` is used for the energy-dependent slew correction.

ZS tower timing is not recalibrated and is copied from the standard calibrated tower unchanged.

Towers with invalid timing calibration are assigned `NaN`. Downstream analyses should require `std::isfinite(tower->get_time())` before using tower timing.

The custom timing calibration payload is currently read from the shared GPFS directory:

`/gpfs/mnt/gpfs02/sphenix/user/dading/my_tower_time_calibrations/macro/timing_cdb`

This custom payload is separate from and does not overwrite the existing standard `CEMC_meanTime`, `HCALIN_meanTime`, or `HCALOUT_meanTime` CDB payloads.

The code has been successfully built and installed as part of `libcalo_reco.so` using the updated `CaloReco/Makefile.am`.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Add timing calibration for CEMC, HCALIN, and HCALOUT towers without changing standard calibrated tower nodes.

## Key changes

- Add `CaloTowerTimeCalibration` to `CaloReco`.
- Create timing-calibrated sidecar nodes after `CaloTowerCalib`.
- Apply mean-time recovery, sample alignment, sector offsets, tower offsets, and energy-dependent slew corrections.
- Preserve zero-suppression tower timing.
- Assign `NaN` to towers with invalid timing calibration.
- Support configurable calibration sources and QA controls.
- Add QA histograms for timing, energy, and zero-suppression towers.
- Register the subsystem and add the `libqautils` dependency.
- Remove the user-specific GPFS path and use an empty-string check for the related option.

## Potential risk areas

- Calibration payload availability, metadata, and tower coverage can affect timing results.
- `NaN` timing values can affect downstream timing-dependent reconstruction.
- Sidecar nodes increase event memory and processing time.
- QA histogram access requires review for thread safety.
- No changes to standard tower nodes or their format are reported.

## Possible future improvements

- Store custom timing payloads in a versioned CDB location.
- Validate results against reference events and detector timing distributions.
- Measure production-scale CPU and memory overhead.
- Add automated payload validation and concurrency tests.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation and calibration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->