### PR TITLE
Fix mover bug

### DIFF
--- a/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
+++ b/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
@@ -284,8 +284,10 @@ bool TpcPolyClusterTrkrClusterConverter::seedOutputCluster(const Tpc_PolyCluster
   if (!std::isfinite(centroid.x()) || !std::isfinite(centroid.y()) || !std::isfinite(centroid.z())) { return false;
 }
 
+  const Acts::Vector3 sphenix_centroid =  m_geometry->transformTpcEnvelopeToWorld(centroid);
+  
   TrkrDefs::subsurfkey subsurfkey = 0;
-  Surface surface = m_geometry->get_tpc_surface_from_coords(hitsetkey, centroid, subsurfkey);
+  Surface surface = m_geometry->get_tpc_surface_from_coords(hitsetkey, sphenix_centroid, subsurfkey);
   if (!surface)
   {
     subsurfkey = 0;
@@ -326,7 +328,9 @@ void TpcPolyClusterTrkrClusterConverter::buildMovedClusterMap()
                                  cluster->get_centroid_y(),
                                  cluster->get_centroid_z());
     m_movedGlobals[cluskey] = {{centroid.x(), centroid.y(), centroid.z()}};
-    clusters_by_track[track_iter->first].emplace_back(cluskey, centroid);
+
+    const Acts::Vector3 sphenix_centroid =  m_geometry->transformTpcEnvelopeToWorld(centroid);
+    clusters_by_track[track_iter->first].emplace_back(cluskey, sphenix_centroid);
   }
 
   for (const auto& track_clusters : clusters_by_track)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The polycluster conversion to TrkrClusters was missing a step when moving clusters to local coordinates on a surface. The cluster mover expects positions in sPHENIX cluster coordinates, but the poly clusters are in TPC envelope coordinates. This PR transforms the poly cluster centroids to sPHENIX global coordinates before calling the cluster mover.

The change produces a noticeable improvement in the track fit quality - see the plot.
<img width="598" height="576" alt="globalfix_quality" src="https://github.com/user-attachments/assets/9828a360-c51a-4cd7-9522-d32304376a20" />
 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

The cluster mover expects cluster positions in sPHENIX global coordinates. Polycluster centroids were provided in TPC envelope coordinates. This caused incorrect surface lookup and reduced track-fit quality.

## Key changes

- Transform cluster centroids from TPC envelope coordinates to sPHENIX global coordinates.
- Apply the transformation before surface lookup and cluster-mover processing.
- No public or exported declarations changed.
- Track-quality distributions show improved reconstruction after the correction.

## Potential risk areas

- Reconstruction behavior changes for polyclusters.
- No I/O format or thread-safety changes are expected.
- The coordinate transformation adds negligible performance cost.

## Possible future improvements

- Add regression tests for coordinate transformations and surface lookup.
- Validate the correction across additional runs and detector conditions.
- Monitor track-fit quality after integration.

AI-generated summaries can contain errors. Review the implementation and reconstruction results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->