### PR TITLE
Fix for full event corruption for all packets

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -758,6 +758,7 @@ void SingleTriggeredInput::FillPool()
         return;
       }
       m_DitchPackets.clear();
+      Event* refill_evt = nullptr;
 
       for (const auto& [pid, sebdiff] : m_bclkdiffarray_map)
       {
@@ -848,19 +849,32 @@ void SingleTriggeredInput::FillPool()
             {
               m_bclkdiffarray_map[pid][i] = ComputeClockDiff(m_bclkarray_map[pid][i + 1], m_bclkarray_map[pid][i]);
             }
-            Event* evt = GetEventIterator()->getNextEvent();
-            if (evt)
+            if (!refill_evt)
             {
-              evt->convert();
-              std::vector<Packet*> pktvec = evt->getPacketVector();
-              for (Packet* pkt : pktvec)
+              refill_evt = GetEventIterator()->getNextEvent();
+              while (refill_evt && refill_evt->getEvtType() != DATAEVENT)
               {
-                if (pkt->getIdentifier() == pid)
-                {
-                  FillPacketClock(evt, pkt, packetpoolsize - 1);
-                  m_PacketEventDeque[pid].push_back(evt);
-                }
+                delete refill_evt;
+                refill_evt = GetEventIterator()->getNextEvent();
+              }
+              if (refill_evt)
+              {
+                refill_evt->convert();
+                std::cout << Name() << ": shift by -1 for prdf event " << refill_evt->getEvtSequence() << std::endl;
+              }
+            }
+            if (refill_evt)
+            {
+              Packet* pkt = refill_evt->getPacket(pid);
+              if (pkt)
+              {
+                FillPacketClock(refill_evt, pkt, packetpoolsize - 1);
+                m_PacketEventDeque[pid].push_back(refill_evt);
                 delete pkt;
+              }
+              else
+              {
+                std::cout << Name() << ": refill event " << refill_evt->getEvtSequence() << " and no packet pid : " << pid << std::endl;
               }
             }
             else

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -729,9 +729,6 @@ void SingleTriggeredInput::FillPool()
   if (!FilesDone())
   {
     int eventvectorsize = FillEventVector();
-    // this seems a unique signature for raw data files which only contain the
-    // begin and end run event but no data events. FillEventVector() returns -1
-    // and since no events were read the m_PacketEventDeque is empty
     if (eventvectorsize < 0 && m_PacketEventDeque.empty())
     {
       std::cout << Name() << ": No data Events in input file " << FileName() << std::endl;
@@ -1030,9 +1027,6 @@ void SingleTriggeredInput::CreateDSTNodes(Event* evt)
   }
   else
   {
-    // if we want to keep a few packets, we need two detNodes, Packet and PacketKeep
-    // this construct here allows for the KeepMyPackets flag to take effect, then both
-    // node pointers detNode and detNodeKeep point to the same (so KeepMyPackets has precedence)
     detNode = dynamic_cast<PHCompositeNode*>(iterDst.findFirst("PHCompositeNode", CompositeNodeName));
     if (!detNode)
     {

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -759,6 +759,7 @@ void SingleTriggeredInput::FillPool()
       }
       m_DitchPackets.clear();
       Event* refill_evt = nullptr;
+      bool refill_used = false;
 
       for (const auto& [pid, sebdiff] : m_bclkdiffarray_map)
       {
@@ -852,6 +853,16 @@ void SingleTriggeredInput::FillPool()
             if (!refill_evt)
             {
               refill_evt = GetEventIterator()->getNextEvent();
+              while (!refill_evt)
+              {
+                fileclose();
+                if (OpenNextFile() == InputFileHandlerReturnCodes::FAILURE)
+                {
+                  FilesDone(1);
+                  break;
+                }
+                refill_evt = GetEventIterator()->getNextEvent();
+              }
               while (refill_evt && refill_evt->getEvtType() != DATAEVENT)
               {
                 delete refill_evt;
@@ -870,11 +881,14 @@ void SingleTriggeredInput::FillPool()
               {
                 FillPacketClock(refill_evt, pkt, packetpoolsize - 1);
                 m_PacketEventDeque[pid].push_back(refill_evt);
+                refill_used = true;
                 delete pkt;
               }
               else
               {
-                std::cout << Name() << ": refill event " << refill_evt->getEvtSequence() << " and no packet pid : " << pid << std::endl;
+                std::cout << Name() << ": refill event " << refill_evt->getEvtSequence() << " has no packet " << pid << " - marking packet as bad" << std::endl;
+                m_PacketAlignmentProblem[pid] = true;
+                continue;
               }
             }
             else
@@ -978,6 +992,10 @@ void SingleTriggeredInput::FillPool()
 
           m_PrevPoolLastDiffBad[pid] = false;
         }
+      }
+      if (refill_evt && !refill_used)
+      {
+        delete refill_evt;
       }
     }
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This is to handle rare cases happening in some of the cosmic runs. 
I have not seen this in collision beam data so far. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This change addresses rare full-event corruption observed during some cosmic runs. The issue has not been observed in collision beam data.

## Key Changes

- Reuses the refill event during `shift == -1` packet alignment.
- Skips non-data events once before converting the data event.
- Refills only the requested packet ID.
- Logs missing packets.
- Avoids fetching and scanning a separate event for each packet.

## Potential Risk Areas

- No exported or public interface changes.
- No I/O format changes are indicated.
- Packet alignment and reconstruction behavior may change for affected event streams.
- The refill path may improve performance by reducing event reads and packet scans.
- Thread-safety risk appears limited because the change uses local event state, but concurrent input behavior should be verified.

## Possible Future Improvements

- Add regression tests for cosmic-run event corruption and `shift == -1` alignment.
- Add tests for missing packet handling.
- Monitor packet-loss and event-corruption rates in representative cosmic and collision data.

AI-generated summaries can contain errors. Contributors should verify these points against the implementation and relevant run data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->