### PR TITLE
reset bits before the jet trigger emulator

### DIFF
--- a/offline/packages/trigger/CaloTriggerEmulator.cc
+++ b/offline/packages/trigger/CaloTriggerEmulator.cc
@@ -1891,6 +1891,7 @@ int CaloTriggerEmulator::process_trigger()
     // Make the jet primitives
     m_triggerid = TriggerDefs::TriggerId::jetTId;
     std::vector<unsigned int> *trig_bits = m_ll1out_jet->GetTriggerBits();
+    std::fill(bits.begin(), bits.end(), 0);
     std::vector<unsigned int> jet_map[32][9]{};
     for (auto &ie : jet_map)
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

The jet trigger emulator could include stale PHOTON trigger bits in its output. This change resets the bits before jet trigger processing so the JET result is computed independently.

## Key changes

- Added `std::fill(bits.begin(), bits.end(), 0)` before accumulating JET trigger bits in `CaloTriggerEmulator::process_trigger`.
- Prevented PHOTON trigger bits from propagating into `m_ll1out_jet`.

## Potential risk areas

- No I/O format or public interface changes.
- Reconstruction behavior changes for affected JET trigger bits.
- Negligible performance impact from resetting the vector.
- No apparent thread-safety impact.

## Possible future improvements

- Add a regression test that verifies JET bits do not contain PHOTON bits.
- Review similar per-trigger bit accumulation for stale-state risks.

AI-generated summaries can contain mistakes. Contributors should verify the behavior against the implementation and relevant trigger tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->