### PR TITLE
CaloCDB: Add HCal BadTowerMaps and Support distinct QA dataset tags

### DIFF
--- a/calibrations/calorimeter/calo_cdb/FilterDatasets.cc
+++ b/calibrations/calorimeter/calo_cdb/FilterDatasets.cc
@@ -29,7 +29,13 @@ void FilterDatasets::readRunInfo(const std::string &line)
     return;
   }
 
-  m_runInfo.emplace_back(tokens[0], tokens[1]);
+  std::string dsttype_group;
+  if (tokens.size() >= 3)
+  {
+    dsttype_group = tokens[2];
+  }
+
+  m_runInfo.emplace_back(tokens[0], tokens[1], dsttype_group);
 }
 
 std::string FilterDatasets::getCalibration(const std::string &pl_type, uint64_t iov)
@@ -55,22 +61,40 @@ void FilterDatasets::analyze(const std::string &input, const std::string &output
   }
 
   // write the header for the CSV
-  file << "runnumber" << std::endl;
+  file << "runnumber,dsttype_group" << std::endl;
 
   // loop over each run to check if any is missing the latest calibration
   // if a run is missing the latest calibration then write it to the CSV for processing
-  for (const auto &run_dataset : m_runInfo)
+  for (const auto &run_dataset_type : m_runInfo)
   {
-    std::string run = run_dataset.first;
-    std::string dataset = run_dataset.second;
+    std::string run = std::get<0>(run_dataset_type);
+    std::string dataset = std::get<1>(run_dataset_type);
+    std::string dsttype_group = std::get<2>(run_dataset_type);
     ++m_ctr["ctr_run"];
-    std::cout << "Run: " << run << ", Dataset: " << dataset << ", Processing: "
+    std::cout << "Run: " << run << ", Dataset: " << dataset << ", Group: " << dsttype_group << ", Processing: "
               << m_ctr["ctr_run"] << ", " << m_ctr["ctr_run"] * 100. / static_cast<Double_t>(m_runInfo.size()) << " %" << std::endl;
 
     Bool_t keep = false;
 
     for (const auto &cdbName : m_cdbName)
     {
+      if (dsttype_group == "HIST_JETQA")
+      {
+        if (cdbName.find("ZSCrossCalib") != std::string::npos)
+        {
+          continue;
+        }
+      }
+      else if (dsttype_group == "HIST_CALOFITTINGQA")
+      {
+        if (cdbName.find("BadTowerMap") != std::string::npos ||
+            cdbName.find("meanTime") != std::string::npos ||
+            cdbName.find("fracBadChi2") != std::string::npos)
+        {
+          continue;
+        }
+      }
+
       if (m_debug)
       {
         std::cout << "Attempt to get Calibration" << std::endl;
@@ -82,9 +106,16 @@ void FilterDatasets::analyze(const std::string &input, const std::string &output
       }
 
       std::stringstream ss;
-      if (cdbName == "CEMC_BadTowerMap")
+      if (cdbName.find("BadTowerMap") != std::string::npos)
       {
-        ss << "EMCalHotMap_" << dataset << "_" << run << "cdb.root";
+        if (cdbName == "CEMC_BadTowerMap")
+        {
+          ss << "EMCalHotMap_" << dataset << "_" << run << "cdb.root";
+        }
+        else
+        {
+          ss << cdbName << "_" << dataset << "_" << run << "cdb.root";
+        }
       }
       else
       {
@@ -109,7 +140,7 @@ void FilterDatasets::analyze(const std::string &input, const std::string &output
 
     if (keep)
     {
-      file << run << std::endl;
+      file << run << "," << dsttype_group << std::endl;
     }
   }
 

--- a/calibrations/calorimeter/calo_cdb/FilterDatasets.h
+++ b/calibrations/calorimeter/calo_cdb/FilterDatasets.h
@@ -23,7 +23,7 @@ class FilterDatasets
   std::vector<std::pair<std::string, std::string>> m_runInfo;
   std::map<std::string, int> m_ctr;
 
-  std::vector<std::string> m_cdbName = {"CEMC_BadTowerMap"
+  std::vector<std::string> m_cdbName = {"CEMC_BadTowerMap", "HCALIN_BadTowerMap", "HCALOUT_BadTowerMap"
                                       , "CEMC_meanTime", "HCALIN_meanTime", "HCALOUT_meanTime"
                                       , "CEMC_hotTowers_fracBadChi2", "HCALIN_hotTowers_fracBadChi2", "HCALOUT_hotTowers_fracBadChi2"
                                       , "CEMC_ZSCrossCalib", "HCALIN_ZSCrossCalib", "HCALOUT_ZSCrossCalib"};

--- a/calibrations/calorimeter/calo_cdb/FilterDatasets.h
+++ b/calibrations/calorimeter/calo_cdb/FilterDatasets.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <tuple>
 
 class FilterDatasets
 {
@@ -20,7 +21,7 @@ class FilterDatasets
 
   std::string getCalibration(const std::string &pl_type, uint64_t iov);
 
-  std::vector<std::pair<std::string, std::string>> m_runInfo;
+  std::vector<std::tuple<std::string, std::string, std::string>> m_runInfo;
   std::map<std::string, int> m_ctr;
 
   std::vector<std::string> m_cdbName = {"CEMC_BadTowerMap", "HCALIN_BadTowerMap", "HCALOUT_BadTowerMap"

--- a/calibrations/calorimeter/calo_cdb/GenStatus.cc
+++ b/calibrations/calorimeter/calo_cdb/GenStatus.cc
@@ -315,7 +315,12 @@ void GenStatus::process(const std::string &input, const std::string &output)
   std::string outputDir = datasetDir.str();
 
   std::string hotMapFile = "EMCalHotMap_" + m_dataset + "_" + m_run + ".root";
+  std::string hotMapFile_IHCAL = "HCALIN_BadTowerMap_" + m_dataset + "_" + m_run + ".root";
+  std::string hotMapFile_OHCAL = "HCALOUT_BadTowerMap_" + m_dataset + "_" + m_run + ".root";
+
   std::string hotMapOutput = datasetDir.str() + "/" + hotMapFile;
+  std::string hotMapOutput_IHCAL = datasetDir.str() + "/" + hotMapFile_IHCAL;
+  std::string hotMapOutput_OHCAL = datasetDir.str() + "/" + hotMapFile_OHCAL;
 
   datasetDir << "/QA";
 
@@ -323,6 +328,8 @@ void GenStatus::process(const std::string &input, const std::string &output)
   std::filesystem::create_directories(datasetDir.str());
 
   std::string hotMapOutputQA = datasetDir.str() + "/" + hotMapFile;
+  std::string hotMapOutputQA_IHCAL = datasetDir.str() + "/" + hotMapFile_IHCAL;
+  std::string hotMapOutputQA_OHCAL = datasetDir.str() + "/" + hotMapFile_OHCAL;
 
   // merges individal qa into one per run
   int ret = readHists(input);
@@ -336,9 +343,21 @@ void GenStatus::process(const std::string &input, const std::string &output)
   std::unique_ptr<emcNoisyTowerFinder> calo = std::make_unique<emcNoisyTowerFinder>();
   calo->FindHot(m_CaloValid_list, hotMapOutput, "h_CaloValid_cemc_etaphi");
 
+  std::unique_ptr<emcNoisyTowerFinder> calo_ihcal = std::make_unique<emcNoisyTowerFinder>();
+  calo_ihcal->set_ihcal();
+  calo_ihcal->Verbosity(1);
+  calo_ihcal->FindHot(m_CaloValid_list, hotMapOutput_IHCAL, "h_CaloValid_ihcal_etaphi");
+
+  std::unique_ptr<emcNoisyTowerFinder> calo_ohcal = std::make_unique<emcNoisyTowerFinder>();
+  calo_ohcal->set_ohcal();
+  calo_ohcal->Verbosity(1);
+  calo_ohcal->FindHot(m_CaloValid_list, hotMapOutput_OHCAL, "h_CaloValid_ohcal_etaphi");
+
   if (std::filesystem::exists(hotMapOutput))
   {
     std::filesystem::rename(hotMapOutput, hotMapOutputQA);
+    std::filesystem::rename(hotMapOutput_IHCAL, hotMapOutputQA_IHCAL);
+    std::filesystem::rename(hotMapOutput_OHCAL, hotMapOutputQA_OHCAL);
   }
   else
   {

--- a/calibrations/calorimeter/calo_cdb/GenStatus.cc
+++ b/calibrations/calorimeter/calo_cdb/GenStatus.cc
@@ -23,6 +23,8 @@ void GenStatus::setRunDataset(const std::string &input)
   std::string basename = std::filesystem::path(input).filename().stem().string();
   m_run = basename.substr(0, basename.find('_'));
   m_dataset = basename.substr(basename.find('_') + 1, basename.size() - basename.find('_'));
+  m_dataset_jetqa.clear();
+  m_dataset_calofittingqa.clear();
 }
 
 std::string GenStatus::extractTag(const std::string &filename, const std::string &prefix)
@@ -333,6 +335,9 @@ void GenStatus::analyze(const std::string &outputDir)
 
 void GenStatus::process(const std::string &input, const std::string &output)
 {
+  m_dataset_jetqa.clear();
+  m_dataset_calofittingqa.clear();
+
   std::cout << "#############################" << std::endl;
   std::cout << "Run Parameters" << std::endl;
   std::cout << "input: " << input << std::endl;

--- a/calibrations/calorimeter/calo_cdb/GenStatus.cc
+++ b/calibrations/calorimeter/calo_cdb/GenStatus.cc
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <vector>
 
 void GenStatus::setRunDataset(const std::string &input)
 {
@@ -395,14 +396,33 @@ void GenStatus::process(const std::string &input, const std::string &output)
   calo_ohcal->Verbosity(1);
   calo_ohcal->FindHot(m_CaloValid_list, hotMapOutput_OHCAL, "h_CaloValid_ohcal_etaphi");
 
-  if (std::filesystem::exists(hotMapOutput))
+  struct HotMapInfo
   {
-    std::filesystem::rename(hotMapOutput, hotMapOutputQA);
-    std::filesystem::rename(hotMapOutput_IHCAL, hotMapOutputQA_IHCAL);
-    std::filesystem::rename(hotMapOutput_OHCAL, hotMapOutputQA_OHCAL);
-  }
-  else
+    std::string name;
+    std::string src;
+    std::string dst;
+  };
+
+  const std::vector<HotMapInfo> hotMaps = {
+      {"EMCal", hotMapOutput, hotMapOutputQA},
+      {"IHCAL", hotMapOutput_IHCAL, hotMapOutputQA_IHCAL},
+      {"OHCAL", hotMapOutput_OHCAL, hotMapOutputQA_OHCAL}
+  };
+
+  for (const auto &hotMap : hotMaps)
   {
-    std::cout << "ERROR: EMCal Hot Map FAILED to Create." << std::endl;
+    std::error_code ec;
+    if (std::filesystem::exists(hotMap.src, ec))
+    {
+      std::filesystem::rename(hotMap.src, hotMap.dst, ec);
+      if (ec)
+      {
+        std::cout << "ERROR: Failed to move " << hotMap.name << " Hot Map: " << ec.message() << std::endl;
+      }
+    }
+    else
+    {
+      std::cout << "ERROR: " << hotMap.name << " Hot Map FAILED to Create." << std::endl;
+    }
   }
 }

--- a/calibrations/calorimeter/calo_cdb/GenStatus.cc
+++ b/calibrations/calorimeter/calo_cdb/GenStatus.cc
@@ -25,6 +25,27 @@ void GenStatus::setRunDataset(const std::string &input)
   m_dataset = basename.substr(basename.find('_') + 1, basename.size() - basename.find('_'));
 }
 
+std::string GenStatus::extractTag(const std::string &filename, const std::string &prefix)
+{
+  std::string base = std::filesystem::path(filename).filename().string();
+  size_t pos1 = base.find(prefix);
+  if (pos1 == std::string::npos)
+  {
+    return "";
+  }
+  size_t pos2 = base.find('_', pos1 + prefix.length());
+  if (pos2 == std::string::npos)
+  {
+    return "";
+  }
+  size_t pos3 = base.find('-', pos2 + 1);
+  if (pos3 == std::string::npos)
+  {
+    return "";
+  }
+  return base.substr(pos2 + 1, pos3 - pos2 - 1);
+}
+
 int GenStatus::readHists(const std::string &input)
 {
   // Create an input stream
@@ -76,9 +97,20 @@ int GenStatus::readHists(const std::string &input)
 
     ++ctr["successfully_opened_files"];
 
-    if (line.find("HIST_CALOQA") != std::string::npos)
+    if (line.find("HIST_JETQA") != std::string::npos)
     {
       outfile << line << std::endl;
+      if (m_dataset_jetqa.empty())
+      {
+        m_dataset_jetqa = extractTag(line, "HIST_JETQA_");
+      }
+    }
+    else if (line.find("HIST_CALOFITTINGQA") != std::string::npos)
+    {
+      if (m_dataset_calofittingqa.empty())
+      {
+        m_dataset_calofittingqa = extractTag(line, "HIST_CALOFITTINGQA_");
+      }
     }
 
     auto *h = dynamic_cast<TProfile2D *>(tf->Get("h_CaloValid_cemc_etaphi_badChi2"));
@@ -235,21 +267,24 @@ void GenStatus::histToCaloCDBTree(const std::string &outputfile, const std::stri
 
 void GenStatus::analyze(const std::string &outputDir)
 {
+  std::string tag_jetqa = m_dataset_jetqa.empty() ? m_dataset : m_dataset_jetqa;
+  std::string tag_calofittingqa = m_dataset_calofittingqa.empty() ? m_dataset : m_dataset_calofittingqa;
+
   std::string detector = "CEMC";
   // fracBadChi2
-  std::string payloadName = outputDir + "/" + detector + "_hotTowers_fracBadChi2" + "_" + m_dataset + "_" + m_run + ".root";
+  std::string payloadName = outputDir + "/" + detector + "_hotTowers_fracBadChi2" + "_" + tag_jetqa + "_" + m_run + ".root";
   if (h_CaloValid_cemc_etaphi_badChi2->GetEntries())
   {
     histToCaloCDBTree(payloadName, "fraction", 0, h_CaloValid_cemc_etaphi_badChi2.get());
   }
   // time
-  payloadName = outputDir + "/" + detector + "_meanTime" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_meanTime" + "_" + tag_jetqa + "_" + m_run + ".root";
   if (h_CaloValid_cemc_etaphi_time_raw->GetEntries())
   {
     histToCaloCDBTree(payloadName, "time", 0, h_CaloValid_cemc_etaphi_time_raw.get());
   }
   // ZSCrossCalib
-  payloadName = outputDir + "/" + detector + "_ZSCrossCalib" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_ZSCrossCalib" + "_" + tag_calofittingqa + "_" + m_run + ".root";
   if (h_CaloFittingQA_cemc_etaphi_ZScrosscalib->GetEntries())
   {
     histToCaloCDBTree(payloadName, "ratio", 0, h_CaloFittingQA_cemc_etaphi_ZScrosscalib.get());
@@ -257,19 +292,19 @@ void GenStatus::analyze(const std::string &outputDir)
 
   detector = "HCALIN";
   // fracBadChi2
-  payloadName = outputDir + "/" + detector + "_hotTowers_fracBadChi2" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_hotTowers_fracBadChi2" + "_" + tag_jetqa + "_" + m_run + ".root";
   if (h_CaloValid_ihcal_etaphi_badChi2->GetEntries())
   {
     histToCaloCDBTree(payloadName, "fraction", 1, h_CaloValid_ihcal_etaphi_badChi2.get());
   }
   // time
-  payloadName = outputDir + "/" + detector + "_meanTime" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_meanTime" + "_" + tag_jetqa + "_" + m_run + ".root";
   if (h_CaloValid_ihcal_etaphi_time_raw->GetEntries())
   {
     histToCaloCDBTree(payloadName, "time", 1, h_CaloValid_ihcal_etaphi_time_raw.get());
   }
   // ZSCrossCalib
-  payloadName = outputDir + "/" + detector + "_ZSCrossCalib" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_ZSCrossCalib" + "_" + tag_calofittingqa + "_" + m_run + ".root";
   if (h_CaloFittingQA_ihcal_etaphi_ZScrosscalib->GetEntries())
   {
     histToCaloCDBTree(payloadName, "ratio", 1, h_CaloFittingQA_ihcal_etaphi_ZScrosscalib.get());
@@ -277,19 +312,19 @@ void GenStatus::analyze(const std::string &outputDir)
 
   detector = "HCALOUT";
   // fracBadChi2
-  payloadName = outputDir + "/" + detector + "_hotTowers_fracBadChi2" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_hotTowers_fracBadChi2" + "_" + tag_jetqa + "_" + m_run + ".root";
   if (h_CaloValid_ohcal_etaphi_badChi2->GetEntries())
   {
     histToCaloCDBTree(payloadName, "fraction", 1, h_CaloValid_ohcal_etaphi_badChi2.get());
   }
   // time
-  payloadName = outputDir + "/" + detector + "_meanTime" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_meanTime" + "_" + tag_jetqa + "_" + m_run + ".root";
   if (h_CaloValid_ohcal_etaphi_time_raw->GetEntries())
   {
     histToCaloCDBTree(payloadName, "time", 1, h_CaloValid_ohcal_etaphi_time_raw.get());
   }
   // ZSCrossCalib
-  payloadName = outputDir + "/" + detector + "_ZSCrossCalib" + "_" + m_dataset + "_" + m_run + ".root";
+  payloadName = outputDir + "/" + detector + "_ZSCrossCalib" + "_" + tag_calofittingqa + "_" + m_run + ".root";
   if (h_CaloFittingQA_ohcal_etaphi_ZScrosscalib->GetEntries())
   {
     histToCaloCDBTree(payloadName, "ratio", 1, h_CaloFittingQA_ohcal_etaphi_ZScrosscalib.get());
@@ -314,22 +349,10 @@ void GenStatus::process(const std::string &input, const std::string &output)
 
   std::string outputDir = datasetDir.str();
 
-  std::string hotMapFile = "EMCalHotMap_" + m_dataset + "_" + m_run + ".root";
-  std::string hotMapFile_IHCAL = "HCALIN_BadTowerMap_" + m_dataset + "_" + m_run + ".root";
-  std::string hotMapFile_OHCAL = "HCALOUT_BadTowerMap_" + m_dataset + "_" + m_run + ".root";
-
-  std::string hotMapOutput = datasetDir.str() + "/" + hotMapFile;
-  std::string hotMapOutput_IHCAL = datasetDir.str() + "/" + hotMapFile_IHCAL;
-  std::string hotMapOutput_OHCAL = datasetDir.str() + "/" + hotMapFile_OHCAL;
-
   datasetDir << "/QA";
 
   // create output & QA directory
   std::filesystem::create_directories(datasetDir.str());
-
-  std::string hotMapOutputQA = datasetDir.str() + "/" + hotMapFile;
-  std::string hotMapOutputQA_IHCAL = datasetDir.str() + "/" + hotMapFile_IHCAL;
-  std::string hotMapOutputQA_OHCAL = datasetDir.str() + "/" + hotMapFile_OHCAL;
 
   // merges individal qa into one per run
   int ret = readHists(input);
@@ -337,6 +360,20 @@ void GenStatus::process(const std::string &input, const std::string &output)
   {
     return;
   }
+
+  std::string tag_jetqa = m_dataset_jetqa.empty() ? m_dataset : m_dataset_jetqa;
+
+  std::string hotMapFile = "EMCalHotMap_" + tag_jetqa + "_" + m_run + ".root";
+  std::string hotMapFile_IHCAL = "HCALIN_BadTowerMap_" + tag_jetqa + "_" + m_run + ".root";
+  std::string hotMapFile_OHCAL = "HCALOUT_BadTowerMap_" + tag_jetqa + "_" + m_run + ".root";
+
+  std::string hotMapOutput = outputDir + "/" + hotMapFile;
+  std::string hotMapOutput_IHCAL = outputDir + "/" + hotMapFile_IHCAL;
+  std::string hotMapOutput_OHCAL = outputDir + "/" + hotMapFile_OHCAL;
+
+  std::string hotMapOutputQA = datasetDir.str() + "/" + hotMapFile;
+  std::string hotMapOutputQA_IHCAL = datasetDir.str() + "/" + hotMapFile_IHCAL;
+  std::string hotMapOutputQA_OHCAL = datasetDir.str() + "/" + hotMapFile_OHCAL;
 
   analyze(outputDir);
 

--- a/calibrations/calorimeter/calo_cdb/GenStatus.h
+++ b/calibrations/calorimeter/calo_cdb/GenStatus.h
@@ -27,6 +27,9 @@ class GenStatus
 
   std::string m_run;
   std::string m_dataset;
+  std::string m_dataset_jetqa;
+  std::string m_dataset_calofittingqa;
+  std::string extractTag(const std::string& filename, const std::string& prefix);
 
   std::unique_ptr<TProfile2D> h_CaloValid_cemc_etaphi_badChi2;
   std::unique_ptr<TProfile2D> h_CaloValid_ihcal_etaphi_badChi2;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduces support for Inner and Outer HCal BadTowerMaps and updates both `GenStatus` and `FilterDatasets` to properly handle distinct QA dataset tags (`HIST_JETQA` vs. `HIST_CALOFITTINGQA`).
Key updates include:
1. **HCal BadTowerMaps**: Added generation and verification of `HCALIN_BadTowerMap` and `HCALOUT_BadTowerMap`.
2. **QA Tag Separation in `GenStatus`**: Switched from legacy `CALOQA` to `JETQA`, and dynamically parsed per-dataset tags from input QA files so `ZSCrossCalib` payloads receive the `CALOFITTINGQA` tag while tower maps and timing payloads receive the `JETQA` tag.
3. **Payload Filtering & Suffix Correction in `FilterDatasets`**: Added `dsttype_group` tracking to prevent false missing payload detections across QA types, and standardized the check to expect `cdb.root` suffixes across all BadTowerMap types.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/macros/pull/1386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Support separate QA dataset tags and generate verified Inner and Outer HCal bad-tower maps for calorimeter calibration workflows.

## Key changes

- Add `HCALIN_BadTowerMap` and `HCALOUT_BadTowerMap` handling.
- Parse QA dataset tags from input filenames.
- Assign `CALOFITTINGQA` to `ZSCrossCalib` payloads.
- Assign `JETQA` to tower-map and timing payloads.
- Track `dsttype_group` in `FilterDatasets` and include it in CSV output.
- Apply group-specific payload filtering.
- Standardize BadTowerMap filenames with the `cdb.root` suffix.
- Generate hot maps only when `HIST_JETQA` input is present.
- Generate EMCal, Inner HCal, and Outer HCal hot maps through `generateHotMaps`.
- Reset stored QA dataset tags before processing.

## Potential risk areas

- Existing run-info files without the optional third CSV column must remain supported.
- Unexpected filename formats can produce incorrect dataset tags.
- Incorrect `dsttype_group` values can exclude valid payloads.
- New HCal maps can change calibration inputs.
- Additional file operations can increase processing time.
- Thread-safety behavior is unchanged.

Review finding counts and test results are not available from the supplied evidence.

## Possible future improvements

- Validate CSV schemas and filename tags with explicit errors.
- Add tests for tag extraction, CSV parsing, filtering, and map naming.
- Document the expected QA filename and `dsttype_group` formats.
- Measure processing time for large QA datasets.

AI-generated summaries can contain mistakes. Contributors should verify these points against the implementation and workflow requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->