### PR TITLE
extrapolation enumeration fix

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1374,7 +1374,7 @@ void PHActsTrkFitter::updateSvtxTrack(
         }
       };
 
-      if( m_extrapolation_mode == ExtrapolationMode::Default )
+      if( m_extrapolation_mode == ExtrapolationMode::Legacy )
       {
 
         // extrapolate from track parameters
@@ -1481,7 +1481,7 @@ void PHActsTrkFitter::updateSvtxTrack(
 
       switch( m_extrapolation_mode )
       {
-        case ExtrapolationMode::Default:
+        case ExtrapolationMode::Legacy:
         {
 
           // extrapolate from track parameters

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -160,7 +160,7 @@ class PHActsTrkFitter : public SubsysReco
   /// extrapolation mode
   enum class ExtrapolationMode
   {
-    Default, // the default extrapolation mode, using fitter track parameters at origin
+    Legacy, // uses fitter track parameters at origin as startomg point for extrapolation
     Forward, // uses the track state vector closest to the requested layer, before
     Backward, // uses the track state vector closest to the requested layer, after
     Bidirectional // uses the weighted average of the forward and backward extrapolation, when available

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1029,7 +1029,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
       const TVector3 pos_A(globalPosition.x(), globalPosition.y(), globalPosition.z() );
       const auto r_cluster = get_r(globalPosition.x(),globalPosition.y());
 
-      if( m_extrapolation_mode == ExtrapolationMode::Default )
+      if( m_extrapolation_mode == ExtrapolationMode::Legacy )
       {
           try
           {

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -145,7 +145,7 @@ class PHGenFitTrkFitter : public SubsysReco
   /// extrapolation mode
   enum class ExtrapolationMode
   {
-    Default, // use track parameters at vertex for the extrapolation
+    Legacy, // use track parameters at vertex for the extrapolation
     Forward, // uses the track state vector closest to the requested layer, before
     Backward, // uses the track state vector closest to the requested layer, after
     Bidirectional // uses the weighted average of the forward and backward extrapolation, when available


### PR DESCRIPTION
Changed ExtrapolationMode::Default to ExtrapolationMode::Legacy, to avoid confusion.
(as discussed yesterday during the time-averaged distortion meeting.)
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Rename `ExtrapolationMode::Default` to `ExtrapolationMode::Legacy` to clarify existing behavior. This is a bug fix. It does not add a feature or introduce a breaking change.

## Key Changes

- Renamed the enum value in `PHActsTrkFitter` and `PHGenFitTrkFitter`.
- Updated TPC-cluster, Micromegas, and disabled-layer extrapolation branches.
- Preserved the existing extrapolation behavior.
- Made no I/O format, macro repository, thread-safety, or performance changes.

## Potential Risk Areas

The main risk is incorrect use of the renamed public enum value by external code. Reconstruction behavior should remain unchanged because only the identifier changed. Contributors should update any downstream references to `ExtrapolationMode::Legacy`.

AI-generated summaries can contain mistakes. Review the code and downstream usage before merging.

## Possible Future Improvements

- Search dependent packages and external consumers for the old enum name.
- Add or update tests that verify legacy extrapolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->