### PR TITLE
CaloTowerCalib: Flag Negative Energy Towers

### DIFF
--- a/offline/packages/CaloReco/CaloTowerCalib.cc
+++ b/offline/packages/CaloReco/CaloTowerCalib.cc
@@ -89,16 +89,21 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
     m_DETECTOR = TowerInfoContainer::SEPD;
   }
 
+  m_apply_neg_energy_threshold = m_doNegEnergyThreshold &&
+                                 (m_dettype == CaloTowerDefs::CEMC ||
+                                  m_dettype == CaloTowerDefs::HCALIN ||
+                                  m_dettype == CaloTowerDefs::HCALOUT);
+
   ///////////////////////////////////////
   // energy calibration getting from CDB
-  std::string default_time_independent_calib = m_detector+"_calib_ADC_to_ETower_default"; 
+  std::string default_time_independent_calib = m_detector+"_calib_ADC_to_ETower_default";
   if (!m_overrideCalibName)
   {
     m_calibName = m_detector+"_calib_ADC_to_ETower";
   }
   if (!m_overrideFieldName)
   {
-    m_fieldname = m_detector+"_calib_ADC_to_ETower"; 
+    m_fieldname = m_detector+"_calib_ADC_to_ETower";
   }
 
   if (m_giveDirectURL)
@@ -175,14 +180,14 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
   m_calibName_ZScrosscalib = m_detector + "_ZSCrossCalib";
   m_fieldname_ZScrosscalib = "ratio";
 
-  if (m_doZScrosscalib) 
-  { 
+  if (m_doZScrosscalib)
+  {
     if (m_giveDirectURL_ZScrosscalib)
     {
       calibdir = m_directURL_ZScrosscalib;
       std::cout << "CaloTowerCalib::InitRun: Using setted url " << calibdir << std::endl;
       cdbttree_ZScrosscalib = new CDBTTree(calibdir);
-    } 
+    }
     else
     {
       calibdir = CDBInterface::instance()->getUrl(m_calibName_ZScrosscalib);
@@ -208,7 +213,7 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
         }
       }
     }
-  } 
+  }
 
   PHNodeIterator iter(topNode);
 
@@ -272,28 +277,36 @@ int CaloTowerCalib::process_event(PHCompositeNode *topNode)
   for (unsigned int channel = 0; channel < ntowers; channel++)
   {
     TowerInfo *caloinfo_raw = _raw_towers->get_tower_at_channel(channel);
-    _calib_towers->get_tower_at_channel(channel)->copy_tower(caloinfo_raw);
+    TowerInfo *calib_tower = _calib_towers->get_tower_at_channel(channel);
+    calib_tower->copy_tower(caloinfo_raw);
     float raw_amplitude = caloinfo_raw->get_energy();
     float calibconst = m_cdbInfo_vec[channel].calibconst;
     bool isZS = caloinfo_raw->get_isZS();
 
+    float calib_energy = 0.0F;
     if (isZS && m_doZScrosscalib)
     {
       float crosscalibconst = m_cdbInfo_vec[channel].crosscalibconst;
-      if (crosscalibconst == 0) 
-      { 
-        crosscalibconst = 1; 
+      if (crosscalibconst == 0)
+      {
+        crosscalibconst = 1;
       }
-      _calib_towers->get_tower_at_channel(channel)->set_energy(raw_amplitude * calibconst * crosscalibconst);
+      calib_energy = raw_amplitude * calibconst * crosscalibconst;
     }
     else
     {
-      _calib_towers->get_tower_at_channel(channel)->set_energy(raw_amplitude * calibconst);
+      calib_energy = raw_amplitude * calibconst;
     }
-   
+    calib_tower->set_energy(calib_energy);
+
+    if (m_apply_neg_energy_threshold && calib_energy < m_negEnergyThreshold)
+    {
+      calib_tower->set_isBadChi2(true);
+    }
+
     if (calibconst == 0)
     {
-      _calib_towers->get_tower_at_channel(channel)->set_isNoCalib(true);
+      calib_tower->set_isNoCalib(true);
     }
     if(m_dotimecalib)
     {
@@ -303,7 +316,7 @@ int CaloTowerCalib::process_event(PHCompositeNode *topNode)
       //I realized that there is no point to do timing calibration for the towerinfov1 object since the resolution is not enough...
       float raw_time = caloinfo_raw->get_time();
       float meantime = m_cdbInfo_vec[channel].meantime;
-      _calib_towers->get_tower_at_channel(channel)->set_time(raw_time - meantime);
+      calib_tower->set_time(raw_time - meantime);
       }
     }
   }

--- a/offline/packages/CaloReco/CaloTowerCalib.h
+++ b/offline/packages/CaloReco/CaloTowerCalib.h
@@ -9,6 +9,7 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <cmath>
 #include <iostream>
 #include <string>
 
@@ -85,7 +86,7 @@ class CaloTowerCalib : public SubsysReco
 
   void set_doCalibOnly(bool docalib = true)
   {
-    if (docalib) 
+    if (docalib)
     {
       m_dotimecalib = false;
       m_doZScrosscalib = false;
@@ -119,6 +120,24 @@ class CaloTowerCalib : public SubsysReco
   }
 
   void set_use_TowerInfov2(bool use) { m_use_TowerInfov2 = use; }
+
+  void set_negEnergyThreshold(bool do_threshold, float threshold = NAN)
+  {
+    m_doNegEnergyThreshold = do_threshold;
+    if (!std::isnan(threshold))
+    {
+      m_negEnergyThreshold = threshold;
+    }
+  }
+
+  void set_negEnergyThreshold(float threshold)
+  {
+    m_doNegEnergyThreshold = true;
+    m_negEnergyThreshold = threshold;
+  }
+
+  float get_negEnergyThreshold() const { return m_negEnergyThreshold; }
+  bool get_doNegEnergyThreshold() const { return m_doNegEnergyThreshold; }
 
  private:
   CaloTowerDefs::DetectorSystem m_dettype;
@@ -154,6 +173,10 @@ class CaloTowerCalib : public SubsysReco
   bool m_doAbortNoEnergyCalib{false};
   bool m_doAbortNoTimeCalib{false};
   bool m_doAbortNoZSCalib{false};
+
+  bool m_doNegEnergyThreshold{true};
+  float m_negEnergyThreshold{-2.0F}; /*GeV*/
+  bool m_apply_neg_energy_threshold{false};
 
   CDBTTree *cdbttree = nullptr;
   CDBTTree *cdbttree_time = nullptr;

--- a/offline/packages/CaloReco/CaloTowerCalib.h
+++ b/offline/packages/CaloReco/CaloTowerCalib.h
@@ -9,7 +9,6 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <cmath>
 #include <iostream>
 #include <string>
 
@@ -121,18 +120,13 @@ class CaloTowerCalib : public SubsysReco
 
   void set_use_TowerInfov2(bool use) { m_use_TowerInfov2 = use; }
 
-  void set_negEnergyThreshold(bool do_threshold, float threshold = NAN)
+  void set_doNegEnergyThreshold(bool do_threshold)
   {
     m_doNegEnergyThreshold = do_threshold;
-    if (!std::isnan(threshold))
-    {
-      m_negEnergyThreshold = threshold;
-    }
   }
 
   void set_negEnergyThreshold(float threshold)
   {
-    m_doNegEnergyThreshold = true;
     m_negEnergyThreshold = threshold;
   }
 


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Flag towers below negative energy threshold as `badChi2`. Towers with severe negative reconstructed energy (e.g., from uncalibrated channels, pedestal fluctuations, or waveform fitting artifacts) can distort downstream clustering and jet reconstruction. This adds a negative energy threshold check to flag such towers with `isBadChi2`. Key changes:
- Flag towers where calibrated energy is below a configurable threshold as badChi2 (`set_isBadChi2(true)`).
- By default, the threshold is enabled and set to **-2.0 GeV**.
- Apply threshold checking exclusively to EMCal and HCal detectors (CEMC, HCALIN, HCALOUT).
- Add setter/getter methods to CaloTowerCalib:
    - `set_doNegEnergyThreshold(bool do_threshold)`: Allows to enable / disable negative energy threshold.
    - `set_negEnergyThreshold(float threshold)`: Set the threshold directly.
    - `get_negEnergyThreshold()` and `get_doNegEnergyThreshold()` getters.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Flag EMCal and HCal towers with calibrated energy below a configurable negative threshold. The default threshold is `-2.0 GeV`. This identifies problematic towers through `badChi2`.

## Key changes

- Added methods to enable or disable negative-energy thresholding.
- Added methods to set and retrieve the threshold.
- Removed the ambiguous setter overload.
- Applied the check to CEMC, HCALIN, and HCALOUT towers.
- Marked towers as bad with `set_isBadChi2()` when calibrated energy is below the threshold.
- Reused the calibrated tower pointer during event processing.

## Potential risk areas

- The default setting changes reconstruction behavior for towers below `-2.0 GeV`.
- No I/O format changes are indicated.
- The implementation adds one per-tower comparison. No material performance impact is expected.
- No new thread-safety concerns are apparent.

## Possible future improvements

- Add tests for configuration, detector selection, and threshold boundaries.
- Monitor the number of towers marked with `badChi2`.
- Document the threshold choice and its physics impact.

AI-generated summaries can contain mistakes. Contributors should verify the implementation and physics behavior against the source code and collaboration conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->