### PR TITLE
TTree cachesize

### DIFF
--- a/offline/framework/fun4all/Fun4AllMemoryHistograms.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryHistograms.cc
@@ -1,0 +1,102 @@
+#include "Fun4AllMemoryHistograms.h"
+
+#include "Fun4AllHistoManager.h"
+#include "Fun4AllUtils.h"
+
+#include <TH1.h>
+#include <TSystem.h>
+
+#include <iostream>
+#include <utility>  // for pair, make_pair
+
+Fun4AllMemoryHistograms *Fun4AllMemoryHistograms::mInstance {nullptr};
+
+Fun4AllMemoryHistograms::Fun4AllMemoryHistograms()
+  : Fun4AllBase("Fun4AllMemoryHistograms")
+{
+}
+
+void Fun4AllMemoryHistograms::FillHistos()
+{
+  if (! m_Enabled)
+  {
+    return;
+  }
+  if (! m_HistosCreated)
+  {
+    CreateHistos();
+  }
+
+  Fun4AllUtils::memoryvals mymem;
+  Fun4AllUtils::GetMemory(mymem);
+  if (m_EventCount >= m_NumChannels)
+  {
+    increase_TH1_channelcount();
+  }
+  int EventCountPlus1 = m_EventCount+1; // histos start at channel 1 ....
+  m_histovector[0]->SetBinContent(EventCountPlus1,mymem.arena);
+  m_histovector[1]->SetBinContent(EventCountPlus1,mymem.uordblks);
+  m_histovector[2]->SetBinContent(EventCountPlus1,mymem.fordblks);
+  m_histovector[3]->SetBinContent(EventCountPlus1,mymem.hblkhd);
+  m_histovector[4]->SetBinContent(EventCountPlus1,mymem.VmHWM);
+  m_histovector[5]->SetBinContent(EventCountPlus1,mymem.VmRSS);
+  m_EventCount++;
+}
+
+void Fun4AllMemoryHistograms::SaveHistos(const std::string &fname)
+{
+  if (! m_Enabled)
+  {
+    return;
+  }
+  Fun4AllHistoManager *hm = new Fun4AllHistoManager("MEMHISTOS");
+  for (auto iter : m_histovector)
+  {
+    hm->registerHisto(iter);
+  }
+  hm->dumpHistos(fname);
+  return;
+}
+
+void Fun4AllMemoryHistograms::increase_TH1_channelcount()
+{
+  m_NumChannels += 10000;
+  float m_Range = m_NumChannels + 0.5;
+  for (TH1* histo : m_histovector)
+  {
+    const int old_nbins = histo->GetNbinsX();
+    std::vector<double> old_content(old_nbins + 2);
+// TH1::SetBins wipes the content, so we need to save it
+    for (int bin = 0; bin <= old_nbins + 1; ++bin)
+    {
+      old_content[bin] = histo->GetBinContent(bin);
+    }
+
+    histo->SetBins(m_NumChannels, 0.5, m_Range);  // set number of bins which wipes the old histo content
+
+// and then restore it
+    for (int bin = 0; bin <= old_nbins + 1; ++bin)
+    {
+      histo->SetBinContent(bin, old_content[bin]);
+    }
+  }
+  return;
+}
+
+void Fun4AllMemoryHistograms::CreateHistos()
+{
+  float m_Range = m_NumChannels + 0.5;
+  TH1 *arena = new TH1D("arena","arena size",m_NumChannels,0.5,m_Range);
+  m_histovector.push_back(arena);
+  TH1 *uordblks = new TH1D("uordblks","uordblks size",m_NumChannels,0.5,m_Range);
+  m_histovector.push_back(uordblks);
+  TH1 *fordblks = new TH1D("fordblks","fordblks size",m_NumChannels,0.5,m_Range);
+  m_histovector.push_back(fordblks);
+  TH1 *hblkhd = new TH1D("hblkhd","hblkhd size",m_NumChannels,0.5,m_Range);
+  m_histovector.push_back(hblkhd);
+  TH1 *VmHWM = new TH1D("VmHWM","VmHWM size",m_NumChannels,0.5,m_Range);
+  m_histovector.push_back(VmHWM);
+  TH1 *VmRSS = new TH1D("VmRSS","VmRSS size",m_NumChannels,0.5,m_Range);
+  m_histovector.push_back(VmRSS);
+  m_HistosCreated = true;
+}

--- a/offline/framework/fun4all/Fun4AllMemoryHistograms.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryHistograms.cc
@@ -50,7 +50,7 @@ void Fun4AllMemoryHistograms::SaveHistos(const std::string &fname)
     return;
   }
   Fun4AllHistoManager *hm = new Fun4AllHistoManager("MEMHISTOS");
-  for (auto iter : m_histovector)
+  for (auto *iter : m_histovector)
   {
     hm->registerHisto(iter);
   }

--- a/offline/framework/fun4all/Fun4AllMemoryHistograms.h
+++ b/offline/framework/fun4all/Fun4AllMemoryHistograms.h
@@ -1,0 +1,43 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FUN4ALL_FUN4ALLMEMORYHISTOGRAMS_H
+#define FUN4ALL_FUN4ALLMEMORYHISTOGRAMS_H
+
+#include "Fun4AllBase.h"
+
+
+#include <map>
+#include <string>
+#include <vector>
+
+class TH1;
+
+class Fun4AllMemoryHistograms : public Fun4AllBase
+{
+ public:
+  static Fun4AllMemoryHistograms *instance()
+  {
+    if (mInstance) return mInstance;
+    mInstance = new Fun4AllMemoryHistograms();
+    return mInstance;
+  }
+  ~Fun4AllMemoryHistograms() override = default;
+  void Enable() {m_Enabled = true;}
+  void CreateHistos();
+  void FillHistos();
+  void SaveHistos(const std::string &fname);
+  void increase_TH1_channelcount();
+  
+ private:
+  Fun4AllMemoryHistograms();
+  static Fun4AllMemoryHistograms *mInstance;
+  
+  int m_EventCount {0};
+  int m_NumChannels {10000};
+  bool m_Enabled {false};
+  bool m_HistosCreated {false};
+
+  std::vector<TH1 *> m_histovector;
+};
+
+#endif

--- a/offline/framework/fun4all/Fun4AllUtils.cc
+++ b/offline/framework/fun4all/Fun4AllUtils.cc
@@ -3,7 +3,9 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
 
+#include <malloc.h>
 #include <algorithm>  // for max
+#include <fstream>
 #include <iostream>
 #include <vector>
 
@@ -58,4 +60,46 @@ Fun4AllUtils::GetRunSegment(const std::string& filename)
     std::cout << "returning " << runnumber << " as run number" << std::endl;
   }
   return std::make_pair(runnumber, segment);
+}
+
+void Fun4AllUtils::GetMemory(memoryvals& ret)
+{
+  const struct mallinfo2 m = mallinfo2();
+  ret.arena = m.arena;
+  ret.uordblks = m.uordblks;
+  ret.fordblks = m.fordblks;
+  ret.hblkhd = m.hblkhd;
+  std::ifstream status("/proc/self/status");
+  std::string line;
+  static uint64_t save_VmHWM = 0;
+  while (std::getline(status, line))
+  {
+    if (line.rfind("VmRSS:", 0) == 0)
+    {
+      std::istringstream fields(line);
+      std::string label;
+      uint64_t kib = 0;
+      std::string unit;
+
+      fields >> label >> kib >> unit;
+      ret.VmRSS = kib;
+    }
+    else if (line.rfind("VmHWM:", 0) == 0)
+    {
+      std::istringstream fields(line);
+      std::string label;
+      uint64_t kib = 0;
+      std::string unit;
+
+      fields >> label >> kib >> unit;
+      ret.VmHWM = kib;
+      if (save_VmHWM > kib)
+      {
+        std::cout << "VmHWM has decreased from " << save_VmHWM << " to " << kib
+                  << std::endl;
+        std::cout << "line: " << line << std::endl;
+      }
+      save_VmHWM = kib;
+    }
+  }
 }

--- a/offline/framework/fun4all/Fun4AllUtils.h
+++ b/offline/framework/fun4all/Fun4AllUtils.h
@@ -3,12 +3,24 @@
 #ifndef FUN4ALL_FUN4ALLUTILS_H
 #define FUN4ALL_FUN4ALLUTILS_H
 
+#include <cstdint>
 #include <string>
 #include <utility>  // for pair
 
 namespace Fun4AllUtils
 {
+  struct memoryvals
+  {
+    uint64_t arena{0};
+    uint64_t uordblks{0};
+    uint64_t fordblks{0};
+    uint64_t hblkhd{0};
+    uint64_t VmHWM{0};
+    uint64_t VmRSS{0};
+  };
+
   std::pair<int, int> GetRunSegment(const std::string &filename);
-}
+  void GetMemory(memoryvals &ret);
+}  // namespace Fun4AllUtils
 
 #endif

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -19,6 +19,7 @@ pkginclude_HEADERS = \
   Fun4AllHistoBinDefs.h \
   Fun4AllHistoManager.h \
   Fun4AllInputManager.h \
+  Fun4AllMemoryHistograms.h \
   Fun4AllMemoryTracker.h \
   Fun4AllMonitoring.h \
   Fun4AllNoSyncDstInputManager.h \
@@ -53,6 +54,7 @@ libfun4all_la_SOURCES = \
   Fun4AllHistoManager.cc \
   Fun4AllInputManager.cc \
   Fun4AllMonitoring.cc \
+  Fun4AllMemoryHistograms.cc \
   Fun4AllMemoryTracker.cc \
   Fun4AllNoSyncDstInputManager.cc \
   Fun4AllOutputManager.cc \

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -99,6 +99,7 @@ bool PHNodeIOManager::setFile(const std::string& f, const std::string& title,
     }
     file->SetCompressionSettings(m_CompressionSetting);
     tree = new TTree(TreeName.c_str(), title.c_str());
+    tree->SetMaxVirtualSize(0);
     TTree::SetMaxTreeSize(900000000000LL);  // set max size to ~900 GB
     gROOT->cd(currdir.c_str());
     return true;
@@ -378,6 +379,10 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   {
     tree->SetCacheSize(m_TTreeCacheSize);
   }
+// avoids retaining old, already-read decompressed basket buffers
+// since we only read forward, keeping old buffers would not help us in any way
+  tree->SetMaxVirtualSize(0);
+
   // ROOT sucks, we need a unique name for the tree so we can open multiple
   // files. So we take the memory location of the file pointer which
   // should be unique within this process to create it

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -68,7 +68,7 @@ private:
   TFile *file{nullptr};
   TTree *tree{nullptr};
   std::string TreeName{"T"};
-  int64_t m_TTreeCacheSize {-1};
+  int64_t m_TTreeCacheSize {0};
   int accessMode{PHReadOnly};
   int m_CompressionSetting{505};  // ZSTD
   int isFunctionalFlag{0};        // flag to tell if that object initialized properly


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR sets the default for the TTree cache size to zero - disabling it - which leads to significant memory savings. Also setting tree->SetMaxVirtualSize(0); (for input ttrees) which discards old buffers instead of retaining them. It has a negative effect when used for our output ttrees but for our input it reduces the rss by a bit

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Reduce resident memory use during input `TTree` processing by disabling cache retention and releasing previously read buffers.

## Key changes

- Set the default `TTree` cache size to zero.
- Set `TTree` maximum virtual size to zero for relevant input and output trees.
- Add `Fun4AllUtils::GetMemory()` to collect allocator and process memory statistics.
- Add `Fun4AllMemoryHistograms` to record and save six memory metrics.
- Integrate the new memory histogram class into the `fun4all` build.

## Potential risks

- Disabled caching can reduce I/O performance.
- The virtual-size setting can reduce output-tree performance.
- Input reconstruction now discards previously read decompressed buffers.
- The singleton and ROOT histograms require thread-safety review.
- Memory statistics depend on `mallinfo2()` and Linux `/proc/self/status`.

## Possible future improvements

- Apply separate memory settings to input and output trees.
- Benchmark resident memory and I/O performance.
- Add tests for memory collection and histogram growth.
- Define thread-safety requirements for histogram filling.

AI-generated summaries can contain mistakes. Verify these points against the implementation and workflow requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->