### PR TITLE
Fix laser event identifier

### DIFF
--- a/offline/packages/tpc/LaserEventIdentifier.cc
+++ b/offline/packages/tpc/LaserEventIdentifier.cc
@@ -59,16 +59,14 @@ int LaserEventIdentifier::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_geom_container =
-      findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
+  m_geom_container = findNode::getClass<PHG4TpcGeomContainer>(topNode, "TPCGEOMCONTAINER");
   if (!m_geom_container)
   {
     std::cout << PHWHERE << "ERROR: Can't find node TPCGEOMCONTAINER" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_tGeometry = findNode::getClass<ActsGeometry>(topNode,
-                                                 "ActsGeometry");
+  m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   if (!m_tGeometry)
   {
     std::cout << PHWHERE
@@ -86,8 +84,7 @@ int LaserEventIdentifier::InitRun(PHCompositeNode *topNode)
   }
 
   PHNodeIterator dstiter(dstNode);
-  PHCompositeNode *DetNode =
-      dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
   if (!DetNode)
   {
     DetNode = new PHCompositeNode("TRKR");
@@ -143,7 +140,8 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
     std::cout << "no GL1RAWHIT node" << std::endl;
     m_laserEventInfo->setIsGl1LaserEvent(false);
     m_laserEventInfo->setIsGl1LaserPileupEvent(false);
-    // return Fun4AllReturnCodes::ABORTRUN;
+    isGl1LaserEvent = false;
+    isGl1LaserPileupEvent = false;
   }
   else if (m_runnumber > 66153)
   {

--- a/offline/packages/tpc/LaserEventIdentifier.cc
+++ b/offline/packages/tpc/LaserEventIdentifier.cc
@@ -3,6 +3,7 @@
 #include "LaserEventInfo.h"
 #include "LaserEventInfov2.h"
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHit.h>
@@ -29,10 +30,23 @@
 
 #include <TF1.h>
 #include <TFile.h>
+#include <TH1.h>
+#include <TTree.h>
 
 LaserEventIdentifier::LaserEventIdentifier(const std::string &name)
   : SubsysReco(name)
 {
+}
+
+LaserEventIdentifier::~LaserEventIdentifier()
+{
+  if (! m_debug) // if m_debug set, histos are added to debug TTree and must not be deleted
+  {
+    delete m_itHist_0;
+    delete m_itHist_1;
+  }
+  delete m_f0;
+  delete m_f1;
 }
 
 int LaserEventIdentifier::InitRun(PHCompositeNode *topNode)
@@ -84,6 +98,9 @@ int LaserEventIdentifier::InitRun(PHCompositeNode *topNode)
 
   PHIODataNode<PHObject> *laserEventInfoNode = new PHIODataNode<PHObject>(laserEventInfo, "LaserEventInfo", "PHObject");
   DetNode->addNode(laserEventInfoNode);
+
+  m_f0 = new TF1("f0", "gausn(0)");
+  m_f1 = new TF1("f1", "gausn(0)");
 
   if (m_debug)
   {
@@ -211,30 +228,28 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
   double itMaxContent_1 = m_itHist_1->GetMaximum();
   m_itHist_1->GetXaxis()->SetRange(0, 0);
 
-  auto f0 = std::make_unique<TF1>("f0", "gausn(0)");
-  f0->SetParameters(itMaxContent_0, itMax_0, 1);
-  f0->SetParLimits(1, itMax_0 - 2, itMax_0 + 2);
-  m_itHist_0->Fit(f0.get(), "Bq0");
+  m_f0->SetParameters(itMaxContent_0, itMax_0, 1);
+  m_f0->SetParLimits(1, itMax_0 - 2, itMax_0 + 2);
+  m_itHist_0->Fit(m_f0, "Bq0N"); // N to not store fit in histo
 
-  auto f1 = std::make_unique<TF1>("f1", "gausn(0)");
-  f1->SetParameters(itMaxContent_1, itMax_1, 1);
-  f1->SetParLimits(1, itMax_1 - 2, itMax_1 + 2);
-  m_itHist_1->Fit(f1.get(), "Bq0");
+  m_f1->SetParameters(itMaxContent_1, itMax_1, 1);
+  m_f1->SetParLimits(1, itMax_1 - 2, itMax_1 + 2);
+  m_itHist_1->Fit(m_f1, "Bq0N"); // N to not store fit in histo
 
 
   if ((itMaxContent_0 / itMeanContent_0 >= 7 && itMaxContent_0 > 1000) || (itMaxContent_1 / itMeanContent_1 >= 7 && itMaxContent_1 > 1000))
   {
     m_laserEventInfo->setIsLaserEvent(true);
     m_laserEventInfo->setPeakSample(false, (int) itMax_0);
-    m_laserEventInfo->setPeakWidth(false, f0->GetParameter(2));
+    m_laserEventInfo->setPeakWidth(false, m_f0->GetParameter(2));
     m_laserEventInfo->setPeakSample(true, (int) itMax_1);
-    m_laserEventInfo->setPeakWidth(true, f1->GetParameter(2));
+    m_laserEventInfo->setPeakWidth(true, m_f1->GetParameter(2));
 
     isLaserEvent = true;
     peakSample0 = (int) itMax_0;
     peakSample1 = (int) itMax_1;
-    peakWidth0 = f0->GetParameter(2);
-    peakWidth1 = f1->GetParameter(2);
+    peakWidth0 = m_f0->GetParameter(2);
+    peakWidth1 = m_f1->GetParameter(2);
   }
   else
   {

--- a/offline/packages/tpc/LaserEventIdentifier.cc
+++ b/offline/packages/tpc/LaserEventIdentifier.cc
@@ -40,7 +40,7 @@ LaserEventIdentifier::LaserEventIdentifier(const std::string &name)
 
 LaserEventIdentifier::~LaserEventIdentifier()
 {
-  if (! m_debug) // if m_debug set, histos are added to debug TTree and must not be deleted
+  if (!m_debug)  // if m_debug set, histos are added to debug TTree and must not be deleted
   {
     delete m_itHist_0;
     delete m_itHist_1;
@@ -143,11 +143,11 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
     std::cout << "no GL1RAWHIT node" << std::endl;
     m_laserEventInfo->setIsGl1LaserEvent(false);
     m_laserEventInfo->setIsGl1LaserPileupEvent(false);
-    //return Fun4AllReturnCodes::ABORTRUN;
+    // return Fun4AllReturnCodes::ABORTRUN;
   }
-  else if(m_runnumber > 66153)
+  else if (m_runnumber > 66153)
   {
-    if ((gl1pkt->getGTMAllBusyVector() & (1U<<14U)) == 0)
+    if ((gl1pkt->getGTMAllBusyVector() & (1U << 14U)) == 0)
     {
       m_laserEventInfo->setIsGl1LaserEvent(true);
       m_laserEventInfo->setIsGl1LaserPileupEvent(false);
@@ -155,7 +155,7 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
       isGl1LaserPileupEvent = false;
       prev_BCO = gl1pkt->getBCO();
     }
-    else if ((gl1pkt->getBCO() - prev_BCO) < 350.0/30*16)
+    else if ((gl1pkt->getBCO() - prev_BCO) < 350.0 / 30 * 16)
     {
       m_laserEventInfo->setIsGl1LaserEvent(false);
       m_laserEventInfo->setIsGl1LaserPileupEvent(true);
@@ -177,8 +177,6 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
     m_laserEventInfo->setIsGl1LaserEvent(false);
     m_laserEventInfo->setIsGl1LaserPileupEvent(false);
   }
-  
-
 
   TrkrHitSetContainer::ConstRange hitsetrange = m_hits->getHitSets(TrkrDefs::TrkrId::tpcId);
   for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
@@ -230,12 +228,11 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
 
   m_f0->SetParameters(itMaxContent_0, itMax_0, 1);
   m_f0->SetParLimits(1, itMax_0 - 2, itMax_0 + 2);
-  m_itHist_0->Fit(m_f0, "Bq0N"); // N to not store fit in histo
+  m_itHist_0->Fit(m_f0, "Bq0N");  // N to not store fit in histo
 
   m_f1->SetParameters(itMaxContent_1, itMax_1, 1);
   m_f1->SetParLimits(1, itMax_1 - 2, itMax_1 + 2);
-  m_itHist_1->Fit(m_f1, "Bq0N"); // N to not store fit in histo
-
+  m_itHist_1->Fit(m_f1, "Bq0N");  // N to not store fit in histo
 
   if ((itMaxContent_0 / itMeanContent_0 >= 7 && itMaxContent_0 > 1000) || (itMaxContent_1 / itMeanContent_1 >= 7 && itMaxContent_1 > 1000))
   {
@@ -266,7 +263,6 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
   {
     m_hitTree->Fill();
   }
-  
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpc/LaserEventIdentifier.h
+++ b/offline/packages/tpc/LaserEventIdentifier.h
@@ -2,26 +2,24 @@
 #define TPC_LASEREVENTIDENTIFIER_H
 
 #include <fun4all/SubsysReco.h>
-#include <g4detectors/PHG4TpcGeomContainer.h>
-#include <trackbase/ActsGeometry.h>
-#include <trackbase/TrkrDefs.h>
 
-
-#include <TFile.h>
-#include <TH1I.h>
-#include <TTree.h>
-
+class ActsGeometry;
 class PHCompositeNode;
-class TrkrHitSet;
-class TrkrHitSetContainer;
 class PHG4TpcGeom;
 class PHG4TpcGeomContainer;
 class LaserEventInfo;
+class TF1;
+class TFile;
+class TH1;
+class TrkrHitSet;
+class TrkrHitSetContainer;
+class TTree;
+
 class LaserEventIdentifier : public SubsysReco
 {
  public:
   LaserEventIdentifier(const std::string &name = "LaserEventIdentifier");
-  ~LaserEventIdentifier() override = default;
+  ~LaserEventIdentifier() override;// = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -34,30 +32,37 @@ class LaserEventIdentifier : public SubsysReco
 
   void set_debug(bool debug) { m_debug = debug; }
   void set_debug_name(const std::string &name) { m_debugFileName = name; }
- private:
-  int m_time_samples_max=425;
 
-  TrkrHitSetContainer *m_hits = nullptr;
-  ActsGeometry *m_tGeometry = nullptr;
-  PHG4TpcGeomContainer *m_geom_container = nullptr;
+private:
 
-  LaserEventInfo *m_laserEventInfo = nullptr ;
-  bool m_debug = false;
-  std::string m_debugFileName = "LaserEventIdentifier_debug.root";
-  TFile *m_debugFile = nullptr;
-  TTree *m_hitTree = nullptr;
-  TH1I *m_itHist_0 = nullptr;
-  TH1I *m_itHist_1 = nullptr;
-  bool isLaserEvent = false;
-  bool isGl1LaserEvent = false;
-  bool isGl1LaserPileupEvent = false;
-  int peakSample0 = -999;
-  int peakSample1 = -999;
-  double peakWidth0 = -999;
-  double peakWidth1 = -999;
-  int m_runnumber = 0;
+  TrkrHitSetContainer *m_hits {nullptr};
+  ActsGeometry *m_tGeometry {nullptr};
+  PHG4TpcGeomContainer *m_geom_container {nullptr};
+  LaserEventInfo *m_laserEventInfo {nullptr} ;
 
-  uint64_t prev_BCO = 0;
+  TF1 *m_f0 {nullptr};
+  TF1 *m_f1 {nullptr};
+  TFile *m_debugFile {nullptr};
+  TH1 *m_itHist_0 {nullptr};
+  TH1 *m_itHist_1 {nullptr};
+  TTree *m_hitTree {nullptr};
+
+  uint64_t prev_BCO {0};
+
+  double peakWidth0 {-999};
+  double peakWidth1 {-999};
+
+  int m_runnumber {0};
+  int m_time_samples_max {425};
+  int peakSample0 {-999};
+  int peakSample1 {-999};
+
+  bool isLaserEvent {false};
+  bool isGl1LaserEvent {false};
+  bool isGl1LaserPileupEvent {false};
+  bool m_debug {false};
+
+  std::string m_debugFileName = {"LaserEventIdentifier_debug.root"};
 };
 
 #endif

--- a/offline/packages/tpc/LaserEventIdentifier.h
+++ b/offline/packages/tpc/LaserEventIdentifier.h
@@ -19,7 +19,7 @@ class LaserEventIdentifier : public SubsysReco
 {
  public:
   LaserEventIdentifier(const std::string &name = "LaserEventIdentifier");
-  ~LaserEventIdentifier() override;// = default;
+  ~LaserEventIdentifier() override;  // = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -33,34 +33,33 @@ class LaserEventIdentifier : public SubsysReco
   void set_debug(bool debug) { m_debug = debug; }
   void set_debug_name(const std::string &name) { m_debugFileName = name; }
 
-private:
+ private:
+  TrkrHitSetContainer *m_hits{nullptr};
+  ActsGeometry *m_tGeometry{nullptr};
+  PHG4TpcGeomContainer *m_geom_container{nullptr};
+  LaserEventInfo *m_laserEventInfo{nullptr};
 
-  TrkrHitSetContainer *m_hits {nullptr};
-  ActsGeometry *m_tGeometry {nullptr};
-  PHG4TpcGeomContainer *m_geom_container {nullptr};
-  LaserEventInfo *m_laserEventInfo {nullptr} ;
+  TF1 *m_f0{nullptr};
+  TF1 *m_f1{nullptr};
+  TFile *m_debugFile{nullptr};
+  TH1 *m_itHist_0{nullptr};
+  TH1 *m_itHist_1{nullptr};
+  TTree *m_hitTree{nullptr};
 
-  TF1 *m_f0 {nullptr};
-  TF1 *m_f1 {nullptr};
-  TFile *m_debugFile {nullptr};
-  TH1 *m_itHist_0 {nullptr};
-  TH1 *m_itHist_1 {nullptr};
-  TTree *m_hitTree {nullptr};
+  uint64_t prev_BCO{0};
 
-  uint64_t prev_BCO {0};
+  double peakWidth0{-999};
+  double peakWidth1{-999};
 
-  double peakWidth0 {-999};
-  double peakWidth1 {-999};
+  int m_runnumber{0};
+  int m_time_samples_max{425};
+  int peakSample0{-999};
+  int peakSample1{-999};
 
-  int m_runnumber {0};
-  int m_time_samples_max {425};
-  int peakSample0 {-999};
-  int peakSample1 {-999};
-
-  bool isLaserEvent {false};
-  bool isGl1LaserEvent {false};
-  bool isGl1LaserPileupEvent {false};
-  bool m_debug {false};
+  bool isLaserEvent{false};
+  bool isGl1LaserEvent{false};
+  bool isGl1LaserPileupEvent{false};
+  bool m_debug{false};
 
   std::string m_debugFileName = {"LaserEventIdentifier_debug.root"};
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes TF1's adding 1MB memory per event by going back to raw pointers.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Fix `TF1` pointer handling to prevent approximately 1 MB of memory growth per event.

## Key changes

- Reuse persistent Gaussian fit functions.
- Fit both side histograms without storing per-event fit results.
- Record fitted peak widths.
- Correct destructor cleanup for fit functions and debug-owned histograms.
- Replace several header includes with forward declarations.
- Generalize histogram pointers from `TH1I*` to `TH1*`.
- Preserve GL1 laser-event handling.

## Potential risk areas

- Reused fit functions may affect reconstruction behavior.
- Histogram ownership and cleanup require validation.
- No I/O format change is expected.
- Thread safety is not established for concurrent use.

## Possible future improvements

- Add tests for memory growth and fitted peak widths.
- Document object ownership.
- Validate concurrent event processing.

AI-generated summaries can contain mistakes. Contributors should verify the source changes and test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->