### PR TITLE
fix SingleTriggeredInput dtor, delete evt only once

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -44,15 +44,20 @@ SingleTriggeredInput::~SingleTriggeredInput()
       dq.pop_front();
     }
   }
+  // by design multiple packets save the same event pointer, this makes sure
+  // we delete them only once
+  for (auto& [pid, evt] : m_PacketEventBackup)
+  {
+    if (evt)
+    {
+      evtset.insert(evt);
+    }
+  }
   for (auto* evt : evtset)
   {
     delete evt;
   }
   evtset.clear();
-  for (auto& [pid, evt] : m_PacketEventBackup)
-  {
-    delete evt;
-  }
 
   delete m_EventIterator;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The dtor deleted the same evt multiple times if it was stored for a few packet ids in the m_PacketEventBackup map. This seems to affect all runs with an issue at the first event.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Fixes a double-deletion bug in `SingleTriggeredInput` destruction. The bug can occur when the same event is stored for multiple packet IDs, especially when a problem occurs at the first event.

## Key changes

- Collects non-null pointers from `m_PacketEventBackup` in a shared event set.
- Deletes each event only once.
- Preserves safe cleanup when backup entries also reference events in `m_PacketEventDeque`.
- Does not change public declarations or I/O formats.

## Potential risk areas

- No expected reconstruction or output-format changes.
- The change affects destruction-time ownership and cleanup.
- Incorrect pointer ownership assumptions could still cause leaks or invalid access.
- No thread-safety or performance impact is expected.

## Possible future improvements

- Add regression coverage for first-event failures and repeated event pointers.
- Document ownership rules for `m_PacketEventBackup` and `m_PacketEventDeque`.
- Use sanitizers to verify destruction paths.

AI-generated summaries can contain errors. Contributors should verify the ownership behavior against the full implementation and relevant tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->