### PR TITLE
Ttreecache

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -132,6 +132,10 @@ int Fun4AllDstInputManager::fileopen(const std::string &filenam)
     setBranches();                // set branch selections
     AddToFileOpened(FileName());  // add file to the list of files which were opened
                                   // check if our input file has a sync object or not
+    if (TTreeCacheSize() > -1)
+    {
+       m_IManager->TTreeCacheSize(TTreeCacheSize());
+    }
     if (ReadCacheDisabled())
     {
       m_IManager->DisableReadCache();
@@ -205,8 +209,7 @@ readagain:
   // check if the local SubsysReco discards this event
   if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
   {
-    // NOLINTNEXTLINE(hicpp-avoid-goto)
-    goto readagain;
+    goto readagain;// NOLINT(hicpp-avoid-goto)
   }
   syncobject = findNode::getClass<SyncObject>(dstNode, syncdefs::SYNCNODENAME);
   return 0;
@@ -653,4 +656,14 @@ int Fun4AllDstInputManager::HasSyncObject() const
     exit(1);
   }
   return 0;
+}
+
+void Fun4AllDstInputManager::TTreeCacheSize(int64_t size)
+{
+  m_TTreeCacheSize = size;
+  if (m_IManager)
+  {
+    m_IManager->TTreeCacheSize(size);
+  }
+  return;
 }

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -26,11 +26,12 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   int SyncIt(const SyncObject *mastersync) override;
   int BranchSelect(const std::string &branch, const int iflag) override;
   int setBranches() override;
-  void CacheSize(uint64_t size) { m_IManager->CacheSize(size); }
   virtual int setSyncBranches(PHNodeIOManager *iman);
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
   int HasSyncObject() const override;
+  void TTreeCacheSize(int64_t size) override;
+  int64_t TTreeCacheSize() const override {return m_TTreeCacheSize;}
 
  protected:
   int ReadNextEventSyncObject();
@@ -53,6 +54,7 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   PHCompositeNode *m_RunNodeSum{nullptr};
   PHNodeIOManager *m_IManager{nullptr};
   SyncObject *syncobject{nullptr};
+  int64_t m_TTreeCacheSize {-1}; // TTree default, don't ask
   int m_ReadRunTTree{1};
   int events_total{0};
   int events_thisfile{0};

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -52,10 +52,14 @@ class Fun4AllInputManager : public Fun4AllBase, public InputFileHandler
   void Verbosity(const uint64_t ival) override;
   virtual int NoRunTTree() {return -1;}
 
+  virtual void TTreeCacheSize(int64_t /*size*/) { return;}
+  virtual int64_t TTreeCacheSize() const { return -1; }
+
+  void DisableReadCache() { m_disable_read_cache_flag = true; }
+
 protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
   Fun4AllSyncManager *MySyncManager() { return m_MySyncManager; }
-  void DisableReadCache() { m_disable_read_cache_flag = true; }
   bool ReadCacheDisabled() const { return m_disable_read_cache_flag; }
 
  private:

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -100,7 +100,6 @@ bool PHNodeIOManager::setFile(const std::string& f, const std::string& title,
     file->SetCompressionSettings(m_CompressionSetting);
     tree = new TTree(TreeName.c_str(), title.c_str());
     TTree::SetMaxTreeSize(900000000000LL);  // set max size to ~900 GB
-
     gROOT->cd(currdir.c_str());
     return true;
     break;
@@ -110,6 +109,11 @@ bool PHNodeIOManager::setFile(const std::string& f, const std::string& title,
     if (!file)
     {
       return false;
+    }
+    if (m_DisableReadCache_Flag)
+    {
+      std::cout << PHWHERE << " disabling read cache" << std::endl;
+      file->SetCacheRead(nullptr);
     }
     selectObjectToRead("*", true);
     gROOT->cd(currdir.c_str());
@@ -294,11 +298,6 @@ bool PHNodeIOManager::readEventFromFile(size_t requestedEvent)
   TFile* file_ptr = gFile;  // save current gFile
   file->cd();
   
-  if (m_cacheSize != std::numeric_limits<uint64_t>::max())
-  {
-    tree->SetCacheSize(m_cacheSize);
-  }
-
   if (requestedEvent)
   {
     bytesRead = tree->GetEvent(requestedEvent);
@@ -306,6 +305,7 @@ bool PHNodeIOManager::readEventFromFile(size_t requestedEvent)
     {
       eventNumber = requestedEvent + 1;
     }
+//    tree->DropBaskets();
   }
   else
   {
@@ -374,6 +374,10 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
               << TreeName << " not found in file " << file->GetName() << std::endl;
     return nullptr;
   }
+  if (m_TTreeCacheSize > -1)
+  {
+    tree->SetCacheSize(m_TTreeCacheSize);
+  }
   // ROOT sucks, we need a unique name for the tree so we can open multiple
   // files. So we take the memory location of the file pointer which
   // should be unique within this process to create it
@@ -389,8 +393,7 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   {
     for (it = objectToRead.begin(); it != objectToRead.end(); ++it)
     {
-      tree->SetBranchStatus((it->first).c_str(),
-                            static_cast<bool>(it->second));
+      tree->SetBranchStatus((it->first).c_str(), static_cast<bool>(it->second));
     }
   }
   // The file contains a TTree with a list of the TBranchObjects
@@ -620,9 +623,26 @@ bool PHNodeIOManager::NodeExist(const std::string& nodename)
 
 void PHNodeIOManager::DisableReadCache()
 {
+  // this flag is read during opening of the TFile
+  m_DisableReadCache_Flag = true;
+
+  // in case the file was already opened, set this after the fact
+  // delete the existing cache after disconnecting it from the TFile
   if (file)
   {
+    auto* cache = file->GetCacheRead();
     file->SetCacheRead(nullptr);
+    delete cache;
+  }
+  return;
+}
+
+void PHNodeIOManager::TTreeCacheSize(int64_t size)
+{
+  m_TTreeCacheSize = size;
+  if (tree)
+  {
+    tree->SetCacheSize(size);
   }
   return;
 }

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -54,8 +54,8 @@ class PHNodeIOManager : public PHIOManager
   void BufferSize(const int size) { buffersize = size; }
   int SplitLevel() const { return splitlevel; }
   int BufferSize() const { return buffersize; }
-  int CacheSize() const { return m_cacheSize; }
-  void CacheSize(uint64_t size) { m_cacheSize = size;}
+  int TTreeCacheSize() const { return m_TTreeCacheSize; }
+  void TTreeCacheSize(int64_t size);
   
   void DisableReadCache();
 
@@ -68,12 +68,13 @@ private:
   TFile *file{nullptr};
   TTree *tree{nullptr};
   std::string TreeName{"T"};
-  uint64_t m_cacheSize = std::numeric_limits<uint64_t>::max();
+  int64_t m_TTreeCacheSize {-1};
   int accessMode{PHReadOnly};
   int m_CompressionSetting{505};  // ZSTD
   int isFunctionalFlag{0};        // flag to tell if that object initialized properly
   int buffersize{std::numeric_limits<int>::min()};
   int splitlevel{std::numeric_limits<int>::min()};
+  bool m_DisableReadCache_Flag {false};
   std::map<std::string, TBranch *> fBranches;
   std::map<std::string, bool> objectToRead;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the capability to set the TTree cache size in the fun4all macro. The default setting (-1) translates to 30MB cache size. For our 63 file clustering setting it to zero reduces the memory use by about 2GB by disabling the caching. We need to test how this impacts the processing time and the i/o of lustre

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

This change allows Fun4All macros to configure the ROOT `TTree` cache through the DST input manager. The default value `-1` keeps the ROOT default of 30 MB. A value of `0` disables caching and can reduce memory use by approximately 2 GB for the 63-file clustering configuration.

## Key changes

- Added `TTreeCacheSize(int64_t)` setter and getter APIs.
- Applied the configured cache size when `PHNodeIOManager` opens a file.
- Applied cache-size changes immediately when a manager is already active.
- Improved read-cache disabling for both newly opened and already open files.
- Removed per-event cache-size assignment.
- Preserved `-1` as the default setting.

## Potential risk areas

- Processing time and Lustre I/O performance may change when caching is disabled or resized.
- Cache behavior during node-tree reconstruction has changed.
- The API replacement may affect callers that use `CacheSize()`.
- No IO format changes are expected.
- Thread-safety implications of changing cache settings on an active manager should be reviewed.

## Possible future improvements

- Benchmark processing time, memory use, and Lustre I/O for multiple cache sizes.
- Validate behavior with representative DST workflows.
- Document the new macro flag and recommended settings.
- Review and update downstream callers that use the removed `CacheSize()` API.

This summary is based on AI-generated change descriptions. Contributors should verify the implementation and performance claims against the source and production workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->