### PR TITLE
Fix mover bug

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -168,6 +168,7 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     Acts::Vector3 global_new = global;
     TrkrDefs::subsurfkey new_subsurfkey = sskey;
     bool ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
+
     if (!ret)
     {
       global_moved.emplace_back(cluskey, global);
@@ -178,53 +179,30 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
       continue;
     }
 
-    auto global_new_keep = global_new;
-    auto sskey_keep = sskey;
-    int iter = 0;
-    while (new_subsurfkey != sskey)
-    {
-	iter++;
-	if(iter > 2)
+
+    if(new_subsurfkey == sskey)
+      {
+	// we are done with this cluster, add the new position and surface to the return object
+	global_moved.emplace_back(cluskey, global_new);
+      }
+    else
+      {
+	// sskey changed, update the subsurface in the cluster key
+	cluster->setSubSurfKey(new_subsurfkey);
+	global_moved.emplace_back(cluskey, global_new);
+    
+	// check
+	TrkrDefs::subsurfkey check_subsurfkey = new_subsurfkey;
+	TrkrDefs::hitsetkey hkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+	auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, check_subsurfkey);
+	if(check_subsurfkey != new_subsurfkey)
 	  {
-	    // cluster has been updated with subsurfkey from last iteration, global_new is still from last iteration - move on
-	    break;
+	    std::cout << "Warning - subsurface keys inconsistent: original sskey " << sskey
+		      << " new_sskey " << new_subsurfkey
+		      << " check_sskey " << check_subsurfkey << std::endl;
 	  }
-
-	// surface changed, cluster subsurface has been updated, redo with new surface
-	sskey = new_subsurfkey;
-	ret = get_moved_position(cluskey, cluster, fitpars, global, global_new, new_subsurfkey);
-	if(!ret)
-	  {
-	    global_new = global_new_keep;
-	    cluster->setSubSurfKey(sskey_keep);
-	    break;
-	  }
-	if(_verbosity > 2)
-	  {
-	    if(new_subsurfkey != sskey)
-	      {
-		std::cout << PHWHERE << "Warning: subsurfkey changed on iteration " << iter << " from "
-			  << sskey << " to " << new_subsurfkey << std::endl;
-	      }
-	    else
-	      {
-		std::cout << PHWHERE << "Good: subsurfkey unchanged on iteration " << iter << std::endl;
-	      }
-	  }	
-    }
-
-
-    if (_verbosity > 2)
-    {
-      std::cout << "    iterations " << iter << " clusterkey " << cluskey << " subsurfkey in " << sskey << " new " << new_subsurfkey << std::endl;
-      std::cout << "        global_in " << global[0] << "  " << global[1] << "  " << global[2] << std::endl;
-      std::cout << "        global_moved " << global_new[0] << "  " << global_new[1] << "  " << global_new[2] << std::endl;
-    }
-
-    // add the new position and surface to the return object
-    global_moved.emplace_back(cluskey, global_new);
+      }
   }
-
   return global_moved;
 }
 
@@ -267,19 +245,10 @@ bool TpcClusterMover::get_moved_position(TrkrDefs::cluskey cluskey, TrkrCluster*
   global_new(1) = ynew;
   global_new(2) = znew;
 
-  bool update_sskey = true;
-  if (update_sskey)
-  {
-    unsigned int sskey = cluster->getSubSurfKey();
-
-    TrkrDefs::hitsetkey hkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
-    auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
-    if (new_surf && (new_subsurfkey != sskey))
-    {
-      cluster->setSubSurfKey(new_subsurfkey);
-    }
-  }
-
+  // get the subsurface key for this new position and return it 
+  TrkrDefs::hitsetkey hkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+  auto new_surf = _tGeometry->get_tpc_surface_from_coords(hkey, global_new, new_subsurfkey);
+  
   return true;
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Simplify the logic for finding a new subsurface key after moving TPC clusters to a surface.
Tested with CA seeding with survey geometry, and polyseeding with ideal geometry.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

This PR fixes subsurface-key lookup after TPC clusters move to a surface. It replaces iterative key updates with simpler, explicit handling.

## Key changes

- `processTrack` performs a single subsurface-key check after movement.
- `get_moved_position` returns the key for the new coordinates without modifying the cluster key.
- Update the cluster key only when the returned key changes.
- Add a warning when the updated key is inconsistent with the surface from the new coordinates.
- Tested with CA seeding and survey geometry, and with polyseeding and ideal geometry.

## Potential risk areas

- No IO format or public API changes are indicated.
- Reconstruction behavior can change when a moved cluster receives a different subsurface key.
- Geometry or key-mapping inconsistencies now produce warnings.
- No direct thread-safety change is apparent.

## Possible future improvements

- Add regression tests for changed and unchanged subsurface keys.
- Define handling for key-to-surface consistency failures.
- Monitor warnings in reconstruction workflows.

AI-generated summaries can contain mistakes. Contributors should verify the implementation and reconstruction results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->