### PR TITLE
CaloTowerStatus: Flag non-finite chi2 as badChi2

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -229,7 +229,7 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
         m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
       }
     }
-    if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
+    if (!std::isfinite(chi2) || chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
     }


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add a check for `!std::isfinite(chi2)` when evaluating tower chi2 status so that NaN or Inf values are properly flagged as badChi2.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Non-finite `chi2` values can indicate invalid tower reconstruction results. This change flags `NaN` and infinite values as `badChi2`.

## Key changes

- Updated `CaloTowerStatus::process_event`.
- Added `!std::isfinite(chi2)` to the `badChi2` condition.
- Preserved the existing threshold-based checks.
- Made no public or exported declaration changes.

## Potential risk areas

- No I/O format changes.
- Reconstruction behavior changes for towers with non-finite `chi2`.
- Negligible performance impact from the finite-value check.
- No expected thread-safety impact.

## Possible future improvements

- Add focused tests for `NaN`, positive infinity, and negative infinity.
- Review other reconstruction status checks for similar non-finite values.
- Confirm that downstream monitoring reports these towers clearly.

AI-generated summaries can contain mistakes. Contributors should verify the code and test behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->