### PR TITLE
add all channel case for O+O centralityreco

### DIFF
--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -204,13 +204,16 @@ int CentralityReco::FillVars()
   {
     m_mbd_hit = m_mbd_container->get_pmt(i);
 
-    if ((m_mbd_hit->get_q()) < mbd_charge_cut)
+    if (!m_sum_all_channels)
     {
-      continue;
-    }
-    if (fabs(m_mbd_hit->get_time()) > mbd_time_cut)
-    {
-      continue;
+      if ((m_mbd_hit->get_q()) < mbd_charge_cut)
+      {
+        continue;
+      }
+      if (fabs(m_mbd_hit->get_time()) > mbd_time_cut)
+      {
+        continue;
+      }
     }
     m_mbd_total_charge += m_mbd_hit->get_q() * scale_factor * m_centrality_scale;
   }

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -38,6 +38,9 @@ class CentralityReco : public SubsysReco
   int process_event(PHCompositeNode *) override;
   int ResetEvent(PHCompositeNode *) override;
 
+  //! for no q/t cut case (O+O) 
+  void set_sum_all_channels(bool b) { m_sum_all_channels = b; }
+
   // Interface with CDB
   int Download_centralityDivisions(const std::string &dbfile);
   int Download_centralityScale(const std::string &dbfile);
@@ -85,8 +88,9 @@ class CentralityReco : public SubsysReco
 
   static constexpr int NDIVS{100};
 
-  static constexpr float mbd_charge_cut{0.5};
-  static constexpr float mbd_time_cut{25};
+  bool m_sum_all_channels{false};
+  static constexpr float mbd_charge_cut{0.4};
+  static constexpr float mbd_time_cut{20};
 
   unsigned int m_key{std::numeric_limits<unsigned int>::max()};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Add support for all-channel O+O centrality reconstruction.

## Key Changes

- Added `set_sum_all_channels(bool)` and the `m_sum_all_channels` flag.
- When enabled, `FillVars()` uses charge from all MBD PMT channels.
- When enabled, per-channel charge and timing rejection is skipped.
- Updated MBD charge and timing cuts from `0.5` to `0.4` and from `25` to `20`.

## Potential Risk Areas

- Reconstruction behavior changes for all-channel and standard modes.
- Centrality calibration consistency requires validation.
- No I/O format or thread-safety changes are indicated.
- Performance may increase slightly when processing all channels.

## Possible Future Improvements

- Add regression tests for all-channel and per-channel reconstruction.
- Document the calibration and physics motivation for the updated cuts.
- Validate results against reference O+O data and centrality distributions.

AI-generated summaries can contain errors. Review the implementation and validate the physics results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->