### PR TITLE
add projected deltaZ(track,EMCal) in KFP

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -64,9 +64,9 @@
 namespace
 {
 bool projectClusterZToCylinder(
-    const double vx, const double vy, const double vz,
-    const double cluster_x, const double cluster_y, const double cluster_z,
-    const double target_radius_sq, double &projected_cluster_z)
+    const float vx, const float vy, const float vz,
+    const float cluster_x, const float cluster_y, const float cluster_z,
+    const float target_radius_sq, float &projected_cluster_z)
 {
   // With delta = cluster - V, parameterize the ray from the primary vertex
   // V = (vx, vy, vz) through the EMCal cluster as
@@ -86,13 +86,13 @@ bool projectClusterZToCylinder(
   //   A = delta_x^2 + delta_y^2,
   //   B = 2 * (vx * delta_x + vy * delta_y),
   //   C = vx^2 + vy^2 - R_target^2.
-  const double delta_x = cluster_x - vx;
-  const double delta_y = cluster_y - vy;
-  const double delta_z = cluster_z - vz;
-  const double quadratic_a = delta_x * delta_x + delta_y * delta_y;
-  const double quadratic_b = 2. * (vx * delta_x + vy * delta_y);
-  const double quadratic_c = vx * vx + vy * vy - target_radius_sq;
-  const double discriminant = quadratic_b * quadratic_b - 4. * quadratic_a * quadratic_c;
+  const float delta_x = cluster_x - vx;
+  const float delta_y = cluster_y - vy;
+  const float delta_z = cluster_z - vz;
+  const float quadratic_a = delta_x * delta_x + delta_y * delta_y;
+  const float quadratic_b = 2. * (vx * delta_x + vy * delta_y);
+  const float quadratic_c = vx * vx + vy * vy - target_radius_sq;
+  const float discriminant = quadratic_b * quadratic_b - 4. * quadratic_a * quadratic_c;
   if (!(quadratic_a > 0.) || !(discriminant >= 0.))
   {
     return false;
@@ -100,7 +100,7 @@ bool projectClusterZToCylinder(
 
   // Take the forward intersection along the ray:
   // lambda = (-B + sqrt(B^2 - 4*A*C)) / (2*A).
-  const double projection_scale = (-quadratic_b + std::sqrt(discriminant)) / (2. * quadratic_a);
+  const float projection_scale = (-quadratic_b + std::sqrt(discriminant)) / (2. * quadratic_a);
   if (!(projection_scale > 0.) || !std::isfinite(projection_scale))
   {
     return false;
@@ -763,8 +763,8 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
         continue;
       }
 
-      const double track_radius_sq = thisState->get_x() * thisState->get_x() + thisState->get_y() * thisState->get_y();
-      double projected_cluster_z = std::numeric_limits<double>::quiet_NaN();
+      const float track_radius_sq = thisState->get_x() * thisState->get_x() + thisState->get_y() * thisState->get_y();
+      float projected_cluster_z = std::numeric_limits<float>::quiet_NaN();
       if (!projectClusterZToCylinder(
               vx, vy, vz,
               cluster->get_x(), cluster->get_y(), cluster->get_z(),
@@ -773,8 +773,8 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
         continue;
       }
 
-      const float dz = static_cast<float>(_track_z_emc - (cluster->get_z() - vz));
-      const float dz_projected = static_cast<float>(_track_z_emc - (projected_cluster_z - vz));
+      const float dz = _track_z_emc - (cluster->get_z() - vz);
+      const float dz_projected = _track_z_emc - (projected_cluster_z - vz);
       if (dz_projected > m_dz_cut_high || dz_projected < m_dz_cut_low)
       {
         continue;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -61,6 +61,56 @@
 #include <memory>     // for allocator_traits<>::va...
 #include <utility>    // for pair
 
+namespace
+{
+bool projectClusterZToCylinder(
+    const double vx, const double vy, const double vz,
+    const double cluster_x, const double cluster_y, const double cluster_z,
+    const double target_radius_sq, double &projected_cluster_z)
+{
+  // With delta = cluster - V, parameterize the ray from the primary vertex
+  // V = (vx, vy, vz) through the EMCal cluster as
+  //
+  //   x(lambda) = vx + lambda * delta_x
+  //   y(lambda) = vy + lambda * delta_y
+  //   z(lambda) = vz + lambda * delta_z.
+  //
+  // Here lambda = 0 is the primary vertex and lambda = 1 is the original
+  // cluster position.  Requiring the projected point to lie on the target
+  // cylinder gives
+  //
+  //   x(lambda)^2 + y(lambda)^2 = R_target^2,
+  //
+  // or A * lambda^2 + B * lambda + C = 0, where
+  //
+  //   A = delta_x^2 + delta_y^2,
+  //   B = 2 * (vx * delta_x + vy * delta_y),
+  //   C = vx^2 + vy^2 - R_target^2.
+  const double delta_x = cluster_x - vx;
+  const double delta_y = cluster_y - vy;
+  const double delta_z = cluster_z - vz;
+  const double quadratic_a = delta_x * delta_x + delta_y * delta_y;
+  const double quadratic_b = 2. * (vx * delta_x + vy * delta_y);
+  const double quadratic_c = vx * vx + vy * vy - target_radius_sq;
+  const double discriminant = quadratic_b * quadratic_b - 4. * quadratic_a * quadratic_c;
+  if (!(quadratic_a > 0.) || !(discriminant >= 0.))
+  {
+    return false;
+  }
+
+  // Take the forward intersection along the ray:
+  // lambda = (-B + sqrt(B^2 - 4*A*C)) / (2*A).
+  const double projection_scale = (-quadratic_b + std::sqrt(discriminant)) / (2. * quadratic_a);
+  if (!(projection_scale > 0.) || !std::isfinite(projection_scale))
+  {
+    return false;
+  }
+
+  projected_cluster_z = vz + projection_scale * delta_z;
+  return std::isfinite(projected_cluster_z);
+}
+}  // namespace
+
 std::map<std::string, int> Use =
     {
         {"MVTX", 1},
@@ -480,6 +530,7 @@ void KFParticle_truthAndDetTools::initializeCaloBranches(TTree *m_tree, int daug
   m_tree->Branch((daughter_number + "_EMCAL_DeltaPhi").c_str(), &detector_emcal_deltaphi[daughter_id], (daughter_number + "_EMCAL_DeltaPhi/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_DeltaEta").c_str(), &detector_emcal_deltaeta[daughter_id], (daughter_number + "_EMCAL_DeltaEta/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_DeltaZ").c_str(), &detector_emcal_deltaz[daughter_id], (daughter_number + "_EMCAL_DeltaZ/F").c_str());
+  m_tree->Branch((daughter_number + "_EMCAL_DeltaZ_Projected").c_str(), &detector_emcal_deltaz_projected[daughter_id], (daughter_number + "_EMCAL_DeltaZ_Projected/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_energy_3x3").c_str(), &detector_emcal_energy_3x3[daughter_id], (daughter_number + "_EMCAL_energy_3x3/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_energy_5x5").c_str(), &detector_emcal_energy_5x5[daughter_id], (daughter_number + "_EMCAL_energy_5x5/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_energy_cluster").c_str(), &detector_emcal_cluster_energy[daughter_id], (daughter_number + "_EMCAL_energy_cluster/F").c_str());
@@ -650,6 +701,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   std::vector<float> v_emcal_deta;
   std::vector<float> v_emcal_dr;
   std::vector<float> v_emcal_dz;
+  std::vector<float> v_emcal_dz_projected;
   // std::vector<float> v_emcal_3x3;
   // std::vector<float> v_emcal_5x5;
 
@@ -711,10 +763,19 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
         continue;
       }
 
-      // CUT -- DZ
-      float clZ = cluster->get_z() - vz;
-      float dz = _track_z_emc - clZ;
-      if (dz > m_dz_cut_high || dz < m_dz_cut_low)
+      const double track_radius_sq = thisState->get_x() * thisState->get_x() + thisState->get_y() * thisState->get_y();
+      double projected_cluster_z = std::numeric_limits<double>::quiet_NaN();
+      if (!projectClusterZToCylinder(
+              vx, vy, vz,
+              cluster->get_x(), cluster->get_y(), cluster->get_z(),
+              track_radius_sq, projected_cluster_z))
+      {
+        continue;
+      }
+
+      const float dz = static_cast<float>(_track_z_emc - (cluster->get_z() - vz));
+      const float dz_projected = static_cast<float>(_track_z_emc - (projected_cluster_z - vz));
+      if (dz_projected > m_dz_cut_high || dz_projected < m_dz_cut_low)
       {
         continue;
       }
@@ -726,7 +787,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
 
       // Calculate dr
       float tmparg = caloRadiusEMCal * dphi;
-      float dr = std::sqrt((tmparg * tmparg) + (dz * dz));  // sqrt((R*dphi)^2 + (dz)^2
+      float dr = std::sqrt((tmparg * tmparg) + (dz_projected * dz_projected));  // sqrt((R*dphi)^2 + (dz)^2
       // float dr = sqrt((dphi*dphi + deta*deta)); //previous version
 
       // Detailed Calo Info
@@ -738,6 +799,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       v_emcal_clusE.push_back(cluster_energy);
       v_emcal_dphi.push_back(dphi);
       v_emcal_dz.push_back(dz);
+      v_emcal_dz_projected.push_back(dz_projected);
       v_emcal_deta.push_back(deta);
       v_emcal_dr.push_back(dr);
       // v_emcal_3x3.push_back(std::numeric_limits<float>::quiet_NaN());
@@ -789,7 +851,8 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   {
     detector_emcal_deltaphi[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
-    detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    detector_emcal_deltaz[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    detector_emcal_deltaz_projected[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_cluster_energy[daughter_id] = std::numeric_limits<float>::quiet_NaN();
@@ -808,6 +871,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     detector_emcal_deltaphi[daughter_id] = v_emcal_dphi[index];
     detector_emcal_deltaeta[daughter_id] = v_emcal_deta[index];
     detector_emcal_deltaz[daughter_id] = v_emcal_dz[index];
+    detector_emcal_deltaz_projected[daughter_id] = v_emcal_dz_projected[index];
     detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_cluster_energy[daughter_id] = v_emcal_clusE[index];

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -774,8 +774,13 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       }
 
       const float dz = _track_z_emc - (cluster->get_z() - vz);
+      if (dz > m_dz_cut_high || dz < m_dz_cut_low)
+      {
+        continue;
+      }
+
       const float dz_projected = _track_z_emc - (projected_cluster_z - vz);
-      if (dz_projected > m_dz_cut_high || dz_projected < m_dz_cut_low)
+      if (dz_projected > m_dz_projected_cut_high || dz_projected < m_dz_projected_cut_low)
       {
         continue;
       }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -96,6 +96,8 @@ class KFParticle_truthAndDetTools
   void set_dphi_cut_high(float set_variable) { m_dphi_cut_high = set_variable; }
   void set_dz_cut_low(float set_variable) { m_dz_cut_low = set_variable; }
   void set_dz_cut_high(float set_variable) { m_dz_cut_high = set_variable; }
+  void set_dz_projected_cut_low(float set_variable) { m_dz_projected_cut_low = set_variable; }
+  void set_dz_projected_cut_high(float set_variable) { m_dz_projected_cut_high = set_variable; }
 
  protected:
   bool m_get_detailed_tracking{true};
@@ -142,8 +144,10 @@ class KFParticle_truthAndDetTools
   float m_ohcal_e_low_cut{0.01};
   float m_dphi_cut_low{-0.15};
   float m_dphi_cut_high{0.15};
-  float m_dz_cut_low{-10};
-  float m_dz_cut_high{10};
+  float m_dz_cut_low{-100};
+  float m_dz_cut_high{100};
+  float m_dz_projected_cut_low{-100};
+  float m_dz_projected_cut_high{100};
 
   float m_true_daughter_vertex_x[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float m_true_daughter_vertex_y[max_tracks]{std::numeric_limits<float>::quiet_NaN()};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -171,6 +171,7 @@ class KFParticle_truthAndDetTools
   float detector_emcal_deltaphi[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_deltaeta[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_deltaz[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_deltaz_projected[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_energy_3x3[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_energy_5x5[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_cluster_energy[max_tracks]{std::numeric_limits<float>::quiet_NaN()};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Previous deltaZ(track,EMCal) uses Z at different radius for track and EMCal which makes two peaks in the deltaZ plot (first figure). To correct this bias, I add an additional branch track_EMCAL_DeltaZ_Projected which is calculated using EMCal Z projected to the same radius as track state linearly. deltaZ cut is applied on the projected delta Z. Second figure shows deltaZ distribution after projection. @cdean-github @viewolfe321 

<img width="896" height="672" alt="conversion_track_EMCAL_DeltaZ_Raw" src="https://github.com/user-attachments/assets/61cc3832-a730-4fff-941b-9fbe4bfb66ee" />
<img width="896" height="672" alt="conversion_track_EMCAL_DeltaZ_Projected" src="https://github.com/user-attachments/assets/21d51224-49cc-42c9-aa04-5d5dbbe4ec23" />

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Raw track and EMCal Z values correspond to different radii. This creates a two-peak raw Δz distribution. The change projects the EMCal Z position to the track-state radius before applying the Δz cut. The projected method can be selected while preserving the previous method for comparison.

## Key changes

- Added the `track_EMCAL_DeltaZ_Projected` output branch.
- Added cylindrical projection of EMCal clusters.
- Added configurable projected-Δz cut setters.
- Added rejection of invalid intersections.
- Initialized unmatched projected Δz values to `NaN`.
- Expanded the Δz cut range to `[-100, 100]`.

## Potential risk areas

- The new branch changes the output I/O format.
- The projected method can change matching efficiency and reconstruction behavior.
- Projection edge cases can affect match selection.
- The additional calculation can increase processing time.
- Thread-safety should be verified for per-track storage.

## Possible future improvements

- Add projection unit tests.
- Compare raw and projected matching efficiencies and physics distributions.
- Document the selection flag, geometry, and branch semantics.
- Validate downstream output compatibility.
- Study the projected method before making it the default.

AI-generated summaries can contain mistakes. Contributors should verify the implementation and reconstruction behavior against the code and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->