### PR TITLE
Tpc geometry

### DIFF
--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.cc
@@ -116,8 +116,6 @@ Tpc_PolyClusterizer::~Tpc_PolyClusterizer()
 {
   delete m_idealPadMap;
   m_idealPadMap = nullptr;
-  delete m_garfield;
-  m_garfield = nullptr;
 }
 
 bool Tpc_PolyClusterizer::load_cdb_inputs()
@@ -252,18 +250,30 @@ int Tpc_PolyClusterizer::InitRun(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  PHG4TpcGeom* layergeom = m_geomContainerTpc->GetLayerCellGeom(20);
-  double rot_x = layergeom->get_rot_x();
-  double rot_y = layergeom->get_rot_y();
-  double rot_z = layergeom->get_rot_z();
-  double place_x = layergeom->get_place_x();
-  double place_y = layergeom->get_place_y();
-  double place_z = layergeom->get_place_z();
+  // get layer geometry for layer 20.
+  auto* layergeom = m_geomContainerTpc->GetLayerCellGeom(20);
   if (use_survey_geometry)
   {
+    // apply survey geometry
+    const double rot_x = layergeom->get_rot_x();
+    const double rot_y = layergeom->get_rot_y();
+    const double rot_z = layergeom->get_rot_z();
+
+    const double place_x = layergeom->get_place_x();
+    const double place_y = layergeom->get_place_y();
+    const double place_z = layergeom->get_place_z();
+
     m_tpcMove = {place_x, place_y, place_z};
     m_tpcRotations = {{{rot_x, rot_y, rot_z}, {0.0, 0.0, 0.0}}};
   }
+
+  // update m_startZSouth and m_startZNorth, based on TPC geometry
+  m_startZSouth = -(layergeom->get_max_driftlength() + layergeom->get_CM_halfwidth());
+  m_startZNorth = layergeom->get_max_driftlength() + layergeom->get_CM_halfwidth();
+
+  // printout
+  std::cout << Name() << "::InitRun - m_startZSouth: " << m_startZSouth << " cm" << std::endl;
+  std::cout << Name() << "::InitRun - m_startZNorth: " << m_startZNorth << " cm" << std::endl;
 
   if (!load_cdb_inputs())
   {
@@ -271,12 +281,9 @@ int Tpc_PolyClusterizer::InitRun(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  delete m_garfield;
-  m_garfield = nullptr;
+  m_garfield.reset( new PHGarfield(Name() + "_PHGarfield", "", m_kEffSide0, m_kEffSide1) );
 
-  m_garfield = new PHGarfield(Name() + "_PHGarfield", "", m_kEffSide0, m_kEffSide1);
-
-  configure_garfield(m_garfield);
+  configure_garfield(m_garfield.get());
   if (m_garfield->InitRun(topNode) != Fun4AllReturnCodes::EVENT_OK)
   {
     std::cerr << Name() << "::InitRun - PHGarfield InitRun failed" << std::endl;
@@ -1045,7 +1052,7 @@ int Tpc_PolyClusterizer::process_event(PHCompositeNode* topNode)
 
               iphi_sum += static_cast<double>(iphi) * adc;
               iphi2_sum += square(static_cast<double>(iphi)) * adc;
-              
+
               const double t = layergeom->get_zcenter(it);
               t_sum += t * adc;
               t2_sum += square(t) * adc;

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
@@ -7,6 +7,7 @@
 #include <trackbase/TrkrDefs.h>
 
 #include <array>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -175,7 +176,9 @@ class Tpc_PolyClusterizer : public SubsysReco
   TpcCrossingDecisionContainer* m_crossingDecisions {nullptr};
   TrkrHitSetContainer* m_hits{nullptr};
   IdealPadMap* m_idealPadMap{nullptr};
-  PHGarfield* m_garfield{nullptr};
+
+  std::unique_ptr<PHGarfield> m_garfield{};
+
   PHG4TpcGeomContainer* m_geomContainerTpc{nullptr};
   std::array<DriftPolyline, 48 * 2 * 12 * NPhiSamples> m_driftLookup;
   unsigned int m_event{0};
@@ -183,8 +186,15 @@ class Tpc_PolyClusterizer : public SubsysReco
   double m_tpcAdcClock{56.881262};
   double m_crossingPeriodNs {106.56};
   double m_reverseDriftStepNs{56.881262};
-  double m_startZSouth{-102.325};
-  double m_startZNorth{102.325};
+
+
+  //! starting z position for primary electron backward drift
+  /**
+   * quoted values must be kept consistent with _max_driftlength + _CM_halfwidth
+   * as defined in offline/packages/trackbase/ActsGeometry.h
+   */
+  double m_startZSouth{-102.515};
+  double m_startZNorth{102.515};
   double m_kEffSide0{0.0};
   double m_kEffSide1{0.0};
   double m_cmVoltageDefault{375.0};

--- a/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyClusterizer.h
@@ -193,8 +193,8 @@ class Tpc_PolyClusterizer : public SubsysReco
    * quoted values must be kept consistent with _max_driftlength + _CM_halfwidth
    * as defined in offline/packages/trackbase/ActsGeometry.h
    */
-  double m_startZSouth{-102.515};
-  double m_startZNorth{102.515};
+  double m_startZSouth{-102.605};
+  double m_startZNorth{102.605};
   double m_kEffSide0{0.0};
   double m_kEffSide1{0.0};
   double m_cmVoltageDefault{375.0};

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -80,7 +80,7 @@ class ActsGeometry
       TrkrDefs::hitsetkey hitsetkey,
       Acts::Vector3 clus_envelope,
       TrkrDefs::subsurfkey& subsurfkey) const;
-    
+
   Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation) const;
 
   Acts::Vector3 transformTpcWorldToEnvelope(const Acts::Vector3& world) const ;
@@ -95,7 +95,7 @@ class ActsGeometry
   Acts::Transform3 m_tpc_world_envelope_transform;
   Acts::Transform3 m_tpc_envelope_world_transform;
   double _drift_velocity = 8.0e-3;  // cm/ns
-  double _max_driftlength = 102.235;  // cm
+  double _max_driftlength = 102.325;  // cm
   double _CM_halfwidth = 0.28;  // cm
   double _tpc_tzero = 0.0;  // ns
   double _sampa_tzero_bias = 0.0;  // ns

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -340,6 +340,9 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->set_drift_velocity(m_drift_velocity);
   m_actsGeometry->set_max_driftlength(m_max_driftlength);
   m_actsGeometry->set_CM_halfwidth(m_CM_halfwidth);
+  std::cout << "MakeActsGeometry::InitRun - m_max_driftlength: " << m_max_driftlength << std::endl;
+  std::cout << "MakeActsGeometry::InitRun - m_CM_halfwidth: " << m_CM_halfwidth << std::endl;
+
   m_actsGeometry->set_tpc_tzero(m_tpc_tzero);
   m_actsGeometry->set_sampa_tzero_bias(m_sampa_tzero_bias);
   m_actsGeometry->set_tpc_world_envelope_transform(m_tpc_world_envelope_transform);  // transform world position to TPC envelope position


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
As discussed during the trackign meeting, this PR ensures that ActsGeometry and Tpc_PolyClusterizer use consistent max_driftlength, cm_halfwidth, and startZ (North and South). It also printouts the actual values loaded from the geometry object, and (unrelated) use a std::unique_ptr for PHGarfield, instead of cumbersome and error prone new/delete calls in the code. 

@osbornjd @adfrawley @mitrankova: one question though: 

the default value for ActsGeometry::_max_driftlength is 102.235 (see https://github.com/sPHENIX-Collaboration/coresoftware/blob/a9ae0b372f51762838916ee3a0763e812997221b/offline/packages/trackbase/ActsGeometry.h#L98)

the value returned by the TpcGeom object (at https://github.com/sPHENIX-Collaboration/coresoftware/blob/a9ae0b372f51762838916ee3a0763e812997221b/offline/packages/trackreco/MakeActsGeometry.cc#L182) 
is 102.325. 

Can we double check what is the correct one ? (and that one is not a typo of the other). and if the latter is correct, should we change the former (default) value accordingly ? 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

This PR keeps `ActsGeometry` and `Tpc_PolyClusterizer` consistent for drift geometry and North/South `startZ` values. It reduces the risk of mismatched TPC reconstruction geometry.

## Key changes

- Set the `ActsGeometry` default `max_driftlength` to `102.325` cm.
- Read North/South `startZ` values from `TpcLayerGeom`.
- Update `Tpc_PolyClusterizer` defaults to match the configured geometry.
- Print `max_driftlength` and `cm_halfwidth` during `MakeActsGeometry::InitRun`.
- Manage `PHGarfield` with `std::unique_ptr`.
- Apply survey geometry only when `use_survey_geometry` is enabled.

## Potential risk areas

- Drift and starting-Z changes can affect reconstruction results.
- Diagnostic output changes runtime logs but not I/O formats.
- No direct performance or thread-safety impact is expected from the ownership change.
- Geometry values should be validated against detector configuration and reconstruction results.

## Possible future improvements

- Add validation for consistent drift-length and `startZ` values across geometry components.
- Keep geometry defaults and runtime configuration synchronized.
- AI-generated summaries can contain errors. Reviewers should verify numerical values and reconstruction behavior against the implementation and detector geometry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->