### PR TITLE
Fix for memory leakage in corrupted events for cosmic runs 

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -1277,6 +1277,11 @@ int SingleTriggeredInput::ReadEvent()
       [](const std::pair<int, int>& p)
       { return p.second == 0; });
 
+  bool all_packets_minusone = std::all_of(
+      m_PacketShiftOffset.begin(), m_PacketShiftOffset.end(),
+      [](const std::pair<int, int>& p)
+      { return p.second == -1; });
+
   std::set<Event*> events_to_delete;
   for (auto& [pid, dq] : m_PacketEventDeque)
   {
@@ -1367,7 +1372,7 @@ int SingleTriggeredInput::ReadEvent()
       newhit->Reset();
     }
 
-    if (all_packets_unshifted || m_PacketShiftOffset[pid] == 1)
+    if (all_packets_unshifted || all_packets_minusone || m_PacketShiftOffset[pid] == 1)
     {
       events_to_delete.insert(evt);
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Corrupted events during cosmic runs could remain allocated in `SingleTriggeredInput::ReadEvent`, causing memory leakage. This change improves event cleanup.

## Key Changes

- Compute `all_packets_minusone` when all packet shift offsets are `-1`.
- Delete the front event from the packet deque when this condition is true.
- Preserve existing deletion behavior for unshifted packets and `+1` shifts.
- No public or exported declarations changed.

## Potential Risk Areas

- No I/O format changes are expected.
- Event reconstruction behavior may change for corrupted cosmic-run events.
- The change adds negligible performance overhead.
- No thread-safety changes are expected.

## Possible Future Improvements

- Add regression tests for corrupted events with all packet shifts set to `-1`.
- Monitor memory usage during long cosmic runs.
- Verify event-deletion behavior across mixed packet shift offsets.

AI-generated summaries can contain errors. Contributors should verify the behavior against the implementation and relevant cosmic-run tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->