### PR TITLE
Clang tidy fix

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -39,8 +39,6 @@
 #include <set>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 
-using namespace std;
-
 //____________________________________________________________________________..
 PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name)
   : SubsysReco(name)
@@ -63,10 +61,10 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
                       "event:sicrossing:siq:siphi:sieta:six:siy:siz:sipx:sipy:sipz:tpcq:tpcphi:tpceta:tpcx:tpcy:tpcz:tpcpx:tpcpy:tpcpz:tpcid:siid");
   }
   // put these in the output file
-  cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta "
+  std::cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta "
        << _eta_search_win << " _pp_mode " << _pp_mode 
        << " _use_silicon_crossing_only " << _use_silicon_crossing_only
-       << " _use_tpc_crossing_only " << _use_tpc_crossing_only << endl;
+       << " _use_tpc_crossing_only " << _use_tpc_crossing_only << std::endl;
 
   int ret = GetNodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK)
@@ -160,20 +158,17 @@ bool PHSiliconTpcTrackMatching::WindowMatcher::in_window
   if (posQ) {
     double pt = (tpc_pt<min_pt_posQ) ? min_pt_posQ : tpc_pt;
     if (fabs_max_posQ) {
-      return fabs(delta) < fn_exp(posHi, posHi_b0, pt);
-    } else {
-      return (delta > fn_exp(posLo, posLo_b0, pt)
-           && delta < fn_exp(posHi, posHi_b0, pt));
+      return std::fabs(delta) < fn_exp(posHi, posHi_b0, pt);
     }
-  } else {
-    double pt = (tpc_pt<min_pt_negQ) ? min_pt_negQ : tpc_pt;
-    if (fabs_max_negQ) {
-      return fabs(delta) < fn_exp(negHi, negHi_b0, pt);
-    } else {
-      return (delta > fn_exp(negLo, negLo_b0, pt)
-           && delta < fn_exp(negHi, negHi_b0, pt));
-    }
+    return (delta > fn_exp(posLo, posLo_b0, pt)
+	    && delta < fn_exp(posHi, posHi_b0, pt));
   }
+  double pt = (tpc_pt<min_pt_negQ) ? min_pt_negQ : tpc_pt;
+  if (fabs_max_negQ) {
+    return std::fabs(delta) < fn_exp(negHi, negHi_b0, pt);
+  }
+  return (delta > fn_exp(negLo, negLo_b0, pt)
+	  && delta < fn_exp(negHi, negHi_b0, pt));
 }
 
 //____________________________________________________________________________..
@@ -193,7 +188,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
   
   if (Verbosity() > 0)
   {
-    cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << endl;
+    std::cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << std::endl;
   }
 
   if (_track_map->empty())
@@ -282,7 +277,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
       std::cout << std::endl;
     }
 
-    cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;
+    std::cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << std::endl;
   }
   m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
@@ -385,21 +380,21 @@ int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
   _cluster_crossing_map = findNode::getClass<TrkrClusterCrossingAssoc>(topNode, "TRKR_CLUSTERCROSSINGASSOC");
   if (!_cluster_crossing_map)
   {
-    //cerr << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << endl;
+    //std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << std::endl;
     // return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _track_map_silicon = findNode::getClass<TrackSeedContainer>(topNode, _silicon_track_map_name);
   if (!_track_map_silicon)
   {
-    cerr << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << endl;
+    std::cout << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _track_map = findNode::getClass<TrackSeedContainer>(topNode, _track_map_name);
   if (!_track_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find " << _track_map_name.c_str() << endl;
+    std::cout << PHWHERE << " ERROR: Can't find " << _track_map_name.c_str() << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -414,7 +409,7 @@ int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
     /// Check that it is there
     if (!dstNode)
     {
-      std::cerr << "DST Node missing, quitting" << std::endl;
+      std::cout << "DST Node missing, quitting" << std::endl;
       throw std::runtime_error("failed to find DST node in PHActsSourceLinks::createNodes");
     }
 
@@ -476,7 +471,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
           << ": nhits: " << _tracklet_tpc->size_cluster_keys()
           << ": Total tracks: " << _track_map->size()
           << ": phi: " << _tracklet_tpc->get_phi()
-          << endl;
+          << std::endl;
     }
 
     double tpc_phi;
@@ -504,7 +499,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
     } else {
       tpc_phi = _tracklet_tpc->get_phi();
       tpc_eta = _tracklet_tpc->get_eta();
-      tpc_pt = fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
+      tpc_pt = std::fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
 
       tpc_crossing = _tracklet_tpc->get_crossing();
 
@@ -526,7 +521,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
     if (Verbosity() > 3)
     {
-      cout << "TPC tracklet:" << endl;
+      std::cout << "TPC tracklet:" << std::endl;
       _tracklet_tpc->identify();
     }
 
@@ -592,10 +587,10 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
       bool eta_match = false;
       if (window_deta.in_window(is_posQ, tpc_pt, tpc_eta, si_eta))
-      {
+      { // NOLINT(bugprone-branch-clone)
         eta_match = true;
       }
-      else if (fabs(tpc_eta-si_eta) < _deltaeta_min)
+      else if (std::fabs(tpc_eta-si_eta) < _deltaeta_min)
       {
 	eta_match = true;
       }
@@ -620,7 +615,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       {
         phi_match = true;
         // if phi fails, account for case where |tpc_phi-si_phi|>PI
-      } else if (fabs(tpc_phi-si_phi)>M_PI) {
+      } else if (std::fabs(tpc_phi-si_phi)>M_PI) {
         auto tpc_phi_wrap = tpc_phi;
         if ((tpc_phi_wrap - si_phi) > M_PI) {
           tpc_phi_wrap -= 2*M_PI;
@@ -636,10 +631,10 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
       if (Verbosity() > 3)
       {
-        cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt()
-             << " and eta " << _tracklet_tpc->get_eta() << " with Si track " << siid << " with crossing " << _tracklet_si->get_crossing() << endl;
-        cout << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi << " phi search " << _phi_search_win << " tpc_eta " << tpc_eta
-             << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " eta search " << _eta_search_win  << endl;
+        std::cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt()
+             << " and eta " << _tracklet_tpc->get_eta() << " with Si track " << siid << " with crossing " << _tracklet_si->get_crossing() << std::endl;
+        std::cout << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi << " phi search " << _phi_search_win << " tpc_eta " << tpc_eta
+             << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " eta search " << _eta_search_win  << std::endl;
         std::cout << "      tpc x " << tpc_pos.x() << " si x " << si_pos.x() << " tpc y " << tpc_pos.y() << " si y " << si_pos.y() << " tpc_z " << tpc_pos.z() << " si z " << si_pos.z() << std::endl;
         std::cout << "      x search " << _x_search_win  << " y search " << _y_search_win << " z search " << _z_search_win << std::endl;
       }
@@ -652,19 +647,19 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
       if (Verbosity() > 1)
       {
-        cout << " found a match for TPC track " << tpcid << " with Si track " << siid << endl;
-        cout << "          tpc_phi " << tpc_phi << " si_phi " << si_phi << " phi_match " << phi_match
-             << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " eta_match " << eta_match << endl;
+        std::cout << " found a match for TPC track " << tpcid << " with Si track " << siid << std::endl;
+        std::cout << "          tpc_phi " << tpc_phi << " si_phi " << si_phi << " phi_match " << phi_match
+             << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " eta_match " << eta_match << std::endl;
         std::cout << "      tpc x " << tpc_pos.x() << " si x " << si_pos.x() << " tpc y " << tpc_pos.y() << " si y " << si_pos.y() << " tpc_z " << tpc_pos.z() << " si z " << si_pos.z() << std::endl;
       }
 
       // temporary!
       if (_test_windows && Verbosity() > 1)
       {
-        cout << " Try_silicon: crossing" << si_crossing <<  "  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi <<  "   si_q" << si_q << "   tpc_q" << tpc_q
+        std::cout << " Try_silicon: crossing" << si_crossing <<  "  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi <<  "   si_q" << si_q << "   tpc_q" << tpc_q
              << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " tpc_x " << tpc_pos.x() << " tpc_y " << tpc_pos.y() << " tpc_z " << tpc_pos.z()
              << " dx " << tpc_pos.x() - si_pos.x() << " dy " << tpc_pos.y() - si_pos.y() << " dz " << tpc_pos.z() - si_pos.z()
-			 << endl;
+			 << std::endl;
       }
 
     }
@@ -673,7 +668,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
     {
       if (Verbosity() > 1)
       {
-        cout << "inserted unmatched tpc seed " << tpcid << endl;
+        std::cout << "inserted unmatched tpc seed " << tpcid << std::endl;
       }
       tpc_unmatched_set.insert(tpcid);
     }
@@ -711,7 +706,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
       si_z = std::get<4>(TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list_si)).z();
     } else {
-      tpc_pt = fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
+      tpc_pt = std::fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
       tpc_z = TrackSeedHelper::get_z(tpc_track);
       tpc_q = _tracklet_tpc->get_charge();
       si_z = TrackSeedHelper::get_z(si_track);
@@ -736,22 +731,22 @@ void PHSiliconTpcTrackMatching::checkZMatches(
     
     if(_pp_mode)
       {
-	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (fabs(z_mismatch_corrected) < _crossing_deltaz_max))
-	  {
+	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (std::fabs(z_mismatch_corrected) < _crossing_deltaz_max))
+	{ //NOLINT(bugprone-branch-clone)
 	    z_match = true;
 	  }
-	else if (fabs(z_mismatch_corrected) < _crossing_deltaz_min)
+	else if (std::fabs(z_mismatch_corrected) < _crossing_deltaz_min)
 	  {
 	    z_match = true;
 	  }
       }
     else
       {
-	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (fabs(z_mismatch) < _crossing_deltaz_max))
-	  {
+	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (std::fabs(z_mismatch) < _crossing_deltaz_max))
+	  { //NOLINT(bugprone-branch-clone)
 	    z_match = true;
 	  }
-	else if (fabs(z_mismatch) < _crossing_deltaz_min)
+	else if (std::fabs(z_mismatch) < _crossing_deltaz_min)
 	  {
 	    z_match = true;
 	  }

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -1,25 +1,16 @@
 #include "PHSiliconTpcTrackMatching.h"
 
 /// Tracking includes
-#include <trackbase/MvtxDefs.h>
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrackFitUtils.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterCrossingAssoc.h>
-#include <trackbase/TrkrClusterv3.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey, getTrkrId, tpcId
 
 #include <trackbase_historic/SvtxTrackSeed_v3.h>
 #include <trackbase_historic/TrackSeedContainer_v1.h>
-#include <trackbase_historic/TrackSeed_v2.h>
 #include <trackbase_historic/TrackSeedHelper.h>
-
-#include <globalvertex/SvtxVertex.h>  // for SvtxVertex
-#include <globalvertex/SvtxVertexMap.h>
-
-#include <g4main/PHG4Hit.h>       // for PHG4Hit
-#include <g4main/PHG4HitDefs.h>   // for keytype
-#include <g4main/PHG4Particle.h>  // for PHG4Particle
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -28,13 +19,12 @@
 #include <phool/phool.h>
 #include <phool/sphenix_constants.h>
 
-#include <TF1.h>
 #include <TFile.h>
 #include <TNtuple.h>
 
-#include <climits>   // for UINT_MAX
 #include <cmath>     // for fabs, sqrt
 #include <iostream>  // for operator<<, basic_ostream
+#include <limits>
 #include <memory>
 #include <set>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
@@ -46,9 +36,6 @@ PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name)
 {
   InitializeParameters();
 }
-
-//____________________________________________________________________________..
-PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching() = default;
 
 //____________________________________________________________________________..
 int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
@@ -158,14 +145,14 @@ bool PHSiliconTpcTrackMatching::WindowMatcher::in_window
   if (posQ) {
     double pt = (tpc_pt<min_pt_posQ) ? min_pt_posQ : tpc_pt;
     if (fabs_max_posQ) {
-      return std::fabs(delta) < fn_exp(posHi, posHi_b0, pt);
+      return std::abs(delta) < fn_exp(posHi, posHi_b0, pt);
     }
     return (delta > fn_exp(posLo, posLo_b0, pt)
 	    && delta < fn_exp(posHi, posHi_b0, pt));
   }
   double pt = (tpc_pt<min_pt_negQ) ? min_pt_negQ : tpc_pt;
   if (fabs_max_negQ) {
-    return std::fabs(delta) < fn_exp(negHi, negHi_b0, pt);
+    return std::abs(delta) < fn_exp(negHi, negHi_b0, pt);
   }
   return (delta > fn_exp(negLo, negLo_b0, pt)
 	  && delta < fn_exp(negHi, negHi_b0, pt));
@@ -336,7 +323,7 @@ double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_m
 
   if (side == 10)
   {
-    return SHRT_MAX;
+    return std::numeric_limits<short>::max();
   }
 
   if (side_set.size() == 2 && Verbosity() > 1)
@@ -394,7 +381,7 @@ int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
   _track_map = findNode::getClass<TrackSeedContainer>(topNode, _track_map_name);
   if (!_track_map)
   {
-    std::cout << PHWHERE << " ERROR: Can't find " << _track_map_name.c_str() << std::endl;
+    std::cout << PHWHERE << " ERROR: Can't find " << _track_map_name << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -499,7 +486,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
     } else {
       tpc_phi = _tracklet_tpc->get_phi();
       tpc_eta = _tracklet_tpc->get_eta();
-      tpc_pt = std::fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
+      tpc_pt = std::abs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
 
       tpc_crossing = _tracklet_tpc->get_crossing();
 
@@ -590,7 +577,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       { // NOLINT(bugprone-branch-clone)
         eta_match = true;
       }
-      else if (std::fabs(tpc_eta-si_eta) < _deltaeta_min)
+      else if (std::abs(tpc_eta-si_eta) < _deltaeta_min)
       {
 	eta_match = true;
       }
@@ -615,7 +602,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       {
         phi_match = true;
         // if phi fails, account for case where |tpc_phi-si_phi|>PI
-      } else if (std::fabs(tpc_phi-si_phi)>M_PI) {
+      } else if (std::abs(tpc_phi-si_phi)>M_PI) {
         auto tpc_phi_wrap = tpc_phi;
         if ((tpc_phi_wrap - si_phi) > M_PI) {
           tpc_phi_wrap -= 2*M_PI;
@@ -706,7 +693,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
       si_z = std::get<4>(TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list_si)).z();
     } else {
-      tpc_pt = std::fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
+      tpc_pt = std::abs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
       tpc_z = TrackSeedHelper::get_z(tpc_track);
       tpc_q = _tracklet_tpc->get_charge();
       si_z = TrackSeedHelper::get_z(si_track);
@@ -723,7 +710,7 @@ void PHSiliconTpcTrackMatching::checkZMatches(
 
     std::vector<short int> crossing_list = getBestCrossing(tpcid, si_id);
     short int crossing = crossing_list[3];        // the fourth entry is the best crossing choice
-    if(crossing == SHRT_MAX) { continue; }  // no INTT or TPC crossing, maybe can recover in the fitter using geometric crossing - don't delete
+    if(crossing == std::numeric_limits<short>::max()) { continue; }  // no INTT or TPC crossing, maybe can recover in the fitter using geometric crossing - don't delete
     
     float z_mismatch = tpc_z - si_z;
     float tpc_z_corrected = TpcClusterZCrossingCorrection::correctZ(tpc_z, this_side, crossing);
@@ -731,22 +718,22 @@ void PHSiliconTpcTrackMatching::checkZMatches(
     
     if(_pp_mode)
       {
-	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (std::fabs(z_mismatch_corrected) < _crossing_deltaz_max))
+	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (std::abs(z_mismatch_corrected) < _crossing_deltaz_max))
 	{ //NOLINT(bugprone-branch-clone)
 	    z_match = true;
 	  }
-	else if (std::fabs(z_mismatch_corrected) < _crossing_deltaz_min)
+	else if (std::abs(z_mismatch_corrected) < _crossing_deltaz_min)
 	  {
 	    z_match = true;
 	  }
       }
     else
       {
-	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (std::fabs(z_mismatch) < _crossing_deltaz_max))
+	if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (std::abs(z_mismatch) < _crossing_deltaz_max))
 	  { //NOLINT(bugprone-branch-clone)
 	    z_match = true;
 	  }
-	else if (std::fabs(z_mismatch) < _crossing_deltaz_min)
+	else if (std::abs(z_mismatch) < _crossing_deltaz_min)
 	  {
 	    z_match = true;
 	  }
@@ -818,10 +805,10 @@ std::vector<short int>  PHSiliconTpcTrackMatching::getBestCrossing(unsigned int 
 
   // get the best crossing reference for this track
   
-  short int crossing = SHRT_MAX;
+  short int crossing = std::numeric_limits<short>::max();
 
   // discard the track if there is no input crossing, or no geometric reference
-  if ((intt_crossing == SHRT_MAX && tpc_crossing == SHRT_MAX) || geom_crossing == SHRT_MAX)
+  if ((intt_crossing == std::numeric_limits<short>::max() && tpc_crossing == std::numeric_limits<short>::max()) || geom_crossing == std::numeric_limits<short>::max())
     {
       crossing_list.emplace_back(crossing);
       return crossing_list;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -3,19 +3,27 @@
 #ifndef PHSILICONTPCTRACKMATCHING_H
 #define PHSILICONTPCTRACKMATCHING_H
 
-#include <fun4all/SubsysReco.h>
-#include <phparameter/PHParameterInterface.h>
 #include <tpc/TpcClusterZCrossingCorrection.h>
-#include <trackbase/ActsGeometry.h>
 
+#include <trackbase/TrkrDefs.h>
+
+#include <phparameter/PHParameterInterface.h>
+
+#include <fun4all/SubsysReco.h>
+
+#include <array>
+#include <cmath>
+#include <limits>
 #include <map>
+#include <set>
 #include <string>
+#include <vector>
 
+class ActsGeometry;
 class PHCompositeNode;
 class TrackSeedContainer;
 class TrackSeed;
 class TrkrClusterContainer;
-class TF1;
 class TrkrClusterCrossingAssoc;
 class TFile;
 class TNtuple;
@@ -25,7 +33,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
  public:
   PHSiliconTpcTrackMatching(const std::string &name = "PHSiliconTpcTrackMatching");
 
-  ~PHSiliconTpcTrackMatching() override;
+  ~PHSiliconTpcTrackMatching() override = default;
 
   void SetDefaultParameters() override;
   
@@ -59,14 +67,14 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     Arr3D negHi { 100, 0, 0 }; // (above a1,b1,c1), 100 for treat all tracks pos Q
 
     // efficiency flags set during PHSiliconTpcTrackMatching::InitRun()
-    bool fabs_max_posQ  = true;
-    bool fabs_max_negQ  = true;
-    bool negLo_b0 = true;
-    bool negHi_b0 = true;
-    bool posLo_b0 = true;
-    bool posHi_b0 = true;
-    double min_pt_posQ  = 0.25; // only grow function windows down to 150 MeV
-    double min_pt_negQ  = 0.25; // only grow function windows down to 150 MeV
+    bool fabs_max_posQ  {true};
+    bool fabs_max_negQ  {true};
+    bool negLo_b0 {true};
+    bool negHi_b0 {true};
+    bool posLo_b0 {true};
+    bool posHi_b0 {true};
+    double min_pt_posQ  {0.25}; // only grow function windows down to 150 MeV
+    double min_pt_negQ  {0.25}; // only grow function windows down to 150 MeV
 
     WindowMatcher(
         const Arr3D& _posLo={100,0,0},
@@ -177,21 +185,21 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   double getBunchCrossing(unsigned int trid, double z_mismatch);
   std::vector<short int>  getBestCrossing(unsigned int tpcid, unsigned int si_id);
   
-  TFile *_file = nullptr;
-  TNtuple *_tree = nullptr;
+  TFile *_file {nullptr};
+  TNtuple *_tree {nullptr};
 
-  std::string _file_name = "track_match.root";
+  std::string _file_name {"track_match.root"};
 
   // default values, can be replaced from the macro
-  double _phi_search_win = 0.01;
-  double _eta_search_win = 0.004;
-  double _x_search_win = 0.3;
-  double _y_search_win = 0.3;
-  double _z_search_win = 0.4;
+  double _phi_search_win {0.01};
+  double _eta_search_win {0.004};
+  double _x_search_win {0.3};
+  double _y_search_win {0.3};
+  double _z_search_win {0.4};
 
-  //  bool _use_old_matching = false;  // normally false
+  //  bool _use_old_matching {false};  // normally false
 
-  bool _zero_field = false;     // fit straight lines if true
+  bool _zero_field {false};     // fit straight lines if true
 
   TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeedContainer *_track_map{nullptr};
@@ -201,31 +209,31 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   TrkrClusterContainer *_cluster_map{nullptr};
   ActsGeometry *_tGeometry{nullptr};
   TrkrClusterCrossingAssoc *_cluster_crossing_map{nullptr};
-  int m_event = 0;
+  int m_event {0};
   std::map<unsigned int, double> _z_mismatch_map;
 
-  short int _max_crossing_diff = 20;  // good for CA seeds, use 10 for polyseeding
+  short int _max_crossing_diff {20};  // good for CA seeds, use 10 for polyseeding
   
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
-  float _crossing_deltaz_max = 10.0;
-  float _crossing_deltaz_min = 1.5;
-  float _deltaeta_min = 0.03;
+  float _crossing_deltaz_max {10.0};
+  float _crossing_deltaz_min {1.5};
+  float _deltaeta_min {0.03};
 
-  //  double _collision_rate = 50e3;  // input rate for phi correction
-  //  double _reference_collision_rate = 50e3;  // reference rate for phi correction
-  //  double _si_vertex_dzmax = 0.25;  // mm
+  //  double _collision_rate {50e3};  // input rate for phi correction
+  //  double _reference_collision_rate {50e3};  // reference rate for phi correction
+  //  double _si_vertex_dzmax {0.25};  // mm
   double fieldstrength{std::numeric_limits<double>::quiet_NaN()};
 
-  bool _test_windows = false;
-  bool _pp_mode = false;
-  bool _use_tpc_crossing_only = false;
-  bool _use_silicon_crossing_only = false;
+  bool _test_windows {false};
+  bool _pp_mode {false};
+  bool _use_tpc_crossing_only {false};
+  bool _use_silicon_crossing_only {false};
 
-  int _n_iteration = 0;
-  std::string _track_map_name = "TpcTrackSeedContainer";
-  std::string _silicon_track_map_name = "SiliconTrackSeedContainer";
-  std::string _cluster_map_name = "TRKR_CLUSTER";
-  std::string m_fieldMap = "1.4";
+  int _n_iteration {0};
+  std::string _track_map_name {"TpcTrackSeedContainer"};
+  std::string _silicon_track_map_name {"SiliconTrackSeedContainer"};
+  std::string _cluster_map_name {"TRKR_CLUSTER"};
+  std::string m_fieldMap {"1.4"};
   std::vector<TrkrDefs::cluskey> getTrackletClusterList(TrackSeed* tracklet);
 };
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -82,7 +82,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
       return (b_is_0 ? arr[0] : arr[0]+arr[1]*exp(arr[2]/pT));
     }
 
-    void init_bools(const std::string& which_window="", const bool print=false);
+    void init_bools(const std::string& tag="", const bool print=false);
 
     bool in_window(bool posQ, const double tpc_pt, const double tpc_X, const double si_X);
 
@@ -173,7 +173,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 		     std::multimap<unsigned int, unsigned int> &bad_map);
   short int getCrossingIntt(TrackSeed *_tracklet_si);
   // void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
-  short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
+  short int findCrossingGeometrically(unsigned int tpcid, unsigned int si_id);
   double getBunchCrossing(unsigned int trid, double z_mismatch);
   std::vector<short int>  getBestCrossing(unsigned int tpcid, unsigned int si_id);
   


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes the clang-tidy errors which snuck in with a recent PR

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

This non-breaking bug fix resolves `clang-tidy` errors in `PHSiliconTpcTrackMatching`.

## Key Changes

- Removed obsolete includes and the file-wide `using namespace std` directive.
- Added explicit `std::` qualification for streams, absolute-value calls, and maximum-value handling.
- Defaulted the destructor inline and reduced header dependencies.
- Replaced assignment-style default initialization with brace initialization.
- Renamed parameters in `WindowMatcher::init_bools` and `findCrossingGeometrically`.
- Preserved matching, crossing selection, z-validation, and error handling:
  - Missing crossing-association nodes remain non-fatal.
  - Missing track containers still abort processing.

## Potential Risk Areas

- No I/O format changes.
- No intended reconstruction behavior changes.
- No intended thread-safety or performance changes.
- AI-generated summaries can contain errors. Reviewers should verify the implementation against the source code.

## Possible Future Improvements

- Run the project’s `clang-tidy` checks and relevant track-reconstruction tests in CI.
- Add focused tests for missing crossing associations and missing track containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->