### PR TITLE
fix crash in SingleTriggeredInput dtor

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -577,6 +577,10 @@ int SingleTriggeredInput::FillEventVector()
         continue;
       }
       FillPacketClock(thisevt, pkt, i);
+      if (m_PacketShiftOffset[pid] == 1 && i == 0)
+      {
+	m_PacketEventBackup.erase(pid); // erase stale pointer which crashes the dtor
+      }
       m_PacketEventDeque[pid].push_back(thisevt);
 
       delete pkt;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The dtor tried to delete a stale event pointer under certain conditions. The crash itself was hit or miss, valgrind would have picked it up though. This PR erases the stale pointer from the m_PacketEventBackup map.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Fix a crash in the `SingleTriggeredInput` destructor. Under specific packet-processing conditions, the destructor could attempt to delete a stale event pointer.

## Key Changes

- Erase the stale `m_PacketEventBackup` entry when a packet has shift offset `1` and is processed at pool index `0`.
- Prevent the stale pointer from reaching destructor cleanup.
- Preserve existing interfaces and data formats.

## Potential Risk Areas

- No I/O format changes are expected.
- No reconstruction behavior changes are expected.
- No thread-safety or performance impact is expected beyond the map erase operation.
- The change affects event-backup lifetime management and should be checked against packet processing and shutdown tests.

## Possible Future Improvements

- Add a regression test for shift offset `1` at pool index `0`.
- Add destructor and event-ownership checks for stale backup entries.

AI-generated summaries can contain errors. Please verify these points against the implementation and relevant tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->