### PR TITLE
Phg4 in event to truth info

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
@@ -37,10 +37,6 @@
 // convenient aliases for deep copying nodes
 namespace
 {
-  using PHG4Particle_t = PHG4Particlev3;
-  using PHG4VtxPoint_t = PHG4VtxPointv1;
-  using PHG4Hit_t = PHG4Hitv1;
-
   //! utility class to find all PHG4Hit container nodes from the DST node
   class FindG4HitContainer : public PHNodeOperation
   {
@@ -157,7 +153,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
       {
         // clone vertex, insert in map, and add index conversion
         const auto &sourceVertex = iter->second;
-        auto *newVertex = new PHG4VtxPoint_t(sourceVertex);
+        PHG4VtxPoint *newVertex = dynamic_cast<PHG4VtxPoint *> (sourceVertex->CloneMe());
         newVertex->set_t(sourceVertex->get_t() + delta_t);
         m_g4truthinfo->AddVertex(++key, newVertex);
         vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
@@ -177,7 +173,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
       {
         // clone vertex, shift time, insert in map, and add index conversion
         const auto &sourceVertex = iter->second;
-        auto *newVertex = new PHG4VtxPoint_t(sourceVertex);
+        PHG4VtxPoint *newVertex = dynamic_cast<PHG4VtxPoint *> (sourceVertex->CloneMe());
         newVertex->set_t(sourceVertex->get_t() + delta_t);
         m_g4truthinfo->AddVertex(--key, newVertex);
         vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
@@ -191,7 +187,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
       for (auto iter = range.first; iter != range.second; ++iter)
       {
         const auto &source = iter->second;
-        auto *dest = new PHG4Particle_t(source);
+        PHG4Particle *dest = dynamic_cast<PHG4Particle *> (source->CloneMe()); //save same phparticle version
         m_g4truthinfo->AddParticle(++key, dest);
         dest->set_track_id(key);
 
@@ -232,7 +228,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
           ++iter)
       {
         const auto &source = iter->second;
-        auto *dest = new PHG4Particle_t(source);
+        PHG4Particle *dest = dynamic_cast<PHG4Particle *> (source->CloneMe()); //save same phparticle version
         m_g4truthinfo->AddParticle(--key, dest);
         dest->set_track_id(key);
 
@@ -294,7 +290,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
           continue;
         }
 
-        auto *dest = new PHG4Particle_t(source);
+        PHG4Particle *dest = dynamic_cast<PHG4Particle *> (source->CloneMe()); //save same phparticle version
         dest->set_track_id(keyiter->second);
 
         if (source->get_parent_id() == 0)
@@ -393,7 +389,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
       {
         // clone hit
         const auto &sourceHit = iter->second;
-        auto *newHit = new PHG4Hit_t(sourceHit);
+        PHG4Hit *newHit = dynamic_cast<PHG4Hit *> (sourceHit->CloneMe());
 
         // shift time
         newHit->set_t(0, sourceHit->get_t(0) + delta_t);

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -117,6 +117,7 @@ libg4testbench_la_SOURCES = \
   PHG4EtaParameterization.cc \
   PHG4EtaPhiParameterization.cc \
   PHG4HeadReco.cc \
+  PHG4InEventToTruthInfo.cc \
   PHG4InputFilter.cc \
   PHG4IonGun.cc \
   PHG4MagneticField.cc \
@@ -172,6 +173,7 @@ pkginclude_HEADERS = \
   PHG4HitEval.h \
   PHG4HitContainer.h \
   PHG4InEvent.h \
+  PHG4InEventToTruthInfo.h \
   PHG4IonGun.h \
   PHG4MCProcessDefs.h \
   PHG4Particle.h \

--- a/simulation/g4simulation/g4main/PHG4EventAction.h
+++ b/simulation/g4simulation/g4main/PHG4EventAction.h
@@ -9,20 +9,16 @@ class PHCompositeNode;
 class PHG4EventAction
 {
  public:
-  PHG4EventAction()
-  {
-  }
+  PHG4EventAction() = default;
 
-  virtual ~PHG4EventAction()
-  {
-  }
+  virtual ~PHG4EventAction() = default;
 
-  virtual void BeginOfEventAction(const G4Event *) {}
+  virtual void BeginOfEventAction(const G4Event *) { return; }
 
-  virtual void EndOfEventAction(const G4Event *) {}
+  virtual void EndOfEventAction(const G4Event *) { return; }
 
   //! get relevant nodes from top node passed as argument
-  virtual void SetInterfacePointers(PHCompositeNode *) {}
+  virtual void SetInterfacePointers(PHCompositeNode *) { return; }
 
   virtual int ResetEvent(PHCompositeNode *) { return 0; }
 };

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -65,7 +65,7 @@ std::ostream& operator<<(std::ostream& stream, const PHG4Hit* hit)
 
 void PHG4Hit::Reset()
 {
-  std::cout << "Reset not implemented by daughter class" << std::endl;
+  std::cout << "Reset not implemented by PHG4Hit daughter class" << std::endl;
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -15,7 +15,7 @@
 class PHG4Hit : public PHObject
 {
  public:
-  PHG4Hit() {}
+  PHG4Hit() = default;
   ~PHG4Hit() = default;
 
   void identify(std::ostream &os = std::cout) const override;
@@ -199,7 +199,7 @@ class PHG4Hit : public PHObject
  protected:
   virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_property_nocheck(const PROPERTY /*prop_id*/, const unsigned int) { return; }
-  ClassDefOverride(PHG4Hit, 1)
+  ClassDefOverride(PHG4Hit, 0)
 };
 
 inline float PHG4Hit::get_avg_x() const { return 0.5 * (get_x(0) + get_x(1)); }

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -17,6 +17,8 @@ class PHG4Hitv1 : public PHG4Hit
   PHG4Hitv1() = default;
   explicit PHG4Hitv1(const PHG4Hit* g4hit);
   ~PHG4Hitv1() override = default;
+  PHObject* CloneMe() const override { return new PHG4Hitv1(*this);}
+  
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;
 

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
@@ -128,17 +128,6 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
 
 PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
 {
-  if (particle->get_name().empty())
-  {
-    if (TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
-    {
-      particle->set_name(TDatabasePDG::Instance()->GetParticle(particle->get_pid())->GetName());
-    }
-    else
-    {
-      particle->set_name("unknown");
-    }
-  }
   PHG4Particle *particle_return{nullptr};
   if (particle->isIon())
   {
@@ -149,6 +138,17 @@ PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
     particle_return = new PHG4Particlev2(particle);
   }
 
+  if (particle_return->get_name().empty())
+  {
+    if (TDatabasePDG::Instance()->GetParticle(particle_return->get_pid()))
+    {
+      particle_return->set_name(TDatabasePDG::Instance()->GetParticle(particle_return->get_pid())->GetName());
+    }
+    else
+    {
+      particle_return->set_name("unknown");
+    }
+  }
   if (!std::isfinite(particle_return->get_e()))
   {
     if (TDatabasePDG::Instance()->GetParticle(particle->get_pid()))

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 
@@ -127,9 +128,13 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
 
 PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
 {
-  if (particle->get_name().empty())
+  if (particle->get_name().empty() && TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
   {
     particle->set_name(TDatabasePDG::Instance()->GetParticle(particle->get_pid())->GetName());
+  }
+  else
+  {
+    particle->set_name("unknown");
   }
   PHG4Particle *particle_return{nullptr};
   if (particle->isIon())
@@ -141,11 +146,15 @@ PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
     particle_return = new PHG4Particlev2(particle);
   }
 
-  if (!std::isfinite(particle_return->get_e()))
+  if (!std::isfinite(particle_return->get_e()) && TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
   {
     double m = TDatabasePDG::Instance()->GetParticle(particle->get_pid())->Mass();
     double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
     particle_return->set_e(e);
+  }
+  else
+  {
+    particle_return->set_e(std::numeric_limits<double>::quiet_NaN());
   }
   return particle_return;
 }

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
@@ -128,13 +128,16 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
 
 PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
 {
-  if (particle->get_name().empty() && TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
+  if (particle->get_name().empty())
   {
-    particle->set_name(TDatabasePDG::Instance()->GetParticle(particle->get_pid())->GetName());
-  }
-  else
-  {
-    particle->set_name("unknown");
+    if (TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
+    {
+      particle->set_name(TDatabasePDG::Instance()->GetParticle(particle->get_pid())->GetName());
+    }
+    else
+    {
+      particle->set_name("unknown");
+    }
   }
   PHG4Particle *particle_return{nullptr};
   if (particle->isIon())
@@ -146,11 +149,18 @@ PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
     particle_return = new PHG4Particlev2(particle);
   }
 
-  if (!std::isfinite(particle_return->get_e()) && TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
+  if (!std::isfinite(particle_return->get_e()))
   {
-    double m = TDatabasePDG::Instance()->GetParticle(particle->get_pid())->Mass();
-    double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
-    particle_return->set_e(e);
+    if (TDatabasePDG::Instance()->GetParticle(particle->get_pid()))
+    {
+      double m = TDatabasePDG::Instance()->GetParticle(particle->get_pid())->Mass();
+      double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
+      particle_return->set_e(e);
+    }
+    else
+    {
+      particle_return->set_e(std::numeric_limits<double>::quiet_NaN());
+    }
   }
   return particle_return;
 }

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
@@ -51,7 +51,7 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
     }
     return Fun4AllReturnCodes::EVENT_OK;
   }
-  
+
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
   std::map<int, int> input_to_truth_vtxid;
@@ -60,15 +60,18 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
   {
     const int input_vtxid = vtxiter->first;
     const int truth_vtxid = truthinfo->maxvtxindex() + 1;
-    std::unique_ptr<PHG4VtxPoint> truth_vtx(makePrimaryVertexCopy(vtxiter->second, truth_vtxid));
+    PHG4VtxPoint *truth_vtx = dynamic_cast<PHG4VtxPoint *>(vtxiter->second->CloneMe());
+    truth_vtx->set_id(truth_vtxid);
 
-    const auto inserted = truthinfo->AddVertex(truth_vtxid, truth_vtx.get());
+    const auto inserted = truthinfo->AddVertex(truth_vtxid, truth_vtx);
     if (inserted == truthinfo->GetVtxRange().second)
     {
-      return Fun4AllReturnCodes::ABORTEVENT;
+      std::cout << PHWHERE << " Failure to insert vertex " << truth_vtxid << " into TruthInfo" << std::endl;
+      truth_vtx->identify();
+      gSystem->Exit(1);
+      exit(1);
     }
 
-    truth_vtx.release();
     input_to_truth_vtxid[input_vtxid] = truth_vtxid;
   }
 
@@ -96,16 +99,19 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
     const int truth_trackid = truthinfo->maxtrkindex() + 1;
     const int truth_vtxid = vtxid_iter->second;
 
-    std::unique_ptr<PHG4Particle> truth_particle(makeParticleCopy(input_particle));
+    PHG4Particle *truth_particle = makeParticleCopy(input_particle);
     truth_particle->set_track_id(truth_trackid);
     truth_particle->set_vtx_id(truth_vtxid);
     truth_particle->set_parent_id(0);
     truth_particle->set_primary_id(truth_trackid);
 
-    const auto inserted = truthinfo->AddParticle(truth_trackid, truth_particle.get());
+    const auto inserted = truthinfo->AddParticle(truth_trackid, truth_particle);
     if (inserted == truthinfo->GetParticleRange().second)
     {
-      return Fun4AllReturnCodes::ABORTEVENT;
+      std::cout << PHWHERE << " Failure to insert particle " << truth_trackid << " into TruthInfo" << std::endl;
+      truth_particle->identify();
+      gSystem->Exit(1);
+      exit(1);
     }
 
     const int embed_flag = inevent->isEmbeded(input_particle);
@@ -114,8 +120,6 @@ int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
       truthinfo->AddEmbededTrkId(truth_trackid, embed_flag);
       truthinfo->AddEmbededVtxId(truth_vtxid, embed_flag);
     }
-
-    truth_particle.release();
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -127,8 +131,7 @@ PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
   {
     particle->set_name(TDatabasePDG::Instance()->GetParticle(particle->get_pid())->GetName());
   }
-  particle->identify();
-  PHG4Particle *particle_return {nullptr};
+  PHG4Particle *particle_return{nullptr};
   if (particle->isIon())
   {
     particle_return = new PHG4Particlev3(particle);
@@ -138,29 +141,18 @@ PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
     particle_return = new PHG4Particlev2(particle);
   }
 
-  if (! std::isfinite(particle_return->get_e()))
+  if (!std::isfinite(particle_return->get_e()))
   {
-  double m = TDatabasePDG::Instance()->GetParticle(particle->get_pid())->Mass();
-  double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
-  particle_return->set_e(e);
+    double m = TDatabasePDG::Instance()->GetParticle(particle->get_pid())->Mass();
+    double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
+    particle_return->set_e(e);
   }
   return particle_return;
-
-}
-
-PHG4VtxPoint *PHG4InEventToTruthInfo::makePrimaryVertexCopy(const PHG4VtxPoint *vertex, int vtxid)
-{
-  return new PHG4VtxPointv2(vertex->get_x(),
-                            vertex->get_y(),
-                            vertex->get_z(),
-                            vertex->get_t(),
-                            vtxid,
-                            PHG4MCProcess::kPPrimary);
 }
 
 int PHG4InEventToTruthInfo::CreateNodeTree(PHCompositeNode *topNode)
 {
- PHNodeIterator iter(topNode);
+  PHNodeIterator iter(topNode);
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
@@ -168,11 +160,11 @@ int PHG4InEventToTruthInfo::CreateNodeTree(PHCompositeNode *topNode)
     gSystem->Exit(1);
     exit(1);
   }
-    PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
-  if (! truthinfo)
+  PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if (!truthinfo)
   {
     truthinfo = new PHG4TruthInfoContainer();
     dstNode->addNode(new PHIODataNode<PHObject>(truthinfo, "G4TruthInfo", "PHObject"));
   }
-return Fun4AllReturnCodes::EVENT_OK;
+  return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
@@ -152,10 +152,6 @@ PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
     double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
     particle_return->set_e(e);
   }
-  else
-  {
-    particle_return->set_e(std::numeric_limits<double>::quiet_NaN());
-  }
   return particle_return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.cc
@@ -1,0 +1,178 @@
+#include "PHG4InEventToTruthInfo.h"
+
+#include "PHG4InEvent.h"
+#include "PHG4MCProcessDefs.h"
+#include "PHG4Particle.h"
+#include "PHG4Particlev2.h"
+#include "PHG4Particlev3.h"
+#include "PHG4Showerv1.h"
+#include "PHG4TruthInfoContainer.h"
+#include "PHG4VtxPoint.h"
+#include "PHG4VtxPointv2.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <TDatabasePDG.h>
+#include <TSystem.h>
+
+#include <cmath>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+
+PHG4InEventToTruthInfo::PHG4InEventToTruthInfo(const std::string &name)
+  : SubsysReco(name)
+{
+}
+
+int PHG4InEventToTruthInfo::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4InEventToTruthInfo::process_event(PHCompositeNode *topNode)
+{
+  PHG4InEvent *inevent = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
+  if (!inevent)
+  {
+    if (Verbosity() > 0)
+    {
+      std::cout << PHWHERE << "PHG4INEVENT node not found" << std::endl;
+    }
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+  
+  PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+
+  std::map<int, int> input_to_truth_vtxid;
+  const auto vtxrange = inevent->GetVertices();
+  for (auto vtxiter = vtxrange.first; vtxiter != vtxrange.second; ++vtxiter)
+  {
+    const int input_vtxid = vtxiter->first;
+    const int truth_vtxid = truthinfo->maxvtxindex() + 1;
+    std::unique_ptr<PHG4VtxPoint> truth_vtx(makePrimaryVertexCopy(vtxiter->second, truth_vtxid));
+
+    const auto inserted = truthinfo->AddVertex(truth_vtxid, truth_vtx.get());
+    if (inserted == truthinfo->GetVtxRange().second)
+    {
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    truth_vtx.release();
+    input_to_truth_vtxid[input_vtxid] = truth_vtxid;
+  }
+
+  const auto particlerange = inevent->GetParticles();
+  // reverse to match how G4 inserts particles into the truth table (last particle first)
+  for (auto particleiter = std::make_reverse_iterator(particlerange.second);
+       particleiter != std::make_reverse_iterator(particlerange.first);
+       ++particleiter)
+  {
+    const int input_vtxid = particleiter->first;
+    PHG4Particle *input_particle = particleiter->second;
+    if (!input_particle)
+    {
+      continue;
+    }
+
+    auto vtxid_iter = input_to_truth_vtxid.find(input_vtxid);
+    if (vtxid_iter == input_to_truth_vtxid.end())
+    {
+      std::cout << PHWHERE << "no vertex " << input_vtxid
+                << " found for PHG4InEvent particle" << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    const int truth_trackid = truthinfo->maxtrkindex() + 1;
+    const int truth_vtxid = vtxid_iter->second;
+
+    std::unique_ptr<PHG4Particle> truth_particle(makeParticleCopy(input_particle));
+    truth_particle->set_track_id(truth_trackid);
+    truth_particle->set_vtx_id(truth_vtxid);
+    truth_particle->set_parent_id(0);
+    truth_particle->set_primary_id(truth_trackid);
+
+    const auto inserted = truthinfo->AddParticle(truth_trackid, truth_particle.get());
+    if (inserted == truthinfo->GetParticleRange().second)
+    {
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    const int embed_flag = inevent->isEmbeded(input_particle);
+    if (embed_flag)
+    {
+      truthinfo->AddEmbededTrkId(truth_trackid, embed_flag);
+      truthinfo->AddEmbededVtxId(truth_vtxid, embed_flag);
+    }
+
+    truth_particle.release();
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+PHG4Particle *PHG4InEventToTruthInfo::makeParticleCopy(PHG4Particle *particle)
+{
+  if (particle->get_name().empty())
+  {
+    particle->set_name(TDatabasePDG::Instance()->GetParticle(particle->get_pid())->GetName());
+  }
+  particle->identify();
+  PHG4Particle *particle_return {nullptr};
+  if (particle->isIon())
+  {
+    particle_return = new PHG4Particlev3(particle);
+  }
+  else
+  {
+    particle_return = new PHG4Particlev2(particle);
+  }
+
+  if (! std::isfinite(particle_return->get_e()))
+  {
+  double m = TDatabasePDG::Instance()->GetParticle(particle->get_pid())->Mass();
+  double e = sqrt(particle->get_px() * particle->get_px() + particle->get_py() * particle->get_py() + particle->get_pz() * particle->get_pz() + m * m);
+  particle_return->set_e(e);
+  }
+  return particle_return;
+
+}
+
+PHG4VtxPoint *PHG4InEventToTruthInfo::makePrimaryVertexCopy(const PHG4VtxPoint *vertex, int vtxid)
+{
+  return new PHG4VtxPointv2(vertex->get_x(),
+                            vertex->get_y(),
+                            vertex->get_z(),
+                            vertex->get_t(),
+                            vtxid,
+                            PHG4MCProcess::kPPrimary);
+}
+
+int PHG4InEventToTruthInfo::CreateNodeTree(PHCompositeNode *topNode)
+{
+ PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << "DST node not found" << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+    PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if (! truthinfo)
+  {
+    truthinfo = new PHG4TruthInfoContainer();
+    dstNode->addNode(new PHIODataNode<PHObject>(truthinfo, "G4TruthInfo", "PHObject"));
+  }
+return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.h
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.h
@@ -1,0 +1,32 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MAIN_PHG4INEVENTTOTRUTHINFO_H
+#define G4MAIN_PHG4INEVENTTOTRUTHINFO_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+class PHG4Particle;
+class PHG4TruthInfoContainer;
+class PHG4VtxPoint;
+
+class PHG4InEventToTruthInfo : public SubsysReco
+{
+ public:
+  explicit PHG4InEventToTruthInfo(const std::string &name = "PHG4INEVENTTOTRUTHINFO");
+  ~PHG4InEventToTruthInfo() override = default;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+
+  int CreateNodeTree(PHCompositeNode *topNode);
+
+ private:
+  static PHG4Particle *makeParticleCopy(PHG4Particle *particle);
+  static PHG4VtxPoint *makePrimaryVertexCopy(const PHG4VtxPoint *vertex, int vtxid);
+
+};
+
+#endif  // G4MAIN_PHG4INEVENTTOTRUTHINFO_H

--- a/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.h
+++ b/simulation/g4simulation/g4main/PHG4InEventToTruthInfo.h
@@ -25,8 +25,6 @@ class PHG4InEventToTruthInfo : public SubsysReco
 
  private:
   static PHG4Particle *makeParticleCopy(PHG4Particle *particle);
-  static PHG4VtxPoint *makePrimaryVertexCopy(const PHG4VtxPoint *vertex, int vtxid);
-
 };
 
 #endif  // G4MAIN_PHG4INEVENTTOTRUTHINFO_H

--- a/simulation/g4simulation/g4main/PHG4Particlev3.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev3.cc
@@ -3,6 +3,7 @@
 
 #include <Geant4/G4SystemOfUnits.hh>
 
+#include <cmath>
 #include <string>
 
 PHG4Particlev3::PHG4Particlev3(const PHG4Particle* in)
@@ -38,6 +39,8 @@ void PHG4Particlev3::identify(std::ostream& os) const
      << ", px: " << fpx
      << ", py: " << fpy
      << ", pz: " << fpz
+     << ", phi: " << atan2(fpy, fpx)
+     << ", eta: " << -1 * log(tan(0.5 * acos(fpz / sqrt((fpx * fpx) + (fpy * fpy) + (fpz * fpz)))))
      << ", e: " << fe
      << ", A: " << A
      << ", Z: " << Z

--- a/simulation/g4simulation/g4main/PHG4Shower.cc
+++ b/simulation/g4simulation/g4main/PHG4Shower.cc
@@ -4,6 +4,12 @@ PHG4Shower::ParticleIdSet DummyParticleIdSet;
 PHG4Shower::VertexIdSet DummyVertexIdSet;
 PHG4Shower::HitIdMap DummyHitIdMap;
 
+void PHG4Shower::Reset()
+{
+  std::cout << "Reset not implemented by PHG4Shower daughter class" << std::endl;
+  return;
+}
+
 PHG4Shower::ParticleIdConstIter PHG4Shower::begin_g4particle_id() const
 {
   return DummyParticleIdSet.end();

--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -33,77 +33,77 @@ class PHG4Shower : public PHObject
 
   void identify(std::ostream& os = std::cout) const override { os << "PHG4Shower base class" << std::endl; }
   PHG4Shower* CloneMe() const override { return nullptr; }
-  void Reset() override {}
+  void Reset() override;
   int isValid() const override { return 0; }
 
   // shower info
 
   virtual int get_id() const { return 0; }
-  virtual void set_id(int /*id*/) {}
+  virtual void set_id(int /*id*/) { return; }
 
   virtual int get_parent_particle_id() const { return 0; }
-  virtual void set_parent_particle_id(int /*parent_particle_id*/) {}
+  virtual void set_parent_particle_id(int /*parent_particle_id*/) { return; }
 
   virtual int get_parent_shower_id() const { return 0; }
-  virtual void set_parent_shower_id(int /*parent_shower_id*/) {}
+  virtual void set_parent_shower_id(int /*parent_shower_id*/) { return; }
 
   virtual float get_x() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_x(float) {}
+  virtual void set_x(float) { return; }
 
   virtual float get_y() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_y(float) {}
+  virtual void set_y(float) { return; }
 
   virtual float get_z() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_z(float) {}
+  virtual void set_z(float) { return; }
 
   virtual float get_position(unsigned int /*coor*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {}
+  virtual void set_position(unsigned int /*coor*/, float /*xi*/) { return; }
 
   virtual float get_covar(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_covar(unsigned int /*i*/, unsigned int /*j*/, float /*entry*/) {}
+  virtual void set_covar(unsigned int /*i*/, unsigned int /*j*/, float /*entry*/) { return; }
 
   virtual unsigned int get_nhits(int /*volume*/) const { return 0; }
-  virtual void set_nhits(int /*volume*/, unsigned int /*nhits*/) {}
+  virtual void set_nhits(int /*volume*/, unsigned int /*nhits*/) { return; }
 
   virtual double get_edep() const { return std::numeric_limits<double>::quiet_NaN(); }
   virtual float get_edep(int /*volume*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_edep(int /*volume*/, float /*edep*/) {}
+  virtual void set_edep(int /*volume*/, float /*edep*/) { return; }
 
   virtual double get_eion() const { return std::numeric_limits<double>::quiet_NaN(); }
   virtual float get_eion(int /*volume*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_eion(int /*volume*/, float /*eion*/) {}
+  virtual void set_eion(int /*volume*/, float /*eion*/) { return; }
 
   virtual float get_light_yield(int /*volume*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_light_yield(int /*volume*/, float /*light_yield*/) {}
+  virtual void set_light_yield(int /*volume*/, float /*light_yield*/) { return; }
 
   virtual float get_eh_ratio(int /*volume*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_eh_ratio(int /*volume*/, float /*eh_ratio*/) {}
+  virtual void set_eh_ratio(int /*volume*/, float /*eh_ratio*/) { return; }
 
   virtual bool empty_g4particle_id() const { return true; }
   virtual size_t size_g4particle_id() const { return 0; }
-  virtual void add_g4particle_id(int /*id*/) {}
+  virtual void add_g4particle_id(int /*id*/) { return; }
   virtual ParticleIdIter begin_g4particle_id();
   virtual ParticleIdConstIter begin_g4particle_id() const;
   virtual ParticleIdIter end_g4particle_id();
   virtual ParticleIdConstIter end_g4particle_id() const;
   virtual size_t remove_g4particle_id(int /*id*/) { return 0; }
-  virtual void clear_g4particle_id() {}
+  virtual void clear_g4particle_id() { return; }
   virtual const ParticleIdSet& g4particle_ids() const = 0;
 
   virtual bool empty_g4vertex_id() const { return true; }
   virtual size_t size_g4vertex_id() const { return 0; }
-  virtual void add_g4vertex_id(int /*id*/) {}
+  virtual void add_g4vertex_id(int /*id*/) { return; }
   virtual VertexIdIter begin_g4vertex_id();
   virtual VertexIdConstIter begin_g4vertex_id() const;
   virtual VertexIdIter end_g4vertex_id();
   virtual VertexIdConstIter end_g4vertex_id() const;
   virtual size_t remove_g4vertex_id(int /*id*/) { return 0; }
-  virtual void clear_g4vertex_id() {}
+  virtual void clear_g4vertex_id() { return; }
   virtual const VertexIdSet& g4vertex_ids() const = 0;
 
   virtual bool empty_g4hit_id() const { return true; }
   virtual size_t size_g4hit_id() const { return 0; }
-  virtual void add_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) {}
+  virtual void add_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) { return; }
   virtual HitIdIter begin_g4hit_id();
   virtual HitIdConstIter begin_g4hit_id() const;
   virtual HitIdIter find_g4hit_id(int /*volume*/);
@@ -112,14 +112,14 @@ class PHG4Shower : public PHObject
   virtual HitIdConstIter end_g4hit_id() const;
   virtual size_t remove_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) { return 0; }
   virtual size_t remove_g4hit_volume(int /*volume*/) { return 0; }
-  virtual void clear_g4hit_id() {}
+  virtual void clear_g4hit_id() { return; }
   virtual const HitIdMap& g4hit_ids() const = 0;
 
  protected:
-  PHG4Shower() {}
+  PHG4Shower() = default;
 
  private:
-  ClassDefOverride(PHG4Shower, 1);
+  ClassDefOverride(PHG4Shower, 0);
 };
 
 /**

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
@@ -20,9 +20,7 @@ class PHG4TruthSubsystem : public PHG4Subsystem
   PHG4TruthSubsystem(const std::string &name = "TRUTH");
 
   //! destructor
-  ~PHG4TruthSubsystem() override
-  {
-  }
+  ~PHG4TruthSubsystem() override = default;
 
   //! init
   int InitRun(PHCompositeNode *) override;

--- a/simulation/g4simulation/g4main/PHG4VtxPoint.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPoint.h
@@ -33,7 +33,7 @@ class PHG4VtxPoint : public PHObject
   bool operator==(const PHG4VtxPoint&) const;
 
  protected:
-  PHG4VtxPoint() {}
+  PHG4VtxPoint() = default;
   ClassDefOverride(PHG4VtxPoint, 1)
 };
 

--- a/simulation/g4simulation/g4main/PHG4VtxPointv1.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv1.h
@@ -32,6 +32,8 @@ class PHG4VtxPointv1 : public PHG4VtxPoint
 
   ~PHG4VtxPointv1() override = default;
 
+  PHObject* CloneMe() const override { return new PHG4VtxPointv1(*this); }
+
   // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 

--- a/simulation/g4simulation/g4main/PHG4VtxPointv2.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv2.h
@@ -32,6 +32,8 @@ class PHG4VtxPointv2 : public PHG4VtxPointv1
 
   ~PHG4VtxPointv2() override = default;
 
+  PHObject* CloneMe() const override { return new PHG4VtxPointv2(*this); }
+
   // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR contains the new PHG4InEventToTruthInfo which fills the primary particles in truthinfo directly from PHG4InEvent without going through G4.
The pileup merger was using hardcoded versions for PHG4Particle, PHG4Hit and PHG4VtxPoint which lead to mismatches between input files and output files. Now those objects use the CloneMe() method to make a clone of themselves, preserving the version


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context

This PR converts `PHG4InEvent` data directly into `PHG4TruthInfoContainer` entries without passing through Geant4. It also preserves concrete object versions during pileup merging.

## Key Changes

- Added `PHG4InEventToTruthInfo`.
  - Converts input vertices and particles into truth information.
  - Remaps vertex, track, parent, and primary IDs.
  - Preserves particle names, ion-specific types, and embedding flags.
  - Handles missing or unknown PDG information.
  - Validates required nodes, vertex mappings, and insertion results.
- Updated pileup merging to clone `PHG4Particle`, `PHG4Hit`, and `PHG4VtxPoint` objects through polymorphic `CloneMe()`.
- Added `CloneMe()` implementations for `PHG4Hitv1`, `PHG4VtxPointv1`, and `PHG4VtxPointv2`.
- Added `phi` and `eta` to `PHG4Particlev3::identify()`.
- Added reset and lifecycle cleanup changes.
- Updated ROOT class versions for `PHG4Hit` and `PHG4Shower`.

## Potential Risk Areas

- ROOT class version changes may affect compatibility with existing files.
- Direct truth construction may change reconstruction results compared with the Geant4 path.
- Missing or incorrect `CloneMe()` implementations may affect derived-object cloning.
- Direct conversion and pileup cloning may increase memory use and processing time.
- Invalid input may terminate processing when nodes, mappings, or insertions fail.
- Verify particle names, energy handling, ID remapping, object ownership, and mixed-version I/O with representative files.

AI-generated summaries can contain mistakes. Contributors should confirm these behaviors from the implementation and test representative production workflows.

## Possible Future Improvements

- Add focused tests for direct truth conversion, PDG edge cases, and ID remapping.
- Add compatibility tests for mixed-version input and output files.
- Validate `CloneMe()` support for all relevant `PHG4` derived classes.
- Measure runtime and memory costs for high-pileup events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->