### PR TITLE
CaloFittingQA: Add sEPD QA

### DIFF
--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -169,7 +169,8 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
     sepd_sim_waveforms = findNode::getClass<TowerInfoContainer>(topNode, "WAVEFORM_SEPD");
     if (!sepd_sim_waveforms)
     {
-      std::cout << PHWHERE << "WAVEFORM_SEPD node missing. Proceeding without sEPD sim waveforms." << std::endl;
+      std::cout << PHWHERE << "WAVEFORM_SEPD node missing. Skipping event." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
     }
   }
   else

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -104,8 +104,8 @@ int CaloFittingQA::InitRun(PHCompositeNode* /*unused*/)
   if (!calibdir_sepd.empty())
   {
     cdbttree_sepd = new CDBTTree(calibdir_sepd);
-    m_sepd_channel_map.resize(744);
-    for (int c = 0; c < 744; ++c)
+    m_sepd_channel_map.resize(m_nchannels_sepd);
+    for (int c = 0; c < m_nchannels_sepd; ++c)
     {
       m_sepd_channel_map[c] = cdbttree_sepd->GetIntValue(c, "epd_channel_map2");
     }
@@ -467,10 +467,10 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
     }
   }
 
-  h_cemc_zs_frac_vs_multiplicity->Fill(event_multiplicity, cemc_zs_frac / 24576.0);
-  h_ihcal_zs_frac_vs_multiplicity->Fill(event_multiplicity, ihcal_zs_frac / 1536.0);
-  h_ohcal_zs_frac_vs_multiplicity->Fill(event_multiplicity, ohcal_zs_frac / 1536.0);
-  h_sepd_zs_frac_vs_multiplicity->Fill(event_multiplicity, sepd_zs_frac / 744.0);
+  h_cemc_zs_frac_vs_multiplicity->Fill(event_multiplicity, cemc_zs_frac / m_nchannels_cemc);
+  h_ihcal_zs_frac_vs_multiplicity->Fill(event_multiplicity, ihcal_zs_frac / m_nchannels_ihcal);
+  h_ohcal_zs_frac_vs_multiplicity->Fill(event_multiplicity, ohcal_zs_frac / m_nchannels_ohcal);
+  h_sepd_zs_frac_vs_multiplicity->Fill(event_multiplicity, sepd_zs_frac / m_nchannels_sepd);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -753,64 +753,64 @@ void CaloFittingQA::createHistos()
   assert(hm);
 
   // create and register your histos (all types) here
-  h_cemc_etaphi_ZScrosscalib = new TProfile2D(std::format("{}cemc_etaphi_ZScrosscalib", getHistoPrefix()).c_str(), ";eta;phi", 96, 0, 96, 256, 0, 256, -10, 10);
+  h_cemc_etaphi_ZScrosscalib = new TProfile2D(std::format("{}cemc_etaphi_ZScrosscalib", getHistoPrefix()).c_str(), ";eta;phi", m_netabins_cemc, 0, m_netabins_cemc, m_nphibins_cemc, 0, m_nphibins_cemc, -10, 10);
   h_cemc_etaphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_cemc_etaphi_ZScrosscalib);
 
-  h_ihcal_etaphi_ZScrosscalib = new TProfile2D(std::format("{}ihcal_etaphi_ZScrosscalib", getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, -10, 10);
+  h_ihcal_etaphi_ZScrosscalib = new TProfile2D(std::format("{}ihcal_etaphi_ZScrosscalib", getHistoPrefix()).c_str(), ";eta;phi", m_netabins_hcal, 0, m_netabins_hcal, m_nphibins_hcal, 0, m_nphibins_hcal, -10, 10);
   h_ihcal_etaphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_etaphi_ZScrosscalib);
 
-  h_ohcal_etaphi_ZScrosscalib = new TProfile2D(std::format("{}ohcal_etaphi_ZScrosscalib", getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, -10, 10);
+  h_ohcal_etaphi_ZScrosscalib = new TProfile2D(std::format("{}ohcal_etaphi_ZScrosscalib", getHistoPrefix()).c_str(), ";eta;phi", m_netabins_hcal, 0, m_netabins_hcal, m_nphibins_hcal, 0, m_nphibins_hcal, -10, 10);
   h_ohcal_etaphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_etaphi_ZScrosscalib);
 
-  h_sepd_north_rphi_ZScrosscalib = new TProfile2D(std::format("{}sepd_north_rphi_ZScrosscalib", getHistoPrefix()).c_str(), "sEPD North;r;phi", 16, 0, 16, 24, 0, 24, -10, 10);
+  h_sepd_north_rphi_ZScrosscalib = new TProfile2D(std::format("{}sepd_north_rphi_ZScrosscalib", getHistoPrefix()).c_str(), "sEPD North;r;phi", m_nrbins_sepd, 0, m_nrbins_sepd, m_nphibins_sepd, 0, m_nphibins_sepd, -10, 10);
   h_sepd_north_rphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_sepd_north_rphi_ZScrosscalib);
 
-  h_sepd_south_rphi_ZScrosscalib = new TProfile2D(std::format("{}sepd_south_rphi_ZScrosscalib", getHistoPrefix()).c_str(), "sEPD South;r;phi", 16, 0, 16, 24, 0, 24, -10, 10);
+  h_sepd_south_rphi_ZScrosscalib = new TProfile2D(std::format("{}sepd_south_rphi_ZScrosscalib", getHistoPrefix()).c_str(), "sEPD South;r;phi", m_nrbins_sepd, 0, m_nrbins_sepd, m_nphibins_sepd, 0, m_nphibins_sepd, -10, 10);
   h_sepd_south_rphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_sepd_south_rphi_ZScrosscalib);
 
-  h_cemc_etaphi_pedestal = new TProfile2D(std::format("{}cemc_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", 96, 0, 96, 256, 0, 256, 0, 16400);
+  h_cemc_etaphi_pedestal = new TProfile2D(std::format("{}cemc_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", m_netabins_cemc, 0, m_netabins_cemc, m_nphibins_cemc, 0, m_nphibins_cemc, 0, 16400);
   h_cemc_etaphi_pedestal->SetErrorOption("s");
   h_cemc_etaphi_pedestal->SetDirectory(nullptr);
   hm->registerHisto(h_cemc_etaphi_pedestal);
 
-  h_ihcal_etaphi_pedestal = new TProfile2D(std::format("{}ihcal_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, 0, 16400);
+  h_ihcal_etaphi_pedestal = new TProfile2D(std::format("{}ihcal_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", m_netabins_hcal, 0, m_netabins_hcal, m_nphibins_hcal, 0, m_nphibins_hcal, 0, 16400);
   h_ihcal_etaphi_pedestal->SetErrorOption("s");
   h_ihcal_etaphi_pedestal->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_etaphi_pedestal);
 
-  h_ohcal_etaphi_pedestal = new TProfile2D(std::format("{}ohcal_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, 0, 16400);
+  h_ohcal_etaphi_pedestal = new TProfile2D(std::format("{}ohcal_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", m_netabins_hcal, 0, m_netabins_hcal, m_nphibins_hcal, 0, m_nphibins_hcal, 0, 16400);
   h_ohcal_etaphi_pedestal->SetErrorOption("s");
   h_ohcal_etaphi_pedestal->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_etaphi_pedestal);
 
-  h_sepd_north_rphi_pedestal = new TProfile2D(std::format("{}sepd_north_rphi_pedestal", getHistoPrefix()).c_str(), "sEPD North;r;phi", 16, 0, 16, 24, 0, 24, 0, 16400);
+  h_sepd_north_rphi_pedestal = new TProfile2D(std::format("{}sepd_north_rphi_pedestal", getHistoPrefix()).c_str(), "sEPD North;r;phi", m_nrbins_sepd, 0, m_nrbins_sepd, m_nphibins_sepd, 0, m_nphibins_sepd, 0, 16400);
   h_sepd_north_rphi_pedestal->SetErrorOption("s");
   h_sepd_north_rphi_pedestal->SetDirectory(nullptr);
   hm->registerHisto(h_sepd_north_rphi_pedestal);
 
-  h_sepd_south_rphi_pedestal = new TProfile2D(std::format("{}sepd_south_rphi_pedestal", getHistoPrefix()).c_str(), "sEPD South;r;phi", 16, 0, 16, 24, 0, 24, 0, 16400);
+  h_sepd_south_rphi_pedestal = new TProfile2D(std::format("{}sepd_south_rphi_pedestal", getHistoPrefix()).c_str(), "sEPD South;r;phi", m_nrbins_sepd, 0, m_nrbins_sepd, m_nphibins_sepd, 0, m_nphibins_sepd, 0, 16400);
   h_sepd_south_rphi_pedestal->SetErrorOption("s");
   h_sepd_south_rphi_pedestal->SetDirectory(nullptr);
   hm->registerHisto(h_sepd_south_rphi_pedestal);
 
-  h_cemc_zs_frac_vs_multiplicity = new TH2F(std::format("{}cemc_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
+  h_cemc_zs_frac_vs_multiplicity = new TH2F(std::format("{}cemc_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2840, 0, m_nchannels_total, 100, 0, 1);
   h_cemc_zs_frac_vs_multiplicity->SetDirectory(nullptr);
   hm->registerHisto(h_cemc_zs_frac_vs_multiplicity);
 
-  h_ihcal_zs_frac_vs_multiplicity = new TH2F(std::format("{}ihcal_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
+  h_ihcal_zs_frac_vs_multiplicity = new TH2F(std::format("{}ihcal_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2840, 0, m_nchannels_total, 100, 0, 1);
   h_ihcal_zs_frac_vs_multiplicity->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_zs_frac_vs_multiplicity);
 
-  h_ohcal_zs_frac_vs_multiplicity = new TH2F(std::format("{}ohcal_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
+  h_ohcal_zs_frac_vs_multiplicity = new TH2F(std::format("{}ohcal_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2840, 0, m_nchannels_total, 100, 0, 1);
   h_ohcal_zs_frac_vs_multiplicity->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_zs_frac_vs_multiplicity);
 
-  h_sepd_zs_frac_vs_multiplicity = new TH2F(std::format("{}sepd_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
+  h_sepd_zs_frac_vs_multiplicity = new TH2F(std::format("{}sepd_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2840, 0, m_nchannels_total, 100, 0, 1);
   h_sepd_zs_frac_vs_multiplicity->SetDirectory(nullptr);
   hm->registerHisto(h_sepd_zs_frac_vs_multiplicity);
 

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -101,18 +101,16 @@ int CaloFittingQA::InitRun(PHCompositeNode* /*unused*/)
   }
 
   std::string calibdir_sepd = CDBInterface::instance()->getUrl("SEPD_CHANNELMAP2");
-  if (!calibdir_sepd.empty())
+  if (calibdir_sepd.empty())
   {
-    cdbttree_sepd = new CDBTTree(calibdir_sepd);
-    m_sepd_channel_map.resize(m_nchannels_sepd);
-    for (int c = 0; c < m_nchannels_sepd; ++c)
-    {
-      m_sepd_channel_map[c] = cdbttree_sepd->GetIntValue(c, "epd_channel_map2");
-    }
+    std::cout << PHWHERE << "No sEPD mapping file for domain SEPD_CHANNELMAP2 found in CDB, exiting." << std::endl;
+    exit(1);
   }
-  else
+  cdbttree_sepd = new CDBTTree(calibdir_sepd);
+  m_sepd_channel_map.resize(m_nchannels_sepd);
+  for (int c = 0; c < m_nchannels_sepd; ++c)
   {
-    std::cout << PHWHERE << "No sEPD mapping file for domain SEPD_CHANNELMAP2 found" << std::endl;
+    m_sepd_channel_map[c] = cdbttree_sepd->GetIntValue(c, "epd_channel_map2");
   }
 
   if (Verbosity() > 0)
@@ -422,13 +420,9 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         }
         else
         {
-          if (!sepd_waveforms.empty())
+          if (!sepd_waveforms.empty() && !m_sepd_channel_map.empty() && channel < (int) m_sepd_channel_map.size())
           {
-            int packet_channel = channel;
-            if (!m_sepd_channel_map.empty() && channel < (int) m_sepd_channel_map.size())
-            {
-              packet_channel = m_sepd_channel_map[channel];
-            }
+            int packet_channel = m_sepd_channel_map[channel];
             if (packet_channel >= 0 && packet_channel < (int) sepd_waveforms.size())
             {
               if (sepd_waveforms.at(packet_channel).size() == 2)

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -94,6 +94,11 @@ int CaloFittingQA::InitRun(PHCompositeNode* /*unused*/)
     exit(1);
   }
   cdbttree = new CDBTTree(calibdir);
+  m_cemc_adc_skip_mask.resize(128, 0);
+  for (int pid = 6001; pid <= 6128; ++pid)
+  {
+    m_cemc_adc_skip_mask[pid - 6001] = cdbttree->GetIntValue(pid, m_fieldname);
+  }
 
   std::string calibdir_sepd = CDBInterface::instance()->getUrl("SEPD_CHANNELMAP2");
   if (!calibdir_sepd.empty())
@@ -559,7 +564,10 @@ int CaloFittingQA::process_data(PHCompositeNode* topNode, CaloTowerDefs::Detecto
 
       if (dettype == CaloTowerDefs::CEMC)
       {
-        adc_skip_mask = cdbttree->GetIntValue(pid, m_fieldname);
+        if (pid >= 6001 && pid <= 6128 && (size_t)(pid - 6001) < m_cemc_adc_skip_mask.size())
+        {
+          adc_skip_mask = m_cemc_adc_skip_mask[pid - 6001];
+        }
       }
       if (dettype == CaloTowerDefs::ZDC)
       {

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -3,6 +3,7 @@
 // Calo includes
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoDefs.h>
 #include <caloreco/CaloTowerDefs.h>
 
 #include <cdbobjects/CDBTTree.h>  // for CDBTTree
@@ -140,9 +141,11 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
   std::vector<std::vector<float>> cemc_waveforms;
   std::vector<std::vector<float>> ihcal_waveforms;
   std::vector<std::vector<float>> ohcal_waveforms;
+  std::vector<std::vector<float>> sepd_waveforms;
   TowerInfoContainer* cemc_sim_waveforms = nullptr;
   TowerInfoContainer* ihcal_sim_waveforms = nullptr;
   TowerInfoContainer* ohcal_sim_waveforms = nullptr;
+  TowerInfoContainer* sepd_sim_waveforms = nullptr;
   if (m_SimFlag)
   {
     cemc_sim_waveforms = findNode::getClass<TowerInfoContainer>(topNode, "WAVEFORM_CEMC");
@@ -163,6 +166,11 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
       std::cout << PHWHERE << "WAVEFORM_HCALOUT node missing. Skipping event." << std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
+    sepd_sim_waveforms = findNode::getClass<TowerInfoContainer>(topNode, "WAVEFORM_SEPD");
+    if (!sepd_sim_waveforms)
+    {
+      std::cout << PHWHERE << "WAVEFORM_SEPD node missing. Proceeding without sEPD sim waveforms." << std::endl;
+    }
   }
   else
   {
@@ -181,6 +189,11 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
       std::cout << PHWHERE << "HCALPackets node failed unpacking. Skipping event." << std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
+    if (process_data(topNode, CaloTowerDefs::SEPD, sepd_waveforms) == Fun4AllReturnCodes::ABORTEVENT)
+    {
+      std::cout << PHWHERE << "SEPDPackets node failed unpacking. Skipping event." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
   }
 
   //-------------------------- ZS and multiplicity variables ------------------------------//
@@ -188,6 +201,7 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
   float cemc_zs_frac = 0;
   float ihcal_zs_frac = 0;
   float ohcal_zs_frac = 0;
+  float sepd_zs_frac = 0;
 
   //-------------------------- raw towers ------------------------------//
   {
@@ -354,10 +368,76 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
       }
     }
   }
+  {
+    TowerInfoContainer* towers = findNode::getClass<TowerInfoContainer>(topNode, "TOWERS_SEPD");
+    if (towers)
+    {
+      int size = towers->size();  // online towers should be the same!
+      for (int channel = 0; channel < size; channel++)
+      {
+        TowerInfo* tower = towers->get_tower_at_channel(channel);
+        unsigned int towerkey = towers->encode_key(channel);
+        int arm = TowerInfoDefs::get_epd_arm(towerkey);
+        int rbin = TowerInfoDefs::get_epd_rbin(towerkey);
+        int phibin = TowerInfoDefs::get_epd_phibin(towerkey);
+        float raw_energy = tower->get_energy();
+        if (raw_energy > m_sepd_hit_threshold)
+        {
+          event_multiplicity += 1;
+        }
+        float zs_energy = -9999;
+        if (m_SimFlag)
+        {
+          if (sepd_sim_waveforms && sepd_sim_waveforms->size() > 0)
+          {
+            zs_energy = sepd_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(6) - sepd_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0);
+            if (arm == 1) {
+              h_sepd_north_rphi_pedestal->Fill(rbin, phibin, sepd_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0));
+            } else {
+              h_sepd_south_rphi_pedestal->Fill(rbin, phibin, sepd_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0));
+            }
+          }
+        }
+        else
+        {
+          if (!sepd_waveforms.empty())
+          {
+            if (sepd_waveforms.at(channel).size() == 2)
+            {
+              zs_energy = sepd_waveforms.at(channel).at(1) - sepd_waveforms.at(channel).at(0);
+              sepd_zs_frac += 1;
+            }
+            else
+            {
+              zs_energy = sepd_waveforms.at(channel).at(6) - sepd_waveforms.at(channel).at(0);
+            }
+            if (arm == 1) {
+              h_sepd_north_rphi_pedestal->Fill(rbin, phibin, sepd_waveforms.at(channel).at(0));
+            } else {
+              h_sepd_south_rphi_pedestal->Fill(rbin, phibin, sepd_waveforms.at(channel).at(0));
+            }
+          }
+        }
+        if (Verbosity() > 0)
+        {
+          std::cout << "sEPD channel " << channel << " arm " << arm << " rbin " << rbin << " phibin " << phibin << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
+        }
+        if (raw_energy > m_sepd_adc_threshold && raw_energy < m_sepd_high_adc_threshold)
+        {
+          if (arm == 1) {
+            h_sepd_north_rphi_ZScrosscalib->Fill(rbin, phibin, zs_energy / raw_energy);
+          } else {
+            h_sepd_south_rphi_ZScrosscalib->Fill(rbin, phibin, zs_energy / raw_energy);
+          }
+        }
+      }
+    }
+  }
 
   h_cemc_zs_frac_vs_multiplicity->Fill(event_multiplicity, cemc_zs_frac / 24576.0);
   h_ihcal_zs_frac_vs_multiplicity->Fill(event_multiplicity, ihcal_zs_frac / 1536.0);
   h_ohcal_zs_frac_vs_multiplicity->Fill(event_multiplicity, ohcal_zs_frac / 1536.0);
+  h_sepd_zs_frac_vs_multiplicity->Fill(event_multiplicity, sepd_zs_frac / 744.0);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -649,6 +729,14 @@ void CaloFittingQA::createHistos()
   h_ohcal_etaphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_etaphi_ZScrosscalib);
 
+  h_sepd_north_rphi_ZScrosscalib = new TProfile2D(std::format("{}sepd_north_rphi_ZScrosscalib", getHistoPrefix()).c_str(), "sEPD North;r;phi", 16, 0, 16, 24, 0, 24, -10, 10);
+  h_sepd_north_rphi_ZScrosscalib->SetDirectory(nullptr);
+  hm->registerHisto(h_sepd_north_rphi_ZScrosscalib);
+
+  h_sepd_south_rphi_ZScrosscalib = new TProfile2D(std::format("{}sepd_south_rphi_ZScrosscalib", getHistoPrefix()).c_str(), "sEPD South;r;phi", 16, 0, 16, 24, 0, 24, -10, 10);
+  h_sepd_south_rphi_ZScrosscalib->SetDirectory(nullptr);
+  hm->registerHisto(h_sepd_south_rphi_ZScrosscalib);
+
   h_cemc_etaphi_pedestal = new TProfile2D(std::format("{}cemc_etaphi_pedestal", getHistoPrefix()).c_str(), ";eta;phi", 96, 0, 96, 256, 0, 256, 0, 16400);
   h_cemc_etaphi_pedestal->SetErrorOption("s");
   h_cemc_etaphi_pedestal->SetDirectory(nullptr);
@@ -664,6 +752,16 @@ void CaloFittingQA::createHistos()
   h_ohcal_etaphi_pedestal->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_etaphi_pedestal);
 
+  h_sepd_north_rphi_pedestal = new TProfile2D(std::format("{}sepd_north_rphi_pedestal", getHistoPrefix()).c_str(), "sEPD North;r;phi", 16, 0, 16, 24, 0, 24, 0, 16400);
+  h_sepd_north_rphi_pedestal->SetErrorOption("s");
+  h_sepd_north_rphi_pedestal->SetDirectory(nullptr);
+  hm->registerHisto(h_sepd_north_rphi_pedestal);
+
+  h_sepd_south_rphi_pedestal = new TProfile2D(std::format("{}sepd_south_rphi_pedestal", getHistoPrefix()).c_str(), "sEPD South;r;phi", 16, 0, 16, 24, 0, 24, 0, 16400);
+  h_sepd_south_rphi_pedestal->SetErrorOption("s");
+  h_sepd_south_rphi_pedestal->SetDirectory(nullptr);
+  hm->registerHisto(h_sepd_south_rphi_pedestal);
+
   h_cemc_zs_frac_vs_multiplicity = new TH2F(std::format("{}cemc_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
   h_cemc_zs_frac_vs_multiplicity->SetDirectory(nullptr);
   hm->registerHisto(h_cemc_zs_frac_vs_multiplicity);
@@ -675,6 +773,10 @@ void CaloFittingQA::createHistos()
   h_ohcal_zs_frac_vs_multiplicity = new TH2F(std::format("{}ohcal_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
   h_ohcal_zs_frac_vs_multiplicity->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_zs_frac_vs_multiplicity);
+
+  h_sepd_zs_frac_vs_multiplicity = new TH2F(std::format("{}sepd_zs_frac_vs_multiplicity", getHistoPrefix()).c_str(), ";Nhit > 0.3 GeV;ZS fraction (%)", 2700, 0, 27648, 100, 0, 1);
+  h_sepd_zs_frac_vs_multiplicity->SetDirectory(nullptr);
+  hm->registerHisto(h_sepd_zs_frac_vs_multiplicity);
 
   h_packet_events = new TH1I(std::format("{}packet_events", getHistoPrefix()).c_str(), ";packet id", 6010, 6000, 12010);
   h_packet_events->SetDirectory(nullptr);

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -56,6 +56,7 @@ CaloFittingQA::CaloFittingQA(const std::string& name)
 CaloFittingQA::~CaloFittingQA()
 {
   delete cdbttree;
+  delete cdbttree_sepd;
 }
 
 int CaloFittingQA::Init(PHCompositeNode* /*unused*/)
@@ -93,6 +94,21 @@ int CaloFittingQA::InitRun(PHCompositeNode* /*unused*/)
     exit(1);
   }
   cdbttree = new CDBTTree(calibdir);
+
+  std::string calibdir_sepd = CDBInterface::instance()->getUrl("SEPD_CHANNELMAP2");
+  if (!calibdir_sepd.empty())
+  {
+    cdbttree_sepd = new CDBTTree(calibdir_sepd);
+    m_sepd_channel_map.resize(744);
+    for (int c = 0; c < 744; ++c)
+    {
+      m_sepd_channel_map[c] = cdbttree_sepd->GetIntValue(c, "epd_channel_map2");
+    }
+  }
+  else
+  {
+    std::cout << PHWHERE << "No sEPD mapping file for domain SEPD_CHANNELMAP2 found" << std::endl;
+  }
 
   if (Verbosity() > 0)
   {
@@ -403,19 +419,30 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         {
           if (!sepd_waveforms.empty())
           {
-            if (sepd_waveforms.at(channel).size() == 2)
+            int packet_channel = channel;
+            if (!m_sepd_channel_map.empty() && channel < (int) m_sepd_channel_map.size())
             {
-              zs_energy = sepd_waveforms.at(channel).at(1) - sepd_waveforms.at(channel).at(0);
-              sepd_zs_frac += 1;
+              packet_channel = m_sepd_channel_map[channel];
             }
-            else
+            if (packet_channel >= 0 && packet_channel < (int) sepd_waveforms.size())
             {
-              zs_energy = sepd_waveforms.at(channel).at(6) - sepd_waveforms.at(channel).at(0);
-            }
-            if (arm == 1) {
-              h_sepd_north_rphi_pedestal->Fill(rbin, phibin, sepd_waveforms.at(channel).at(0));
-            } else {
-              h_sepd_south_rphi_pedestal->Fill(rbin, phibin, sepd_waveforms.at(channel).at(0));
+              if (sepd_waveforms.at(packet_channel).size() == 2)
+              {
+                zs_energy = sepd_waveforms.at(packet_channel).at(1) - sepd_waveforms.at(packet_channel).at(0);
+                sepd_zs_frac += 1;
+              }
+              else if (sepd_waveforms.at(packet_channel).size() > 6)
+              {
+                zs_energy = sepd_waveforms.at(packet_channel).at(6) - sepd_waveforms.at(packet_channel).at(0);
+              }
+              if (!sepd_waveforms.at(packet_channel).empty())
+              {
+                if (arm == 1) {
+                  h_sepd_north_rphi_pedestal->Fill(rbin, phibin, sepd_waveforms.at(packet_channel).at(0));
+                } else {
+                  h_sepd_south_rphi_pedestal->Fill(rbin, phibin, sepd_waveforms.at(packet_channel).at(0));
+                }
+              }
             }
           }
         }

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -111,6 +111,7 @@ class CaloFittingQA : public SubsysReco
   CDBTTree* cdbttree = nullptr;
   CDBTTree* cdbttree_sepd = nullptr;
   std::vector<int> m_sepd_channel_map;
+  std::vector<unsigned int> m_cemc_adc_skip_mask;
 
   int _eventcounter{0};
 

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -109,6 +109,8 @@ class CaloFittingQA : public SubsysReco
   TH1* h_missing_packets{nullptr};
 
   CDBTTree* cdbttree = nullptr;
+  CDBTTree* cdbttree_sepd = nullptr;
+  std::vector<int> m_sepd_channel_map;
 
   int _eventcounter{0};
 

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -62,6 +62,14 @@ class CaloFittingQA : public SubsysReco
   {
     m_hcal_high_adc_threshold = hath;
   }
+  void set_sepd_lowadcthreshold(int lath)
+  {
+    m_sepd_adc_threshold = lath;
+  }
+  void set_sepd_highadcthreshold(int hath)
+  {
+    m_sepd_high_adc_threshold = hath;
+  }
   void set_cemc_hit_threshold(int hthres)
   {
     m_cemc_hit_threshold = hthres;
@@ -74,6 +82,10 @@ class CaloFittingQA : public SubsysReco
   {
     m_ohcal_hit_threshold = hthres;
   }
+  void set_sepd_hit_threshold(int hthres)
+  {
+    m_sepd_hit_threshold = hthres;
+  }
 
  private:
   void createHistos();
@@ -81,12 +93,17 @@ class CaloFittingQA : public SubsysReco
   TProfile2D* h_cemc_etaphi_ZScrosscalib{nullptr};
   TProfile2D* h_ihcal_etaphi_ZScrosscalib{nullptr};
   TProfile2D* h_ohcal_etaphi_ZScrosscalib{nullptr};
+  TProfile2D* h_sepd_north_rphi_ZScrosscalib{nullptr};
+  TProfile2D* h_sepd_south_rphi_ZScrosscalib{nullptr};
   TProfile2D* h_cemc_etaphi_pedestal{nullptr};
   TProfile2D* h_ihcal_etaphi_pedestal{nullptr};
   TProfile2D* h_ohcal_etaphi_pedestal{nullptr};
+  TProfile2D* h_sepd_north_rphi_pedestal{nullptr};
+  TProfile2D* h_sepd_south_rphi_pedestal{nullptr};
   TH2* h_cemc_zs_frac_vs_multiplicity{nullptr};
   TH2* h_ihcal_zs_frac_vs_multiplicity{nullptr};
   TH2* h_ohcal_zs_frac_vs_multiplicity{nullptr};
+  TH2* h_sepd_zs_frac_vs_multiplicity{nullptr};
   TH1* h_packet_events{nullptr};
   TH1* h_empty_packets{nullptr};
   TH1* h_missing_packets{nullptr};
@@ -102,10 +119,13 @@ class CaloFittingQA : public SubsysReco
   float m_cemc_high_adc_threshold = 2000.;
   float m_hcal_adc_threshold = 100.;
   float m_hcal_high_adc_threshold = 2000.;
+  float m_sepd_adc_threshold = 300.;
+  float m_sepd_high_adc_threshold = 2000.;
 
   float m_cemc_hit_threshold = 200;   // ~ 300 MeV
   float m_ihcal_hit_threshold = 600;  // ~ 300 MeV
   float m_ohcal_hit_threshold = 100;  // ~ 300 MeV
+  float m_sepd_hit_threshold = 300;
   bool m_PacketNodesFlag{false};
 
   std::string m_calibName;

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -129,6 +129,20 @@ class CaloFittingQA : public SubsysReco
   float m_ihcal_hit_threshold = 600;  // ~ 300 MeV
   float m_ohcal_hit_threshold = 100;  // ~ 300 MeV
   float m_sepd_hit_threshold = 300;
+
+  static constexpr float m_nchannels_cemc = 24576.0;
+  static constexpr float m_nchannels_ihcal = 1536.0;
+  static constexpr float m_nchannels_ohcal = 1536.0;
+  static constexpr float m_nchannels_sepd = 744.0;
+  static constexpr float m_nchannels_total = m_nchannels_cemc + m_nchannels_ihcal + m_nchannels_ohcal + m_nchannels_sepd;
+
+  static constexpr int m_netabins_cemc = 96;
+  static constexpr int m_nphibins_cemc = 256;
+  static constexpr int m_netabins_hcal = 24;
+  static constexpr int m_nphibins_hcal = 64;
+  static constexpr int m_nrbins_sepd = 16;
+  static constexpr int m_nphibins_sepd = 24;
+
   bool m_PacketNodesFlag{false};
 
   std::string m_calibName;


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add sEPD QA and template fit cross-calibration to CaloFittingQA:
- Add sEPD raw waveform parsing from SEPDPackets and `WAVEFORM_SEPD` nodes
- Implement ZS cross-calibration (ratio of raw "6 - 0" ADC to template fit energy) for sEPD North and South disks
- Add pedestal monitoring histograms for sEPD North and South disks
- Add sEPD zero-suppression fraction vs. event multiplicity histogram
- Add configurable sEPD ADC and hit threshold parameters

Example Plots (Tested on 1k events from Run 68144)
<img width="651" height="748" alt="Screenshot from 2026-08-17 19-13-28" src="https://github.com/user-attachments/assets/4852797b-a904-451b-9263-2e7fb5ec939a" />
<img width="987" height="770" alt="Screenshot from 2026-08-17 19-12-46" src="https://github.com/user-attachments/assets/1d2e119d-45ce-49a3-b79a-7be9e9de897e" />
<img width="987" height="770" alt="Screenshot from 2026-08-17 19-12-36" src="https://github.com/user-attachments/assets/52100a0d-d284-4888-8c59-da9310626fa7" />
<img width="973" height="770" alt="Screenshot from 2026-08-17 19-12-22" src="https://github.com/user-attachments/assets/f2d289a7-091e-4ecf-81dc-dd14bc1697ed" />
<img width="947" height="770" alt="Screenshot from 2026-08-17 19-12-09" src="https://github.com/user-attachments/assets/f29f5bbc-67a9-4029-891e-51a474c3a966" />


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

This PR adds sEPD quality assurance to `CaloFittingQA`. It monitors raw waveforms, pedestals, zero suppression, and template-fit cross-calibration for the North and South disks.

## Key changes

- Load and validate the `SEPD_CHANNELMAP2` calibration during `InitRun()`.
- Parse sEPD data from `SEPDPackets` and `WAVEFORM_SEPD`.
- Process sEPD waveforms for data and simulation.
- Add configurable thresholds through:
  - `set_sepd_lowadcthreshold(int)`
  - `set_sepd_highadcthreshold(int)`
  - `set_sepd_hit_threshold(int)`
- Add North and South pedestal histograms.
- Add North and South zero-suppression cross-calibration histograms.
- Add zero-suppression fraction versus event multiplicity.
- Include sEPD channels in multiplicity limits.
- Cache CEMC ADC skip masks during run initialization.
- Abort simulation events when required sEPD data or packet unpacking fails.

## Potential risk areas

- The implementation depends on the `SEPD_CHANNELMAP2`, `SEPDPackets`, and `WAVEFORM_SEPD` formats.
- Invalid channel maps or waveform indices can affect event processing.
- Missing-node and packet-unpacking failures change simulation event handling.
- Waveform processing and additional histograms can increase CPU and memory use.
- Thread-safety should be checked if `CaloFittingQA` runs concurrently.
- Validation used 1,000 events from Run 68144. Broader data and simulation coverage is required.

## Possible future improvements

- Add automated tests for channel-map validation, packet decoding, waveform handling, thresholds, and failure behavior.
- Validate results across additional runs and detector conditions.
- Document histogram definitions and recommended threshold settings.
- Measure performance in representative production workflows.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation and detector data before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->