### PR TITLE
allow only sphnxpro account for certain actions

### DIFF
--- a/offline/database/sphenixnpc/SphenixClient.cc
+++ b/offline/database/sphenixnpc/SphenixClient.cc
@@ -9,6 +9,27 @@
 #include <iostream>
 #include <stdexcept>
 
+#include <pwd.h>
+#include <unistd.h>
+
+namespace
+{
+  bool is_sphnxpro()
+  {
+    passwd pwd{};
+    passwd* result = nullptr;
+    std::array<char, 4096> buffer{};
+
+    if (getpwnam_r("sphnxpro", &pwd, buffer.data(), buffer.size(), &result) != 0 ||
+        result == nullptr)
+    {
+      return false;
+    }
+
+    return geteuid() == result->pw_uid;
+  }
+}  // namespace
+
 SphenixClient::SphenixClient(const std::string& gt_name)
   : nopayloadclient::NoPayloadClient(gt_name)
   , m_CachedGlobalTag(gt_name)
@@ -124,11 +145,21 @@ void SphenixClient::DumpCalibrations(long long iov, const std::string& filename)
 
 nlohmann::json SphenixClient::deletePayloadIOV(const std::string& pl_type, long long iov_start)
 {
+  if (!is_sphnxpro())
+  {
+    std::string message = "only the sphnxpro account can delete a PayloadIOV";
+    return {{"code", -1}, {"msg", message}};
+  }
   return nopayloadclient::NoPayloadClient::deletePayloadIOV(pl_type, 0, iov_start);
 }
 
 nlohmann::json SphenixClient::deletePayloadIOV(const std::string& pl_type, long long iov_start, long long iov_end)
 {
+  if (!is_sphnxpro())
+  {
+    std::string message = "only the sphnxpro account can delete a PayloadIOV";
+    return {{"code", -1}, {"msg", message}};
+  }
   return nopayloadclient::NoPayloadClient::deletePayloadIOV(pl_type, 0, iov_start, 0, iov_end);
 }
 
@@ -148,6 +179,11 @@ std::string SphenixClient::getCalibration(const std::string& pl_type, long long 
 
 nlohmann::json SphenixClient::unlockGlobalTag(const std::string& gt_name)
 {
+  if (!is_sphnxpro())
+  {
+    std::string message = "only the sphnxpro account can unlock a global tag";
+    return {{"code", -1}, {"msg", message}};
+  }
   if (existGlobalTag(gt_name))
   {
     return nopayloadclient::NoPayloadClient::unlockGlobalTag(gt_name);
@@ -169,12 +205,22 @@ nlohmann::json SphenixClient::lockGlobalTag(const std::string& gt_name)
 nlohmann::json SphenixClient::insertPayload(const std::string& pl_type, const std::string& file_url,
                                             long long iov_start)
 {
+  if (!is_sphnxpro())
+  {
+    std::string message = "only the sphnxpro account can insert a Payload";
+    return {{"code", -1}, {"msg", message}};
+  }
   return nopayloadclient::NoPayloadClient::insertPayload(pl_type, file_url, 0, iov_start);
 }
 
 nlohmann::json SphenixClient::insertPayload(const std::string& pl_type, const std::string& file_url,
                                             long long iov_start, long long iov_end)
 {
+  if (!is_sphnxpro())
+  {
+    std::string message = "only the sphnxpro account can insert a Payload";
+    return {{"code", -1}, {"msg", message}};
+  }
   return nopayloadclient::NoPayloadClient::insertPayload(pl_type, file_url, 0, iov_start, 0, iov_end);
 }
 
@@ -182,6 +228,11 @@ nlohmann::json SphenixClient::insertPayload(const std::string& pl_type, const st
                                             long long major_iov_start, long long minor_iov_start,
                                             long long major_iov_end, long long minor_iov_end)
 {
+  if (!is_sphnxpro())
+  {
+    std::string message = "only the sphnxpro account can insert a Payload";
+    return {{"code", -1}, {"msg", message}};
+  }
   return nopayloadclient::NoPayloadClient::insertPayload(pl_type, file_url, major_iov_start, minor_iov_start, major_iov_end, minor_iov_end);
 }
 
@@ -244,6 +295,11 @@ int SphenixClient::cache_set_GlobalTag(const std::string& tagname)
 int SphenixClient::createDomain(const std::string& domain)
 {
   int iret = -1;
+  if (!is_sphnxpro())
+  {
+    std::cout << "only the sphnxpro account can create a Payload Type (domain)" << std::endl;
+    return iret;
+  }
   nlohmann::json resp;
   if (m_DomainCache.empty())
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
We had now two cases of users trying to insert calibrations into our main cdb. This PR protects methods which change the main cdb by requiring that they are executed under the sphnxpro account. One can hack around this but this level of protection should be good enough for us

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Protect the main calibration database (CDB) from unauthorized calibration insertions and modifications. The affected operations must run under the `sphnxpro` account.

## Key Changes

- Added an `is_sphnxpro()` helper that checks the effective user account.
- Restricted payload deletion, payload insertion, global-tag unlocking, and payload-type creation to `sphnxpro`.
- Rejected unauthorized requests before calling the underlying client APIs.
- Returned an error JSON or `-1` for rejected operations.

## Potential Risk Areas

- No I/O format changes are expected.
- No reconstruction behavior changes are expected.
- The account lookup adds a small overhead to protected operations.
- Thread-safety risk appears limited because the change performs read-only account checks.

## Possible Future Improvements

- Add focused tests for authorized and unauthorized accounts.
- Standardize error reporting across all protected methods.
- Consider a configurable authorization mechanism if deployment requirements change.

AI-generated summaries can contain mistakes. Review the implementation and test behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->