### PR TITLE
Cluster subsuface key inconsistency fix

### DIFF
--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -712,7 +712,7 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     {
       continue;
     }
-    auto lcluster = _cluster_map->findCluster(trackKeyChain.back());
+    auto* lcluster = _cluster_map->findCluster(trackKeyChain.back());
     const auto& lclusterglob = globalPositions.at(trackKeyChain.back());
     const float lclusterrad = sqrt(lclusterglob(0) * lclusterglob(0) + lclusterglob(1) * lclusterglob(1));
     double last_cluster_phierr = lcluster->getRPhiError() / lclusterrad;

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -356,12 +356,15 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
   // loop over all clusters
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_raw;
 
+  // keep track of old cluster keys
+  std::vector<std::pair<TrkrCluster*,int> old_subsurfkey_map;
+
   for (auto clusIter = track->begin_cluster_keys();
        clusIter != track->end_cluster_keys();
        ++clusIter)
   {
     auto key = *clusIter;
-    
+
     auto* cluster = clusterContainer->findCluster(key);
     if (!cluster)
     {
@@ -391,6 +394,10 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
     const unsigned int trkrid = TrkrDefs::getTrkrId(key);
     if (trkrid == TrkrDefs::tpcId)
     {
+      // store old subsurface keys in map. They will need to be restored after the cluster mover has been called
+      old_subsurfkey_map.emplace(cluster, cluster->getSubSurfKey() );
+
+
       if (m_verbosity > 2)
       {
         unsigned int this_layer = TrkrDefs::getLayer(key);
@@ -444,14 +451,14 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
     if (std::isnan(global.x()) || std::isnan(global.y()))
     {
       if (m_verbosity > 1)
-	{
-	  std::cout << "MakeSourceLinks::getSourceLinksClusterMover - invalid position"
-		    << " key: " << cluskey
-		    << " layer: " << (int) TrkrDefs::getLayer(cluskey)
-		    << " position: " << global
-		    << std::endl;
-	}
-      continue;
+      {
+        std::cout << "MakeSourceLinks::getSourceLinksClusterMover - invalid position"
+          << " key: " << cluskey
+          << " layer: " << (int) TrkrDefs::getLayer(cluskey)
+          << " position: " << global
+          << std::endl;
+        }
+        continue;
     }
 
     // clustermover updates the subsurface key after moving the clusters to the surface, so this is safe
@@ -467,7 +474,7 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
         continue;
       }
     }
-    
+
     if (!surf)
     {
       std::cout << "MakeSourceLinks::getSourceLinksClusterMover -  Failed to find surface for cluskey " << cluskey << std::endl;
@@ -555,6 +562,12 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
     sourcelinks.push_back(actsSL);
   }
 
+  // restore old subsurface keys
+  /* this ensures that cluster's unmodified local coordinate and subsurface key remain consistent */
+  for( const auto& [cluster,subsurfkey]:old_subsurfkey_map )
+  { cluster->setSubSurfKey(subsurfkey); }
+
+  // all done
   SLTrackTimer.stop();
   auto SLTime = SLTrackTimer.get_accumulated_time();
 

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -395,7 +395,7 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
     if (trkrid == TrkrDefs::tpcId)
     {
       // store old subsurface keys in map. They will need to be restored after the cluster mover has been called
-      old_subsurfkey_map.emplace(cluster, cluster->getSubSurfKey() );
+      old_subsurfkey_map.emplace_back(cluster, cluster->getSubSurfKey() );
 
 
       if (m_verbosity > 2)

--- a/offline/packages/trackreco/MakeSourceLinks.cc
+++ b/offline/packages/trackreco/MakeSourceLinks.cc
@@ -357,7 +357,7 @@ SourceLinkVec MakeSourceLinks::getSourceLinksClusterMover(
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_raw;
 
   // keep track of old cluster keys
-  std::vector<std::pair<TrkrCluster*,int> old_subsurfkey_map;
+  std::vector<std::pair<TrkrCluster*, int>> old_subsurfkey_map;
 
   for (auto clusIter = track->begin_cluster_keys();
        clusIter != track->end_cluster_keys();


### PR DESCRIPTION
This PR
- stores old subsurface key prior to calling the cluster mover,
- restores the old subsurface keys in cluster once the source links have been created.
This ensures that subsurface keys remain consistent with internal cluster coordinates, while still passing the correct information, via SourceLinks to the cluster fitter. 
This restores proper residuals in TPOT

@adfrawley please have a look. I think this is the simpler fix so far. Feel free to come up with a different solution though. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Fix inconsistent TPC cluster subsurface keys. This restores correct TPOT residuals without changing I/O formats or public APIs.

## Key changes

- Preserve each cluster’s original subsurface key during cluster movement.
- Restore the key after source-link creation.
- Declare the `findCluster` result as a pointer in `ALICEKalmanFilter`.
- Clean up diagnostic formatting.

## Potential risk areas

- Reconstruction behavior changes for subsurface-key handling.
- No expected I/O, thread-safety, or performance impact.
- Regression testing should confirm cluster coordinates, source links, and TPOT residuals.

## Possible future improvements

- Add automated tests for subsurface-key preservation.
- Validate key and coordinate consistency after source-link creation.

AI-generated summaries can contain errors. Contributors should verify these points against the implementation and reconstruction tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->