### PR TITLE
use std::move to save some memory

### DIFF
--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -117,5 +117,5 @@ void TpcRawHitv3::Clear(Option_t * /*unused*/)
 
 void TpcRawHitv3::move_adc_waveform(const uint16_t start_time, std::vector<uint16_t> &&adc)
 {
-  m_adcData.emplace_back(start_time, adc);
+  m_adcData.emplace_back(start_time, std::move(adc));
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
suggestion from codex to use std::move, 
m_adcData.emplace_back(start_time, std::move(adc));
instead of
m_adcData.emplace_back(start_time, adc);
which saves one copy. The memory growth is less with this change and valgrind is happy

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

This change reduces memory growth in `TpcRawHitv3::move_adc_waveform` by avoiding an unnecessary copy of ADC waveform data.

## Key changes

- Move `adc` into `m_adcData` with `std::move(adc)`.
- Preserve the existing data format and public interfaces.
- Valgrind validation reports reduced memory use.

## Potential risks

- No I/O format or reconstruction behavior changes are expected.
- The change should not affect thread safety.
- Performance should improve through lower copying overhead.
- Callers must not rely on `adc` retaining its contents after the move.

## Possible future improvements

- Add a regression test that verifies waveform contents after insertion.
- Measure memory and runtime improvements with representative events.

AI-generated summaries can contain errors. Contributors should verify these points against the implementation and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->