### PR TITLE
fix: add check for zbin boundary

### DIFF
--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
@@ -1033,6 +1033,10 @@ int Tpc_PolyClusterizer::process_event(PHCompositeNode* topNode)
 
               const int iphi = static_cast<int>(p.pad);
               const int it = static_cast<int>(p.tbin);
+              if(it >= layergeom->get_zbins())
+              {
+                continue;
+              }
               const double adc = p.adc;
               phibinhi = std::max(iphi, phibinhi);
               phibinlo = std::min(iphi, phibinlo);
@@ -1041,7 +1045,7 @@ int Tpc_PolyClusterizer::process_event(PHCompositeNode* topNode)
 
               iphi_sum += static_cast<double>(iphi) * adc;
               iphi2_sum += square(static_cast<double>(iphi)) * adc;
-
+              
               const double t = layergeom->get_zcenter(it);
               t_sum += t * adc;
               t2_sum += square(t) * adc;


### PR DESCRIPTION
This adds a check that the time bin actually falls within the number of z bins in the layer geometry object. When running from the raw evt files there are sometimes instances where you get tbin==nzbins, which causes a crash. The check just skips the relevant hit from being added to the cluster phi/timebin/adc weighted sum

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Prevent crashes when raw event files contain hits with `tbin == nzbins`, which is outside the layer geometry range.

## Key changes

- Skip points with `it >= layergeom->get_zbins()` during ADC-weighted cluster sum calculations.
- Exclude invalid points from the cluster phi, time-bin, and ADC-weighted sums.
- Preserve existing interfaces and input/output formats.

## Potential risk areas

- Reconstruction results may change for clusters containing out-of-range time bins.
- No I/O format or thread-safety changes are expected.
- The added boundary check has negligible performance impact.

## Possible future improvements

- Add regression tests for `tbin == nzbins` and other out-of-range values.
- Review whether invalid time bins should be logged or counted for monitoring.

AI-generated summaries can contain mistakes. Contributors should verify the implementation and its physics behavior against the source code and representative raw events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->