### PR TITLE
Revert "CaloTowerStatus: Flag non-finite chi2 as badChi2"

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -229,7 +229,7 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
         m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
       }
     }
-    if (!std::isfinite(chi2) || chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
+    if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
     }


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/coresoftware#4408

Revert "CaloTowerStatus: Flag non-finite chi2 as badChi2"
Revert the `!std::isfinite(chi2)` check in `CaloTowerStatus`. Unconditionally tagging non-finite chi2 as `badChi2` erroneously flags **all normal zero-suppressed towers** (which have chi2 = NaN by default) as bad, causing them to fail `get_isGood()` downstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

This change reverts the non-finite `chi2` check from PR `#4408`. Non-finite `chi2` values are the default for normal zero-suppressed towers. Marking these towers as `badChi2` causes downstream `get_isGood()` failures.

## Key changes

- Remove the `!std::isfinite(chi2)` condition in `CaloTowerStatus::process_event`.
- Mark towers as bad only when `chi2` exceeds the calculated threshold.
- No public or exported declarations changed.

## Potential risk areas

- Reconstruction behavior changes for towers with non-finite `chi2`.
- No IO format, thread-safety, or performance changes are expected.
- Downstream code must continue to handle non-finite `chi2` values correctly.

## Possible future improvements

- Document the expected `chi2` value for zero-suppressed towers.
- Add regression tests for non-finite `chi2` values and `get_isGood()` behavior.
- Review downstream handling of non-finite `chi2` values.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation and detector reconstruction requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->