### PR TITLE
Printout statistics about fraction of GL1 BCO not found in data strea…

### DIFF
--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -167,6 +167,21 @@ SingleMicromegasPoolInput_v2::~SingleMicromegasPoolInput_v2()
   // timer statistics
   m_timer.print_stat();
 
+  // dropped GL1 statistics
+  for( const auto& [packet,found]:m_packet_stat.found_packet )
+  {
+    const auto& total = m_packet_stat.total;
+    const auto dropped = total-found;
+    const double dropped_fraction = double(dropped)/total;
+    std::cout << "SingleMicromegasPoolInput_v2::~SingleMicromegasPoolInput_v2 -"
+      << " packet: " << packet
+      << " gl1_bco_total: " << total
+      << " gl1_dropped: " << dropped
+      << " ratio_bco: " << dropped_fraction
+      << std::endl;
+  }
+  std::cout << std::endl;
+
   // dropped waveforms
   for (const auto& [packet, counter] : m_waveform_counters)
   {
@@ -234,7 +249,10 @@ void SingleMicromegasPoolInput_v2::FillPool(const uint64_t target_bco)
 {
 
   if (AllDone())  // no more files and all events read
-  { return; }
+  {
+    std::cout << "SingleMicromegasPoolInput_v2::FillPool - We are done." << std::endl;
+    return;
+  }
 
   while (!GetEventiterator())  // at startup this is a null pointer
   {
@@ -470,12 +488,19 @@ void SingleMicromegasPoolInput_v2::FillBcoQA(uint64_t gtm_bco)
 
   // per packet statistics
   h_packet_stat->Fill("Reference", 1);
+  ++m_packet_stat.total;
 
   for (const auto& packet_id : found_packets)
   {
     h_packet_stat->Fill(std::to_string(packet_id).c_str(), 1);
+    ++m_packet_stat.found_packet[packet_id];
   }
-  h_packet_stat->Fill("All", found_packets.size() >= m_npackets_active);
+
+  if( found_packets.size() >= m_npackets_active )
+  {
+    h_packet_stat->Fill("All", 1);
+    ++m_packet_stat.found_all;
+  }
 
   // how many packet_id found for this BCO
   h_packet->Fill(found_packets.size());

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -170,6 +170,24 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   /* it is filled on the fly. It allows to quickly retrieve BCO matching information from FEE index */
   std::array<unsigned int,MAX_FEECOUNT> m_fee_packet{};
 
+  /// keep track of found GL1 BCO in data stream
+  class packet_stat_t
+  {
+    public:
+
+    // total number of GL1 BCO
+    uint64_t total {0};
+
+    // per packet number of found GL1 BCO
+    std::map<int,uint64_t> found_packet;
+
+    // number of found GL1 for all packets
+    uint64_t found_all {0};
+  };
+
+  /// keep track of found GL1 BCO in data stream
+  packet_stat_t m_packet_stat;
+
   class counter_t
   {
    public:
@@ -189,19 +207,19 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
     double dropped_fraction_pool() const { return double(dropped_pool) / total; }
   };
 
-  // keep track of waveform statistics per fee
+  /// keep track of waveform statistics per fee
   std::map<int, counter_t> m_fee_waveform_counters{};
 
-  // keep track of waveform statistics per packet
+  /// keep track of waveform statistics per packet
   std::map<int, counter_t> m_waveform_counters{};
 
-  // keep track of heartbeat statistics per fee
+  /// keep track of heartbeat statistics per fee
   std::map<int, counter_t> m_fee_heartbeat_counters{};
 
-  // keep track of heartbeat statistics per packet
+  /// keep track of heartbeat statistics per packet
   std::map<int, counter_t> m_heartbeat_counters{};
 
-  // timer
+  /// timer
   PHTimer m_timer{"SingleMicromegasPoolInput_v2"};
 
   ///@name QA histograms


### PR DESCRIPTION
…m, at destructor.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

This change adds statistics for GL1 BCOs that are not found in the data stream. The statistics are printed when the relevant input object is destroyed. They support packet-quality monitoring and debugging.

## Key changes

- Track total GL1 BCO references.
- Track GL1 BCOs found for each packet.
- Track references for which all active packets were found.
- Print total, found, dropped, and drop-ratio statistics in the destructor.
- Log when `FillPool` finishes processing.
- Update private documentation comments without changing public interfaces or behavior.

## Potential risk areas

- No IO format or public API changes are reported.
- Reconstruction behavior should remain unchanged because the new logic records QA statistics.
- The added counters introduce low per-packet memory and processing overhead.
- Thread-safety requires review if the input object is accessed concurrently.

## Possible future improvements

- Add automated tests for found, dropped, and mixed packet cases.
- Define the statistics output format for stable machine parsing.
- Validate counter behavior during object destruction and unusual packet-flow conditions.

AI-generated summaries can contain mistakes. Review the implementation and test results before relying on these conclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->