### PR TITLE
KFP: new calo info, changes to detailed calo

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -722,7 +722,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     m_tree->Fill();
   }
 
-  if (m_truth_matching || m_detector_info)
+  if (m_truth_matching || m_detector_info || m_get_calo_5x5_cell_info)
   {
     clearVectors();
   }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -56,10 +56,20 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
       m_detector_info = true;
     }
   }
+  // Function that will add additional calorimetry info to the output TTree
   void GetDetailedCalorimetry(bool set_variable = true)
   {
     m_get_detailed_calorimetry = set_variable;
     if (m_get_detailed_calorimetry)
+    {
+      m_calo_info = true;
+    }
+  }
+  // Function that will add info from the 5x5 cell of towers around the cluster center to the output TTree
+  void GetCalo5x5CellInfo(bool set_variable = true) 
+  {
+    m_get_calo_5x5_cell_info = set_variable;
+    if (m_get_calo_5x5_cell_info)
     {
       m_calo_info = true;
     }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -641,7 +641,8 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   thisState = track->get_state(caloRadiusEMCal);
 
   // Print out additional track states with high verbosity:
-  if(m_track2caloVerbosity > 10){
+  if(m_track2caloVerbosity > 10 && thisState != nullptr)
+  {
     thisState->identify();
     std::cout << "size states " << (size_t)track->size_states() << std::endl;
     for (auto state_iter = track->begin_states();
@@ -650,7 +651,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       {
         SvtxTrackState* tstate = state_iter->second;
         tstate->identify();
-        std::cout<< "radius " << sqrt((tstate->get_x())*(tstate->get_x()) + (tstate->get_y())*(tstate->get_y())) << std::endl;
+        std::cout<< "radius " << std::sqrt((tstate->get_x())*(tstate->get_x()) + (tstate->get_y())*(tstate->get_y())) << std::endl;
       }
     assert(thisState);
     // Useful for debugging:
@@ -806,7 +807,8 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       is_match = true;
 
       // Print outs
-      if(m_track2caloVerbosity > 5){
+      if(m_track2caloVerbosity > 5)
+      {
         std::cout << "**********DELTA INFORMATION************" << std::endl;
         std::cout << "dphi = " << dphi << std::endl;
         std::cout << "deta = " << deta << std::endl;
@@ -847,9 +849,9 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   if (index == -1)
   {
     // Basic info
+    detector_emcal_deltaz[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_deltaphi[daughter_id] = std::numeric_limits<float>::quiet_NaN();
-    detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
-    detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_cluster_energy[daughter_id] = std::numeric_limits<float>::quiet_NaN();
@@ -860,9 +862,9 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       detector_emcal_projection_z[daughter_id] = std::numeric_limits<float>::quiet_NaN();
       detector_emcal_projection_eta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
       detector_emcal_projection_phi[daughter_id] = std::numeric_limits<float>::quiet_NaN();
-      detector_emcal_cluster_z[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
-      detector_emcal_cluster_eta[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
-      detector_emcal_cluster_phi[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
+      detector_emcal_cluster_z[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+      detector_emcal_cluster_eta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+      detector_emcal_cluster_phi[daughter_id] = std::numeric_limits<float>::quiet_NaN();
       detector_emcal_ntowers[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
       detector_emcal_chi2[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     }
@@ -916,7 +918,8 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     }
 
     // 5x5 cell
-    if(m_get_calo_5x5_cell_info){
+    if(m_get_calo_5x5_cell_info)
+    {
       detector_emcal_5x5Cell_Phi[daughter_id] = v_detector_emcal_5x5Cell_Phi;
       detector_emcal_5x5Cell_Eta[daughter_id] = v_detector_emcal_5x5Cell_Eta;
       detector_emcal_5x5Cell_E[daughter_id] = v_detector_emcal_5x5Cell_E;
@@ -1316,7 +1319,10 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(
     
     // Add towers to 3x3 if not first or last rows in phi
     bool addto3x3 = false;
-    if(i < 4 && i > 0) addto3x3 = true;
+    if(i < 4 && i > 0) 
+    {
+      addto3x3 = true;
+    }
     
     // Loop over eta
     for (int j = 0; j < eta_range; j++)
@@ -1332,15 +1338,23 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(
       E5x5+=energytmp;
       v_Tower_E.push_back(energytmp);
        // Store in vectors
-      if(m_get_calo_5x5_cell_info){
+      if(m_get_calo_5x5_cell_info)
+      {
         v_emcal_5x5Cell_Phi.push_back(iphi);
         v_emcal_5x5Cell_Eta.push_back(jeta);
         v_emcal_5x5Cell_E.push_back(energytmp);
       }
 
-      if(!addto3x3) continue; // Skip adding to E3x3 if phi is outside 3x3 grid
+      if(!addto3x3) 
+      {
+        continue; // Skip adding to E3x3 if phi is outside 3x3 grid
+      }
       int etadiff = (int) jeta-center_eta;
-      if(etadiff < 2 && etadiff > -2) E3x3+=energytmp;
+      if(etadiff < 2 && etadiff > -2) 
+      {
+        E3x3+=energytmp;
+      }
+
     }
   }
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -872,9 +872,10 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     // 5x5 cell
     if (m_get_calo_5x5_cell_info)
     { 
-      detector_emcal_5x5Cell_Phi[daughter_id].push_back(std::numeric_limits<unsigned int>::quiet_NaN());
-      detector_emcal_5x5Cell_Eta[daughter_id].push_back(std::numeric_limits<unsigned int>::quiet_NaN());
-      detector_emcal_5x5Cell_E[daughter_id].push_back(std::numeric_limits<float>::quiet_NaN());
+      // Fill with nothing -- no match found, so vectors should be empty ! 
+      // detector_emcal_5x5Cell_Phi[daughter_id].push_back(std::numeric_limits<unsigned int>::quiet_NaN());
+      // detector_emcal_5x5Cell_Eta[daughter_id].push_back(std::numeric_limits<unsigned int>::quiet_NaN());
+      // detector_emcal_5x5Cell_E[daughter_id].push_back(std::numeric_limits<float>::quiet_NaN());
     }
 
     isTrackEMCalmatch = false;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -483,6 +483,29 @@ void KFParticle_truthAndDetTools::initializeCaloBranches(TTree *m_tree, int daug
   m_tree->Branch((daughter_number + "_EMCAL_energy_3x3").c_str(), &detector_emcal_energy_3x3[daughter_id], (daughter_number + "_EMCAL_energy_3x3/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_energy_5x5").c_str(), &detector_emcal_energy_5x5[daughter_id], (daughter_number + "_EMCAL_energy_5x5/F").c_str());
   m_tree->Branch((daughter_number + "_EMCAL_energy_cluster").c_str(), &detector_emcal_cluster_energy[daughter_id], (daughter_number + "_EMCAL_energy_cluster/F").c_str());
+  
+  // Detailed calo info
+  if (m_get_detailed_calorimetry)
+  {
+    m_tree->Branch((daughter_number + "_EMCAL_projection_z").c_str(),   &detector_emcal_projection_z[daughter_id], (daughter_number + "_EMCAL_projection_z/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_projection_eta").c_str(), &detector_emcal_projection_eta[daughter_id], (daughter_number + "_EMCAL_projection_eta/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_projection_phi").c_str(), &detector_emcal_projection_phi[daughter_id], (daughter_number + "_EMCAL_projection_phi/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_cluster_z").c_str(),   &detector_emcal_cluster_z[daughter_id], (daughter_number + "_EMCAL_cluster_z/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_cluster_eta").c_str(), &detector_emcal_cluster_eta[daughter_id], (daughter_number + "_EMCAL_cluster_eta/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_cluster_phi").c_str(), &detector_emcal_cluster_phi[daughter_id], (daughter_number + "_EMCAL_cluster_phi/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_Chi2").c_str(), &detector_emcal_chi2[daughter_id], (daughter_number + "_EMCAL_Chi2/F").c_str());
+    m_tree->Branch((daughter_number + "_EMCAL_nTowers").c_str(), &detector_emcal_ntowers[daughter_id], (daughter_number + "_EMCAL_nTowers/i").c_str());
+  }
+
+  // 5x5 cell info 
+  if (m_get_calo_5x5_cell_info)
+  {
+    m_tree->Branch((daughter_number + "_EMCAL_5x5Cell_binPhi").c_str(), &detector_emcal_5x5Cell_Phi[daughter_id]);
+    m_tree->Branch((daughter_number + "_EMCAL_5x5Cell_binEta").c_str(), &detector_emcal_5x5Cell_Eta[daughter_id]);
+    m_tree->Branch((daughter_number + "_EMCAL_5x5Cell_E").c_str(), &detector_emcal_5x5Cell_E[daughter_id]);
+  }
+
+  // Inner and outer HCal -- not yet functional; fills with NAN by default until software is developed
   m_tree->Branch((daughter_number + "_IHCAL_DeltaPhi").c_str(), &detector_ihcal_deltaphi[daughter_id], (daughter_number + "_IHCAL_DeltaPhi/F").c_str());
   m_tree->Branch((daughter_number + "_IHCAL_DeltaEta").c_str(), &detector_ihcal_deltaeta[daughter_id], (daughter_number + "_IHCAL_DeltaEta/F").c_str());
   m_tree->Branch((daughter_number + "_IHCAL_energy_3x3").c_str(), &detector_ihcal_energy_3x3[daughter_id], (daughter_number + "_IHCAL_energy_3x3/F").c_str());
@@ -493,27 +516,17 @@ void KFParticle_truthAndDetTools::initializeCaloBranches(TTree *m_tree, int daug
   m_tree->Branch((daughter_number + "_OHCAL_energy_3x3").c_str(), &detector_ohcal_energy_3x3[daughter_id], (daughter_number + "_OHCAL_energy_3x3/F").c_str());
   m_tree->Branch((daughter_number + "_OHCAL_energy_5x5").c_str(), &detector_ohcal_energy_5x5[daughter_id], (daughter_number + "_OHCAL_energy_5x5/F").c_str());
   m_tree->Branch((daughter_number + "_OHCAL_energy_cluster").c_str(), &detector_ohcal_cluster_energy[daughter_id], (daughter_number + "_OHCAL_energy_cluster/F").c_str());
-
-  // Cluster Shape Studies
-  if (m_get_detailed_calorimetry)
-  {
-    m_tree->Branch((daughter_number + "_EMCAL_5x5Cell_binPhi").c_str(), &detector_emcal_5x5Cell_Phi[daughter_id]);
-    m_tree->Branch((daughter_number + "_EMCAL_5x5Cell_binEta").c_str(), &detector_emcal_5x5Cell_Eta[daughter_id]);
-    m_tree->Branch((daughter_number + "_EMCAL_5x5Cell_E").c_str(), &detector_emcal_5x5Cell_E[daughter_id]);
-    m_tree->Branch((daughter_number + "_EMCAL_nTowers").c_str(), &detector_emcal_ntowers[daughter_id], (daughter_number + "_EMCAL_nTowers/i").c_str());
-    m_tree->Branch((daughter_number + "_EMCAL_Chi2").c_str(), &detector_emcal_chi2[daughter_id], (daughter_number + "_EMCAL_Chi2/F").c_str());
-  }
 }
 
 /*
-The following function matches tracks to calo clusters. As of 7/1/2025, this only extends to the EMCal. HCal matching is in development.
-
-To run EMCal matching, DST_CALO files must be read into the Fun4All server.
+The following function matches tracks to calo clusters. As of 8/18/2025, this only extends to the EMCal. HCal matching is in development.
 */
 void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
                                                  TTree * /*m_tree*/, const KFParticle &daughter, int daughter_id, bool &isTrackEMCalmatch,
                                                  const KFParticle &vertex_in)
 {
+
+  // Get track map
   dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name_nTuple);
   if (!dst_trackmap)
   {
@@ -522,8 +535,10 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     exit(1);
   }
 
+  // Get track
   track = getTrack(daughter.Id(), dst_trackmap);
 
+  // EMCal info
   if (!clustersEM)
   {
     clustersEM = findNode::getClass<RawClusterContainer>(topNode, "CLUSTERINFO_CEMC");
@@ -611,7 +626,7 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   // double caloRadiusIHCal;
   // double caloRadiusOHCal;
   // caloRadiusEMCal = 100.70;
-  // caloRadiusEMCal = EMCalGeo->get_radius(); //This requires DST_CALOFITTING
+  // caloRadiusEMCal = EMCalGeo->get_radius();
   // caloRadiusOHCal = OHCalGeo->get_radius();
   // caloRadiusIHCal = IHCalGeo->get_radius();
 
@@ -621,56 +636,75 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   RawCluster *cluster;
 
   // EMCAL******************************************************
-
+  // Get state
   SvtxTrackState *thisState = nullptr;
   thisState = track->get_state(caloRadiusEMCal);
 
-  // Debugging:
-  //  thisState->identify();
-  //  std::cout << "size states " << (size_t)track->size_states() << std::endl;
-  //  for (auto state_iter = track->begin_states();
-  //        state_iter != track->end_states();
-  //        ++state_iter)
-  //    {
-  //      SvtxTrackState* tstate = state_iter->second;
-  //      tstate->identify();
-  //      std::cout<< "radius " << sqrt((tstate->get_x())*(tstate->get_x()) + (tstate->get_y())*(tstate->get_y())) << std::endl;
-  //    }
-  //  assert(thisState);
+  // Print out additional track states with high verbosity:
+  if(m_track2caloVerbosity > 10){
+    thisState->identify();
+    std::cout << "size states " << (size_t)track->size_states() << std::endl;
+    for (auto state_iter = track->begin_states();
+          state_iter != track->end_states();
+          ++state_iter)
+      {
+        SvtxTrackState* tstate = state_iter->second;
+        tstate->identify();
+        std::cout<< "radius " << sqrt((tstate->get_x())*(tstate->get_x()) + (tstate->get_y())*(tstate->get_y())) << std::endl;
+      }
+    assert(thisState);
+    // Useful for debugging:
+    // clustersEM->identify();
+  }
 
+  // Declare variables:
+  // Track 
   float _track_phi_emc = std::numeric_limits<float>::quiet_NaN();
   float _track_eta_emc = std::numeric_limits<float>::quiet_NaN();
   float _track_x_emc = std::numeric_limits<float>::quiet_NaN();
   float _track_y_emc = std::numeric_limits<float>::quiet_NaN();
   float _track_z_emc = std::numeric_limits<float>::quiet_NaN();
 
-  // EMCal variables and vectors
+  // Projected track state info
+  float projection_x_emc = std::numeric_limits<float>::quiet_NaN();
+  float projection_y_emc = std::numeric_limits<float>::quiet_NaN();
+  float projection_z_emc = std::numeric_limits<float>::quiet_NaN();
+  float projection_phi_emc = std::numeric_limits<float>::quiet_NaN();
+  float projection_eta_emc = std::numeric_limits<float>::quiet_NaN();
+  
+  // Basic EMCal vectors
   std::vector<float> v_emcal_clusE;
   std::vector<float> v_emcal_dphi;
   std::vector<float> v_emcal_deta;
   std::vector<float> v_emcal_dr;
   std::vector<float> v_emcal_dz;
-  // std::vector<float> v_emcal_3x3;
-  // std::vector<float> v_emcal_5x5;
 
-  // Detailed Calo Info
-  float _emcal_nTowers = std::numeric_limits<float>::quiet_NaN();
-  float _emcal_chi2 = std::numeric_limits<float>::quiet_NaN();
+  // Detailed Calo Info vectors
+  std::vector<float> v_projection_z_emc;
+  std::vector<float> v_projection_phi_emc;
+  std::vector<float> v_projection_eta_emc;
+  std::vector<float> v_emcal_cluster_z;
+  std::vector<float> v_emcal_cluster_eta;
+  std::vector<float> v_emcal_cluster_phi;
   std::vector<float> v_emcal_nTowers;
   std::vector<float> v_emcal_chi2;
+
+  // 5x5 cell info
   RawClusterDefs::keytype _clus_key;
   std::vector<RawClusterDefs::keytype> v_clus_key;
+  std::vector<unsigned int> v_detector_emcal_5x5Cell_Phi;
+  std::vector<unsigned int> v_detector_emcal_5x5Cell_Eta;
+  std::vector<float> v_detector_emcal_5x5Cell_E;
+
 
   // Set variables for matching
   is_match = false;
   index = -1;
 
-  // Useful for debugging:
-  // clustersEM->identify();
-
-  if (thisState != nullptr)
-  {
-    // Vertex x,y,z
+  // If the state exists, start matching process
+  if (thisState != nullptr){
+    
+    // Vertex x,y,z for forrecting position when matching
     float vx = vertex_in.GetX();
     float vy = vertex_in.GetY();
     float vz = vertex_in.GetZ();
@@ -681,6 +715,15 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
     _track_z_emc = thisState->get_z() - vz;
     _track_phi_emc = std::atan2(_track_y_emc, _track_x_emc);
     _track_eta_emc = std::asinh(_track_z_emc / std::sqrt((_track_x_emc * _track_x_emc) + (_track_y_emc * _track_y_emc)));
+
+    // Same quantities as above but in detector coordinates i.e. wrt (0,0,0); 
+    // There are to be stored in nTuple -- not used in any calculations
+    projection_x_emc = thisState->get_x();
+    projection_y_emc = thisState->get_y();
+    projection_z_emc = thisState->get_z();
+    projection_phi_emc = std::atan2(projection_y_emc, projection_x_emc);
+    projection_eta_emc = std::asinh(projection_z_emc / std::sqrt((projection_x_emc * projection_x_emc) + (projection_y_emc * projection_y_emc)));
+
 
     // Create objects, containers, iterators for clusters
     cluster = nullptr;
@@ -724,38 +767,53 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
       float deta = _track_eta_emc - clEta;
       // if (deta > m_deta_cut_high || deta < m_deta_cut_low) continue;
 
+
       // Calculate dr
       float tmparg = caloRadiusEMCal * dphi;
       float dr = std::sqrt((tmparg * tmparg) + (dz * dz));  // sqrt((R*dphi)^2 + (dz)^2
       // float dr = sqrt((dphi*dphi + deta*deta)); //previous version
 
-      // Detailed Calo Info
-      _emcal_nTowers = cluster->getNTowers();
-      _emcal_chi2 = cluster->get_chi2();
+      // Get detailed Calo Info
+      unsigned int _emcal_nTowers = cluster->getNTowers();
+      float _emcal_chi2 = cluster->get_chi2();
       _clus_key = cluster->get_id();
+      float detectorcoordinates_emcal_x = cluster->get_x(); // In detector coordinates!!! Not wrt to the PV. It is wrt (0,0,0)
+      float detectorcoordinates_emcal_y = cluster->get_y();
+      float detectorcoordinates_emcal_z = cluster->get_z();
+      float detectorcoordinates_emcal_phi = std::atan2(detectorcoordinates_emcal_y, detectorcoordinates_emcal_x);
+      float arg = (detectorcoordinates_emcal_x * detectorcoordinates_emcal_x) + (detectorcoordinates_emcal_y * detectorcoordinates_emcal_y);
+      float detectorcoordinates_emcal_eta = std::asinh(detectorcoordinates_emcal_z / std::sqrt(arg));
+
 
       // Add potential match's information to vectors
+      // Basic info
       v_emcal_clusE.push_back(cluster_energy);
       v_emcal_dphi.push_back(dphi);
       v_emcal_dz.push_back(dz);
       v_emcal_deta.push_back(deta);
       v_emcal_dr.push_back(dr);
-      // v_emcal_3x3.push_back(std::numeric_limits<float>::quiet_NaN());
-      // v_emcal_5x5.push_back(std::numeric_limits<float>::quiet_NaN());
-
+      
       // Detailed Calo Info
+      v_emcal_cluster_z.push_back(detectorcoordinates_emcal_z);
+      v_emcal_cluster_eta.push_back(detectorcoordinates_emcal_eta);
+      v_emcal_cluster_phi.push_back(detectorcoordinates_emcal_phi);
       v_emcal_nTowers.push_back(_emcal_nTowers);
       v_emcal_chi2.push_back(_emcal_chi2);
+      
+      // 5x5 call -- key used later in Get5x5CellInfo()
       v_clus_key.push_back(_clus_key);
 
       is_match = true;
-      // Useful for debugging:
-      // std::cout << "**********DELTA INFORMATION************" << std::endl;
-      // std::cout << "dphi = " << dphi << std::endl;
-      // std::cout << "deta = " << deta << std::endl;
-      // std::cout << "dz =   " << dz <<   std::endl;
-      // std::cout << "dr =   " << dr <<   std::endl;
-      // std::cout << "****************************************" << std::endl;
+
+      // Print outs
+      if(m_track2caloVerbosity > 5){
+        std::cout << "**********DELTA INFORMATION************" << std::endl;
+        std::cout << "dphi = " << dphi << std::endl;
+        std::cout << "deta = " << deta << std::endl;
+        std::cout << "dz =   " << dz <<   std::endl;
+        std::cout << "dr =   " << dr <<   std::endl;
+        std::cout << "****************************************" << std::endl;
+      }
     }
 
     // Find the closest match from all potential matches
@@ -785,38 +843,86 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   */
 
   // Save values to the branches!
+  // If no match:
   if (index == -1)
   {
+    // Basic info
     detector_emcal_deltaphi[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_deltaeta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
     detector_emcal_cluster_energy[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    
+    // Detailed Calo
     if (m_get_detailed_calorimetry)
     {
+      detector_emcal_projection_z[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+      detector_emcal_projection_eta[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+      detector_emcal_projection_phi[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+      detector_emcal_cluster_z[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
+      detector_emcal_cluster_eta[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
+      detector_emcal_cluster_phi[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
       detector_emcal_ntowers[daughter_id] = std::numeric_limits<unsigned int>::quiet_NaN();
       detector_emcal_chi2[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    }
+    
+    // 5x5 cell
+    if (m_get_calo_5x5_cell_info)
+    { 
       detector_emcal_5x5Cell_Phi[daughter_id].push_back(std::numeric_limits<unsigned int>::quiet_NaN());
       detector_emcal_5x5Cell_Eta[daughter_id].push_back(std::numeric_limits<unsigned int>::quiet_NaN());
       detector_emcal_5x5Cell_E[daughter_id].push_back(std::numeric_limits<float>::quiet_NaN());
     }
+
     isTrackEMCalmatch = false;
   }
+
+  // If there is a match:
   else
   {
+    // Grab 3x3 and 5x5 energies & cell info from around the cluster center using the cluster key
+    float energy_3x3 = 0;
+    float energy_5x5 = 0;
+    KFParticle_truthAndDetTools::Get5x5CellInfo(
+      v_clus_key[index], 
+      energy_3x3, 
+      energy_5x5, 
+      v_detector_emcal_5x5Cell_Phi,
+      v_detector_emcal_5x5Cell_Eta,
+      v_detector_emcal_5x5Cell_E
+    );
+
+    // Now fill the arrays
+    // Basic info
     detector_emcal_deltaphi[daughter_id] = v_emcal_dphi[index];
     detector_emcal_deltaeta[daughter_id] = v_emcal_deta[index];
     detector_emcal_deltaz[daughter_id] = v_emcal_dz[index];
-    detector_emcal_energy_3x3[daughter_id] = std::numeric_limits<float>::quiet_NaN();
-    detector_emcal_energy_5x5[daughter_id] = std::numeric_limits<float>::quiet_NaN();
+    detector_emcal_energy_3x3[daughter_id] = energy_3x3;
+    detector_emcal_energy_5x5[daughter_id] = energy_5x5;
     detector_emcal_cluster_energy[daughter_id] = v_emcal_clusE[index];
-    if (m_get_detailed_calorimetry)
+    
+    // Detailed Calo
+    if (m_get_detailed_calorimetry) 
     {
+      detector_emcal_projection_z[daughter_id] = projection_z_emc;
+      detector_emcal_projection_eta[daughter_id] = projection_eta_emc;
+      detector_emcal_projection_phi[daughter_id] = projection_phi_emc;
+      detector_emcal_cluster_z[daughter_id] = v_emcal_cluster_z[index];
+      detector_emcal_cluster_eta[daughter_id] = v_emcal_cluster_eta[index];
+      detector_emcal_cluster_phi[daughter_id] = v_emcal_cluster_phi[index];
       detector_emcal_ntowers[daughter_id] = v_emcal_nTowers[index];
       detector_emcal_chi2[daughter_id] = v_emcal_chi2[index];
-      KFParticle_truthAndDetTools::Get5x5CellInfo(v_clus_key[index], daughter_id);  // Adds the tower info to the vectors
     }
+
+    // 5x5 cell
+    if(m_get_calo_5x5_cell_info){
+      detector_emcal_5x5Cell_Phi[daughter_id] = v_detector_emcal_5x5Cell_Phi;
+      detector_emcal_5x5Cell_Eta[daughter_id] = v_detector_emcal_5x5Cell_Eta;
+      detector_emcal_5x5Cell_E[daughter_id] = v_detector_emcal_5x5Cell_E;
+    }
+    
+
     isTrackEMCalmatch = true;
   }
 
@@ -1114,14 +1220,24 @@ void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
   // std::cout << "OHCAL CLLUSTERS MATCHED TO TRACK" << std::endl;
 }
 
-void KFParticle_truthAndDetTools::Get5x5CellInfo(RawClusterDefs::keytype key_in, int daughter_id)
-{
+void KFParticle_truthAndDetTools::Get5x5CellInfo(
+  RawClusterDefs::keytype key_in, 
+  float &E3x3, 
+  float &E5x5,
+  std::vector<unsigned int> &v_emcal_5x5Cell_Phi,
+  std::vector<unsigned int> &v_emcal_5x5Cell_Eta,
+  std::vector<float> &v_emcal_5x5Cell_E
+  ){
+  // Make sure energy values are reset to start at 0
+  E5x5 = 0.0;
+  E3x3 = 0.0; 
+
   // Get cluster from cluster key
   RawCluster *clus = clustersEM->getCluster(key_in);
 
   // Set up variables for looping over towers
-  int center_phi = std::numeric_limits<int>::quiet_NaN();
-  int center_eta = std::numeric_limits<int>::quiet_NaN();
+  unsigned int center_phi = std::numeric_limits<int>::quiet_NaN();
+  unsigned int center_eta = std::numeric_limits<int>::quiet_NaN();
   float center_energy = -9999;
   const RawCluster::TowerConstRange begin_end_Towers = clus->get_towers();
   RawCluster::TowerConstIterator towersIter;
@@ -1143,6 +1259,8 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(RawClusterDefs::keytype key_in,
   // Vectors used in next for loops
   std::vector<unsigned int> v_phi_tmp;
   std::vector<unsigned int> v_eta_tmp;
+  std::vector<float> v_Tower_E;
+//   bool printthis = false;
 
   // Get phi bins, and account for wrap-around case
   for (int i = -2; i <= 2; i++)
@@ -1150,7 +1268,7 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(RawClusterDefs::keytype key_in,
     int phibin = center_phi + i;
     // Wraparound
     if (phibin < 0 || phibin > 255)
-    {
+    { 
       if (phibin == -1)
       {
         phibin = 255;
@@ -1180,18 +1298,11 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(RawClusterDefs::keytype key_in,
   {
     int etabin = center_eta + i;
     // End of eta acceptance case
-    if (etabin < 0 || etabin > 95)
-    {
+    if (etabin < 0 || etabin > 95) {
       continue;
     }
     v_eta_tmp.push_back(etabin);
-    // else{ v_eta_tmp.push_back(etabin); }
   }
-
-  // Vector to hold keys and energies
-  std::vector<unsigned int> v_tower_phi = {};
-  std::vector<unsigned int> v_tower_eta = {};
-  std::vector<float> v_tower_energy = {};
 
   // Ranges for for-loops
   int phi_range = v_phi_tmp.size();
@@ -1202,7 +1313,12 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(RawClusterDefs::keytype key_in,
   {
     // Get ith phi bin
     const unsigned int iphi = v_phi_tmp[i];
-
+    
+    // Add towers to 3x3 if not first or last rows in phi
+    bool addto3x3 = false;
+    if(i < 4 && i > 0) addto3x3 = true;
+    
+    // Loop over eta
     for (int j = 0; j < eta_range; j++)
     {
       // Get jth eta bin
@@ -1212,11 +1328,19 @@ void KFParticle_truthAndDetTools::Get5x5CellInfo(RawClusterDefs::keytype key_in,
       // Get energy
       TowerInfo *tower = _towersEM->get_tower_at_key(towerinfo_key);
       float energytmp = tower->get_energy();
+      // Add to 5x5 energy float
+      E5x5+=energytmp;
+      v_Tower_E.push_back(energytmp);
+       // Store in vectors
+      if(m_get_calo_5x5_cell_info){
+        v_emcal_5x5Cell_Phi.push_back(iphi);
+        v_emcal_5x5Cell_Eta.push_back(jeta);
+        v_emcal_5x5Cell_E.push_back(energytmp);
+      }
 
-      // Store in vectors
-      detector_emcal_5x5Cell_Phi[daughter_id].push_back(iphi);
-      detector_emcal_5x5Cell_Eta[daughter_id].push_back(jeta);
-      detector_emcal_5x5Cell_E[daughter_id].push_back(energytmp);
+      if(!addto3x3) continue; // Skip adding to E3x3 if phi is outside 3x3 grid
+      int etadiff = (int) jeta-center_eta;
+      if(etadiff < 2 && etadiff > -2) E3x3+=energytmp;
     }
   }
 }
@@ -1552,7 +1676,7 @@ void KFParticle_truthAndDetTools::clearVectors()
     allPV_daughter_PV_DCA_StdDev[i].clear();
 
     // Detailed Calo
-    if (m_get_detailed_calorimetry)
+    if (m_get_calo_5x5_cell_info)
     {
       detector_emcal_5x5Cell_Phi[i].clear();
       detector_emcal_5x5Cell_Eta[i].clear();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -65,8 +65,14 @@ class KFParticle_truthAndDetTools
 
   virtual void initializeCaloBranches(TTree *m_tree, int daughter_id, const std::string &daughter_number);
   virtual void fillCaloBranch(PHCompositeNode *topNode, TTree *m_tree, const KFParticle &daughter, int daughter_id, bool &isTrackEMCalmatch, const KFParticle &vertex);
-  void Get5x5CellInfo(RawClusterDefs::keytype key_in, int daughter_id);
-
+  void Get5x5CellInfo(
+    RawClusterDefs::keytype key_in, 
+    float &E3x3, 
+    float &E5x5,
+    std::vector<unsigned int> &v_emcal_5x5Cell_Phi,
+    std::vector<unsigned int> &v_emcal_5x5Cell_Eta,
+    std::vector<float> &v_emcal_5x5Cell_E
+  );
   void initializeDetectorBranches(TTree *m_tree, int daughter_id, const std::string &daughter_number);
   void initializeSubDetectorBranches(TTree *m_tree, const std::string &detectorName, int daughter_id, const std::string &daughter_number);
   void fillDetectorBranch(PHCompositeNode *topNode, TTree *m_tree, const KFParticle &daughter, int daughter_id);
@@ -79,9 +85,13 @@ class KFParticle_truthAndDetTools
 
   void clearVectors();
 
-  float get_e3x3(RawCluster *cluster, RawTowerContainer *Towers, int layer);  // Nonfunctional; for now, tree fills with NAN
-  float get_e5x5(RawCluster *cluster, RawTowerContainer *Towers, int layer);
-
+  // Verbosity
+  int m_track2caloVerbosity{0};
+  void setVerbosityTrack2Calo(int verb){
+    m_track2caloVerbosity = verb;
+  }
+ 
+  // Helper functions
   float PiRange(float deltaPhi)
   {
     if (deltaPhi > M_PI) deltaPhi -= 2 * M_PI;
@@ -89,7 +99,7 @@ class KFParticle_truthAndDetTools
     return deltaPhi;
   }
 
-  // Functions to set cuts
+  // Functions to set cuts on track-emcal matching 
   void set_emcal_radius_user(float set_variable) { m_emcal_radius_user = set_variable; }
   void set_emcal_e_low_cut(float set_variable) { m_emcal_e_low_cut = set_variable; }
   void set_dphi_cut_low(float set_variable) { m_dphi_cut_low = set_variable; }
@@ -100,6 +110,7 @@ class KFParticle_truthAndDetTools
  protected:
   bool m_get_detailed_tracking{true};
   bool m_get_detailed_calorimetry{false};
+  bool m_get_calo_5x5_cell_info{false};
   bool m_use_mbd_vertex_truth{false};
   bool m_dont_use_global_vertex_truth{false};
 
@@ -168,15 +179,13 @@ class KFParticle_truthAndDetTools
   std::vector<float> m_true_daughter_track_history_pE[max_tracks];
   std::vector<float> m_true_daughter_track_history_pT[max_tracks];
 
+  // Vectors for calo info
   float detector_emcal_deltaphi[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_deltaeta[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_deltaz[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_energy_3x3[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_energy_5x5[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_emcal_cluster_energy[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
-  // float detector_emcal_eta[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
-  // float detector_emcal_phi[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
-  // float detector_emcal_z[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_ihcal_deltaphi[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_ihcal_deltaeta[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_ihcal_energy_3x3[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
@@ -188,12 +197,20 @@ class KFParticle_truthAndDetTools
   float detector_ohcal_energy_5x5[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   float detector_ohcal_cluster_energy[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
   // Detailed Calo Info
+  float detector_emcal_projection_z[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_projection_eta[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_projection_phi[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_cluster_z[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_cluster_eta[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_cluster_phi[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  float detector_emcal_chi2[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
+  unsigned int detector_emcal_ntowers[max_tracks]{std::numeric_limits<unsigned int>::quiet_NaN()};
+  // 5x5 grid
   std::vector<unsigned int> detector_emcal_5x5Cell_Phi[max_tracks];
   std::vector<unsigned int> detector_emcal_5x5Cell_Eta[max_tracks];
   std::vector<float> detector_emcal_5x5Cell_E[max_tracks];
-  unsigned int detector_emcal_ntowers[max_tracks]{std::numeric_limits<unsigned int>::quiet_NaN()};
-  float detector_emcal_chi2[max_tracks]{std::numeric_limits<float>::quiet_NaN()};
 
+  // Containers for calo info
   RawTowerGeomContainer *EMCalGeo{nullptr};
   RawClusterContainer *clustersEM{nullptr};
   TowerInfoContainer *_towersEM{nullptr};


### PR DESCRIPTION
This PR adds branches to the KFP output TTree, patches a small bug, and reworks track-calo flags slightly. MINOR disruption to analyzers if they are using track-calo matching in KFParticle -- no changes for anyone not using this feature.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR changes the track-calo flags slightly. Now, you can use the following functions to retrieve corresponding information:
- `getCaloInfo()` (No changes): Still tells KFP to get basic calo info, including cluster energy and track-calo residuals. NOTE: E3x3 and E5x5 now functional!! So those branches will no longer be filled with NAN!
- `GetDetailedCalorimetry()` (Altered slightly): cluster position info and projected state info (as well as nTowers and emcal chi2)
- `GetCalo5x5CellInfo()` (New flag!!): The 5x5 cell of calo info around the cluster center tower. This is relatively memory heavy in comparison to the other info KFP gets by default, so I've opted to move this into its own flag. 

Running any of these functions will tell KFP to get calo info, but `GetDetailedCalorimetry()` and `GetCalo5x5CellInfo()` are independent from each other. So if you want detailed calo AND the 5x5 grid, you need to run BOTH functions. 

I've patched a bug. The function that clears vectors used in `KFParticle_truthAndDetTools` will now run if the user runs `GetCalo5x5CellInfo()`. 

I also did some clean up. I hid some printouts behind verbosity and added a lot of comments to help with clarity. 


## TODOs (if applicable)
For developers: add state weighted-averaging for varied projected radii (meaning, add functionality for projected states at radii not saved in tracking DSTs). I've been working on this, likely will submit another PR in the coming weeks. 

For others: If you have been using `GetDetailedCalorimetry()`, make sure you update your macros to make sure you're getting the correct info for your analysis. 



[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context

Extend KFP output with calorimeter information for track–calorimeter studies. Fix vector cleanup when 5×5 cell output is enabled.

## Key changes

- Add E3x3 and E5x5 cluster-energy branches.
- Add detailed calorimeter branches for cluster position, projected track state, tower count, and EMCal χ².
- Add `GetCalo5x5CellInfo()` for 5×5 cell data.
- Keep detailed calorimetry and 5×5 cell output independently configurable.
- Update `Get5x5CellInfo()` to return energy sums and cell vectors.
- Remove obsolete `get_e3x3()` and `get_e5x5()` helpers.
- Add track-to-calorimeter verbosity control.
- Clear output vectors when 5×5 cell information is enabled.

## Potential risk areas

- The KFP output TTree schema changes. Downstream readers may require updates.
- Track–calorimeter matching flags and reconstruction behavior have changed. Affected analyzers require validation.
- 5×5 cell vectors can increase output size and processing time.
- Callers must enable both options to retrieve detailed calorimetry and 5×5 cell data.
- Shared output vectors and tool instances require thread-safety review if used concurrently.

## Possible future improvements

- Add regression tests for branch contents, option combinations, vector cleanup, and energy sums.
- Document the updated TTree schema and API usage.
- Benchmark output size and runtime with 5×5 cell information enabled.
- Validate downstream analyzer compatibility and provide migration guidance.

AI-generated summaries can contain errors. Contributors should verify the implementation, branch names, and API behavior against the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->