### PR TITLE
Revert "CaloTowerStatus: Flag non-finite chi2 as badChi2"

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -229,7 +229,7 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
         m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
       }
     }
-    if (!std::isfinite(chi2) || chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
+    if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic), badChi2_treshold_max))
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
     }


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/coresoftware#4408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

This change reverts the behavior introduced by “CaloTowerStatus: Flag non-finite chi2 as badChi2.” Non-finite `chi2` values are no longer automatically classified as bad.

## Key changes

- Updated `CaloTowerStatus::process_event`.
- `isBadChi2` now depends only on the configured `chi2` threshold.
- No public declarations or I/O formats changed.

## Potential risk areas

- Reconstruction behavior changes for towers with non-finite `chi2`.
- No expected thread-safety or performance impact.
- Downstream users may receive different `isBadChi2` flags for invalid `chi2` values.

## Possible future improvements

- Define and document the intended handling of non-finite `chi2` values.
- Add focused tests for NaN, infinity, and threshold-boundary cases.

AI-generated summaries can contain mistakes. Contributors should verify this interpretation against the implementation and expected reconstruction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->