### PR TITLE
Z shift south side

### DIFF
--- a/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
+++ b/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
@@ -251,7 +251,10 @@ bool TpcPolyClusterTrkrClusterConverter::localFromMovedGlobal(const Tpc_PolyClus
       local.y() + static_cast<double>(crossing) * z_bunch_separation :
       local.y() - static_cast<double>(crossing) * z_bunch_separation;
   const double tuncorrected = (side == 0) ? (zloc_uncorrected + half_drift) / drift_velocity : (half_drift - zloc_uncorrected) / drift_velocity;
-  const double stored_t_uncorrected = tuncorrected - m_geometry->get_tpc_tzero() - m_geometry->get_sampa_tzero_bias();
+  //const double stored_t_uncorrected = tuncorrected - m_geometry->get_tpc_tzero() - m_geometry->get_sampa_tzero_bias();
+  const double stored_t_uncorrected = (side == 0) ?
+      tuncorrected - m_geometry->get_tpc_tzero() + 2 * m_geometry->get_sampa_tzero_bias() :
+      tuncorrected - m_geometry->get_tpc_tzero() - m_geometry->get_sampa_tzero_bias();
   if (!std::isfinite(stored_t_uncorrected)) { return false;
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Make z shift for south side of the TPC (Tracking Meeting slides https://indico.bnl.gov/event/33414/contributions/126427/attachments/72009/123299/TPC_SA.pdf)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This bug fix applies the required z-shift to the south side of the TPC. The change follows the TPC tracking meeting context and does not alter public interfaces.

## Key Changes

- Updated `localFromMovedGlobal` in `TpcPolyClusterTrkrClusterConverter.cc`.
- Applied side-dependent SAMPA time-zero bias handling when computing `stored_t_uncorrected`.
- Added twice the bias for side 0 after subtracting the TPC time zero.
- Subtracted the bias for side 1.

## Potential Risk Areas

- The change affects TPC reconstruction behavior for cluster timing.
- No I/O format, public API, thread-safety, or performance changes are indicated.
- Validation should confirm the corrected south-side z position and timing behavior for both TPC sides.

## Possible Future Improvements

- Add focused regression tests for both side-dependent bias paths.
- Document the SAMPA time-zero convention and the z-shift correction.
- Compare reconstructed tracks with and without the correction using representative data.

AI-generated summaries can contain errors. Review the implementation and validate the physics behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->