### PR TITLE
add track-only output and TPC bunch-crossing selection

### DIFF
--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
@@ -245,7 +245,8 @@ int TpcV0CandidateTree::Init(PHCompositeNode *topNode)
   }
   if (!m_use_pattern_cluster_tracks &&
       (m_required_crossing != NoCrossingSelection ||
-       m_max_crossing_tier >= 0 || m_require_same_crossing))
+       m_max_crossing_tier >= 0 ||
+       (m_reconstruct_pairs && m_require_same_crossing)))
   {
     std::cerr << PHWHERE << Name()
               << ": bunch-crossing selection is only available for pattern-track input"
@@ -322,7 +323,8 @@ int TpcV0CandidateTree::process_event(PHCompositeNode *topNode)
     }
     const bool crossing_metadata_required =
         m_required_crossing != NoCrossingSelection ||
-        m_max_crossing_tier >= 0 || m_require_same_crossing;
+        m_max_crossing_tier >= 0 ||
+        (m_reconstruct_pairs && m_require_same_crossing);
     if (!crossing_decisions && crossing_metadata_required)
     {
       std::cerr << PHWHERE << Name() << ": missing required crossing-decision node "

--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
@@ -1,5 +1,7 @@
 #include "TpcV0CandidateTree.h"
 
+#include <tpctrackreco/TpcCrossingDecision.h>
+#include <tpctrackreco/TpcCrossingDecisionContainer.h>
 #include <tpctrackreco/TpcTrackHelixFitter.h>
 #include <tpctrackreco/TpcTrackKalmanFitter.h>
 #include <tpctrackreco/Tpc_PolyCluster.h>
@@ -222,6 +224,35 @@ bool TpcV0CandidateTree::set_track_fit_method(const std::string &mode)
 
 int TpcV0CandidateTree::Init(PHCompositeNode *topNode)
 {
+  if (m_required_crossing != NoCrossingSelection &&
+      (m_required_crossing < std::numeric_limits<short>::min() ||
+       m_required_crossing >= std::numeric_limits<short>::max()))
+  {
+    std::cerr << PHWHERE << Name() << ": required crossing " << m_required_crossing
+              << " is outside the supported range ["
+              << std::numeric_limits<short>::min() << ", "
+              << std::numeric_limits<short>::max() - 1 << "]" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  if (m_max_crossing_tier < -1 ||
+      m_max_crossing_tier >= std::numeric_limits<unsigned char>::max())
+  {
+    std::cerr << PHWHERE << Name() << ": maximum crossing tier " << m_max_crossing_tier
+              << " is outside the supported range [-1, "
+              << static_cast<int>(std::numeric_limits<unsigned char>::max()) - 1
+              << "]" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  if (!m_use_pattern_cluster_tracks &&
+      (m_required_crossing != NoCrossingSelection ||
+       m_max_crossing_tier >= 0 || m_require_same_crossing))
+  {
+    std::cerr << PHWHERE << Name()
+              << ": bunch-crossing selection is only available for pattern-track input"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
   if (m_use_kalman_field_map && m_kalman_config.magnetic_field == nullptr && topNode != nullptr)
   {
     m_kalman_config.magnetic_field =
@@ -268,6 +299,8 @@ int TpcV0CandidateTree::process_event(PHCompositeNode *topNode)
         topNode, m_tpc_sa_cluster_node);
     auto *tracks = findNode::getClass<Tpc_PolyTrackContainer>(
         topNode, m_tpc_sa_track_node);
+    auto *crossing_decisions = findNode::getClass<TpcCrossingDecisionContainer>(
+        topNode, m_crossing_decision_node);
     pattern_vertices = findNode::getClass<Tpc_PolyTrackVertexContainer>(
         topNode, m_tpc_sa_track_vertex_node);
 
@@ -287,7 +320,23 @@ int TpcV0CandidateTree::process_event(PHCompositeNode *topNode)
                 << m_tpc_sa_track_vertex_node
                 << "; trackTree vertex_z will use the configured fallback vertex" << std::endl;
     }
-    tracklet_map = build_pattern_tracklets(clusters, tracks);
+    const bool crossing_metadata_required =
+        m_required_crossing != NoCrossingSelection ||
+        m_max_crossing_tier >= 0 || m_require_same_crossing;
+    if (!crossing_decisions && crossing_metadata_required)
+    {
+      std::cerr << PHWHERE << Name() << ": missing required crossing-decision node "
+                << m_crossing_decision_node << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+    if (!crossing_decisions && Verbosity() > 1)
+    {
+      std::cout << PHWHERE << Name() << ": optional crossing-decision node "
+                << m_crossing_decision_node
+                << " is unavailable; crossing branches will contain unknown values"
+                << std::endl;
+    }
+    tracklet_map = build_pattern_tracklets(clusters, tracks, crossing_decisions);
   }
   else
   {
@@ -493,6 +542,7 @@ int TpcV0CandidateTree::End(PHCompositeNode * /*topNode*/)
   if (Verbosity() > 0)
   {
     std::cout << Name() << ": pair counters: raw=" << m_counter_raw_pairs
+              << " reject_crossing=" << m_counter_reject_pair_crossing
               << " reject_charge=" << m_counter_reject_charge
               << " reject_preselection=" << m_counter_reject_preselection
               << " reject_pca=" << m_counter_reject_pca
@@ -503,6 +553,9 @@ int TpcV0CandidateTree::End(PHCompositeNode * /*topNode*/)
               << " tracks_written=" << m_counter_tracks_written
               << " reject_helix_anchor=" << m_counter_reject_helix_anchor
               << " cluster_residuals_written=" << m_counter_cluster_residuals_written
+              << " missing_crossing_decision=" << m_counter_missing_crossing_decision
+              << " reject_required_crossing=" << m_counter_reject_required_crossing
+              << " reject_crossing_tier=" << m_counter_reject_crossing_tier
               << std::endl;
   }
 
@@ -709,7 +762,8 @@ std::map<int, TpcV0CandidateTree::Tracklet> TpcV0CandidateTree::build_tracklets(
 
 std::map<int, TpcV0CandidateTree::Tracklet> TpcV0CandidateTree::build_pattern_tracklets(
     Tpc_PolyClusterContainer *clusters,
-    Tpc_PolyTrackContainer *tracks) const
+    Tpc_PolyTrackContainer *tracks,
+    const TpcCrossingDecisionContainer *crossing_decisions) const
 {
   std::map<int, Tracklet> tracklets;
 
@@ -750,6 +804,45 @@ std::map<int, TpcV0CandidateTree::Tracklet> TpcV0CandidateTree::build_pattern_tr
     Tracklet tracklet;
     tracklet.track_id = track_id;
     tracklet.shower_id = static_cast<int>(source_id);
+    tracklet.source_assembled_track_id = source_id;
+
+    const TpcCrossingDecision *crossing_decision =
+        crossing_decisions ? crossing_decisions->get_decision(source_id) : nullptr;
+    if (crossing_decision)
+    {
+      tracklet.has_crossing_decision = true;
+      tracklet.crossing_status = static_cast<int>(crossing_decision->get_status());
+      tracklet.crossing_tier = static_cast<int>(crossing_decision->get_selected_tier());
+      tracklet.crossing_score = crossing_decision->get_selected_score();
+      const short selected_crossing = crossing_decision->get_selected_crossing();
+      tracklet.has_selected_crossing =
+          selected_crossing != std::numeric_limits<short>::max() &&
+          tracklet.crossing_tier != std::numeric_limits<unsigned char>::max();
+      if (tracklet.has_selected_crossing)
+      {
+        tracklet.crossing = selected_crossing;
+      }
+    }
+    else
+    {
+      ++m_counter_missing_crossing_decision;
+    }
+
+    if (m_required_crossing != NoCrossingSelection &&
+        (!tracklet.has_selected_crossing ||
+         tracklet.crossing != static_cast<short>(m_required_crossing)))
+    {
+      ++m_counter_reject_required_crossing;
+      continue;
+    }
+    if (m_max_crossing_tier >= 0 &&
+        (!tracklet.has_selected_crossing ||
+         tracklet.crossing_tier > m_max_crossing_tier))
+    {
+      ++m_counter_reject_crossing_tier;
+      continue;
+    }
+
     tracklet.charge = sign_to_charge(track->get_charge());
     tracklet.position = {track->get_x(), track->get_y(), track->get_z()};
     tracklet.momentum = {track->get_px(), track->get_py(), track->get_pz()};
@@ -1035,6 +1128,14 @@ bool TpcV0CandidateTree::make_pair_row(const Tracklet &track1, const Tracklet &t
 {
   ++m_counter_raw_pairs;
 
+  if (m_require_same_crossing &&
+      (!track1.has_selected_crossing || !track2.has_selected_crossing ||
+       track1.crossing != track2.crossing))
+  {
+    ++m_counter_reject_pair_crossing;
+    return false;
+  }
+
   if (!m_write_same_sign_pairs && track1.charge == track2.charge)
   {
     ++m_counter_reject_charge;
@@ -1232,8 +1333,18 @@ bool TpcV0CandidateTree::make_pair_row(const Tracklet &track1, const Tracklet &t
   reset_pair_row();
   m_pair.run = run_number;
   m_pair.evt = event_number;
-  m_pair.cross1 = 0;
-  m_pair.cross2 = 0;
+  m_pair.cross1 = track1.crossing;
+  m_pair.cross2 = track2.crossing;
+  m_pair.has_crossing_decision1 = track1.has_crossing_decision ? 1 : 0;
+  m_pair.has_crossing_decision2 = track2.has_crossing_decision ? 1 : 0;
+  m_pair.has_selected_crossing1 = track1.has_selected_crossing ? 1 : 0;
+  m_pair.has_selected_crossing2 = track2.has_selected_crossing ? 1 : 0;
+  m_pair.crossing_status1 = track1.crossing_status;
+  m_pair.crossing_status2 = track2.crossing_status;
+  m_pair.crossing_tier1 = track1.crossing_tier;
+  m_pair.crossing_tier2 = track2.crossing_tier;
+  m_pair.crossing_score1 = static_cast<float>(track1.crossing_score);
+  m_pair.crossing_score2 = static_cast<float>(track2.crossing_score);
   m_pair.px1 = static_cast<float>(mom1.x);
   m_pair.py1 = static_cast<float>(mom1.y);
   m_pair.pz1 = static_cast<float>(mom1.z);
@@ -1350,6 +1461,13 @@ void TpcV0CandidateTree::fill_track_row(const Tracklet &tracklet,
   m_track.side = tracklet.side;
   m_track.npoints = tracklet.npoints;
   m_track.ntpc_clusters = tracklet.ntpc_clusters;
+  m_track.source_assembled_track_id = tracklet.source_assembled_track_id;
+  m_track.has_crossing_decision = tracklet.has_crossing_decision ? 1 : 0;
+  m_track.has_selected_crossing = tracklet.has_selected_crossing ? 1 : 0;
+  m_track.crossing = tracklet.crossing;
+  m_track.crossing_status = tracklet.crossing_status;
+  m_track.crossing_tier = tracklet.crossing_tier;
+  m_track.crossing_score = static_cast<float>(tracklet.crossing_score);
   m_track.has_helix = tracklet.has_helix ? 1 : 0;
   m_track.has_kalman = tracklet.has_kalman ? 1 : 0;
   m_track.is_primary = tracklet.is_primary;
@@ -1956,6 +2074,20 @@ void TpcV0CandidateTree::create_branches()
   m_pair_tree->Branch("evt", &m_pair.evt, "evt/I");
   m_pair_tree->Branch("cross1", &m_pair.cross1, "cross1/S");
   m_pair_tree->Branch("cross2", &m_pair.cross2, "cross2/S");
+  m_pair_tree->Branch("has_crossing_decision1", &m_pair.has_crossing_decision1,
+                      "has_crossing_decision1/I");
+  m_pair_tree->Branch("has_crossing_decision2", &m_pair.has_crossing_decision2,
+                      "has_crossing_decision2/I");
+  m_pair_tree->Branch("has_selected_crossing1", &m_pair.has_selected_crossing1,
+                      "has_selected_crossing1/I");
+  m_pair_tree->Branch("has_selected_crossing2", &m_pair.has_selected_crossing2,
+                      "has_selected_crossing2/I");
+  m_pair_tree->Branch("crossing_status1", &m_pair.crossing_status1, "crossing_status1/I");
+  m_pair_tree->Branch("crossing_status2", &m_pair.crossing_status2, "crossing_status2/I");
+  m_pair_tree->Branch("crossing_tier1", &m_pair.crossing_tier1, "crossing_tier1/I");
+  m_pair_tree->Branch("crossing_tier2", &m_pair.crossing_tier2, "crossing_tier2/I");
+  m_pair_tree->Branch("crossing_score1", &m_pair.crossing_score1, "crossing_score1/F");
+  m_pair_tree->Branch("crossing_score2", &m_pair.crossing_score2, "crossing_score2/F");
   m_pair_tree->Branch("px1", &m_pair.px1, "px1/F");
   m_pair_tree->Branch("py1", &m_pair.py1, "py1/F");
   m_pair_tree->Branch("pz1", &m_pair.pz1, "pz1/F");
@@ -2040,6 +2172,16 @@ void TpcV0CandidateTree::create_branches()
   m_track_tree->Branch("side", &m_track.side, "side/I");
   m_track_tree->Branch("npoints", &m_track.npoints, "npoints/I");
   m_track_tree->Branch("ntpc_clusters", &m_track.ntpc_clusters, "ntpc_clusters/i");
+  m_track_tree->Branch("source_assembled_track_id", &m_track.source_assembled_track_id,
+                       "source_assembled_track_id/i");
+  m_track_tree->Branch("has_crossing_decision", &m_track.has_crossing_decision,
+                       "has_crossing_decision/I");
+  m_track_tree->Branch("has_selected_crossing", &m_track.has_selected_crossing,
+                       "has_selected_crossing/I");
+  m_track_tree->Branch("crossing", &m_track.crossing, "crossing/S");
+  m_track_tree->Branch("crossing_status", &m_track.crossing_status, "crossing_status/I");
+  m_track_tree->Branch("crossing_tier", &m_track.crossing_tier, "crossing_tier/I");
+  m_track_tree->Branch("crossing_score", &m_track.crossing_score, "crossing_score/F");
   m_track_tree->Branch("has_helix", &m_track.has_helix, "has_helix/I");
   m_track_tree->Branch("has_kalman", &m_track.has_kalman, "has_kalman/I");
   m_track_tree->Branch("is_primary", &m_track.is_primary, "is_primary/I");

--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.cc
@@ -387,43 +387,54 @@ int TpcV0CandidateTree::process_event(PHCompositeNode *topNode)
               << std::endl;
   }
 
-  const auto pair_loop_start = std::chrono::steady_clock::now();
-  std::uint64_t event_pairs_processed = 0;
-  const std::uint64_t event_pairs_total =
-      tracklets.size() > 1
-          ? static_cast<std::uint64_t>(tracklets.size()) *
-                static_cast<std::uint64_t>(tracklets.size() - 1) / 2
-          : 0;
-  if (m_print_timing)
+  double pair_loop_seconds = 0.0;
+  if (m_reconstruct_pairs)
+  {
+    const auto pair_loop_start = std::chrono::steady_clock::now();
+    std::uint64_t event_pairs_processed = 0;
+    const std::uint64_t event_pairs_total =
+        tracklets.size() > 1
+            ? static_cast<std::uint64_t>(tracklets.size()) *
+                  static_cast<std::uint64_t>(tracklets.size() - 1) / 2
+            : 0;
+    if (m_print_timing)
+    {
+      std::cout << "[V0TimingStage] run=" << run_number
+                << " event=" << event_number
+                << " stage=pair_loop_start"
+                << " pairs=" << event_pairs_total
+                << std::endl;
+    }
+    for (std::size_t i = 0; i < tracklets.size(); ++i)
+    {
+      for (std::size_t j = i + 1; j < tracklets.size(); ++j)
+      {
+        make_pair_row(*tracklets[i], *tracklets[j], primary_vertex, run_number, event_number);
+        ++event_pairs_processed;
+        if (m_print_timing &&
+            (event_pairs_processed == 1 || event_pairs_processed % 1000 == 0))
+        {
+          std::cout << "[V0TimingPair] run=" << run_number
+                    << " event=" << event_number
+                    << " done=" << event_pairs_processed
+                    << " total=" << event_pairs_total
+                    << " pair_loop_s=" << std::chrono::duration<double>(std::chrono::steady_clock::now() - pair_loop_start).count()
+                    << " kalman_pca_s=" << (m_timing_kalman_pca_seconds - kalman_pca_before)
+                    << std::endl;
+        }
+      }
+    }
+    pair_loop_seconds = std::chrono::duration<double>(
+                            std::chrono::steady_clock::now() - pair_loop_start)
+                            .count();
+  }
+  else if (m_print_timing)
   {
     std::cout << "[V0TimingStage] run=" << run_number
               << " event=" << event_number
-              << " stage=pair_loop_start"
-              << " pairs=" << event_pairs_total
+              << " stage=pair_loop_skipped"
               << std::endl;
   }
-  for (std::size_t i = 0; i < tracklets.size(); ++i)
-  {
-    for (std::size_t j = i + 1; j < tracklets.size(); ++j)
-    {
-      make_pair_row(*tracklets[i], *tracklets[j], primary_vertex, run_number, event_number);
-      ++event_pairs_processed;
-      if (m_print_timing &&
-          (event_pairs_processed == 1 || event_pairs_processed % 1000 == 0))
-      {
-        std::cout << "[V0TimingPair] run=" << run_number
-                  << " event=" << event_number
-                  << " done=" << event_pairs_processed
-                  << " total=" << event_pairs_total
-                  << " pair_loop_s=" << std::chrono::duration<double>(std::chrono::steady_clock::now() - pair_loop_start).count()
-                  << " kalman_pca_s=" << (m_timing_kalman_pca_seconds - kalman_pca_before)
-                  << std::endl;
-      }
-    }
-  }
-  const double pair_loop_seconds = std::chrono::duration<double>(
-                                       std::chrono::steady_clock::now() - pair_loop_start)
-                                       .count();
   const double total_seconds = std::chrono::duration<double>(
                                    std::chrono::steady_clock::now() - event_start)
                                    .count();

--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.h
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.h
@@ -8,6 +8,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -22,10 +23,13 @@ class TTree;
 class Tpc_PolyClusterContainer;
 class Tpc_PolyTrackContainer;
 class Tpc_PolyTrackVertexContainer;
+class TpcCrossingDecisionContainer;
 
 class TpcV0CandidateTree : public SubsysReco
 {
  public:
+  static constexpr int NoCrossingSelection = std::numeric_limits<short>::max();
+
   TpcV0CandidateTree(const std::string &name = "TpcV0CandidateTree",
                      const std::string &filename = "TpcV0Candidates.root");
   ~TpcV0CandidateTree() override = default;
@@ -40,6 +44,7 @@ class TpcV0CandidateTree : public SubsysReco
   void set_tpc_sa_cluster_node(const std::string &name) { m_tpc_sa_cluster_node = name; }
   void set_tpc_sa_track_node(const std::string &name) { m_tpc_sa_track_node = name; }
   void set_tpc_sa_track_vertex_node(const std::string &name) { m_tpc_sa_track_vertex_node = name; }
+  void set_crossing_decision_node(const std::string &name) { m_crossing_decision_node = name; }
   void use_pattern_cluster_tracks(const bool value = true) { m_use_pattern_cluster_tracks = value; }
   void set_use_truth_primary_vertex(const bool value) { m_use_truth_primary_vertex = value; }
   void set_primary_vertex(const double x, const double y, const double z);
@@ -176,6 +181,9 @@ class TpcV0CandidateTree : public SubsysReco
   void set_pair_alpha_abs_max(const double value) { m_pair_alpha_abs_max = value; }
   void set_pair_dca_max(const double value) { m_pair_dca_max = value; }
   void set_pair_dira_min(const double value) { m_pair_dira_min = value; }
+  void set_required_crossing(const int value) { m_required_crossing = value; }
+  void set_require_same_crossing(const bool value) { m_require_same_crossing = value; }
+  void set_max_crossing_tier(const int value) { m_max_crossing_tier = value; }
   void set_reconstruct_pairs(const bool value) { m_reconstruct_pairs = value; }
   void set_write_same_sign_pairs(const bool value) { m_write_same_sign_pairs = value; }
   void set_write_cluster_residual_tree(const bool value) { m_write_cluster_residual_tree = value; }
@@ -205,6 +213,13 @@ class TpcV0CandidateTree : public SubsysReco
     int side{-1};
     int npoints{0};
     unsigned int ntpc_clusters{0};
+    unsigned int source_assembled_track_id{0};
+    bool has_crossing_decision{false};
+    bool has_selected_crossing{false};
+    short crossing{std::numeric_limits<short>::max()};
+    int crossing_status{0};
+    int crossing_tier{std::numeric_limits<unsigned char>::max()};
+    double crossing_score{std::numeric_limits<double>::quiet_NaN()};
     bool has_dedx{false};
     double dedx{0.0};
     Vec3 position;
@@ -247,8 +262,18 @@ class TpcV0CandidateTree : public SubsysReco
   {
     int run{0};
     int evt{0};
-    short cross1{0};
-    short cross2{0};
+    short cross1{std::numeric_limits<short>::max()};
+    short cross2{std::numeric_limits<short>::max()};
+    int has_crossing_decision1{0};
+    int has_crossing_decision2{0};
+    int has_selected_crossing1{0};
+    int has_selected_crossing2{0};
+    int crossing_status1{0};
+    int crossing_status2{0};
+    int crossing_tier1{std::numeric_limits<unsigned char>::max()};
+    int crossing_tier2{std::numeric_limits<unsigned char>::max()};
+    float crossing_score1{std::numeric_limits<float>::quiet_NaN()};
+    float crossing_score2{std::numeric_limits<float>::quiet_NaN()};
 
     float px1{0.0F};
     float py1{0.0F};
@@ -343,6 +368,13 @@ class TpcV0CandidateTree : public SubsysReco
     int side{-1};
     int npoints{0};
     unsigned int ntpc_clusters{0};
+    unsigned int source_assembled_track_id{0};
+    int has_crossing_decision{0};
+    int has_selected_crossing{0};
+    short crossing{std::numeric_limits<short>::max()};
+    int crossing_status{0};
+    int crossing_tier{std::numeric_limits<unsigned char>::max()};
+    float crossing_score{std::numeric_limits<float>::quiet_NaN()};
     int has_helix{0};
     int has_kalman{0};
     int is_primary{0};
@@ -492,7 +524,8 @@ class TpcV0CandidateTree : public SubsysReco
   std::map<int, Tracklet> build_tracklets(PHG4HitContainer *truth_points,
                                           PHG4TruthInfoContainer *truth_info) const;
   std::map<int, Tracklet> build_pattern_tracklets(Tpc_PolyClusterContainer *clusters,
-                                                  Tpc_PolyTrackContainer *tracks) const;
+                                                  Tpc_PolyTrackContainer *tracks,
+                                                  const TpcCrossingDecisionContainer *crossing_decisions) const;
   bool finalize_pattern_tracklet(Tracklet &tracklet, bool has_upstream_state) const;
   bool make_pair_row(const Tracklet &track1, const Tracklet &track2,
                      const Vec3 &primary_vertex, const int run_number,
@@ -614,6 +647,7 @@ class TpcV0CandidateTree : public SubsysReco
   std::string m_tpc_sa_cluster_node{"TPC_POLYCLUSTERS"};
   std::string m_tpc_sa_track_node{"TPC_POLYTRACKS"};
   std::string m_tpc_sa_track_vertex_node{"TPC_POLYTRACKVERTICES"};
+  std::string m_crossing_decision_node{"TPC_CROSSING_DECISIONS"};
   bool m_use_pattern_cluster_tracks{false};
 
   TFile *m_file{nullptr};
@@ -662,11 +696,15 @@ class TpcV0CandidateTree : public SubsysReco
   double m_pair_alpha_abs_max{-1.0};
   double m_pair_dca_max{-1.0};
   double m_pair_dira_min{-2.0};
+  int m_required_crossing{NoCrossingSelection};
+  int m_max_crossing_tier{-1};
+  bool m_require_same_crossing{false};
   bool m_reconstruct_pairs{true};
   bool m_write_same_sign_pairs{false};
   bool m_print_timing{false};
 
   std::uint64_t m_counter_raw_pairs{0};
+  std::uint64_t m_counter_reject_pair_crossing{0};
   std::uint64_t m_counter_reject_charge{0};
   std::uint64_t m_counter_reject_preselection{0};
   std::uint64_t m_counter_reject_pca{0};
@@ -676,6 +714,9 @@ class TpcV0CandidateTree : public SubsysReco
   std::uint64_t m_counter_written{0};
   std::uint64_t m_counter_tracks_written{0};
   std::uint64_t m_counter_cluster_residuals_written{0};
+  mutable std::uint64_t m_counter_missing_crossing_decision{0};
+  mutable std::uint64_t m_counter_reject_required_crossing{0};
+  mutable std::uint64_t m_counter_reject_crossing_tier{0};
   mutable std::uint64_t m_counter_reject_helix_anchor{0};
   std::uint64_t m_timing_events{0};
   mutable std::uint64_t m_timing_kalman_fits{0};

--- a/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.h
+++ b/offline/packages/TrackingDiagnostics/TpcV0CandidateTree.h
@@ -176,6 +176,7 @@ class TpcV0CandidateTree : public SubsysReco
   void set_pair_alpha_abs_max(const double value) { m_pair_alpha_abs_max = value; }
   void set_pair_dca_max(const double value) { m_pair_dca_max = value; }
   void set_pair_dira_min(const double value) { m_pair_dira_min = value; }
+  void set_reconstruct_pairs(const bool value) { m_reconstruct_pairs = value; }
   void set_write_same_sign_pairs(const bool value) { m_write_same_sign_pairs = value; }
   void set_write_cluster_residual_tree(const bool value) { m_write_cluster_residual_tree = value; }
 
@@ -661,6 +662,7 @@ class TpcV0CandidateTree : public SubsysReco
   double m_pair_alpha_abs_max{-1.0};
   double m_pair_dca_max{-1.0};
   double m_pair_dira_min{-2.0};
+  bool m_reconstruct_pairs{true};
   bool m_write_same_sign_pairs{false};
   bool m_print_timing{false};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR extends `TpcV0CandidateTree` with two optional features:

- A track-fit-only mode controlled by `set_reconstruct_pairs(false)`.
  Tracks are still built, fitted, and written to `trackTree`, while the
  pair-reconstruction loop is skipped.
- TPC bunch-crossing metadata and selection using
  `TpcCrossingDecisionContainer`.

The crossing information is associated with the source assembled track and
written to both `trackTree` and `pairTree`. Optional selections support:

- requiring a selected crossing;
- limiting the crossing-decision tier;
- requiring both daughters in a pair to have the same crossing.

Existing behavior is preserved by default:

- pair reconstruction remains enabled;
- crossing selection remains disabled;
- existing helix, Kalman, residual, and V0 reconstruction options remain
  available.
## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
- sPHENIX macros PR: https://github.com/sPHENIX-Collaboration/macros/pull/1379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Extend `TpcV0CandidateTree` for track-fit studies and TPC bunch-crossing studies while preserving default behavior.

## Key changes

- Add track-fit-only mode with `set_reconstruct_pairs(false)`.
- Record crossing status, tier, score, selected crossing, and source track information.
- Write crossing metadata to `trackTree` and `pairTree`.
- Add optional crossing, tier, and same-crossing pair filters.
- Validate crossing configuration and required input nodes.
- Add crossing-related rejection counters.
- Keep pair reconstruction and existing reconstruction options enabled by default.

## Potential risk areas

- New branches change the tree I/O format.
- Crossing filters can reduce track and pair yields.
- Track-fit-only mode skips pair reconstruction.
- Crossing lookups and mutable counters may affect performance or thread-safety.
- The macros repository requires matching configuration support.

## Possible future improvements

- Add tests for crossing filters, missing nodes, same-crossing pairs, and track-fit-only mode.
- Document the new setters and tree branches.
- Measure crossing lookup and filtering performance.
- Validate the corresponding macros repository update.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation and related macros changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->