### PR TITLE
Clean phgarfield

### DIFF
--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <utility>  // for pair, make_pair
 
-Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
+Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance {nullptr};
 
 Fun4AllMemoryTracker::Fun4AllMemoryTracker()
   : Fun4AllBase("Fun4AllMemoryTracker")
@@ -27,6 +27,10 @@ Fun4AllMemoryTracker::~Fun4AllMemoryTracker()
 
 void Fun4AllMemoryTracker::Snapshot(const std::string &trackername, const std::string &group)
 {
+  if (! enabled)
+  {
+    return;
+  }
   std::string name = CreateFullTrackerName(trackername, group);
   auto iter = mMemoryTrackerMap.find(name);
   if (iter != mMemoryTrackerMap.end())
@@ -48,6 +52,10 @@ void Fun4AllMemoryTracker::Snapshot(const std::string &trackername, const std::s
 
 void Fun4AllMemoryTracker::Start(const std::string &trackername, const std::string &group)
 {
+  if (! enabled)
+  {
+    return;
+  }
   std::string name = CreateFullTrackerName(trackername, group);
   auto iter = mStartMem.find(name);
   int RSSMemory = GetRSSMemory();
@@ -67,6 +75,10 @@ void Fun4AllMemoryTracker::Start(const std::string &trackername, const std::stri
 
 void Fun4AllMemoryTracker::Stop(const std::string &trackername, const std::string &group)
 {
+  if (! enabled)
+  {
+    return;
+  }
   std::string name = CreateFullTrackerName(trackername, group);
   auto iter = mStartMem.find(name);
   int RSSMemory = GetRSSMemory();
@@ -104,6 +116,12 @@ std::string Fun4AllMemoryTracker::CreateFullTrackerName(const std::string &track
 
 void Fun4AllMemoryTracker::PrintMemoryTracker(const std::string &name) const
 {
+    if (! enabled)
+  {
+    std::cout << "Fun4AllMemoryTracker is not enabled" << std::endl;
+    return;
+  }
+
   std::map<std::string, std::vector<int>>::const_iterator iter;
   if (name.empty())
   {

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -26,9 +26,12 @@ class Fun4AllMemoryTracker : public Fun4AllBase
   static int GetRSSMemory();
   void PrintMemoryTracker(const std::string &name = "") const;
   std::vector<int> GetMemoryVector(const std::string &name) const;
+  void Enable(bool b = true) {enabled = b;}
+  bool isEnabled() const {return enabled;}
 
  private:
   Fun4AllMemoryTracker();
+  bool enabled {false};
   static std::string CreateFullTrackerName(const std::string &trackername, const std::string &group = "");
   static Fun4AllMemoryTracker *mInstance;
   std::map<std::string, std::vector<int>> mMemoryTrackerMap;

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -38,7 +38,7 @@
 #include <memory>  // for allocator_traits<>::value_type
 #include <sstream>
 
-// #define FFAMEMTRACKER
+#define FFAMEMTRACKER
 
 Fun4AllServer *Fun4AllServer::__instance = nullptr;
 

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -111,7 +111,7 @@ class Fun4AllServer : public Fun4AllBase
   void NodeIdentify(const std::string &name);
   void KeepDBConnection(const int i = 1) { keep_db_connected = i; }
   void PrintTimer(const std::string &name = "");
-  static void PrintMemoryTracker(const std::string &name = "");
+  void PrintMemoryTracker(const std::string &name = "");
   int RunNumber() const { return runnumber; }
   int EventCounter() const { return eventcounter; }
   std::map<const std::string, PHTimer>::const_iterator timer_begin() { return timer_map.begin(); }

--- a/offline/packages/PHGarfield/Makefile.am
+++ b/offline/packages/PHGarfield/Makefile.am
@@ -19,9 +19,7 @@ lib_LTLIBRARIES = \
 
 libPHGarfield_la_LIBADD = \
   -lffamodules \
-  -lffarawobjects \
   -lcdbobjects \
-  -lEvent \
   -lphool \
   -lphfield \
   -lGarfield \

--- a/offline/packages/PHGarfield/PHGarfield.cc
+++ b/offline/packages/PHGarfield/PHGarfield.cc
@@ -1,12 +1,14 @@
 #include "PHGarfield.h"
+
 #include <cdbobjects/CDBTTree.h>
-#include <phool/phool.h>
 
 #include <phfield/PHField3DCartesian.h>
 
 #include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/phool.h>
 
 #include <TAxis.h>
 #include <TFile.h>
@@ -24,7 +26,6 @@
 #include <cmath>
 #include <filesystem>
 #include <functional>
-#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -42,7 +43,6 @@ PHGarfield::PHGarfield(const std::string& name,
                        double spaceChargeScale_side0,
                        double spaceChargeScale_side1)
   : SubsysReco(name)
-  , m_defaultGasfile("/sphenix/user/hemmick/gasfiles_20260624")
   , m_electricFieldMap(electricFieldMap)
   , m_spaceChargeScale_side0(spaceChargeScale_side0)
   , m_spaceChargeScale_side1(spaceChargeScale_side1)
@@ -83,7 +83,7 @@ int PHGarfield::InitRun(PHCompositeNode* /*topNode*/)
   {
     if (!LoadElectricFieldCorrections(m_electricFieldMap))
     {
-      std::cerr << PHWHERE << " Failed to load electric-field correction map: "
+      std::cout << PHWHERE << " Failed to load electric-field correction map: "
                 << m_electricFieldMap << std::endl;
     }
   }
@@ -100,8 +100,8 @@ int PHGarfield::InitRun(PHCompositeNode* /*topNode*/)
   //std::string gasfile("/gpfs/mnt/gpfs02/sphenix/user/hemmick/gasfiles_20260804/Ar75_CF20_iso5.gas");  // for testing only...
   if (gasfile.empty() || !fs::exists(gasfile))
   {
-    std::cerr << PHWHERE << " Missing CDB gasfile: " << gasfile << std::endl;
-    std::cerr << PHWHERE << " Using default gasfile: " << m_defaultGasfile << std::endl;
+    std::cout << PHWHERE << " Missing CDB gasfile: " << gasfile << std::endl;
+    std::cout << PHWHERE << " Using default gasfile: " << m_defaultGasfile << std::endl;
     gasfile = m_defaultGasfile;
   }
   InitializeGas(gasfile);
@@ -172,7 +172,7 @@ void PHGarfield::PrintGasSummary() const
 {
   if (!m_GasFilesLoaded)
   {
-    std::cerr << PHWHERE << "No Gas File(s) have been successfully loaded." << std::endl;
+    std::cout << PHWHERE << "No Gas File(s) have been successfully loaded." << std::endl;
     return;
   }
 
@@ -391,7 +391,7 @@ bool PHGarfield::LoadElectricFieldCorrections(const std::string& filename)
   std::unique_ptr<TFile> input(TFile::Open(filename.c_str(), "READ"));
   if (!input || input->IsZombie())
   {
-    std::cerr << PHWHERE << " Could not open electric-field map: "
+    std::cout << PHWHERE << " Could not open electric-field map: "
               << filename << std::endl;
     return false;
   }
@@ -411,7 +411,7 @@ bool PHGarfield::LoadElectricFieldCorrections(const std::string& filename)
 
   if (!er || !ez)
   {
-    std::cerr << PHWHERE
+    std::cout << PHWHERE
               << " Missing QA/hErDefault or QA/hEzDefault in "
               << filename << std::endl;
     return false;
@@ -496,7 +496,7 @@ void PHGarfield::InitializeGas(const std::string& name)
 
   if (!std::filesystem::exists(name))
   {
-    std::cerr << "Missing gas file or gas directory: " << name << std::endl;
+    std::cout << "Missing gas file or gas directory: " << name << std::endl;
     return;
   }
 
@@ -505,7 +505,7 @@ void PHGarfield::InitializeGas(const std::string& name)
     std::cout << "Loading Garfield gas from file: " << name << std::endl;
     if (!m_gas->LoadGasFile(name))
     {
-      std::cerr << "Failed to load " << name << std::endl;
+      std::cout << "Failed to load " << name << std::endl;
       return;
     }
     m_GasFilesLoaded = true;
@@ -555,11 +555,10 @@ void PHGarfield::InitializeGas(const std::string& name)
   PrintGasSummary();
 }
 
-int PHGarfield::process_event(PHCompositeNode* topNode)
+int PHGarfield::process_event(PHCompositeNode* /* topNode*/)
 {
   // Initial implementation doesn't do anything event-by-event.
   // Nonetheless, a future user might want do do something here...
-  (void) topNode;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -618,7 +617,7 @@ TPolyLine3D* PHGarfield::ReverseDrift(double x, double y, double z, double step_
     if (!std::isfinite(vx) || !std::isfinite(vy) || !std::isfinite(vz) ||
         (vx == 0.0 && vy == 0.0 && vz == 0.0))
     {
-      std::cerr << PHWHERE
+      std::cout << PHWHERE
                 << " Garfield returned invalid/zero electron velocity; stopping drift. "
                 << " p_tpc=(" << x << ", " << y << ", " << z << ") cm"
                 << " E=(" << ex << ", " << ey << ", " << ez << ") V/cm"
@@ -639,7 +638,7 @@ TPolyLine3D* PHGarfield::ReverseDrift(double x, double y, double z, double step_
 
   if (step >= maxSteps)
   {
-    std::cerr << PHWHERE << " ReverseDrift reached maxSteps=" << maxSteps
+    std::cout << PHWHERE << " ReverseDrift reached maxSteps=" << maxSteps
               << "; stopping drift at p_tpc=(" << x << ", " << y << ", " << z
               << ") cm" << std::endl;
   }

--- a/offline/packages/PHGarfield/PHGarfield.h
+++ b/offline/packages/PHGarfield/PHGarfield.h
@@ -3,12 +3,13 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <array>
-#include <numbers>
-#include <string>
-
 #include <TRotation.h>
 #include <TVector3.h>
+
+#include <array>
+#include <cstddef>
+#include <numbers>
+#include <string>
 
 class CDBTTree;
 class PHField3DCartesian;
@@ -95,7 +96,7 @@ class PHGarfield : public SubsysReco
   PHField3DCartesian *m_field{nullptr};           // The standard sPHENIX field holding container.
   Garfield::ComponentUser *m_component{nullptr};  // This handles the interface of the electric and magnetic fields as handed to Garfield
   Garfield::MediumMagboltz *m_gas{nullptr};       // This is the pre-tabulated gas properties required by Garfield...
-  std::string m_defaultGasfile;
+  std::string m_defaultGasfile {"/cvmfs/sphenix.sdcc.bnl.gov/files/gasfiles"};
   bool m_GasFilesLoaded{false};
 
   // Transform convention:


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Small cleanup of PHGarfield. Add Fun4AllMemoryTracker to Fun4all (disabled by default)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Clean up `PHGarfield` by removing unused dependencies and using the shared CVMFS gas-file location. Add optional memory tracking to Fun4All without enabling tracking by default.

## Key changes

- Removed unused `-lffarawobjects` and `-lEvent` dependencies from `libPHGarfield`.
- Set the default PHGarfield gas-file directory to `/cvmfs/sphenix.sdcc.bnl.gov/files/gasfiles`.
- Removed the hard-coded gas-file path and cleaned up diagnostics and event processing.
- Enabled the `FFAMEMTRACKER` build feature.
- Added runtime enable/disable controls to `Fun4AllMemoryTracker`.
- Made memory-tracker operations return without tracking when disabled.
- Changed `Fun4AllServer::PrintMemoryTracker` to a non-static member function.

## Potential risk areas

- Jobs that depend on the previous private gas-file path may fail until they use CVMFS or configure another valid path.
- Changes from `std::cerr` to `std::cout` can affect log filtering and monitoring.
- Memory tracking can add runtime and memory overhead when enabled.
- No file-format, reconstruction-algorithm, or thread-safety changes are evident from the supplied summary.

## Possible future improvements

- Add a clear configuration mechanism and startup validation for the gas-file directory.
- Add tests for missing gas files, disabled tracking, and enabled tracking.
- Measure memory-tracker overhead in representative production jobs.

AI-generated summaries can contain mistakes. Contributors should verify these points against the code and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->