### PR TITLE
g4tpc: add optional path-length primary-ionization cluster model

### DIFF
--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -41,6 +41,9 @@ pkginclude_HEADERS = \
   PHG4TpcPadPlaneReadout.h \
   PHG4TpcSubsystem.h
 
+noinst_HEADERS = \
+  TpcPrimaryIonizationModel.h
+
 libg4tpc_la_SOURCES = \
   PHG4TpcCentralMembrane.cc \
   TpcClusterBuilder.cc \
@@ -58,7 +61,8 @@ libg4tpc_la_SOURCES = \
   PHG4TpcPadPlane.cc \
   PHG4TpcPadPlaneReadout.cc \
   PHG4TpcSteppingAction.cc \
-  PHG4TpcSubsystem.cc
+  PHG4TpcSubsystem.cc \
+  TpcPrimaryIonizationModel.cc
 
 ################################################
 # linking tests

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -5,6 +5,7 @@
 #include "PHG4TpcDistortion.h"
 #include "PHG4TpcPadPlane.h"  // for PHG4TpcPadPlane
 #include "TpcClusterBuilder.h"
+#include "TpcPrimaryIonizationModel.h"
 
 #include <trackbase/ClusHitsVerbosev1.h>
 #include <trackbase/TpcDefs.h>
@@ -63,6 +64,7 @@
 #include <cassert>
 #include <cmath>    // for sqrt, abs, NAN
 #include <cstdlib>  // for exit
+#include <exception>
 #include <format>
 #include <iostream>
 #include <map>      // for _Rb_tree_cons...
@@ -87,6 +89,8 @@ PHG4TpcElectronDrift::PHG4TpcElectronDrift(const std::string &name)
   RandomGenerator.reset(gsl_rng_alloc(gsl_rng_mt19937));
   set_seed(PHRandomSeed());
 }
+
+PHG4TpcElectronDrift::~PHG4TpcElectronDrift() = default;
 
 //_____________________________________________________________
 int PHG4TpcElectronDrift::Init(PHCompositeNode *topNode)
@@ -281,6 +285,51 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   double isobutane_dEdx = 5.93;   // keV/cm
   double isobutane_NTotal = 195;  // Number/cm
   double isobutane_frac = tpcparam->get_double_param("isobutane_frac");
+
+  m_use_primary_cluster_ionization =
+      tpcparam->exist_int_param("use_primary_cluster_ionization") &&
+      tpcparam->get_int_param("use_primary_cluster_ionization") != 0;
+  m_primaryIonizationModel.reset();
+  if (m_use_primary_cluster_ionization)
+  {
+    constexpr double fraction_tolerance = 1.e-12;
+    if (!std::isfinite(Ne_frac) || !std::isfinite(N2_frac) ||
+        std::abs(Ne_frac) > fraction_tolerance ||
+        std::abs(N2_frac) > fraction_tolerance)
+    {
+      std::cerr
+          << Name()
+          << ": the optional primary-cluster ionization model supports only "
+             "Ar/CF4/iC4H10 mixtures; Ne_frac="
+          << Ne_frac << " and N2_frac=" << N2_frac << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+    try
+    {
+      m_primaryIonizationModel =
+          std::make_unique<TpcPrimaryIonizationModel>(
+              TpcPrimaryIonizationModel::GasFractions{
+                  Ar_frac, CF4_frac, isobutane_frac});
+    }
+    catch (const std::exception &error)
+    {
+      std::cerr << Name()
+                << ": failed to configure the optional primary-cluster "
+                   "ionization model: "
+                << error.what() << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+    if (Verbosity() > 0)
+    {
+      std::cout
+          << Name() << ": using path-length primary-cluster ionization; "
+          << m_primaryIonizationModel->primary_clusters_per_cm()
+          << " primary clusters/cm, mean cluster size "
+          << m_primaryIonizationModel->mean_cluster_size() << std::endl;
+    }
+  }
 
   if (m_use_PDG_gas_params)
   {
@@ -522,21 +571,66 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     // Instead, use a temporary map to accumulate the charge from all
     // drifted electrons, then copy to the node tree later
 
-    double eion = hiter->second->get_eion();
-    unsigned int n_electrons = gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev);
+    const double eion = hiter->second->get_eion();
+    unsigned int n_ionization_sources = 0;
+    unsigned int n_electrons = 0;
+    double primary_cluster_mean = 0.0;
+
+    if (m_use_primary_cluster_ionization)
+    {
+      const double path_length_cm = hiter->second->get_path_length();
+      if (!std::isfinite(path_length_cm))
+      {
+        std::cerr
+            << Name() << ": G4 hit " << hiter->first
+            << " has no path_length property, but the persisted TPC geometry "
+               "requests primary-cluster ionization. Regenerate the G4-hit "
+               "input with the same ionization model."
+            << std::endl;
+        return Fun4AllReturnCodes::ABORTRUN;
+      }
+
+      // A zero path marks an active-gas hit that was deliberately classified
+      // as ineligible by the stepping action (neutral or geantino).
+      if (path_length_cm <= 0.0)
+      {
+        continue;
+      }
+
+      primary_cluster_mean =
+          m_primaryIonizationModel->mean_primary_clusters(path_length_cm);
+      n_ionization_sources = static_cast<unsigned int>(
+          gsl_ran_poisson(RandomGenerator.get(), primary_cluster_mean));
+    }
+    else
+    {
+      n_electrons = static_cast<unsigned int>(
+          gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev));
+      n_ionization_sources = n_electrons;
+    }
     //    count_electrons += n_electrons;
 
     if (Verbosity() > 100)
     {
       std::cout << "  new hit with t0, " << t0 << " g4hitid " << hiter->first
-                << " eion " << eion << " n_electrons " << n_electrons
-                << " entry z " << hiter->second->get_z(0) << " exit z "
-                << hiter->second->get_z(1) << " avg z"
-                << (hiter->second->get_z(0) + hiter->second->get_z(1)) / 2.0
-                << std::endl;
+                << " eion " << eion
+                << " n_ionization_sources " << n_ionization_sources;
+      if (m_use_primary_cluster_ionization)
+      {
+        std::cout << " primary_cluster_mean " << primary_cluster_mean;
+      }
+      else
+      {
+        std::cout << " n_electrons " << n_electrons;
+      }
+      std::cout
+          << " entry z " << hiter->second->get_z(0) << " exit z "
+          << hiter->second->get_z(1) << " avg z"
+          << (hiter->second->get_z(0) + hiter->second->get_z(1)) / 2.0
+          << std::endl;
     }
 
-    if (n_electrons == 0)
+    if (n_ionization_sources == 0)
     {
       continue;
     }
@@ -544,8 +638,13 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     if (Verbosity() > 100)
     {
       std::cout << std::endl
-                << "electron drift: g4hit " << hiter->first << " created electrons: "
-                << n_electrons << " from " << eion * 1000000 << " keV" << std::endl;
+                << "electron drift: g4hit " << hiter->first
+                << " created ionization sources: " << n_ionization_sources;
+      if (!m_use_primary_cluster_ionization)
+      {
+        std::cout << " from " << eion * 1000000 << " keV";
+      }
+      std::cout << std::endl;
       std::cout << " entry x,y,z = " << hiter->second->get_x(0) << "  "
                 << hiter->second->get_y(0) << "  " << hiter->second->get_z(0)
                 << " radius " << sqrt(pow(hiter->second->get_x(0), 2) + pow(hiter->second->get_y(0), 2)) << std::endl;
@@ -556,13 +655,33 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
     int notReachingReadout = 0;
     //    int notInAcceptance = 0;
-    for (unsigned int i = 0; i < n_electrons; i++)
+    unsigned int ionization_source = 0;
+    unsigned int cluster_electrons_remaining = 0;
+    double f = 0.0;
+    for (unsigned int i = 0;
+         ionization_source < n_ionization_sources ||
+         cluster_electrons_remaining > 0;
+         ++i)
     {
-      // We choose the electron starting position at random from a flat
-      // distribution along the path length the parameter t is the fraction of
-      // the distance along the path betwen entry and exit points, it has
-      // values between 0 and 1
-      const double f = gsl_ran_flat(RandomGenerator.get(), 0.0, 1.0);
+      if (cluster_electrons_remaining == 0)
+      {
+        unsigned int cluster_size = 1;
+        if (m_use_primary_cluster_ionization)
+        {
+          const double cluster_size_random =
+              gsl_ran_flat(RandomGenerator.get(), 0.0, 1.0);
+          cluster_size = m_primaryIonizationModel->sample_cluster_size(
+              cluster_size_random);
+          n_electrons += cluster_size;
+        }
+
+        // Choose one creation point uniformly along the stored step chord.
+        // Every electron in this primary cluster shares this f value.
+        f = gsl_ran_flat(RandomGenerator.get(), 0.0, 1.0);
+        cluster_electrons_remaining = cluster_size;
+        ++ionization_source;
+      }
+      --cluster_electrons_remaining;
 
       const double x_start_glob = hiter->second->get_x(0) + f * (hiter->second->get_x(1) - hiter->second->get_x(0));
       const double y_start_glob = hiter->second->get_y(0) + f * (hiter->second->get_y(1) - hiter->second->get_y(0));

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -324,7 +324,10 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     if (Verbosity() > 0)
     {
       std::cout
-          << Name() << ": using path-length primary-cluster ionization; "
+          << Name()
+          << ": using path-length primary-cluster ionization for "
+             "non-electron charged particles; electrons and positrons use "
+             "the energy-deposit response; "
           << m_primaryIonizationModel->primary_clusters_per_cm()
           << " primary clusters/cm, mean cluster size "
           << m_primaryIonizationModel->mean_cluster_size() << std::endl;
@@ -575,6 +578,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     unsigned int n_ionization_sources = 0;
     unsigned int n_electrons = 0;
     double primary_cluster_mean = 0.0;
+    bool use_primary_clusters_for_hit = false;
 
     if (m_use_primary_cluster_ionization)
     {
@@ -590,22 +594,33 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
         return Fun4AllReturnCodes::ABORTRUN;
       }
 
-      // A zero path marks an active-gas hit that was deliberately classified
-      // as ineligible by the stepping action (neutral or geantino).
-      if (path_length_cm <= 0.0)
+      if (path_length_cm > 0.0)
       {
-        continue;
+        use_primary_clusters_for_hit = true;
+        primary_cluster_mean =
+            m_primaryIonizationModel->mean_primary_clusters(path_length_cm);
+        n_ionization_sources =
+            gsl_ran_poisson(RandomGenerator.get(), primary_cluster_mean);
       }
-
-      primary_cluster_mean =
-          m_primaryIonizationModel->mean_primary_clusters(path_length_cm);
-      n_ionization_sources = static_cast<unsigned int>(
-          gsl_ran_poisson(RandomGenerator.get(), primary_cluster_mean));
+      else
+      {
+        // A zero path explicitly requests the established energy-deposit
+        // response. This is used for electrons and positrons, as well as for
+        // any other step for which path-based primary clustering is not
+        // applicable. Geantinos and zero-ionization steps produce no charge.
+        if (!(eion > 0.0))
+        {
+          continue;
+        }
+        n_electrons =
+            gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev);
+        n_ionization_sources = n_electrons;
+      }
     }
     else
     {
-      n_electrons = static_cast<unsigned int>(
-          gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev));
+      n_electrons =
+          gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev);
       n_ionization_sources = n_electrons;
     }
     //    count_electrons += n_electrons;
@@ -615,7 +630,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       std::cout << "  new hit with t0, " << t0 << " g4hitid " << hiter->first
                 << " eion " << eion
                 << " n_ionization_sources " << n_ionization_sources;
-      if (m_use_primary_cluster_ionization)
+      if (use_primary_clusters_for_hit)
       {
         std::cout << " primary_cluster_mean " << primary_cluster_mean;
       }
@@ -640,7 +655,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       std::cout << std::endl
                 << "electron drift: g4hit " << hiter->first
                 << " created ionization sources: " << n_ionization_sources;
-      if (!m_use_primary_cluster_ionization)
+      if (!use_primary_clusters_for_hit)
       {
         std::cout << " from " << eion * 1000000 << " keV";
       }
@@ -666,7 +681,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       if (cluster_electrons_remaining == 0)
       {
         unsigned int cluster_size = 1;
-        if (m_use_primary_cluster_ionization)
+        if (use_primary_clusters_for_hit)
         {
           const double cluster_size_random =
               gsl_ran_flat(RandomGenerator.get(), 0.0, 1.0);

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -292,6 +292,15 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   m_primaryIonizationModel.reset();
   if (m_use_primary_cluster_ionization)
   {
+    // For the electron/positron energy-based fallback of the opt-in model,
+    // use the internally consistent stopping powers and total ionization
+    // yields in Table 1 of arXiv:1008.3736. Keep the established values above
+    // unchanged when the optional model is disabled.
+    CF4_dEdx = 6.38;         // keV/cm
+    CF4_NTotal = 120;        // Number/cm
+    isobutane_dEdx = 5.67;   // keV/cm
+    isobutane_NTotal = 220;  // Number/cm
+
     constexpr double fraction_tolerance = 1.e-12;
     if (!std::isfinite(Ne_frac) || !std::isfinite(N2_frac) ||
         std::abs(Ne_frac) > fraction_tolerance ||
@@ -491,7 +500,6 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
-  unsigned int count_g4hits = 0;
   //  int count_electrons = 0;
 
   //  double ecollectedhits = 0.0;
@@ -499,6 +507,63 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   double ihit = 0;
   unsigned int dump_interval = 5000;  // dump temp_hitsetcontainer to the node tree after this many g4hits
   unsigned int dump_counter = 0;
+
+  const auto flush_temp_hitsets = [&]()
+  {
+    const auto temp_hitset_range = temp_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+    if (temp_hitset_range.first == temp_hitset_range.second)
+    {
+      return;
+    }
+
+    double eg4hit = 0.0;
+    for (auto temp_hitset_iter = temp_hitset_range.first;
+         temp_hitset_iter != temp_hitset_range.second;
+         ++temp_hitset_iter)
+    {
+      const auto node_hitsetkey = temp_hitset_iter->first;
+      const auto layer = TrkrDefs::getLayer(node_hitsetkey);
+      const auto sector = TpcDefs::getSectorId(node_hitsetkey);
+      const auto side = TpcDefs::getSide(node_hitsetkey);
+      if (Verbosity() > 100)
+      {
+        std::cout << "PHG4TpcElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer
+                  << " with sector " << sector << " side " << side << std::endl;
+      }
+
+      auto node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
+      const auto temp_hit_range = temp_hitset_iter->second->getHits();
+      for (auto temp_hit_iter = temp_hit_range.first;
+           temp_hit_iter != temp_hit_range.second;
+           ++temp_hit_iter)
+      {
+        const auto temp_hitkey = temp_hit_iter->first;
+        auto *temp_tpchit = temp_hit_iter->second;
+        if (Verbosity() > 10 && layer == print_layer)
+        {
+          std::cout << "      temp_hitkey " << temp_hitkey << " layer " << layer << " pad " << TpcDefs::getPad(temp_hitkey)
+                    << " z bin " << TpcDefs::getTBin(temp_hitkey)
+                    << "  energy " << temp_tpchit->getEnergy() << " eg4hit " << eg4hit << std::endl;
+          eg4hit += temp_tpchit->getEnergy();
+        }
+
+        auto *node_hit = node_hitsetit->second->getHit(temp_hitkey);
+        if (!node_hit)
+        {
+          node_hit = new TrkrHitv2();
+          node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
+        }
+        node_hit->addEnergy(temp_tpchit->getEnergy());
+      }
+
+      if (Verbosity() > 100 && layer == print_layer)
+      {
+        std::cout << "  ihit " << ihit << " collected energy = " << eg4hit << std::endl;
+      }
+    }
+
+    temp_hitsetcontainer->Reset();
+  };
 
   int trkid = -1;
 
@@ -508,7 +573,6 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   // clustering loopers in the same HitSetKey surfaces in multiple passes
   for (auto hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
-    count_g4hits++;
     dump_counter++;
 
     const double t0 = std::fmax(hiter->second->get_t(0), hiter->second->get_t(1));
@@ -890,85 +954,22 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       }
     }
 
-    // Dump the temp_hitsetcontainer to the node tree and reset it
-    //    - after every "dump_interval" g4hits
-    //    - if this is the last g4hit
-    if (dump_counter >= dump_interval || count_g4hits == g4hit->size())
+    if (dump_counter >= dump_interval)
     {
-      // std::cout << " dump_counter " << dump_counter << " count_g4hits " << count_g4hits << std::endl;
-
-      double eg4hit = 0.0;
-      TrkrHitSetContainer::ConstRange temp_hitset_range = temp_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
-      for (TrkrHitSetContainer::ConstIterator temp_hitset_iter = temp_hitset_range.first;
-           temp_hitset_iter != temp_hitset_range.second;
-           ++temp_hitset_iter)
-      {
-        // we have an itrator to one TrkrHitSet for the Tpc from the temp_hitsetcontainer
-        TrkrDefs::hitsetkey node_hitsetkey = temp_hitset_iter->first;
-        const unsigned int layer = TrkrDefs::getLayer(node_hitsetkey);
-        const int sector = TpcDefs::getSectorId(node_hitsetkey);
-        const int side = TpcDefs::getSide(node_hitsetkey);
-        if (Verbosity() > 100)
-        {
-          std::cout << "PHG4TpcElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer
-                    << " with sector " << sector << " side " << side << std::endl;
-        }
-
-        // find or add this hitset on the node tree
-        TrkrHitSetContainer::Iterator node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
-
-        // get all of the hits from the temporary hitset
-        TrkrHitSet::ConstRange temp_hit_range = temp_hitset_iter->second->getHits();
-        for (TrkrHitSet::ConstIterator temp_hit_iter = temp_hit_range.first;
-             temp_hit_iter != temp_hit_range.second;
-             ++temp_hit_iter)
-        {
-          TrkrDefs::hitkey temp_hitkey = temp_hit_iter->first;
-          TrkrHit *temp_tpchit = temp_hit_iter->second;
-          if (Verbosity() > 10 && layer == print_layer)
-          {
-            std::cout << "      temp_hitkey " << temp_hitkey << " layer " << layer << " pad " << TpcDefs::getPad(temp_hitkey)
-                      << " z bin " << TpcDefs::getTBin(temp_hitkey)
-                      << "  energy " << temp_tpchit->getEnergy() << " eg4hit " << eg4hit << std::endl;
-
-            eg4hit += temp_tpchit->getEnergy();
-            //            ecollectedhits += temp_tpchit->getEnergy();
-            //            ncollectedhits++;
-          }
-
-          // find or add this hit to the node tree
-          TrkrHit *node_hit = node_hitsetit->second->getHit(temp_hitkey);
-          if (!node_hit)
-          {
-            // Otherwise, create a new one
-            node_hit = new TrkrHitv2();
-            node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
-          }
-
-          // Either way, add the energy to it
-          node_hit->addEnergy(temp_tpchit->getEnergy());
-
-        }  // end loop over temp hits
-
-        if (Verbosity() > 100 && layer == print_layer)
-        {
-          std::cout << "  ihit " << ihit << " collected energy = " << eg4hit << std::endl;
-        }
-
-      }  // end loop over temp hitsets
-
-      // erase all entries in the temp hitsetcontainer
-      temp_hitsetcontainer->Reset();
-
-      // reset the dump counter
+      flush_temp_hitsets();
       dump_counter = 0;
-    }  // end copy of temp hitsetcontainer to node tree hitsetcontainer
+    }
 
     ++ihit;
 
     single_hitsetcontainer->Reset();
 
   }  // end loop over g4hits
+
+  // A hit near the end of the event can be followed only by G4 hits rejected
+  // by an early-continue condition above. Flush unconditionally so accepted
+  // charge is neither dropped nor carried into the next event.
+  flush_temp_hitsets();
 
   if (truth_track)
   {

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -39,12 +39,13 @@ class TpcClusterBuilder;
 class PHG4TpcGeomContainer;
 class ClusHitsVerbose;
 class ActsGeometry;
+class TpcPrimaryIonizationModel;
 
 class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
 {
  public:
   PHG4TpcElectronDrift(const std::string &name = "PHG4TpcElectronDrift");
-  ~PHG4TpcElectronDrift() override = default;
+  ~PHG4TpcElectronDrift() override;
   int Init(PHCompositeNode *) override;
   int InitRun(PHCompositeNode *) override;
   int process_event(PHCompositeNode *) override;
@@ -142,12 +143,14 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   bool do_ElectronDriftQAHistos{false};
   bool do_getReachReadout{false};
   bool zero_bfield{false};
+  bool m_use_primary_cluster_ionization{false};
   bool m_use_PDG_gas_params{false};
 
   std::unique_ptr<TrkrHitSetContainer> temp_hitsetcontainer;
   std::unique_ptr<TrkrHitSetContainer> single_hitsetcontainer;
   std::unique_ptr<PHG4TpcPadPlane> padplane;
   std::unique_ptr<PHG4TpcDistortion> m_distortionMap;
+  std::unique_ptr<TpcPrimaryIonizationModel> m_primaryIonizationModel;
   std::unique_ptr<TFile> m_outf;
   std::unique_ptr<TFile> EDrift_outf;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
@@ -96,25 +96,30 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
     killtrack->SetTrackStatus(fStopAndKill);
   }
 
+  const int pdg_code =
+      aTrack->GetParticleDefinition()->GetPDGEncoding();
   bool geantino = false;
 
   // the check for the pdg code speeds things up, I do not want to make
   // an expensive string compare for every track when we know
   // geantino or chargedgeantino has pid=0
-  if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+  if (pdg_code == 0 &&
       aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != std::string::npos)
   {
     geantino = true;
   }
 
-  // The optional primary-cluster model is defined only for charged-particle
-  // path through active TPC gas. Store zero path length for other active-gas
-  // hits so ElectronDrift can distinguish an ineligible step from an old DST
-  // in which the required path-length property is absent.
+  // The optional primary-cluster model is defined for non-electron charged-
+  // particle path through active TPC gas. Electrons and positrons retain the
+  // established energy-deposit response because the first path-length model
+  // is calibrated for MIP-like particles. Store zero path length for steps
+  // that should use the energy response so ElectronDrift can distinguish them
+  // from an old DST in which the required path-length property is absent.
   const bool primary_cluster_eligible_step =
       m_UsePrimaryClusterIonization > 0 &&
       whichactive > 0 &&
       !geantino &&
+      std::abs(pdg_code) != 11 &&
       aTrack->GetParticleDefinition()->GetPDGCharge() != 0.0 &&
       aStep->GetStepLength() > 0.0;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
@@ -131,7 +131,7 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
   //       std::cout << "time prepoint: " << prePoint->GetGlobalTime() << std::endl;
   //       std::cout << "time postpoint: " << postPoint->GetGlobalTime() << std::endl;
 
-  if (((m_UseG4StepsFlag > 0 || m_UsePrimaryClusterIonization > 0) &&
+  if (((m_UseG4StepsFlag > 0 || primary_cluster_eligible_step) &&
        whichactive > 0) ||
       prepointstatus == fGeomBoundary ||
       prepointstatus == fUndefined ||
@@ -283,7 +283,7 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
     // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
     // aTrack->GetTrackStatus() == fStopAndKill is also set)
     // aTrack->GetTrackStatus() == fStopAndKill: track ends
-    if (((m_UseG4StepsFlag > 0 || m_UsePrimaryClusterIonization > 0) &&
+    if (((m_UseG4StepsFlag > 0 || primary_cluster_eligible_step) &&
          whichactive > 0) ||
         postPoint->GetStepStatus() == fGeomBoundary ||
         postPoint->GetStepStatus() == fWorldBoundary ||

--- a/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.cc
@@ -46,6 +46,8 @@ PHG4TpcSteppingAction::PHG4TpcSteppingAction(PHG4TpcDetector* detector, const PH
   , m_Detector(detector)
   , m_Params(parameters)
   , m_IsBlackHoleFlag(m_Params->get_int_param("blackhole"))
+  , m_UsePrimaryClusterIonization(
+        m_Params->get_int_param("use_primary_cluster_ionization"))
 {
   if (std::isfinite(m_Params->get_double_param("steplimits")))
   {
@@ -104,6 +106,18 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
   {
     geantino = true;
   }
+
+  // The optional primary-cluster model is defined only for charged-particle
+  // path through active TPC gas. Store zero path length for other active-gas
+  // hits so ElectronDrift can distinguish an ineligible step from an old DST
+  // in which the required path-length property is absent.
+  const bool primary_cluster_eligible_step =
+      m_UsePrimaryClusterIonization > 0 &&
+      whichactive > 0 &&
+      !geantino &&
+      aTrack->GetParticleDefinition()->GetPDGCharge() != 0.0 &&
+      aStep->GetStepLength() > 0.0;
+
   G4StepPoint* prePoint = aStep->GetPreStepPoint();
   G4StepPoint* postPoint = aStep->GetPostStepPoint();
   int prepointstatus = prePoint->GetStepStatus();
@@ -112,7 +126,8 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
   //       std::cout << "time prepoint: " << prePoint->GetGlobalTime() << std::endl;
   //       std::cout << "time postpoint: " << postPoint->GetGlobalTime() << std::endl;
 
-  if ((m_UseG4StepsFlag > 0 && whichactive > 0) ||
+  if (((m_UseG4StepsFlag > 0 || m_UsePrimaryClusterIonization > 0) &&
+       whichactive > 0) ||
       prepointstatus == fGeomBoundary ||
       prepointstatus == fUndefined ||
       (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary))
@@ -222,6 +237,14 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
 
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
+    if (m_UsePrimaryClusterIonization > 0 && whichactive > 0)
+    {
+      m_Hit->set_path_length(
+          primary_cluster_eligible_step
+              ? static_cast<float>(aStep->GetStepLength() / cm)
+              : 0.F);
+    }
+
     // sum up the energy to get total deposited
     m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (whichactive > 0)
@@ -236,7 +259,7 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
         m_Hit->set_eion(-1);
       }
     }
-    if (edep > 0)
+    if (edep > 0 || primary_cluster_eligible_step)
     {
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
@@ -255,14 +278,17 @@ bool PHG4TpcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
     // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
     // aTrack->GetTrackStatus() == fStopAndKill is also set)
     // aTrack->GetTrackStatus() == fStopAndKill: track ends
-    if ((m_UseG4StepsFlag > 0 && whichactive > 0) ||
+    if (((m_UseG4StepsFlag > 0 || m_UsePrimaryClusterIonization > 0) &&
+         whichactive > 0) ||
         postPoint->GetStepStatus() == fGeomBoundary ||
         postPoint->GetStepStatus() == fWorldBoundary ||
         postPoint->GetStepStatus() == fAtRestDoItProc ||
         aTrack->GetTrackStatus() == fStopAndKill)
     {
-      // save only hits with energy deposit (or -1 for geantino)
-      if (m_Hit->get_edep())
+      // In the legacy mode, save only hits with energy deposit (or -1 for a
+      // geantino). The primary-cluster mode additionally retains eligible
+      // charged path segments even when this individual step has zero edep.
+      if (m_Hit->get_edep() || primary_cluster_eligible_step)
       {
         m_CurrentHitContainer->AddHit(layer_id, m_Hit);
         if (m_Shower)

--- a/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.h
@@ -51,6 +51,7 @@ class PHG4TpcSteppingAction : public PHG4SteppingAction
   // do this in every step, the parameters used are cached
   // in the following variables
   int m_IsBlackHoleFlag{0};
+  int m_UsePrimaryClusterIonization{0};
   int m_UseG4StepsFlag{0};
 
   std::string m_HitNodeName;

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -154,6 +154,7 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   // Keep the established energy-deposit ionization response as the default.
   // When enabled, the stepping action persists charged gas-step path lengths
   // for the optional primary-cluster response in PHG4TpcElectronDrift.
+  // Electrons and positrons continue to use the energy-deposit response.
   set_default_int_param("use_primary_cluster_ionization", 0);
 
   // material budget:

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -151,6 +151,10 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_double_param("tpc_length", 205.21);  // 2 * (maxdrift 102.325 + CM halfwidth 0.28) cm 
 
   set_default_double_param("steplimits", 1);  // 1cm by default
+  // Keep the established energy-deposit ionization response as the default.
+  // When enabled, the stepping action persists charged gas-step path lengths
+  // for the optional primary-cluster response in PHG4TpcElectronDrift.
+  set_default_int_param("use_primary_cluster_ionization", 0);
 
   // material budget:
   // Cu (all layers): 0.5 oz cu per square foot, 1oz == 0.0347mm --> 0.5 oz ==  0.00347cm/2.

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -151,11 +151,9 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_double_param("tpc_length", 205.21);  // 2 * (maxdrift 102.325 + CM halfwidth 0.28) cm 
 
   set_default_double_param("steplimits", 1);  // 1cm by default
-  // Keep the established energy-deposit ionization response as the default.
-  // When enabled, the stepping action persists charged gas-step path lengths
-  // for the optional primary-cluster response in PHG4TpcElectronDrift.
-  // Electrons and positrons continue to use the energy-deposit response.
-  set_default_int_param("use_primary_cluster_ionization", 0);
+  // Temporarily enable the primary-cluster response for quantitative CI
+  // validation. 
+  set_default_int_param("use_primary_cluster_ionization", 1);
 
   // material budget:
   // Cu (all layers): 0.5 oz cu per square foot, 1oz == 0.0347mm --> 0.5 oz ==  0.00347cm/2.

--- a/simulation/g4simulation/g4tpc/TpcPrimaryIonizationModel.cc
+++ b/simulation/g4simulation/g4tpc/TpcPrimaryIonizationModel.cc
@@ -1,0 +1,173 @@
+#include "TpcPrimaryIonizationModel.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iterator>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+  constexpr double argon_primary_clusters_per_cm = 23.0;
+  constexpr double cf4_primary_clusters_per_cm = 51.0;
+  constexpr double isobutane_primary_clusters_per_cm = 84.0;
+
+  // Measured single-cluster electron multiplicities for Ar and CH4:
+  // H. Fischle, J. Heintze, B. Schmidt, Nucl. Instrum. Meth. A 301
+  // (1991) 202-214, doi:10.1016/0168-9002(91)90460-8.
+  constexpr std::array<double, 19> argon_cluster_probabilities = {
+      0.656, 0.150, 0.064, 0.035, 0.0225, 0.0155, 0.0105,
+      0.0081, 0.0061, 0.0049, 0.0039, 0.0030, 0.0025, 0.0020,
+      0.0016, 0.0012, 0.00095, 0.00075, 0.00063};
+
+  constexpr std::array<double, 19> methane_cluster_probabilities = {
+      0.786, 0.120, 0.034, 0.016, 0.0095, 0.0060, 0.0044,
+      0.0034, 0.0027, 0.0021, 0.0017, 0.0013, 0.0010, 0.0008,
+      0.0006, 0.00050, 0.00042, 0.00037, 0.00033};
+
+  template <std::size_t Size>
+  std::vector<double> build_cluster_probabilities(
+      const std::array<double, Size> &measured)
+  {
+    std::vector<double> probabilities(
+        TpcPrimaryIonizationModel::maximum_cluster_size + 1, 0.0);
+
+    double measured_sum = 0.0;
+    for (std::size_t index = 0; index < measured.size(); ++index)
+    {
+      probabilities[index + 1] = measured[index];
+      measured_sum += measured[index];
+    }
+
+    if (!(measured_sum > 0.0 && measured_sum <= 1.0))
+    {
+      throw std::logic_error("invalid measured TPC cluster-size probabilities");
+    }
+
+    // The published table is used through n=19. Allocate its remaining
+    // probability to a truncated 1/n^2 tail through the explicit cutoff.
+    constexpr unsigned int tail_begin = Size + 1;
+    double inverse_square_sum = 0.0;
+    for (unsigned int size = tail_begin;
+         size <= TpcPrimaryIonizationModel::maximum_cluster_size;
+         ++size)
+    {
+      inverse_square_sum += 1.0 / static_cast<double>(size * size);
+    }
+
+    const double tail_normalization =
+        (1.0 - measured_sum) / inverse_square_sum;
+    for (unsigned int size = tail_begin;
+         size <= TpcPrimaryIonizationModel::maximum_cluster_size;
+         ++size)
+    {
+      probabilities[size] =
+          tail_normalization / static_cast<double>(size * size);
+    }
+
+    return probabilities;
+  }
+}  // namespace
+
+TpcPrimaryIonizationModel::TpcPrimaryIonizationModel(
+    const GasFractions &fractions)
+{
+  const std::array<double, 3> values = {
+      fractions.argon, fractions.cf4, fractions.isobutane};
+  for (const double fraction : values)
+  {
+    if (!std::isfinite(fraction) || fraction < 0.0)
+    {
+      throw std::invalid_argument(
+          "TPC primary-ionization gas fractions must be finite and nonnegative");
+    }
+  }
+
+  const double fraction_sum =
+      fractions.argon + fractions.cf4 + fractions.isobutane;
+  if (!std::isfinite(fraction_sum) || std::abs(fraction_sum - 1.0) > 1.e-6)
+  {
+    throw std::invalid_argument(
+        "TPC primary-ionization gas fractions must sum to one");
+  }
+
+  const double argon_weight =
+      fractions.argon * argon_primary_clusters_per_cm;
+  const double cf4_weight = fractions.cf4 * cf4_primary_clusters_per_cm;
+  const double isobutane_weight =
+      fractions.isobutane * isobutane_primary_clusters_per_cm;
+  m_primaryClustersPerCm = argon_weight + cf4_weight + isobutane_weight;
+
+  if (!(m_primaryClustersPerCm > 0.0))
+  {
+    throw std::invalid_argument(
+        "TPC primary-ionization gas mixture has zero cluster density");
+  }
+
+  const auto argon_probabilities =
+      build_cluster_probabilities(argon_cluster_probabilities);
+  const auto methane_probabilities =
+      build_cluster_probabilities(methane_cluster_probabilities);
+
+  // No validated CF4 or isobutane table is supplied by this first model.
+  // CF4 therefore uses the Ar shape and isobutane uses CH4 as an explicit
+  // proxy. Each component is weighted by its contribution to the primary
+  // cluster density rather than by volume fraction alone.
+  const double argon_shape_weight =
+      (argon_weight + cf4_weight) / m_primaryClustersPerCm;
+  const double methane_shape_weight =
+      isobutane_weight / m_primaryClustersPerCm;
+
+  m_clusterSizeCdf.resize(maximum_cluster_size + 1, 0.0);
+  double cumulative_probability = 0.0;
+  for (unsigned int size = 1; size <= maximum_cluster_size; ++size)
+  {
+    cumulative_probability +=
+        argon_shape_weight * argon_probabilities[size] +
+        methane_shape_weight * methane_probabilities[size];
+    m_clusterSizeCdf[size] = cumulative_probability;
+  }
+  m_clusterSizeCdf[maximum_cluster_size] = 1.0;
+}
+
+double TpcPrimaryIonizationModel::mean_primary_clusters(
+    const double path_length_cm) const
+{
+  if (!std::isfinite(path_length_cm) || path_length_cm < 0.0)
+  {
+    throw std::invalid_argument(
+        "TPC primary-ionization path length must be finite and nonnegative");
+  }
+  return m_primaryClustersPerCm * path_length_cm;
+}
+
+unsigned int TpcPrimaryIonizationModel::sample_cluster_size(
+    const double uniform_01) const
+{
+  if (!std::isfinite(uniform_01) || uniform_01 < 0.0 || uniform_01 >= 1.0)
+  {
+    throw std::invalid_argument(
+        "TPC cluster-size random variate must lie in [0, 1)");
+  }
+
+  const auto found = std::lower_bound(
+      std::next(m_clusterSizeCdf.begin()),
+      m_clusterSizeCdf.end(),
+      uniform_01);
+  return static_cast<unsigned int>(
+      std::distance(m_clusterSizeCdf.begin(), found));
+}
+
+double TpcPrimaryIonizationModel::mean_cluster_size() const
+{
+  double previous_cdf = 0.0;
+  double mean = 0.0;
+  for (unsigned int size = 1; size <= maximum_cluster_size; ++size)
+  {
+    const double probability = m_clusterSizeCdf[size] - previous_cdf;
+    mean += static_cast<double>(size) * probability;
+    previous_cdf = m_clusterSizeCdf[size];
+  }
+  return mean;
+}

--- a/simulation/g4simulation/g4tpc/TpcPrimaryIonizationModel.h
+++ b/simulation/g4simulation/g4tpc/TpcPrimaryIonizationModel.h
@@ -1,0 +1,44 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4TPC_TPCPRIMARYIONIZATIONMODEL_H
+#define G4TPC_TPCPRIMARYIONIZATIONMODEL_H
+
+#include <vector>
+
+/**
+ * Fast, path-length-based, MIP-calibrated TPC primary-ionization model.
+ *
+ * The model supplies the mean primary-cluster density for a gas mixture and
+ * samples the number of electrons in one primary cluster. Random-number
+ * generation remains the responsibility of the caller so that this class is
+ * deterministic and independently testable.
+ */
+class TpcPrimaryIonizationModel
+{
+ public:
+  struct GasFractions
+  {
+    double argon{0.0};
+    double cf4{0.0};
+    double isobutane{0.0};
+  };
+
+  static constexpr unsigned int maximum_cluster_size = 384;
+
+  explicit TpcPrimaryIonizationModel(const GasFractions &fractions);
+
+  [[nodiscard]] double primary_clusters_per_cm() const
+  {
+    return m_primaryClustersPerCm;
+  }
+
+  [[nodiscard]] double mean_primary_clusters(const double path_length_cm) const;
+  [[nodiscard]] unsigned int sample_cluster_size(const double uniform_01) const;
+  [[nodiscard]] double mean_cluster_size() const;
+
+ private:
+  double m_primaryClustersPerCm{0.0};
+  std::vector<double> m_clusterSizeCdf;
+};
+
+#endif  // G4TPC_TPCPRIMARYIONIZATIONMODEL_H

--- a/simulation/g4simulation/g4tpc/TpcPrimaryIonizationModel.h
+++ b/simulation/g4simulation/g4tpc/TpcPrimaryIonizationModel.h
@@ -6,7 +6,9 @@
 #include <vector>
 
 /**
- * Fast, path-length-based, MIP-calibrated TPC primary-ionization model.
+ * Fast, path-length-based, MIP-calibrated TPC primary-ionization model for
+ * non-electron charged particles. PHG4TpcElectronDrift retains its established
+ * energy-deposit response for electrons and positrons.
  *
  * The model supplies the mean primary-cluster density for a gas mixture and
  * samples the number of electrons in one primary cluster. Random-number


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
tracking software meeting: https://indico.bnl.gov/event/34092/contributions/128792/attachments/72420/124036/simulation_pr_improved_2.pdf
This PR adds an optional path-length-based primary-ionization model to the
TPC simulation. The established energy-deposit response remains the default. Existing
configurations do not automatically enable the new ionization model.

It also fixes an existing end-of-event buffering bug in
PHG4TpcElectronDrift. Buffered TPC charge is now always transferred to the node
tree after the G4-hit loop, including when trailing G4 hits skip the in-loop
flush through early-continue conditions. This fix applies to both the legacy
energy-deposit response and the optional primary-cluster model.

When `use_primary_cluster_ionization=1`:

- the number of primary clusters is sampled from a Poisson distribution whose
  mean is the charged-particle G4 path length multiplied by the gas-mixture
  primary-cluster density;
- the electron multiplicity of each cluster is sampled from a cluster-size
  probability distribution;
- electrons from the same primary cluster share one creation position sampled
  uniformly along the G4 step chord;
- electrons and positrons retain the established energy-deposit response;
- neutral particles and geantinos do not receive path-length ionization;
- required G4 path-length metadata is persisted by the TPC stepping action.

This first implementation is a fast, MIP-calibrated model for non-electron
charged particles. The CF4 cluster-size shape is approximated by Ar, and the
isobutane shape is approximated by CH4. These approximations can later be
replaced by beta-gamma-dependent HEED tables.

This upstream-ready implementation was developed from exploratory primary-ionization work in upsilon-dnl-sim, particularly commits 0fbd06652, 992f45fa53, and 412335a39c. The implementation was restructured for current upstream, isolated from DNL/SERF/QA changes, made explicitly opt-in, and extended with Geant4 path-length metadata and legacy electron-response compatibility.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )



## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Add path-length-based primary-ionization modeling for TPC simulation and validate it in CI. The model is currently enabled by default.

## Key changes

- Add `TpcPrimaryIonizationModel` for MIP-calibrated cluster production.
- Sample clusters from G4 path length and gas-mixture density.
- Sample cluster electron multiplicities from a blended Ar/CH4 distribution.
- Place electrons from each cluster at a shared position along the G4 step chord.
- Keep electrons and positrons on the energy-deposit response.
- Exclude neutral particles and geantinos from path-length ionization.
- Persist path-length metadata through the TPC stepping action.
- Flush buffered TPC charge at intervals and unconditionally at event end.
- Validate supported Ar/CF4/iC4H10 mixtures and configuration values.

## Potential risk areas

- The default response changes simulated charge production and reconstruction inputs.
- Ar and CH4 approximations limit accuracy for CF4 and isobutane.
- Missing path-length metadata can abort a run when the model is enabled.
- Additional sampling can affect performance and random-number reproducibility.
- Hit flushing requires validation at event boundaries.
- Persisted G4-hit data must remain compatible with the required path-length metadata.
- Thread safety requires verification in multithreaded simulation.

## Possible future improvements

- Replace gas approximations with beta-gamma-dependent HEED tables.
- Validate cluster densities, charge yields, and detector observables against measurements.
- Benchmark performance and multithreaded reproducibility.
- Add focused tests for gas validation, cluster sampling, path-length handling, and hit flushing.

AI-generated summaries can contain mistakes. Contributors should verify the implementation and simulation results against the source code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->