### PR TITLE
Fit polyseed clusters in sphenix coordinates

### DIFF
--- a/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
+++ b/offline/packages/tpctrackreco/TpcPolyClusterTrkrClusterConverter.cc
@@ -327,9 +327,10 @@ void TpcPolyClusterTrkrClusterConverter::buildMovedClusterMap()
     const Acts::Vector3 centroid(cluster->get_centroid_x(),
                                  cluster->get_centroid_y(),
                                  cluster->get_centroid_z());
-    m_movedGlobals[cluskey] = {{centroid.x(), centroid.y(), centroid.z()}};
 
     const Acts::Vector3 sphenix_centroid =  m_geometry->transformTpcEnvelopeToWorld(centroid);
+    m_movedGlobals[cluskey] = {{sphenix_centroid.x(), sphenix_centroid.y(), sphenix_centroid.z()}};
+    
     clusters_by_track[track_iter->first].emplace_back(cluskey, sphenix_centroid);
   }
 

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackReco.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackReco.cc
@@ -15,6 +15,8 @@
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
 
+#include <trackbase/ActsGeometry.h>
+
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -147,6 +149,13 @@ double Tpc_PolyTrackReco::calc_dedx(const std::vector<const Tpc_PolyCluster*>& c
 
 int Tpc_PolyTrackReco::getNodes(PHCompositeNode* topNode)
 {
+  m_geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!m_geometry)
+    {
+      std::cerr << Name() << "::getNodes - missing ActsGeometry" << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+  
   m_clusters = findNode::getClass<Tpc_PolyClusterContainer>(topNode, m_inputNodeName);
   if (!m_clusters)
   {
@@ -288,9 +297,17 @@ int Tpc_PolyTrackReco::process_event(PHCompositeNode* topNode)
         continue;
       }
       Tpc_FittingTools::Point fp;
+      Acts::Vector3 fp_envelope(cluster->get_centroid_x(), cluster->get_centroid_y(), cluster->get_centroid_z());
+      const Acts::Vector3 fp_sphenix =  m_geometry->transformTpcEnvelopeToWorld(fp_envelope);
+
+      fp.x = fp_sphenix.x();
+      fp.y = fp_sphenix.y();
+      fp.z = fp_sphenix.z();
+      /*
       fp.x = cluster->get_centroid_x();
       fp.y = cluster->get_centroid_y();
       fp.z = cluster->get_centroid_z();
+      */
       if (std::isfinite(fp.x) && std::isfinite(fp.y) && std::isfinite(fp.z))
       {
         fit_points.push_back(fp);

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackReco.cc
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackReco.cc
@@ -102,9 +102,9 @@ double Tpc_PolyTrackReco::calc_dedx(const std::vector<const Tpc_PolyCluster*>& c
       continue;
     }
 
-    const double x = cluster->get_centroid_x();
-    const double y = cluster->get_centroid_y();
-    const double r = std::hypot(x, y);
+    Acts::Vector3 xyz(cluster->get_centroid_x(), cluster->get_centroid_y(), cluster->get_centroid_z());
+    const Acts::Vector3 xyz_sphenix =  m_geometry->transformTpcEnvelopeToWorld(xyz);
+    const double r = std::hypot(xyz_sphenix.x(), xyz_sphenix.y());
     if (!std::isfinite(r))
     {
       continue;

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackReco.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackReco.h
@@ -57,6 +57,6 @@ class Tpc_PolyTrackReco : public SubsysReco
   unsigned int m_event{0};
   double m_magneticFieldTesla{1.4};
   FitMode m_fitMode{FitMode::Helix};
-  ActsGeometry *m_geometry;
+  ActsGeometry *m_geometry{nullptr};
 };
 #endif

--- a/offline/packages/tpctrackreco/Tpc_PolyTrackReco.h
+++ b/offline/packages/tpctrackreco/Tpc_PolyTrackReco.h
@@ -15,6 +15,7 @@ class IdealPadMap;
 class PHCompositeNode;
 class Tpc_PolyCluster;
 class Tpc_PolyClusterContainer;
+class ActsGeometry;
 
 class Tpc_PolyTrackReco : public SubsysReco
 {
@@ -56,5 +57,6 @@ class Tpc_PolyTrackReco : public SubsysReco
   unsigned int m_event{0};
   double m_magneticFieldTesla{1.4};
   FitMode m_fitMode{FitMode::Helix};
+  ActsGeometry *m_geometry;
 };
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Transform polycluster positions from envelope coordinates to sphenix coordinates before handing them to the polyseed fitter.  This brings the seed projection parameters into the global coordinate system, and improves the alignment with the silicon seeds. The attached plots show (tpcseedz-silseedz) vs eta for, left to right,  TPC clusters and seeds in envelope coordinates, clusters in global coordinates and seeds in envelope coordinates, and finally for both clusters and seeds in global coordinates. The 3rd panel shows that the average seed matching Δz becomes close to zero when the fit is made for global cluster coordinates.  

The small remaining Δz offset between north and south of a few mm may be alignment.

<img width="898" height="276" alt="seeddz_eta" src="https://github.com/user-attachments/assets/3cdce75e-345d-48a6-9b92-1a0a6dfcdbc7" />


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context

TPC polycluster positions were passed to the polyseed fitter in envelope coordinates. This produced incorrect global seed projection parameters and reduced alignment with silicon seeds. The change uses sPHENIX coordinates before fitting.

## Key changes

- Retrieve `ActsGeometry` in `Tpc_PolyTrackReco::getNodes`.
- Transform TPC envelope centroids with `transformTpcEnvelopeToWorld`.
- Use transformed positions for polyseed fitting and dE/dx radius calculations.
- Store transformed positions in `m_movedGlobals`.
- Preserve the existing sPHENIX-coordinate path for `clusters_by_track`.
- Make no I/O format or public API changes.

## Potential risk areas

- Reconstruction behavior changes for polycluster fitting and seed projection.
- Processing aborts when `ActsGeometry` is unavailable.
- The remaining north–south Δz offset of a few millimeters may indicate alignment effects.
- No evident thread-safety, I/O, or significant performance changes.

## Possible future improvements

- Investigate the remaining north–south Δz offset.
- Validate the transformation with alignment and silicon-seed comparisons.
- Add regression tests for envelope-to-sPHENIX coordinate handling.

This summary is based on AI-assisted change analysis. AI can make mistakes. Contributors should verify the implementation and physics results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->