### PR TITLE
Si seed mult

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -40,6 +40,10 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
 
+#include <trackbase_historic/SvtxTrackSeed_v2.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/TrackSeed_v2.h>
+
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
 #include <globalvertex/SvtxVertex.h>
@@ -1538,4 +1542,47 @@ void KFParticle_Tools::printSelectionCheck(const std::string &info, unsigned int
 {
   std::string colour = value > 0 ? accept_colour : reject_colour;
   std::cout << info << " = \033[1;" << colour << "m" << value << "\033[0m" << std::endl;
+}
+
+int KFParticle_Tools::getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing)
+{
+  auto m_siliconSeeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
+  //auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_SEED");
+  if (!m_siliconSeeds)
+  {
+    std::cout << " ERROR: Can't find SiliconTrackSeedContainer " << std::endl;
+    return -1;
+  }
+  //if (!clustermap)
+  //{
+  //  std::cout << " ERROR: Can't find TRKR_CLUSTER " << std::endl;
+  //  return -1;
+  //}
+
+  //std::cout<<"m_siliconSeeds->size(): "<<m_siliconSeeds->size()<<std::endl;
+  TrackSeed *_tracklet_si;
+  int ncharged_multiplicity = 0;
+  const int nMapsCut = 1;  
+  const int nInttCut = 1;  
+  for (unsigned int phtrk_iter_si = 0;
+         phtrk_iter_si < m_siliconSeeds->size();
+         ++phtrk_iter_si)
+    {
+      _tracklet_si = m_siliconSeeds->get(phtrk_iter_si);
+      if(!_tracklet_si)
+      {
+        continue;
+      }
+      //std::cout<<"size cluster seeds: "<<_tracklet_si->size_cluster_keys()<<std::endl;
+      if (_tracklet_si->get_crossing() == bunch_crossing)
+      {
+        if (TrackAnalysisUtils::get_cluster_count(_tracklet_si,TrkrDefs::mvtxId) >= nMapsCut && 
+            TrackAnalysisUtils::get_cluster_count(_tracklet_si,TrkrDefs::inttId) >= nInttCut)
+        {
+          ncharged_multiplicity++;
+        }
+    }
+  }
+  
+  return ncharged_multiplicity;
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1544,7 +1544,7 @@ void KFParticle_Tools::printSelectionCheck(const std::string &info, unsigned int
   std::cout << info << " = \033[1;" << colour << "m" << value << "\033[0m" << std::endl;
 }
 
-int KFParticle_Tools::getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing)
+int KFParticle_Tools::getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing) const
 {
   auto *m_siliconSeeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
   //auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_SEED");

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1546,11 +1546,14 @@ void KFParticle_Tools::printSelectionCheck(const std::string &info, unsigned int
 
 int KFParticle_Tools::getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing)
 {
-  auto m_siliconSeeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
+  auto *m_siliconSeeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
   //auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_SEED");
   if (!m_siliconSeeds)
   {
-    std::cout << " ERROR: Can't find SiliconTrackSeedContainer " << std::endl;
+    if(m_verbosity > 0)
+    {
+      std::cout << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << std::endl;
+    }
     return -1;
   }
   //if (!clustermap)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -67,6 +67,8 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   void getTracksFromBC(PHCompositeNode *topNode, const int &bunch_crossing, const std::string &vertexMapName, int &nTracks, int &nPVs);
 
+  int getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing);
+
   int getTracksFromVertex(PHCompositeNode *topNode, const KFParticle &vertex, const std::string &vertexMapName);
 
   /*const*/ bool isGoodTrack(const KFParticle &particle, const std::vector<KFParticle> &primaryVertices);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -67,7 +67,7 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   void getTracksFromBC(PHCompositeNode *topNode, const int &bunch_crossing, const std::string &vertexMapName, int &nTracks, int &nPVs);
 
-  int getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing);
+  int getNchargedSiSeedMultiplicity(PHCompositeNode *topNode, const int &bunch_crossing) const;
 
   int getTracksFromVertex(PHCompositeNode *topNode, const KFParticle &vertex, const std::string &vertexMapName);
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -308,6 +308,7 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
 
   m_tree->Branch("nPrimaryVerticesOfBC", &m_nPVs, "nPrimaryVerticesOfBC/I");
   m_tree->Branch("nTracksOfBC", &m_multiplicity, "nTracksOfBC/I");
+  m_tree->Branch("nSiSeedMultiplicity", &m_ncharged_siseed_multiplicity, "nSiSeedMultiplicity/I");
   m_tree->Branch("nTracksOfVertex", &m_nTracksOfVertex, "nTracksOfVertex/I");
 
   m_tree->Branch("runNumber", &m_runNumber, "runNumber/I");
@@ -662,6 +663,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
   m_sv_mass = calc_secondary_vertex_mass_noPID(daughters);
 
   kfpTupleTools.getTracksFromBC(topNode, m_calculated_daughter_bunch_crossing[0], m_vtx_map_node_name_nTuple, m_multiplicity, m_nPVs);
+  m_ncharged_siseed_multiplicity = kfpTupleTools.getNchargedSiSeedMultiplicity(topNode, m_calculated_daughter_bunch_crossing[0]);
   // cannot retrieve vertex map info from fake PV, hence the second condition
   if (m_constrain_to_vertex_nTuple && !m_use_fake_pv_nTuple)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -225,6 +225,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
 
   int m_nPVs{-1};
   int m_multiplicity{-1};
+  int m_ncharged_siseed_multiplicity{-1};
   int m_nTracksOfVertex{-1};
 
   int m_runNumber{-1};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Adding Silicon seed multiplicity to KF Particle. Non breaking change. Requires addition or presence of seed DST in data.
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Additional output branch for KF Particle trees. Non breaking change.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Add charged silicon seed multiplicity to KF Particle output trees for analyses that use Silicon seed DST data.

## Key changes

- Add `getNchargedSiSeedMultiplicity` to `KFParticle_Tools`.
- Select seeds by bunch crossing and minimum MVTX and INTT cluster counts.
- Add and fill the `nSiSeedMultiplicity` TTree branch.
- Return `-1` when `SiliconTrackSeedContainer` is missing.
- Print missing-container errors only when verbosity is enabled.

## Potential risk areas

- The new branch changes the KF Particle tree schema.
- Valid values require Silicon seed DST data.
- Downstream analyses must handle the `-1` sentinel.
- Seed iteration adds event-level processing cost.
- No reconstruction or thread-safety changes are expected.

## Possible future improvements

- Document the branch definition and sentinel value.
- Confirm whether the MVTX requirement is necessary in addition to the INTT requirement.
- Add tests for missing containers, bunch-crossing selection, and cluster thresholds.
- Validate reader compatibility and performance with representative events.

AI-generated summaries can contain errors. Review the implementation and output behavior before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->