### PR TITLE
fix: poly cluster cdb read

### DIFF
--- a/offline/packages/tpctrackreco/TpcCrossingFinder.cc
+++ b/offline/packages/tpctrackreco/TpcCrossingFinder.cc
@@ -7,6 +7,7 @@
 #include "TpcCrossingDecisionv1.h"
 #include "Tpc_FittingTools.h"
 
+#include <cdbobjects/CDBTTree.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <phool/PHCompositeNode.h>
@@ -134,7 +135,18 @@ int TpcCrossingFinder::InitRun(PHCompositeNode* topNode)
   }
 
   delete m_garfield;
-  const std::string electricFieldMap = CDBInterface::instance()->getUrl("Tpc_PolySeeding_Efield");
+  const std::string electricFieldMap = CDBInterface::instance()->getUrl("Tpc_PolySeeding_EField");
+
+  const auto kefffile = CDBInterface::instance()->getUrl("Tpc_PolyClusterizer_kEff");
+
+  if (!kefffile.empty())
+  {
+    auto keffcdbtree = std::make_unique<CDBTTree>(kefffile);
+    keffcdbtree->LoadCalibrations();
+    m_kEffSide0 = keffcdbtree->GetSingleFloatValue("keffside0");
+    m_kEffSide1 = keffcdbtree->GetSingleFloatValue("keffside1");
+ }
+
   m_garfield = new PHGarfield(Name() + "_PHGarfield", electricFieldMap, m_kEffSide0, m_kEffSide1);
   configure_garfield(m_garfield);
   if (m_garfield->InitRun(topNode) != Fun4AllReturnCodes::EVENT_OK)

--- a/offline/packages/tpctrackreco/TpcCrossingFinder.cc
+++ b/offline/packages/tpctrackreco/TpcCrossingFinder.cc
@@ -15,6 +15,10 @@
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
 
+#include <ffamodules/CDBInterface.h>
+
+#include <globalvertex/SvtxVertex.h>
+#include <globalvertex/SvtxVertexMap.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrClusterContainer.h>
@@ -22,8 +26,6 @@
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
-#include <globalvertex/SvtxVertex.h>
-#include <globalvertex/SvtxVertexMap.h>
 
 #include <phgarfield/PHGarfield.h>
 #include <TPolyLine3D.h>
@@ -132,7 +134,7 @@ int TpcCrossingFinder::InitRun(PHCompositeNode* topNode)
   }
 
   delete m_garfield;
-  const std::string electricFieldMap = "/sphenix/user/mitrankov/garf/include/sphenix_rossegger_garfield_field.root";
+  const std::string electricFieldMap = CDBInterface::instance()->getUrl("Tpc_PolySeeding_Efield");
   m_garfield = new PHGarfield(Name() + "_PHGarfield", electricFieldMap, m_kEffSide0, m_kEffSide1);
   configure_garfield(m_garfield);
   if (m_garfield->InitRun(topNode) != Fun4AllReturnCodes::EVENT_OK)

--- a/offline/packages/tpctrackreco/Tpc_ModuleTrackReco.cc
+++ b/offline/packages/tpctrackreco/Tpc_ModuleTrackReco.cc
@@ -1141,10 +1141,11 @@ int Tpc_ModuleTrackReco::process_event(PHCompositeNode* /*unused*/)
       }
     }
   }
-
+  if(Verbosity() > 1)
+  {
   std::cout << Name() << "::process_event - event " << m_event
             << " has " << tdata.size() << " non-empty modules" << std::endl;
-
+  }
   const unsigned int maxLive = std::max(1U,
                                         std::min(m_maxThreads, static_cast<unsigned int>(tdata.size())));
 

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
@@ -147,8 +147,8 @@ int Tpc_PolyClusterizer::InitRun(PHCompositeNode* topNode)
 
   delete m_garfield;
   // m_garfield = new PHGarfield(Name() + "_PHGarfield");
-
-  const std::string electricFieldMap = "/sphenix/user/mitrankov/garf/include/sphenix_rossegger_garfield_field.root";
+  const std::string electricFieldMap = CDBInterface::instance()->getUrl("Tpc_PolySeeding_EField");
+  
   // sphenix_3d_ibf_field_new.root sphenix_rossegger_garfield_field.root;
 
   const auto kefffile = CDBInterface::instance()->getUrl("Tpc_PolyClusterizer_kEff");

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
@@ -8,8 +8,10 @@
 #include "TpcCrossingDecision.h"
 #include "TpcCrossingDecisionContainer.h"
 
+#include <cdbobjects/CDBTTree.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 
+#include <ffamodules/CDBInterface.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
@@ -148,6 +150,20 @@ int Tpc_PolyClusterizer::InitRun(PHCompositeNode* topNode)
 
   const std::string electricFieldMap = "/sphenix/user/mitrankov/garf/include/sphenix_rossegger_garfield_field.root";
   // sphenix_3d_ibf_field_new.root sphenix_rossegger_garfield_field.root;
+
+  const auto kefffile = CDBInterface::instance()->getUrl("Tpc_PolyClusterizer_kEff");
+  
+  if (!kefffile.empty())
+  {
+    auto keffcdbtree = std::make_unique<CDBTTree>(kefffile);
+    keffcdbtree->LoadCalibrations();
+    m_kEffSide0 = keffcdbtree->GetSingleFloatValue("keffside0");
+    m_kEffSide1 = keffcdbtree->GetSingleFloatValue("keffside1");
+
+    std::cout << PHWHERE << "Poly clusterizer loading calibrations from " << kefffile << std::endl 
+              <<"    with values keffside0 = " << m_kEffSide0 << ", keffside1 = " << m_kEffSide1 << std::endl;
+  }
+
 
   m_garfield = new PHGarfield(Name() + "_PHGarfield", electricFieldMap, m_kEffSide0, m_kEffSide1);
   configure_garfield(m_garfield);


### PR DESCRIPTION
This PR modifies the poly clusterizer and associated code to
1. Lookup the electric field map from the cdb
2. Check to see if there are keff calibrations in the cdb for this particular run, and if not the values used in the header file (or set at the macro level) are still used

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

The poly clusterizer must use run-dependent conditions from the CDB. This change removes a hard-coded electric-field map path and supports CDB-based `keff` calibration.

## Key Changes

- Retrieve the Garfield electric-field map from `Tpc_PolySeeding_Efield`.
- Check for `keff` calibration data for the current run.
- Load `keffside0` and `keffside1` when the CDB entry exists.
- Retain configured header or macro values when no CDB calibration exists.
- Print the module-count diagnostic only when verbosity is greater than 1.

## Potential Risk Areas

- Incorrect or unavailable CDB entries can affect electric-field setup and cluster reconstruction.
- Changes to `keff` inputs can alter reconstructed track quantities.
- The new CDB reads add small initialization-time I/O overhead.
- No thread-safety or I/O format changes are apparent.

## Possible Future Improvements

- Add tests for valid, missing, and malformed CDB entries.
- Validate the electric-field map and `keff` values before reconstruction.
- Document the expected CDB keys and fallback behavior.

AI-generated summaries can contain mistakes. Review the implementation and run-dependent behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->