### PR TITLE
RetowerCEMC: Add optional masking for negative energy towers

### DIFF
--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -144,7 +144,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         unsigned int towerindex = emcal_retower->decode_key(towerkey);
         TowerInfo *towerinfo = emcal_retower->get_tower_at_channel(towerindex);
         double scalefactor = retower_badarea / retower_totalarea[ieta_ihcal];
-        if (scalefactor > _frac_cut)
+        if (scalefactor >= 1.0 || scalefactor > _frac_cut)
         {
           towerinfo->set_energy(0);
           towerinfo->set_isHot(true);

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -84,9 +84,15 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
       unsigned int channelkey = towerinfosEM3->encode_key(channel);
       int ieta = towerinfosEM3->getTowerEtaBin(channelkey);
       int iphi = towerinfosEM3->getTowerPhiBin(channelkey);
-      rawtower_e[ieta][iphi] = tower->get_energy();
+      double energy = tower->get_energy();
+      rawtower_e[ieta][iphi] = energy;
       rawtower_time[ieta][iphi] = tower->get_time();
-      rawtower_status[ieta][iphi] = !tower->get_isGood();
+      bool is_bad = !tower->get_isGood();
+      if (_mask_zero_suppressed && tower->get_isZS() && energy < _zero_suppressed_threshold)
+      {
+        is_bad = true;
+      }
+      rawtower_status[ieta][iphi] = is_bad;
     }
     EMRetowerName = m_towerNodePrefix + "_CEMC_RETOWER";
     TowerInfoContainer *emcal_retower = findNode::getClass<TowerInfoContainer>(topNode, EMRetowerName);

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -88,7 +88,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
       rawtower_e[ieta][iphi] = energy;
       rawtower_time[ieta][iphi] = tower->get_time();
       bool is_bad = !tower->get_isGood();
-      if (_mask_zero_suppressed && tower->get_isZS() && energy < _zero_suppressed_threshold)
+      if (_mask_negative_energy && energy < _negative_energy_threshold)
       {
         is_bad = true;
       }

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -25,6 +25,8 @@ class RetowerCEMC : public SubsysReco
     m_towerNodePrefix = prefix;
     return;
   }
+  void set_mask_zero_suppressed(bool b) { _mask_zero_suppressed = b; }
+  void set_zero_suppressed_threshold(double t) { _zero_suppressed_threshold = t; }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
@@ -37,6 +39,8 @@ class RetowerCEMC : public SubsysReco
   bool _do_rescale{false};
   bool m_use_towerinfo{false};
   std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
+  bool _mask_zero_suppressed{false};
+  double _zero_suppressed_threshold{-2.0}; /*GeV*/
 
   static const int neta_ihcal{24};
   static const int neta_emcal{96};

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -25,8 +25,8 @@ class RetowerCEMC : public SubsysReco
     m_towerNodePrefix = prefix;
     return;
   }
-  void set_mask_zero_suppressed(bool b) { _mask_zero_suppressed = b; }
-  void set_zero_suppressed_threshold(double t) { _zero_suppressed_threshold = t; }
+  void set_mask_negative_energy(bool b) { _mask_negative_energy = b; }
+  void set_negative_energy_threshold(double t) { _negative_energy_threshold = t; }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
@@ -39,8 +39,8 @@ class RetowerCEMC : public SubsysReco
   bool _do_rescale{false};
   bool m_use_towerinfo{false};
   std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
-  bool _mask_zero_suppressed{false};
-  double _zero_suppressed_threshold{-2.0}; /*GeV*/
+  bool _mask_negative_energy{false};
+  double _negative_energy_threshold{-2.0}; /*GeV*/
 
   static const int neta_ihcal{24};
   static const int neta_emcal{96};


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add a backward-compatible feature to optionally mask large negative energy EMCal towers if their energy falls below a specified threshold. Introduced two new setters to `RetowerCEMC` to configure the masking:
- `set_mask_negative_energy(bool)` (default: false)
- `set_negative_energy_threshold(double)` (default: -2.0 GeV)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This change adds optional masking for negative energy EMCal towers during retowering. The default behavior remains unchanged.

## Key Changes

- Added `set_mask_negative_energy(bool)`.
- Added `set_negative_energy_threshold(double)`.
- Marked negative energy towers as bad when masking is enabled and energy is below the threshold.
- Set defaults to disabled masking and `-2.0 GeV`.

## Potential Risk Areas

- Reconstruction behavior changes when the option is enabled.
- No I/O format changes are expected.
- No new thread-safety concerns are apparent.
- The performance impact should be negligible.

## Possible Future Improvements

- Add focused tests for threshold boundaries and masking behavior.
- Document the configuration in user-facing retowering guidance.
- Monitor reconstruction effects in representative datasets.

This summary is based on AI-generated change descriptions. AI can make mistakes, so contributors should verify the implementation and physics behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->